### PR TITLE
fix: flatten Tours submenu to single item, add About step to chat tour

### DIFF
--- a/frontend/components/auth/profile-menu.tsx
+++ b/frontend/components/auth/profile-menu.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { useUser, useClerk } from '@clerk/nextjs'
-import { User, Settings, LogOut, ChevronDown, Sparkles, RotateCcw, ChevronRight } from 'lucide-react'
+import { User, Settings, LogOut, ChevronDown, Sparkles } from 'lucide-react'
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
 import { usePathname } from 'next/navigation'
 
@@ -130,62 +130,28 @@ export function ProfileMenu() {
                         <span>Settings</span>
                     </DropdownMenu.Item>
 
-                    <DropdownMenu.Sub>
-                        <DropdownMenu.SubTrigger className="flex items-center justify-between px-3 py-2.5 rounded-lg text-sm text-slate-300 hover:text-white hover:bg-slate-800/80 cursor-pointer outline-none transition-colors">
-                            <span className="flex items-center space-x-3">
-                                <Sparkles className="w-4 h-4 text-orange-400" />
-                                <span>Tours</span>
-                            </span>
-                            <ChevronRight className="w-3.5 h-3.5 text-slate-500" />
-                        </DropdownMenu.SubTrigger>
-                        <DropdownMenu.Portal>
-                            <DropdownMenu.SubContent
-                                className="min-w-[200px] bg-slate-900/95 backdrop-blur-xl border border-slate-700/50 rounded-xl shadow-2xl p-2 animate-in fade-in-0 zoom-in-95"
-                                sideOffset={8}
-                            >
-                                <DropdownMenu.Item
-                                    className="flex items-center space-x-3 px-3 py-2.5 rounded-lg text-sm text-slate-300 hover:text-white hover:bg-slate-800/80 cursor-pointer outline-none transition-colors"
-                                    disabled={!pathname}
-                                    onSelect={() => {
-                                        setOpen(false)
-                                        setTimeout(async () => {
-                                            if (user && pathname) {
-                                                const { getTourForRoute } = await import('@/lib/shepherd/tour-registry')
-                                                const { resetTour } = await import('@/lib/shepherd/tour-storage')
-                                                const entry = getTourForRoute(pathname)
-                                                if (entry) {
-                                                    resetTour(entry.id, user.id)
-                                                    const tour = await entry.factory(user.id)
-                                                    tour.start()
-                                                }
-                                            }
-                                        }, 150)
-                                    }}
-                                >
-                                    <Sparkles className="w-4 h-4 text-orange-400" />
-                                    <span>Tour this page</span>
-                                    <span className="ml-auto text-xs text-slate-500">{currentPage}</span>
-                                </DropdownMenu.Item>
-
-                                <DropdownMenu.Separator className="h-px bg-slate-700/50 my-1.5" />
-
-                                <DropdownMenu.Item
-                                    className="flex items-center space-x-3 px-3 py-2.5 rounded-lg text-sm text-slate-400 hover:text-slate-200 hover:bg-slate-800/80 cursor-pointer outline-none transition-colors"
-                                    onSelect={() => {
-                                        if (user) {
-                                            import('@/lib/shepherd/tour-storage').then(({ resetAllTours }) => {
-                                                resetAllTours(user.id)
-                                            })
-                                        }
-                                        setOpen(false)
-                                    }}
-                                >
-                                    <RotateCcw className="w-4 h-4" />
-                                    <span>Reset All Tours</span>
-                                </DropdownMenu.Item>
-                            </DropdownMenu.SubContent>
-                        </DropdownMenu.Portal>
-                    </DropdownMenu.Sub>
+                    <DropdownMenu.Item
+                        className="flex items-center space-x-3 px-3 py-2.5 rounded-lg text-sm text-slate-300 hover:text-white hover:bg-slate-800/80 cursor-pointer outline-none transition-colors"
+                        disabled={!pathname}
+                        onSelect={() => {
+                            setOpen(false)
+                            setTimeout(async () => {
+                                if (user && pathname) {
+                                    const { getTourForRoute } = await import('@/lib/shepherd/tour-registry')
+                                    const { resetTour } = await import('@/lib/shepherd/tour-storage')
+                                    const entry = getTourForRoute(pathname)
+                                    if (entry) {
+                                        resetTour(entry.id, user.id)
+                                        const tour = await entry.factory(user.id)
+                                        tour.start()
+                                    }
+                                }
+                            }, 150)
+                        }}
+                    >
+                        <Sparkles className="w-4 h-4 text-orange-400" />
+                        <span>Tour this page</span>
+                    </DropdownMenu.Item>
 
                     <DropdownMenu.Separator className="h-px bg-slate-700/50 my-2" />
 

--- a/frontend/lib/shepherd/tours/chat-tour.ts
+++ b/frontend/lib/shepherd/tours/chat-tour.ts
@@ -13,6 +13,25 @@ export function createChatTour(userId: string) {
     keyboardNavigation: true,
   })
 
