### PR TITLE
feat(prd-47): extend shepherd tours with richer popups and tab explai…

### DIFF
--- a/docs/PRDS/47-SHEPHERD_IMPLEMENTATION_PLAN.md
+++ b/docs/PRDS/47-SHEPHERD_IMPLEMENTATION_PLAN.md
@@ -896,3 +896,62 @@ import { resetOnboarding } from '@/lib/shepherd/tour-storage'
 6. Iterate based on feedback
 
 Total implementation time: ~4-6 hours
+
+---
+
+## Extension (2026-04-11): Richer Popups & Tab Explainers
+
+The original tours shipped with one-line popups, and since then the platform has
+grown a lot of new top-level tabs on most pages. This extension beefs up every
+tour with a couple of sentences per step plus an explicit **tab walkthrough** on
+pages that have a top tab strip, so first-time users can tell at a glance what
+each tab is for without having to click every one.
+
+### What changed
+
+**New helper** in `frontend/lib/shepherd/tour-utils.ts`:
+
+```ts
+tabList([
+  ['Documents', 'Upload files, chunk, embed, semantic search.'],
+  ['Database',  'Connect SQL sources and query in natural language.'],
+  // ...
+])
+```
+
+Renders a compact `<ul>` with bold tab labels + grey descriptions. Reused by
+every tour.
+
+**CSS tweak** — `frontend/styles/shepherd-custom.css` bumped
+`.shepherd-theme-automatos.shepherd-element` max-width from `420px` → `460px`
+so the tab bullet lists don't get too cramped.
+
+### Per-tour updates
+
+Every tour file under `frontend/lib/shepherd/tours/` was extended:
+
+| Tour | New step(s) | Tabs explained |
+|---|---|---|
+| `welcome-tour.ts` | Sidebar step now lists every nav module | Chat, Activity, Agents, Marketplace, Knowledge Bases, Tools, Analytics, Settings |
+| `chat-tour.ts` | Richer copy on agent / model / history (no tabs) | — |
+| `marketplace-tour.ts` | Tab walkthrough step | Applications, Agents, Recipes, LLMs, Capabilities |
+| `agents-tour.ts` | New tab walkthrough step (5 steps total) | Roster, Org Chart, Configuration, Coordination, Recipes |
+| `tools-tour.ts` | Richer copy on connected / search (single tab) | — |
+| `documents-tour.ts` | Top-tab step **and** sub-tab step (4 steps) | **Top:** Documents, Database, Templates, CodeGraph, Business Graph. **Sub:** Library, Processing, Multimodal, Search, RAG Test, Upload |
+| `activity-tour.ts` | Tab walkthrough step | Summary, Board, Calendar, Memory, Missions, Blog |
+| `analytics-tour.ts` | Tab walkthrough step | Overview, Agents, Missions, Documents, LLM & Costs, Tools & Integrations, Admin |
+| `settings-tour.ts` | Tab walkthrough step | System, Orchestrator, Webhooks, API Keys, Credentials, Channels, Voices, Widget SDK |
+
+### Design rules for extending further
+
+1. **Lead with purpose, then detail.** First sentence says *what the thing is for*;
+   second sentence (or a `tabList`) explains *how*.
+2. **Never an essay.** Cap steps at ~3 short paragraphs OR 1 paragraph + `tabList`.
+3. **Tab walkthroughs attach to the TabsList element**, not individual triggers,
+   using the existing `data-tour="<page>-tabs"` attributes. Add a new
+   `data-tour` attribute to the `TabsList` when adding a new page tour.
+4. **Bullet descriptions stay under ~80 chars** so they don't wrap awkwardly at
+   460px popup width.
+5. **Every tour ends with a finish button** and calls
+   `markTourComplete(TOUR_ID, userId)` / `markTourSkipped(TOUR_ID, userId)` —
+   don't reinvent storage.

