### PR TITLE
feat: add documentation links to header, sidebar, and empty states

### DIFF
--- a/frontend/components/agents/agent-roster.tsx
+++ b/frontend/components/agents/agent-roster.tsx
@@ -30,7 +30,8 @@ import {
   Zap,
   Cloud,
   Pin,
-  PinOff
+  PinOff,
+  ExternalLink,
 } from 'lucide-react'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
@@ -623,9 +624,18 @@ export function AgentRoster({
         >
           <Bot className="w-12 h-12 text-muted-foreground mx-auto mb-4" />
           <h3 className="text-lg font-semibold mb-2">No agents found</h3>
-          <p className="text-muted-foreground">
+          <p className="text-muted-foreground mb-4">
             Try adjusting your search or create a new agent.
           </p>
+          <a
+            href="https://automatos.gitbook.io/automatos-ai/agents/creating"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 text-sm text-primary hover:text-primary/80 transition-colors"
+          >
+            Read the Agent Guide
+            <ExternalLink className="w-3 h-3" />
+          </a>
         </motion.div>
       )}
 

--- a/frontend/components/documents/document-library.tsx
+++ b/frontend/components/documents/document-library.tsx
@@ -26,7 +26,8 @@ import {
   Calendar,
   User,
   HardDrive,
-  Zap
+  Zap,
+  ExternalLink,
 } from 'lucide-react'
 import { Card, CardContent, CardHeader } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
@@ -574,10 +575,21 @@ export function DocumentLibrary({
                 : 'Upload your first document to get started'
               }
             </p>
-            <Button onClick={() => onRefresh()}>
-              <RefreshCw className="w-4 h-4 mr-2" />
-              Refresh
-            </Button>
+            <div className="flex items-center justify-center gap-3">
+              <Button onClick={() => onRefresh()}>
+                <RefreshCw className="w-4 h-4 mr-2" />
+                Refresh
+              </Button>
+              <a
+                href="https://automatos.gitbook.io/automatos-ai/knowledge/documents"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1.5 text-sm text-primary hover:text-primary/80 transition-colors"
+              >
+                Read the Guide
+                <ExternalLink className="w-3 h-3" />
+              </a>
+            </div>
           </CardContent>
         </Card>
       )}

--- a/frontend/components/layout/header.tsx
+++ b/frontend/components/layout/header.tsx
@@ -1,11 +1,18 @@
 'use client'
 
 import { motion } from 'framer-motion'
-import { Menu } from 'lucide-react'
+import { Menu, BookOpen, ExternalLink, Code2, Bug } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { ThemeToggle } from '@/components/ui/theme-toggle'
 import { ProfileMenu } from '@/components/auth/profile-menu'
 import { NotificationBell } from '@/components/notifications/notification-bell'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
 
 interface HeaderProps {
   onMenuClick: () => void
@@ -43,6 +50,56 @@ export function Header({ onMenuClick }: HeaderProps) {
 
         {/* Right side */}
         <div className="flex items-center space-x-2 md:space-x-4">
+          {/* Help & Docs */}
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="text-muted-foreground hover:text-foreground"
+                aria-label="Help & documentation"
+              >
+                <BookOpen className="w-5 h-5" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-48">
+              <DropdownMenuItem asChild>
+                <a
+                  href="https://automatos.gitbook.io/automatos-ai"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center justify-between"
+                >
+                  Documentation
+                  <ExternalLink className="w-3 h-3 opacity-50" />
+                </a>
+              </DropdownMenuItem>
+              <DropdownMenuItem asChild>
+                <a
+                  href="https://automatos.gitbook.io/automatos-ai/api-reference"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center justify-between"
+                >
+                  API Reference
+                  <Code2 className="w-3 h-3 opacity-50" />
+                </a>
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem asChild>
+                <a
+                  href="https://github.com/AutomatosAI/automatos-ai/issues"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center justify-between"
+                >
+                  Report a Bug
+                  <Bug className="w-3 h-3 opacity-50" />
+                </a>
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+
           {/* Theme Toggle */}
           <ThemeToggle />
 

--- a/frontend/components/layout/mobile-sidebar.tsx
+++ b/frontend/components/layout/mobile-sidebar.tsx
@@ -16,7 +16,9 @@ import {
   BarChart3,
   LayoutDashboard,
   HardDrive,
-  X
+  X,
+  BookOpen,
+  ExternalLink,
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { PremiumIcon } from '@/components/shared'
@@ -195,9 +197,22 @@ export function MobileSidebar({ onNavigate }: MobileSidebarProps) {
         })}
       </nav>
 
-      {/* Settings at bottom — Admin only */}
-      {isAdmin && (
-        <div className="border-t border-border/50 px-3 py-3">
+      {/* Docs + Settings at bottom */}
+      <div className="border-t border-border/50 px-3 py-3 space-y-1">
+        {/* Documentation link */}
+        <a
+          href="https://automatos.gitbook.io/automatos-ai"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center gap-3 w-full px-4 py-3 rounded-xl transition-all duration-200 min-h-[48px] hover:bg-secondary/40 active:bg-secondary/60"
+        >
+          <BookOpen className="w-5 h-5 shrink-0 text-muted-foreground" />
+          <p className="text-sm font-medium text-muted-foreground">Docs</p>
+          <ExternalLink className="w-3 h-3 text-muted-foreground/50 ml-auto" />
+        </a>
+
+        {/* Settings — Admin only */}
+        {isAdmin && (
           <Link
             href="/settings"
             onClick={onNavigate}
@@ -215,8 +230,8 @@ export function MobileSidebar({ onNavigate }: MobileSidebarProps) {
             )}
             <p className="text-sm font-medium text-muted-foreground">Settings</p>
           </Link>
-        </div>
-      )}
+        )}
+      </div>
     </div>
   )
 }