+  // Step 1: About (centered)
+  tour.addStep({
+    id: 'chat-about',
+    title: title('AI', 'Command Line'),
+    text: `
+      <p class="text-gray-300 mb-2">
+        This is your main conversation interface. Chat with any agent,
+        switch models on the fly, and toggle special modes like Code,
+        Plan, and Mission — all from one place.
+      </p>
+      ${stepProgress(1, TOTAL)}
+    `,
+    buttons: [
+      { text: 'Skip', classes: 'shepherd-button-secondary', action: () => tour.cancel() },
+      { text: 'Next', action: tour.next },
+    ],
+  })
+
+  // Step 2: Agent selector
   tour.addStep({
     id: 'chat-agent',
     title: title('Pick an', 'Agent'),
@@ -26,49 +45,31 @@ export function createChatTour(userId: string) {
         Start with <strong>Auto</strong> if you're not sure — it routes your message
         to the best agent for the job.
       </p>
-      ${stepProgress(1, TOTAL)}
+      ${stepProgress(2, TOTAL)}
     `,
     beforeShowPromise: () => waitForElement('[data-tour="chat-agent-selector"]'),
     attachTo: { element: '[data-tour="chat-agent-selector"]', on: 'bottom' },
-    buttons: [
-      { text: 'Skip', classes: 'shepherd-button-secondary', action: () => tour.cancel() },
-      { text: 'Next', action: tour.next },
-    ],
-  })
-
-  tour.addStep({
-    id: 'chat-model',
-    title: title('Choose a', 'Model'),
-    text: `
-      <p class="text-gray-300 mb-2">
-        Pick which LLM powers this conversation. Faster, cheaper models (Haiku, GPT-mini,
-        DeepSeek) are great for quick back-and-forth; bigger models (Opus, Sonnet, GPT-4-class)
-        are better for planning, writing, and reasoning.
-      </p>
-      <p class="text-gray-400 text-sm">
-        You can change models mid-conversation — the history stays.
-      </p>
-      ${stepProgress(2, TOTAL)}
-    `,
-    beforeShowPromise: () => waitForElement('[data-tour="chat-model-selector"]'),
-    attachTo: { element: '[data-tour="chat-model-selector"]', on: 'bottom' },
     buttons: [
       { text: 'Back', classes: 'shepherd-button-secondary', action: tour.back },
       { text: 'Next', action: tour.next },
     ],
   })
 
+  // Step 3: Quick modes
   tour.addStep({
-    id: 'chat-history',
-    title: title('Chat', 'History'),
+    id: 'chat-modes',
+    title: title('Quick', 'Modes'),
     text: `
       <p class="text-gray-300 mb-2">
-        Every conversation is saved automatically. Toggle the chat sidebar to browse,
-        search, rename, pin and resume previous sessions — across any agent.
+        Toggle <strong>Code</strong> for syntax-highlighted output,
+        <strong>Plan</strong> to get a structured step-by-step, or
+        <strong>Mission</strong> to launch a multi-agent objective — all
+        without leaving the chat.
       </p>
       ${stepProgress(3, TOTAL)}
     `,
-    // Centered — no specific attach target needed for final step
+    beforeShowPromise: () => waitForElement('[data-tour="chat-mode-bar"]'),
+    attachTo: { element: '[data-tour="chat-mode-bar"]', on: 'top' },
     buttons: [
       { text: 'Back', classes: 'shepherd-button-secondary', action: tour.back },
       { text: 'Got it!', action: tour.complete },


### PR DESCRIPTION
- Remove Tours submenu — "Tour this page" is now a direct menu item
- Remove Reset All Tours and Welcome Orientation from menu
- Chat tour: add centered About intro step, replace Chat History with Quick Modes