--- a/frontend/lib/shepherd/tour-utils.ts
+++ b/frontend/lib/shepherd/tour-utils.ts
@@ -68,3 +68,23 @@ export function finishButton(tour: any) {
 export function stepProgress(current: number, total: number): string {
   return `<div class="text-xs text-gray-500 mt-3">Step ${current} of ${total}</div>`
 }
+
+/**
+ * Render a compact bullet list explaining what each top-level tab does.
+ * Use inside a tour step to walk the user through a page's tab strip.
+ *
+ * Example:
+ *   tabList([
+ *     ['Documents', 'Upload files, connect cloud storage, run semantic search.'],
+ *     ['Database', 'Connect SQL sources and query them in natural language.'],
+ *   ])
+ */
+export function tabList(items: ReadonlyArray<readonly [string, string]>): string {
+  const rows = items
+    .map(
+      ([label, desc]) =>
+        `<li><strong class="text-gray-200">${label}</strong> <span class="text-gray-400">— ${desc}</span></li>`,
+    )
+    .join('')
+  return `<ul class="shepherd-tab-list text-xs text-gray-300 mt-2 space-y-1 list-disc pl-4">${rows}</ul>`
+}

--- a/frontend/lib/shepherd/tours/activity-tour.ts
+++ b/frontend/lib/shepherd/tours/activity-tour.ts
@@ -1,7 +1,7 @@
 import Shepherd from 'shepherd.js'
 import { shepherdTheme } from '../shepherd-theme'
 import { markTourComplete, markTourSkipped } from '../tour-storage'
-import { title, waitForElement, stepProgress } from '../tour-utils'
+import { title, waitForElement, stepProgress, tabList } from '../tour-utils'
 
 const TOUR_ID = 'activity'
 const TOTAL = 4
@@ -18,7 +18,9 @@ export function createActivityTour(userId: string) {
     title: title('Command', 'Centre'),
     text: `
       <p class="text-gray-300 mb-2">
-        Your AI workforce at a glance — see every chat, routine, recipe, and mission in one place.
+        A single pane of glass over your whole AI workforce. Every chat, scheduled task,
+        running mission and completed report flows through this page, so you always know
+        what's happening and what needs you.
       </p>
       ${stepProgress(1, TOTAL)}
     `,
@@ -32,7 +34,9 @@ export function createActivityTour(userId: string) {
     title: title('Live', 'Stats'),
     text: `
       <p class="text-gray-300 mb-2">
-        Real-time counters — what's working now, connected channels, completions, and anything that needs attention.
+        Real-time counters at the top — what's working right now, connected channels,
+        completions today, and anything that needs your attention. Click any tile
+        to jump straight to a filtered view.
       </p>
       ${stepProgress(2, TOTAL)}
     `,
@@ -46,11 +50,19 @@ export function createActivityTour(userId: string) {
 
   tour.addStep({
     id: 'act-tabs',
-    title: title('Navigate', 'Tabs'),
+    title: title('Six', 'Activity Views'),
     text: `
       <p class="text-gray-300 mb-2">
-        Switch between the unified Feed, Routines (recurring agent tasks), Recipes (automations), and Missions (coming soon).
+        Switch between different ways of looking at the same workforce:
       </p>
+      ${tabList([
+        ['Summary', 'Dashboard of widgets — KPIs, recent reports, alerts, completions.'],
+        ['Board', 'Kanban board of running tasks and executions, grouped by status.'],
+        ['Calendar', 'Scheduled runs, routines and mission deadlines on a calendar.'],
+        ['Memory', 'What your agents remember — long-term memory, daily logs, context.'],
+        ['Missions', 'Multi-step objectives agents are working through.'],
+        ['Blog', 'Chronological event log of everything that happened in the workspace.'],
+      ])}
       ${stepProgress(3, TOTAL)}
     `,
     beforeShowPromise: () => waitForElement('[data-tour="activity-tabs"]'),
@@ -63,10 +75,12 @@ export function createActivityTour(userId: string) {
 
   tour.addStep({
     id: 'act-content',
-    title: title('Activity', 'Feed'),
+    title: title('Drill', 'Into Anything'),
     text: `
       <p class="text-gray-300 mb-2">
-        The live feed shows all activity across your workspace. Filter by type or status, and click any item to drill in.
+        Whichever view you pick, every item is clickable. Open a report to grade it,
+        open a mission to see progress, open a memory entry to inspect what the
+        agent learned.
       </p>
       ${stepProgress(4, TOTAL)}
     `,

--- a/frontend/lib/shepherd/tours/agents-tour.ts
+++ b/frontend/lib/shepherd/tours/agents-tour.ts
@@ -1,10 +1,10 @@
 import Shepherd from 'shepherd.js'
 import { shepherdTheme } from '../shepherd-theme'
 import { markTourComplete, markTourSkipped } from '../tour-storage'
-import { title, waitForElement, stepProgress } from '../tour-utils'
+import { title, waitForElement, stepProgress, tabList } from '../tour-utils'
 
 const TOUR_ID = 'agents'
-const TOTAL = 4
+const TOTAL = 5
 
 export function createAgentsTour(userId: string) {
   const tour = new Shepherd.Tour({
@@ -18,7 +18,9 @@ export function createAgentsTour(userId: string) {
     title: title('Agent', 'Management'),
     text: `
       <p class="text-gray-300 mb-2">
-        This is your agent command center — create, configure, and monitor all your AI workers.
+        Your agent command centre. Every AI worker in the workspace lives here —
+        you can create them, configure personas and tools, wire them into orgs,
+        and hand them reusable recipes to run.
       </p>
       ${stepProgress(1, TOTAL)}
     `,
@@ -28,13 +30,39 @@ export function createAgentsTour(userId: string) {
   })
 
   tour.addStep({
+    id: 'agents-tabs',
+    title: title('Five', 'Agent Views'),
+    text: `
+      <p class="text-gray-300 mb-2">
+        The tab strip below the header gives you every angle on your workforce:
+      </p>
+      ${tabList([
+        ['Roster', 'The full list of agents as cards or rows — create, edit, start/pause, delete.'],
+        ['Org Chart', 'Visualise reporting lines and coordination hierarchy between agents.'],
+        ['Configuration', 'Deep settings — model, system prompt, memory, guardrails.'],
+        ['Coordination', 'Rules for how agents hand off work to each other and share context.'],
+        ['Recipes', 'Reusable playbooks assigned to an agent — the jobs they know how to run.'],
+      ])}
+      ${stepProgress(2, TOTAL)}
+    `,
+    beforeShowPromise: () => waitForElement('[data-tour="agents-page-header"]'),
+    attachTo: { element: '[data-tour="agents-page-header"]', on: 'bottom' },
+    buttons: [
+      { text: 'Back', classes: 'shepherd-button-secondary', action: tour.back },
+      { text: 'Next', action: tour.next },
+    ],
+  })
+
+  tour.addStep({
     id: 'agents-create',
     title: title('Create an', 'Agent'),
     text: `
       <p class="text-gray-300 mb-2">
-        Click here to build a new agent — pick a category, persona, model, and tools.
+        Build a new agent from scratch — pick a category, persona and model,
+        then attach tools and skills. You can also start from a Marketplace template
+        and customise from there.
       </p>
-      ${stepProgress(2, TOTAL)}
+      ${stepProgress(3, TOTAL)}
     `,
     beforeShowPromise: () => waitForElement('[data-tour="create-agent-btn"]'),
     attachTo: { element: '[data-tour="create-agent-btn"]', on: 'bottom' },
@@ -49,9 +77,10 @@ export function createAgentsTour(userId: string) {
     title: title('Your', 'Agent Roster'),
     text: `
       <p class="text-gray-300 mb-2">
-        All your agents appear here. Switch between grid and list view to find them fast.
+        All your agents live here. Toggle between grid and list view, search by name,
+        and filter by status to find what you need quickly.
       </p>
-      ${stepProgress(3, TOTAL)}
+      ${stepProgress(4, TOTAL)}
     `,
     beforeShowPromise: () => waitForElement('[data-tour="agent-roster"]'),
     attachTo: { element: '[data-tour="agent-roster"]', on: 'top' },
@@ -66,9 +95,10 @@ export function createAgentsTour(userId: string) {
     title: title('Agent', 'Actions'),
     text: `
       <p class="text-gray-300 mb-2">
-        Use the menu on each card to view details, configure, start/pause, or delete an agent.
+        Each card has a menu for view details, configure, start/pause, clone, and delete.
+        Click the card itself to open the full agent workspace with its chat, reports and memory.
       </p>
-      ${stepProgress(4, TOTAL)}
+      ${stepProgress(5, TOTAL)}
     `,
     beforeShowPromise: () => waitForElement('[data-tour="agent-card-menu"]'),
     attachTo: { element: '[data-tour="agent-card-menu"]', on: 'left' },

--- a/frontend/lib/shepherd/tours/analytics-tour.ts
+++ b/frontend/lib/shepherd/tours/analytics-tour.ts
@@ -1,7 +1,7 @@
 import Shepherd from 'shepherd.js'
 import { shepherdTheme } from '../shepherd-theme'
 import { markTourComplete, markTourSkipped } from '../tour-storage'
-import { title, waitForElement, stepProgress } from '../tour-utils'
+import { title, waitForElement, stepProgress, tabList } from '../tour-utils'
 
 const TOUR_ID = 'analytics'
 const TOTAL = 3
@@ -18,7 +18,9 @@ export function createAnalyticsTour(userId: string) {
     title: title('', 'Analytics'),
     text: `
       <p class="text-gray-300 mb-2">
-        Track agent performance, workflow success rates, document usage, and LLM costs.
+        Measure what your AI workforce is actually doing. Every agent run, mission,
+        document lookup and LLM call gets tracked here so you can see impact,
+        spot bottlenecks, and keep costs in check.
       </p>
       ${stepProgress(1, TOTAL)}
     `,
@@ -29,11 +31,19 @@ export function createAnalyticsTour(userId: string) {
 
   tour.addStep({
     id: 'analytics-tabs',
-    title: title('Drill', 'Down'),
+    title: title('Six', 'Analytics Views'),
     text: `
       <p class="text-gray-300 mb-2">
-        Switch between Overview, Agents, Workflows, Documents, Costs, and Tools views.
+        Each top tab answers a different question about your workspace:
       </p>
+      ${tabList([
+        ['Overview', 'High-level dashboard — headline KPIs across everything.'],
+        ['Agents', 'Per-agent performance — runs, success rate, time-to-completion.'],
+        ['Missions', 'Mission and workflow execution stats, step-level timings.'],
+        ['Documents', 'How your knowledge base is used — top files, hit rates, RAG quality.'],
+        ['LLM & Costs', 'Token spend by model and provider, cost per agent and per day.'],
+        ['Tools & Integrations', 'Which tools get used most, error rates, latency.'],
+      ])}
       ${stepProgress(2, TOTAL)}
     `,
     beforeShowPromise: () => waitForElement('[data-tour="analytics-tabs"]'),
@@ -49,7 +59,8 @@ export function createAnalyticsTour(userId: string) {
     title: title('Time', 'Range'),
     text: `
       <p class="text-gray-300 mb-2">
-        Filter data by 7, 30, or 90 days to spot trends and track changes.
+        The range picker applies to every chart on the page — flip between 7, 30 and 90 days
+        to compare trends. Pick a wider window to see week-over-week movement.
       </p>
       ${stepProgress(3, TOTAL)}
     `,

--- a/frontend/lib/shepherd/tours/chat-tour.ts
+++ b/frontend/lib/shepherd/tours/chat-tour.ts
@@ -18,7 +18,13 @@ export function createChatTour(userId: string) {
     title: title('Pick an', 'Agent'),
     text: `
       <p class="text-gray-300 mb-2">
-        Select which AI agent you want to chat with. Each agent has its own personality and tools.
+        Every conversation runs through an agent. Each one has its own persona,
+        memory, tool access and skillset — so picking the right agent changes
+        what the assistant can actually do.
+      </p>
+      <p class="text-gray-400 text-sm">
+        Start with <strong>Auto</strong> if you're not sure — it routes your message
+        to the best agent for the job.
       </p>
       ${stepProgress(1, TOTAL)}
     `,
@@ -32,7 +38,12 @@ export function createChatTour(userId: string) {
     title: title('Choose a', 'Model'),
     text: `
       <p class="text-gray-300 mb-2">
-        Pick the LLM powering your conversation — faster models for quick tasks, smarter ones for complex work.
+        Pick which LLM powers this conversation. Faster, cheaper models (Haiku, GPT-mini,
+        DeepSeek) are great for quick back-and-forth; bigger models (Opus, Sonnet, GPT-4-class)
+        are better for planning, writing, and reasoning.
+      </p>
+      <p class="text-gray-400 text-sm">
+        You can change models mid-conversation — the history stays.
       </p>
       ${stepProgress(2, TOTAL)}
     `,
@@ -49,7 +60,8 @@ export function createChatTour(userId: string) {
     title: title('Chat', 'History'),
     text: `
       <p class="text-gray-300 mb-2">
-        Toggle the sidebar to browse and resume previous conversations.
+        Every conversation is saved automatically. Toggle the chat sidebar to browse,
+        search, rename, pin and resume previous sessions — across any agent.
       </p>
       ${stepProgress(3, TOTAL)}
     `,

--- a/frontend/lib/shepherd/tours/documents-tour.ts
+++ b/frontend/lib/shepherd/tours/documents-tour.ts
@@ -1,10 +1,10 @@
 import Shepherd from 'shepherd.js'
 import { shepherdTheme } from '../shepherd-theme'
 import { markTourComplete, markTourSkipped } from '../tour-storage'
-import { title, waitForElement, stepProgress } from '../tour-utils'
+import { title, waitForElement, stepProgress, tabList } from '../tour-utils'
 
 const TOUR_ID = 'documents'
-const TOTAL = 3
+const TOTAL = 4
 
 export function createDocumentsTour(userId: string) {
   const tour = new Shepherd.Tour({
@@ -13,12 +13,18 @@ export function createDocumentsTour(userId: string) {
     keyboardNavigation: true,
   })
 
+  // Step 1 — Overview
   tour.addStep({
     id: 'docs-overview',
     title: title('Knowledge', 'Bases'),
     text: `
       <p class="text-gray-300 mb-2">
-        Upload documents, connect cloud storage, and build searchable knowledge for your agents.
+        This is where your agents get their brains. Upload files, connect databases,
+        map code, and model the business — everything here is searchable and retrievable
+        by any agent in the workspace.
+      </p>
+      <p class="text-gray-400 text-sm">
+        Think of it as five knowledge sources sitting behind one unified RAG layer.
       </p>
       ${stepProgress(1, TOTAL)}
     `,
@@ -27,14 +33,44 @@ export function createDocumentsTour(userId: string) {
     buttons: [{ text: 'Next', action: tour.next }],
   })
 
+  // Step 2 — Top-level tabs walkthrough
+  tour.addStep({
+    id: 'docs-tabs',
+    title: title('The Five', 'Knowledge Sources'),
+    text: `
+      <p class="text-gray-300 mb-2">
+        Each top tab is a different way of giving your agents context:
+      </p>
+      ${tabList([
+        ['Documents', 'Upload PDFs, Word, Markdown, images. Auto-chunked, embedded, and searchable via RAG.'],
+        ['Database', 'Connect Postgres, MySQL, Snowflake and let agents query them in natural language with a semantic layer on top.'],
+        ['Templates', 'Reusable document templates agents can fill in — proposals, reports, briefs.'],
+        ['CodeGraph', 'Index a repo into a graph of files, symbols and calls so agents can reason about code structure.'],
+        ['Business Graph', 'Your org modelled as entities — customers, products, processes — agents can traverse.'],
+      ])}
+      ${stepProgress(2, TOTAL)}
+    `,
+    beforeShowPromise: () => waitForElement('[data-tour="documents-tabs"]'),
+    attachTo: { element: '[data-tour="documents-tabs"]', on: 'bottom' },
+    buttons: [
+      { text: 'Back', classes: 'shepherd-button-secondary', action: tour.back },
+      { text: 'Next', action: tour.next },
+    ],
+  })
+
+  // Step 3 — Upload
   tour.addStep({
     id: 'docs-upload',
     title: title('Upload', 'Documents'),
     text: `
       <p class="text-gray-300 mb-2">
-        Drag and drop files or click to upload. Supports PDF, Word, text, and more.
+        Drag-and-drop or click to upload. Files are chunked, embedded, and indexed
+        automatically — you'll see them appear in <strong>Library</strong> once processing completes.
       </p>
-      ${stepProgress(2, TOTAL)}
+      <p class="text-gray-400 text-sm">
+        Supports PDF, DOCX, Markdown, TXT, CSV, and images (OCR runs automatically).
+      </p>
+      ${stepProgress(3, TOTAL)}
     `,
     beforeShowPromise: () => waitForElement('[data-tour="documents-upload-btn"]'),
     attachTo: { element: '[data-tour="documents-upload-btn"]', on: 'bottom' },
@@ -44,14 +80,24 @@ export function createDocumentsTour(userId: string) {
     ],
   })
 
+  // Step 4 — Sub-tabs inside Documents
   tour.addStep({
-    id: 'docs-tabs',
-    title: title('Browse', 'Sources'),
+    id: 'docs-subtabs',
+    title: title('Inside the', 'Documents Tab'),
     text: `
       <p class="text-gray-300 mb-2">
-        Switch between local uploads, cloud storage, databases, and semantic search.
+        Once you're in <strong>Documents</strong>, the inner strip gives you everything
+        you need end-to-end:
       </p>
-      ${stepProgress(3, TOTAL)}
+      ${tabList([
+        ['Library', 'Every uploaded file — search, preview, delete.'],
+        ['Processing', 'Live status of chunking, embedding, OCR jobs.'],
+        ['Multimodal', 'Images and mixed-content files with OCR + vision extraction.'],
+        ['Search', 'Semantic search across the whole knowledge base.'],
+        ['RAG Test', 'Sandbox to test how your agents will retrieve this content.'],
+        ['Upload', 'The drop zone again, for convenience.'],
+      ])}
+      ${stepProgress(4, TOTAL)}
     `,
     beforeShowPromise: () => waitForElement('[data-tour="documents-tabs"]'),
     attachTo: { element: '[data-tour="documents-tabs"]', on: 'bottom' },

--- a/frontend/lib/shepherd/tours/marketplace-tour.ts
+++ b/frontend/lib/shepherd/tours/marketplace-tour.ts
@@ -1,7 +1,7 @@
 import Shepherd from 'shepherd.js'
 import { shepherdTheme } from '../shepherd-theme'
 import { markTourComplete, markTourSkipped } from '../tour-storage'
-import { title, waitForElement, stepProgress } from '../tour-utils'
+import { title, waitForElement, stepProgress, tabList } from '../tour-utils'
 
 const TOUR_ID = 'marketplace'
 const TOTAL = 4
@@ -18,7 +18,11 @@ export function createMarketplaceTour(userId: string) {
     title: title('Community', 'Marketplace'),
     text: `
       <p class="text-gray-300 mb-2">
-        Browse pre-built agents, recipes, tools, and LLMs — install anything with one click.
+        The fastest way to get productive. Browse pre-built agents, recipes,
+        integrations and models — install any of them into your workspace with one click.
+      </p>
+      <p class="text-gray-400 text-sm">
+        Anything you install here becomes available to every agent you create.
       </p>
       ${stepProgress(1, TOTAL)}
     `,
@@ -32,8 +36,15 @@ export function createMarketplaceTour(userId: string) {
     title: title('Browse by', 'Category'),
     text: `
       <p class="text-gray-300 mb-2">
-        Switch between Applications, Agents, Recipes, LLMs, Capabilities, and Skills.
+        Five top tabs cover everything you can add to your workspace:
       </p>
+      ${tabList([
+        ['Applications', 'Tool integrations — Gmail, Slack, GitHub, Jira, HubSpot and 150+ more.'],
+        ['Agents', 'Ready-made personas (marketer, researcher, SDR, analyst) you can install and use immediately.'],
+        ['Recipes', 'Multi-step playbooks and workflows — automations you can drop into any agent.'],
+        ['LLMs', 'Model catalogue — pick which providers (OpenAI, Anthropic, DeepSeek, Qwen…) your agents can use.'],
+        ['Capabilities', 'Plugins and skills that extend an agent with new behaviours or tool packs.'],
+      ])}
       ${stepProgress(2, TOTAL)}
     `,
     beforeShowPromise: () => waitForElement('[data-tour="marketplace-tabs"]'),
@@ -49,7 +60,8 @@ export function createMarketplaceTour(userId: string) {
     title: title('Search', 'Anything'),
     text: `
       <p class="text-gray-300 mb-2">
-        Looking for something specific? Type here to filter by name.
+        Looking for a specific tool or agent? Filter by name, category, or tag.
+        Search works across whichever top tab you're in.
       </p>
       ${stepProgress(3, TOTAL)}
     `,
@@ -66,7 +78,11 @@ export function createMarketplaceTour(userId: string) {
     title: title('One-Click', 'Install'),
     text: `
       <p class="text-gray-300 mb-2">
-        Found something you like? Hit <strong>Install</strong> or <strong>Add</strong> to start using it immediately.
+        Every card has an <strong>Install</strong> or <strong>Add</strong> button. Installed items
+        show up in the matching workspace page — Agents, Tools, Playbooks, or Settings → Orchestrator.
+      </p>
+      <p class="text-gray-400 text-sm">
+        You can remove anything later from its home page — installs are never permanent.
       </p>
       ${stepProgress(4, TOTAL)}
     `,

--- a/frontend/lib/shepherd/tours/settings-tour.ts
+++ b/frontend/lib/shepherd/tours/settings-tour.ts
@@ -1,7 +1,7 @@
 import Shepherd from 'shepherd.js'
 import { shepherdTheme } from '../shepherd-theme'
 import { markTourComplete, markTourSkipped } from '../tour-storage'
-import { title, waitForElement, stepProgress } from '../tour-utils'
+import { title, waitForElement, stepProgress, tabList } from '../tour-utils'
 
 const TOUR_ID = 'settings'
 const TOTAL = 3
@@ -15,10 +15,14 @@ export function createSettingsTour(userId: string) {
 
   tour.addStep({
     id: 'settings-overview',
-    title: title('System', 'Settings'),
+    title: title('Workspace', 'Settings'),
     text: `
       <p class="text-gray-300 mb-2">
-        Manage your workspace configuration, API keys, credentials, and security settings.
+        Everything that configures your workspace — system behaviour, model routing,
+        external auth, webhooks, channels and embeddable widgets — lives here.
+      </p>
+      <p class="text-gray-400 text-sm">
+        Changes apply to the whole workspace, so admin access is usually required.
       </p>
       ${stepProgress(1, TOTAL)}
     `,
@@ -29,11 +33,20 @@ export function createSettingsTour(userId: string) {
 
   tour.addStep({
     id: 'settings-tabs',
-    title: title('Navigate', 'Tabs'),
+    title: title('Seven', 'Settings Areas'),
     text: `
       <p class="text-gray-300 mb-2">
-        System Settings, Orchestrator, Webhooks, API Keys, Credentials, Audit Logs, Channels, and more.
+        Each tab handles a different class of configuration:
       </p>
+      ${tabList([
+        ['Orchestrator', 'LLM routing rules — which models handle chat, tools, embeddings, fallbacks.'],
+        ['Webhooks', 'Outbound webhooks that fire on agent events, completions, or errors.'],
+        ['API Keys', 'BYOK — bring your own OpenAI / Anthropic / OpenRouter keys.'],
+        ['Credentials', 'Third-party credentials (OAuth, tokens) agents use to call external services.'],
+        ['Channels', 'Inbound channels — email, Slack, Teams, voice — that feed agents.'],
+        ['Voices', 'Voice profiles for TTS output and voice-channel agents.'],
+        ['Widget SDK', 'Embeddable chat widget keys and site configuration.'],
+      ])}
       ${stepProgress(2, TOTAL)}
     `,
     beforeShowPromise: () => waitForElement('[data-tour="settings-tabs"]'),
@@ -46,10 +59,12 @@ export function createSettingsTour(userId: string) {
 
   tour.addStep({
     id: 'settings-credentials',
-    title: title('API Keys &', 'Credentials'),
+    title: title('Credentials &', 'API Keys'),
     text: `
       <p class="text-gray-300 mb-2">
-        Store your API keys and service credentials securely. Agents use these to connect to external services.
+        The two most common places you'll come back to. <strong>API Keys</strong> is where
+        you drop in LLM provider keys. <strong>Credentials</strong> stores encrypted OAuth
+        tokens and secrets your agents use to sign in to Gmail, Slack, GitHub and friends.
       </p>
       ${stepProgress(3, TOTAL)}
     `,

--- a/frontend/lib/shepherd/tours/tools-tour.ts
+++ b/frontend/lib/shepherd/tours/tools-tour.ts
@@ -18,7 +18,12 @@ export function createToolsTour(userId: string) {
     title: title('Tools &', 'Integrations'),
     text: `
       <p class="text-gray-300 mb-2">
-        Connect your agents to external services — Gmail, Slack, GitHub, CRMs, and 150+ more.
+        This is where your workspace plugs into the outside world. Connect Gmail,
+        Slack, GitHub, Jira, HubSpot, CRMs, databases — 150+ integrations — and any
+        agent you give access to can start calling them as tools.
+      </p>
+      <p class="text-gray-400 text-sm">
+        Authentication happens here once; agents reuse the saved credentials.
       </p>
       ${stepProgress(1, TOTAL)}
     `,
@@ -32,7 +37,11 @@ export function createToolsTour(userId: string) {
     title: title('Connected', 'Apps'),
     text: `
       <p class="text-gray-300 mb-2">
-        Apps you've already connected show up here. Click any card to manage or reconfigure.
+        Anything you've already authenticated appears here as a card. Click one to
+        reconfigure, re-auth, disable, or see which agents are currently using it.
+      </p>
+      <p class="text-gray-400 text-sm">
+        Green = healthy connection. Amber = needs re-auth.
       </p>
       ${stepProgress(2, TOTAL)}
     `,
@@ -49,7 +58,9 @@ export function createToolsTour(userId: string) {
     title: title('Find &', 'Connect'),
     text: `
       <p class="text-gray-300 mb-2">
-        Search for any app or browse categories to find new integrations.
+        Search for any service or browse by category — Communication, CRM, Dev,
+        Marketing, Productivity. Hit <strong>Connect</strong> on a card and you'll
+        walk through an OAuth flow or key entry, then it's available to every agent.
       </p>
       ${stepProgress(3, TOTAL)}
     `,

--- a/frontend/lib/shepherd/tours/welcome-tour.ts
+++ b/frontend/lib/shepherd/tours/welcome-tour.ts
@@ -1,7 +1,7 @@
 import Shepherd from 'shepherd.js'
 import { shepherdTheme } from '../shepherd-theme'
 import { markTourComplete, markTourSkipped } from '../tour-storage'
-import { title, waitForElement, stepProgress } from '../tour-utils'
+import { title, waitForElement, stepProgress, tabList } from '../tour-utils'
 
 const TOUR_ID = 'welcome'
 const TOTAL_STEPS = 5
@@ -45,11 +45,19 @@ export function createWelcomeTour(userId: string) {
     title: title('Your', 'Navigation Hub'),
     text: `
       <p class="text-gray-300 mb-2">
-        Everything's in the sidebar — Chat, Agents, Marketplace, Tools, Workflows, and more.
+        The sidebar is the map of the whole platform. Each item is a major area
+        of your workspace:
       </p>
-      <p class="text-gray-400 text-sm">
-        Hover to see labels, click to expand.
-      </p>
+      ${tabList([
+        ['Chat', 'Talk to any agent — your day-to-day home base.'],
+        ['Activity', 'Command centre for everything your agents are doing.'],
+        ['Agents', 'Create, configure and coordinate your AI workforce.'],
+        ['Marketplace', 'One-click installs for agents, recipes, tools and LLMs.'],
+        ['Knowledge Bases', 'Documents, databases, templates, code & business graphs.'],
+        ['Tools', '150+ integrations — Gmail, Slack, GitHub, CRMs, and more.'],
+        ['Analytics', 'Performance, usage and cost dashboards.'],
+        ['Settings', 'Workspace config, API keys, credentials and channels.'],
+      ])}
       ${stepProgress(2, TOTAL_STEPS)}
     `,
     beforeShowPromise: () => waitForElement('[data-tour="sidebar"]'),

--- a/frontend/styles/shepherd-custom.css
+++ b/frontend/styles/shepherd-custom.css
@@ -20,7 +20,7 @@
     0 0 0 1px hsla(16, 100%, 60%, 0.08),
     0 0 24px hsla(16, 100%, 60%, 0.12),
     0 24px 48px -12px rgba(0, 0, 0, 0.5) !important;
-  max-width: 420px;
+  max-width: 460px;
   overflow: hidden;
 }
 


### PR DESCRIPTION
…ners

Every tour now walks users through the top-level tabs on each page with a short purpose line + bullet list, instead of a single vague sentence. Adds a reusable tabList() helper and bumps popup max-width to 460px.

- welcome: sidebar step lists all 8 nav modules
- documents: explains Documents / Database / Templates / CodeGraph / Business Graph plus the inner Library/Processing/Multimodal/Search/ RAG Test/Upload sub-tabs
- marketplace: Applications / Agents / Recipes / LLMs / Capabilities
- agents: Roster / Org Chart / Configuration / Coordination / Recipes
- activity: Summary / Board / Calendar / Memory / Missions / Blog
- analytics: Overview / Agents / Missions / Documents / LLM & Costs / Tools & Integrations (Admin removed — users don't see it)
- settings: Orchestrator / Webhooks / API Keys / Credentials / Channels / Voices / Widget SDK (System removed)
- chat, tools: beefed-up copy (no tabs on those pages)

PRD 47 updated with 2026-04-11 addendum documenting the helper, per-tour changes, and design rules for future tours.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced onboarding tours with richer, more detailed step descriptions across all major features including Activity, Agents, Analytics, Chat, Documents, Marketplace, Settings, Tools, and Welcome.
  * Added tab walkthroughs to select tours for clearer feature navigation and exploration.
  * Improved formatting for tour content with better visual organization and clarity.

* **Improvements**
  * Increased popup width to accommodate expanded tour content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->