--- a/frontend/components/layout/sidebar.tsx
+++ b/frontend/components/layout/sidebar.tsx
@@ -19,6 +19,8 @@ import {
   BarChart3,
   LayoutDashboard,
   HardDrive,
+  BookOpen,
+  ExternalLink,
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { PremiumIcon } from '@/components/shared'
@@ -271,11 +273,35 @@ export function Sidebar({ collapsed, onToggle }: SidebarProps) {
         })}
       </nav>
 
-      {/* Settings at bottom - visible to all users.
-          Every user needs access to add their own provider API keys.
-          Admin-only sections (Platform API Keys, System Settings) are
-          gated inside the Settings page itself, not at the nav level. */}
-      <div className="absolute bottom-4 left-3 right-3">
+      {/* Docs + Settings at bottom */}
+      <div className="absolute bottom-4 left-3 right-3 space-y-0.5">
+        {/* Documentation link */}
+        <a
+          href="https://automatos.gitbook.io/automatos-ai"
+          target="_blank"
+          rel="noopener noreferrer"
+          className={cn(
+            'flex items-center gap-3 w-full px-3 py-2 rounded-xl transition-all duration-200 group relative',
+            'hover:bg-secondary/40'
+          )}
+        >
+          <BookOpen className="w-[18px] h-[18px] shrink-0 text-muted-foreground group-hover:text-foreground" />
+
+          {!collapsed && (
+            <div className="min-w-0 flex items-center gap-2">
+              <p className="text-sm font-medium text-muted-foreground group-hover:text-foreground truncate">Docs</p>
+              <ExternalLink className="w-3 h-3 text-muted-foreground/50 shrink-0" />
+            </div>
+          )}
+
+          {collapsed && (
+            <div className="absolute left-full ml-2 px-2 py-1 bg-popover/90 border border-border/50 rounded-xl backdrop-blur-lg text-sm whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-50">
+              Documentation
+            </div>
+          )}
+        </a>
+
+        {/* Settings */}
         <Link
           href="/settings"
           data-tour="nav-settings"

--- a/frontend/components/missions/mission-list.tsx
+++ b/frontend/components/missions/mission-list.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import { Target, Search, Plus, RefreshCw } from 'lucide-react'
+import { Target, Search, Plus, RefreshCw, ExternalLink } from 'lucide-react'
 import { motion, useReducedMotion } from 'framer-motion'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -148,14 +148,25 @@ export function MissionList() {
           </div>
 
           {!search && activeFilter === 'all' && (
-            <Button
-              variant="outline"
-              className="border-primary/30 hover:border-primary/50"
-              onClick={() => setShowCreateModal(true)}
-            >
-              <Target className="w-4 h-4 mr-2" />
-              New Mission
-            </Button>
+            <div className="flex items-center gap-3">
+              <Button
+                variant="outline"
+                className="border-primary/30 hover:border-primary/50"
+                onClick={() => setShowCreateModal(true)}
+              >
+                <Target className="w-4 h-4 mr-2" />
+                New Mission
+              </Button>
+              <a
+                href="https://automatos.gitbook.io/automatos-ai/activity/missions"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1.5 text-sm text-primary hover:text-primary/80 transition-colors"
+              >
+                Read the Guide
+                <ExternalLink className="w-3 h-3" />
+              </a>
+            </div>
           )}
         </motion.div>
       )}


### PR DESCRIPTION
Header: help dropdown with Docs, API Reference, and Report a Bug links Sidebar: persistent Docs link above Settings (desktop + mobile) Empty states: "Read the Guide" links on agents, documents, and missions pages All links point to automatos.gitbook.io/automatos-ai