### PR TITLE
fix: rewrite all 9 page tours with consistent content and Skip buttons

### DIFF
--- a/frontend/components/agents/agent-management.tsx
+++ b/frontend/components/agents/agent-management.tsx
@@ -245,7 +245,7 @@ export function AgentManagement() {
         animate={inView ? { opacity: 1, y: 0 } : {}}
         transition={{ duration: 0.6, delay: 0.3 }}
       >
-        <FilterTabs tabs={tabDefs} value={activeTab} onValueChange={setActiveTab} trailing={<ViewToggle value={viewMode} onChange={setViewMode} className="ml-auto" />}>
+        <FilterTabs data-tour="agents-tabs" tabs={tabDefs} value={activeTab} onValueChange={setActiveTab} trailing={<ViewToggle value={viewMode} onChange={setViewMode} className="ml-auto" />}>
           <TabsContent value="roster" className="space-y-6">
             <div data-tour="agent-roster">
               <AgentRoster

--- a/frontend/components/chatbot/chat-mode-bar.tsx
+++ b/frontend/components/chatbot/chat-mode-bar.tsx
@@ -49,7 +49,7 @@ export function ChatModeBar({
   }
 
   return (
-    <div className="flex flex-wrap justify-center gap-3 md:gap-2">
+    <div data-tour="chat-mode-bar" className="flex flex-wrap justify-center gap-3 md:gap-2">
       {/* Code mode */}
       <button
         type="button"

--- a/frontend/components/workspace/workspace-view-toggle.tsx
+++ b/frontend/components/workspace/workspace-view-toggle.tsx
@@ -36,6 +36,7 @@ export function WorkspaceViewToggle({
 }: WorkspaceViewToggleProps) {
   return (
     <ToggleGroup
+      data-tour="workspace-tabs"
       type="single"
       value={view}
       onValueChange={(next) => {

--- a/frontend/lib/shepherd/tour-registry.ts
+++ b/frontend/lib/shepherd/tour-registry.ts
@@ -77,6 +77,14 @@ const registry: Record<string, TourRegistryEntry> = {
       return createSettingsTour(userId)
     },
   },
+  '/workspace': {
+    id: 'workspace',
+    label: 'Workspace',
+    factory: async (userId) => {
+      const { createWorkspaceTour } = await import('./tours/workspace-tour')
+      return createWorkspaceTour(userId)
+    },
+  },
 }
 
 /** Get the tour entry for a given pathname, or undefined if no tour exists */

--- a/frontend/lib/shepherd/tours/activity-tour.ts
+++ b/frontend/lib/shepherd/tours/activity-tour.ts
@@ -26,7 +26,10 @@ export function createActivityTour(userId: string) {
     `,
     beforeShowPromise: () => waitForElement('[data-tour="activity-page-header"]'),
     attachTo: { element: '[data-tour="activity-page-header"]', on: 'bottom' },
-    buttons: [{ text: 'Next', action: tour.next }],
+    buttons: [
+      { text: 'Skip', classes: 'shepherd-button-secondary', action: () => tour.cancel() },
+      { text: 'Next', action: tour.next },
+    ],
   })
 
   tour.addStep({
@@ -84,8 +87,7 @@ export function createActivityTour(userId: string) {
       </p>
       ${stepProgress(4, TOTAL)}
     `,
-    beforeShowPromise: () => waitForElement('[data-tour="activity-content"]'),
-    attachTo: { element: '[data-tour="activity-content"]', on: 'top' },
+    // Centered — no specific attach target needed for final step
     buttons: [
       { text: 'Back', classes: 'shepherd-button-secondary', action: tour.back },
       { text: 'Got it!', action: tour.complete },

--- a/frontend/lib/shepherd/tours/agents-tour.ts
+++ b/frontend/lib/shepherd/tours/agents-tour.ts
@@ -4,7 +4,7 @@ import { markTourComplete, markTourSkipped } from '../tour-storage'
 import { title, waitForElement, stepProgress, tabList } from '../tour-utils'
 
 const TOUR_ID = 'agents'
-const TOTAL = 5
+const TOTAL = 4
 
 export function createAgentsTour(userId: string) {
   const tour = new Shepherd.Tour({
@@ -13,6 +13,7 @@ export function createAgentsTour(userId: string) {
     keyboardNavigation: true,
   })
 
+  // Step 1: Overview (centered)
   tour.addStep({
     id: 'agents-overview',
     title: title('Agent', 'Management'),
@@ -24,18 +25,17 @@ export function createAgentsTour(userId: string) {
       </p>
       ${stepProgress(1, TOTAL)}
     `,
-    beforeShowPromise: () => waitForElement('[data-tour="agents-page-header"]'),
-    attachTo: { element: '[data-tour="agents-page-header"]', on: 'bottom' },
-    buttons: [{ text: 'Next', action: tour.next }],
+    buttons: [
+      { text: 'Skip', classes: 'shepherd-button-secondary', action: () => tour.cancel() },
+      { text: 'Next', action: tour.next },
+    ],
   })
 
+  // Step 2: Tabs
   tour.addStep({
     id: 'agents-tabs',
     title: title('Five', 'Agent Views'),
     text: `
-      <p class="text-gray-300 mb-2">
-        The tab strip below the header gives you every angle on your workforce:
-      </p>
       ${tabList([
         ['Roster', 'The full list of agents as cards or rows — create, edit, start/pause, delete.'],
         ['Org Chart', 'Visualise reporting lines and coordination hierarchy between agents.'],
@@ -45,14 +45,15 @@ export function createAgentsTour(userId: string) {
       ])}
       ${stepProgress(2, TOTAL)}
     `,
-    beforeShowPromise: () => waitForElement('[data-tour="agents-page-header"]'),
-    attachTo: { element: '[data-tour="agents-page-header"]', on: 'bottom' },
+    beforeShowPromise: () => waitForElement('[data-tour="agents-tabs"]'),
+    attachTo: { element: '[data-tour="agents-tabs"]', on: 'bottom' },
     buttons: [
       { text: 'Back', classes: 'shepherd-button-secondary', action: tour.back },
       { text: 'Next', action: tour.next },
     ],
   })
 
+  // Step 3: Create agent button
   tour.addStep({
     id: 'agents-create',
     title: title('Create an', 'Agent'),
@@ -72,36 +73,18 @@ export function createAgentsTour(userId: string) {
     ],
   })
 
+  // Step 4: Agent cards (centered)
   tour.addStep({
-    id: 'agents-roster',
+    id: 'agents-cards',
     title: title('Your', 'Agent Roster'),
     text: `
       <p class="text-gray-300 mb-2">
-        All your agents live here. Toggle between grid and list view, search by name,
-        and filter by status to find what you need quickly.
+        Each agent appears as a card with status, model, and a menu for configure,
+        start/pause, clone, and delete. Click a card to open its full workspace
+        with chat, reports, and memory.
       </p>
       ${stepProgress(4, TOTAL)}
     `,
-    beforeShowPromise: () => waitForElement('[data-tour="agent-roster"]'),
-    attachTo: { element: '[data-tour="agent-roster"]', on: 'top' },
-    buttons: [
-      { text: 'Back', classes: 'shepherd-button-secondary', action: tour.back },
-      { text: 'Next', action: tour.next },
-    ],
-  })
-
-  tour.addStep({
-    id: 'agents-actions',
-    title: title('Agent', 'Actions'),
-    text: `
-      <p class="text-gray-300 mb-2">
-        Each card has a menu for view details, configure, start/pause, clone, and delete.
-        Click the card itself to open the full agent workspace with its chat, reports and memory.
-      </p>
-      ${stepProgress(5, TOTAL)}
-    `,
-    beforeShowPromise: () => waitForElement('[data-tour="agent-card-menu"]'),
-    attachTo: { element: '[data-tour="agent-card-menu"]', on: 'left' },
     buttons: [
       { text: 'Back', classes: 'shepherd-button-secondary', action: tour.back },
       { text: 'Got it!', action: tour.complete },

--- a/frontend/lib/shepherd/tours/analytics-tour.ts
+++ b/frontend/lib/shepherd/tours/analytics-tour.ts
@@ -26,7 +26,10 @@ export function createAnalyticsTour(userId: string) {
     `,
     beforeShowPromise: () => waitForElement('[data-tour="analytics-page-header"]'),
     attachTo: { element: '[data-tour="analytics-page-header"]', on: 'bottom' },
-    buttons: [{ text: 'Next', action: tour.next }],
+    buttons: [
+      { text: 'Skip', classes: 'shepherd-button-secondary', action: () => tour.cancel() },
+      { text: 'Next', action: tour.next },
+    ],
   })
 
   tour.addStep({

--- a/frontend/lib/shepherd/tours/chat-tour.ts
+++ b/frontend/lib/shepherd/tours/chat-tour.ts
@@ -30,7 +30,10 @@ export function createChatTour(userId: string) {
     `,
     beforeShowPromise: () => waitForElement('[data-tour="chat-agent-selector"]'),
     attachTo: { element: '[data-tour="chat-agent-selector"]', on: 'bottom' },
-    buttons: [{ text: 'Next', action: tour.next }],
+    buttons: [
+      { text: 'Skip', classes: 'shepherd-button-secondary', action: () => tour.cancel() },
+      { text: 'Next', action: tour.next },
+    ],
   })
 
   tour.addStep({
@@ -65,8 +68,7 @@ export function createChatTour(userId: string) {
       </p>
       ${stepProgress(3, TOTAL)}
     `,
-    beforeShowPromise: () => waitForElement('[data-tour="nav-chat"]'),
-    attachTo: { element: '[data-tour="nav-chat"]', on: 'right' },
+    // Centered — no specific attach target needed for final step
     buttons: [
       { text: 'Back', classes: 'shepherd-button-secondary', action: tour.back },
       { text: 'Got it!', action: tour.complete },

--- a/frontend/lib/shepherd/tours/documents-tour.ts
+++ b/frontend/lib/shepherd/tours/documents-tour.ts
@@ -28,9 +28,10 @@ export function createDocumentsTour(userId: string) {
       </p>
       ${stepProgress(1, TOTAL)}
     `,
-    beforeShowPromise: () => waitForElement('[data-tour="documents-page-header"]'),
-    attachTo: { element: '[data-tour="documents-page-header"]', on: 'bottom' },
-    buttons: [{ text: 'Next', action: tour.next }],
+    buttons: [
+      { text: 'Skip', classes: 'shepherd-button-secondary', action: () => tour.cancel() },
+      { text: 'Next', action: tour.next },
+    ],
   })
 
   // Step 2 — Top-level tabs walkthrough
@@ -72,8 +73,7 @@ export function createDocumentsTour(userId: string) {
       </p>
       ${stepProgress(3, TOTAL)}
     `,
-    beforeShowPromise: () => waitForElement('[data-tour="documents-upload-btn"]'),
-    attachTo: { element: '[data-tour="documents-upload-btn"]', on: 'bottom' },
+    // Centered — upload button has no stable data-tour target
     buttons: [
       { text: 'Back', classes: 'shepherd-button-secondary', action: tour.back },
       { text: 'Next', action: tour.next },

--- a/frontend/lib/shepherd/tours/marketplace-tour.ts
+++ b/frontend/lib/shepherd/tours/marketplace-tour.ts
@@ -13,37 +13,35 @@ export function createMarketplaceTour(userId: string) {
     keyboardNavigation: true,
   })
 
+  // Step 1: About (centered)
   tour.addStep({
-    id: 'mp-overview',
+    id: 'mp-about',
     title: title('Community', 'Marketplace'),
     text: `
       <p class="text-gray-300 mb-2">
-        The fastest way to get productive. Browse pre-built agents, recipes,
-        integrations and models — install any of them into your workspace with one click.
-      </p>
-      <p class="text-gray-400 text-sm">
-        Anything you install here becomes available to every agent you create.
+        Pre-built agents, automation playbooks, integration tools, LLM models,
+        and capabilities — all installable with one click. This is the fastest
+        way to get your workspace productive.
       </p>
       ${stepProgress(1, TOTAL)}
     `,
-    beforeShowPromise: () => waitForElement('[data-tour="marketplace-stats"]'),
-    attachTo: { element: '[data-tour="marketplace-stats"]', on: 'bottom' },
-    buttons: [{ text: 'Next', action: tour.next }],
+    buttons: [
+      { text: 'Skip', classes: 'shepherd-button-secondary', action: () => tour.cancel() },
+      { text: 'Next', action: tour.next },
+    ],
   })
 
+  // Step 2: Tabs
   tour.addStep({
     id: 'mp-tabs',
     title: title('Browse by', 'Category'),
     text: `
-      <p class="text-gray-300 mb-2">
-        Five top tabs cover everything you can add to your workspace:
-      </p>
       ${tabList([
-        ['Applications', 'Tool integrations — Gmail, Slack, GitHub, Jira, HubSpot and 150+ more.'],
-        ['Agents', 'Ready-made personas (marketer, researcher, SDR, analyst) you can install and use immediately.'],
-        ['Recipes', 'Multi-step playbooks and workflows — automations you can drop into any agent.'],
-        ['LLMs', 'Model catalogue — pick which providers (OpenAI, Anthropic, DeepSeek, Qwen…) your agents can use.'],
-        ['Capabilities', 'Plugins and skills that extend an agent with new behaviours or tool packs.'],
+        ['Applications', 'Tool integrations — Gmail, Slack, GitHub, and 1,000+ more.'],
+        ['Agents', 'Ready-made personas you can install and customise.'],
+        ['Playbooks', 'Multi-step automation recipes for common workflows.'],
+        ['LLMs', 'Model catalogue with pricing, context windows, and capabilities.'],
+        ['Capabilities', 'Plugins and skills that extend what agents can do.'],
       ])}
       ${stepProgress(2, TOTAL)}
     `,
@@ -55,39 +53,41 @@ export function createMarketplaceTour(userId: string) {
     ],
   })
 
+  // Step 3: Featured
   tour.addStep({
-    id: 'mp-search',
-    title: title('Search', 'Anything'),
+    id: 'mp-featured',
+    title: title('Featured &', 'Recommended'),
     text: `
       <p class="text-gray-300 mb-2">
-        Looking for a specific tool or agent? Filter by name, category, or tag.
-        Search works across whichever top tab you're in.
+        The featured section highlights curated picks. Below that,
+        <strong>Recommended for You</strong> suggests items based on your
+        workspace setup. Browse, search, or filter within any tab.
       </p>
       ${stepProgress(3, TOTAL)}
     `,
-    beforeShowPromise: () => waitForElement('[data-tour="marketplace-search"]'),
-    attachTo: { element: '[data-tour="marketplace-search"]', on: 'bottom' },
+    beforeShowPromise: () => waitForElement('[data-tour="marketplace-content"]'),
+    attachTo: { element: '[data-tour="marketplace-content"]', on: 'top' },
     buttons: [
       { text: 'Back', classes: 'shepherd-button-secondary', action: tour.back },
       { text: 'Next', action: tour.next },
     ],
   })
 
+  // Step 4: Install
   tour.addStep({
     id: 'mp-install',
     title: title('One-Click', 'Install'),
     text: `
       <p class="text-gray-300 mb-2">
-        Every card has an <strong>Install</strong> or <strong>Add</strong> button. Installed items
-        show up in the matching workspace page — Agents, Tools, Playbooks, or Settings → Orchestrator.
+        Click <strong>Add to Workspace</strong> and it's yours.
       </p>
       <p class="text-gray-400 text-sm">
-        You can remove anything later from its home page — installs are never permanent.
+        <strong>Important:</strong> LLMs and Tools must be added from the
+        Marketplace before agents can use them. Installed items appear in
+        their respective pages — Agents, Tools, Playbooks, or Settings.
       </p>
       ${stepProgress(4, TOTAL)}
     `,
-    beforeShowPromise: () => waitForElement('[data-tour="marketplace-content"]'),
-    attachTo: { element: '[data-tour="marketplace-content"]', on: 'top' },
     buttons: [
       { text: 'Back', classes: 'shepherd-button-secondary', action: tour.back },
       { text: 'Got it!', action: tour.complete },

--- a/frontend/lib/shepherd/tours/settings-tour.ts
+++ b/frontend/lib/shepherd/tours/settings-tour.ts
@@ -28,7 +28,10 @@ export function createSettingsTour(userId: string) {
     `,
     beforeShowPromise: () => waitForElement('[data-tour="settings-page-header"]'),
     attachTo: { element: '[data-tour="settings-page-header"]', on: 'bottom' },
-    buttons: [{ text: 'Next', action: tour.next }],
+    buttons: [
+      { text: 'Skip', classes: 'shepherd-button-secondary', action: () => tour.cancel() },
+      { text: 'Next', action: tour.next },
+    ],
   })
 
   tour.addStep({

--- a/frontend/lib/shepherd/tours/tools-tour.ts
+++ b/frontend/lib/shepherd/tours/tools-tour.ts
@@ -29,7 +29,10 @@ export function createToolsTour(userId: string) {
     `,
     beforeShowPromise: () => waitForElement('[data-tour="tools-page-header"]'),
     attachTo: { element: '[data-tour="tools-page-header"]', on: 'bottom' },
-    buttons: [{ text: 'Next', action: tour.next }],
+    buttons: [
+      { text: 'Skip', classes: 'shepherd-button-secondary', action: () => tour.cancel() },
+      { text: 'Next', action: tour.next },
+    ],
   })
 
   tour.addStep({

--- a/frontend/lib/shepherd/tours/workspace-tour.ts
+++ b/frontend/lib/shepherd/tours/workspace-tour.ts
@@ -1,0 +1,76 @@
+import Shepherd from 'shepherd.js'
+import { shepherdTheme } from '../shepherd-theme'
+import { markTourComplete, markTourSkipped } from '../tour-storage'
+import { title, waitForElement, stepProgress, tabList } from '../tour-utils'
+
+const TOUR_ID = 'workspace'
+const TOTAL = 3
+
+export function createWorkspaceTour(userId: string) {
+  const tour = new Shepherd.Tour({
+    ...shepherdTheme,
+    exitOnEsc: true,
+    keyboardNavigation: true,
+  })
+
+  // Step 1: About (centered)
+  tour.addStep({
+    id: 'workspace-about',
+    title: title('Your', 'Workspace Files'),
+    text: `
+      <p class="text-gray-300 mb-2">
+        Every deliverable your agents produce — reports, code, documents,
+        images — lands here. Three views give you gallery browsing, a full
+        file explorer, and an activity timeline.
+      </p>
+      ${stepProgress(1, TOTAL)}
+    `,
+    buttons: [
+      { text: 'Skip', classes: 'shepherd-button-secondary', action: () => tour.cancel() },
+      { text: 'Next', action: tour.next },
+    ],
+  })
+
+  // Step 2: Tabs
+  tour.addStep({
+    id: 'workspace-tabs',
+    title: title('Three Ways', 'to Browse'),
+    text: `
+      ${tabList([
+        ['Outputs', 'Gallery of agent deliverables — reports, images, code, and docs. Filter by type or source (chat, tasks, missions, heartbeats, playbooks).'],
+        ['Explorer', 'VS Code-style file browser with tabbed code editor, syntax highlighting, and a built-in interactive terminal.'],
+        ['Activity', 'Live feed of all executions — chats, routines, playbooks, and missions with status tracking.'],
+      ])}
+      ${stepProgress(2, TOTAL)}
+    `,
+    beforeShowPromise: () => waitForElement('[data-tour="workspace-tabs"]'),
+    attachTo: { element: '[data-tour="workspace-tabs"]', on: 'bottom' },
+    buttons: [
+      { text: 'Back', classes: 'shepherd-button-secondary', action: tour.back },
+      { text: 'Next', action: tour.next },
+    ],
+  })
+
+  // Step 3: Outputs preview
+  tour.addStep({
+    id: 'workspace-outputs',
+    title: title('Agent', 'Deliverables'),
+    text: `
+      <p class="text-gray-300 mb-2">
+        Click any output to preview it — markdown reports render inline,
+        code gets syntax highlighting, images display full-size. Download,
+        open in Explorer, or delete from the preview panel.
+      </p>
+      ${stepProgress(3, TOTAL)}
+    `,
+    buttons: [
+      { text: 'Back', classes: 'shepherd-button-secondary', action: tour.back },
+      { text: 'Got it!', action: tour.complete },
+    ],
+  })
+
+  tour.on('complete', () => markTourComplete(TOUR_ID, userId))
+  tour.on('cancel', () => markTourSkipped(TOUR_ID, userId))
+
+  return tour
+}


### PR DESCRIPTION
- Add workspace tour (new) and register /workspace route
- Add Skip button to first step of every tour for consistency
- Fix missing data-tour targets — center steps with no DOM anchor
- Point agents-tabs step at [data-tour="agents-tabs"] instead of header
- Trim agents tour from 5 to 4 steps (merge roster + actions)
- Add data-tour attributes: chat-mode-bar, workspace-tabs, agents-tabs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new guided tour for the Workspace section, providing an interactive walkthrough of workspace features and file browsing options.
  * Added "Skip" button to the first step of all guided tours, allowing users to easily exit tours without completing them.

* **Refactor**
  * Restructured the Agents tour to consolidate steps and improve user experience.
  * Updated tour content and messaging across Analytics, Marketplace, and other sections for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->