### PR TITLE
feat: add platform_schedule_playbook tool, fix board stats missing bl…

### DIFF
--- a/frontend/components/activity/widgets/cost-tracker-widget.tsx
+++ b/frontend/components/activity/widgets/cost-tracker-widget.tsx
@@ -66,6 +66,11 @@ export function CostTrackerWidget({ period, className }: CostTrackerWidgetProps)
           <div className="flex items-center justify-center h-full">
             <Loader2 className="w-5 h-5 animate-spin text-muted-foreground" />
           </div>
+        ) : totalCost === 0 && trend.length === 0 && topAgents.length === 0 ? (
+          <div className="flex flex-col items-center justify-center h-full text-muted-foreground gap-2">
+            <DollarSign className="w-8 h-8 opacity-40" />
+            <p className="text-xs">No cost data yet</p>
+          </div>
         ) : (
           <>
             {/* Big number */}

--- a/orchestrator/api/activity.py
+++ b/orchestrator/api/activity.py
@@ -132,7 +132,7 @@ async def get_board_stats(
             .group_by(BoardTask.status)
             .all()
         )
-        all_statuses = ["inbox", "assigned", "in_progress", "review", "done"]
+        all_statuses = ["inbox", "assigned", "in_progress", "review", "blocked", "done"]
         status_map = dict(status_rows)
         columns = [
             {"status": s, "count": status_map.get(s, 0)}

--- a/orchestrator/consumers/chatbot/auto.py
+++ b/orchestrator/consumers/chatbot/auto.py
@@ -171,6 +171,12 @@ _PLATFORM_KEYWORDS = {
         "how many queries", "agent activity", "what's being used",
         "show stats", "show usage",
     ],
+    "platform_schedule_playbook": [
+        "schedule playbook", "schedule the playbook", "set playbook schedule",
+        "cron playbook", "automate playbook", "recurring playbook",
+        "schedule this playbook", "schedule a playbook",
+        "run playbook on a schedule", "set up recurring playbook",
+    ],
     "platform_execute_recipe": [
         "run the recipe", "execute recipe", "trigger recipe",
         "run automation", "start recipe",

--- a/orchestrator/modules/tools/discovery/actions_playbooks.py
+++ b/orchestrator/modules/tools/discovery/actions_playbooks.py
@@ -282,6 +282,53 @@ def register_playbooks_actions(registry: ActionRegistry) -> None:
         ],
     ))
 
+    # ── Scheduling ───────────────────────────────────────────────────
+
+    registry.register(ActionDefinition(
+        name="platform_schedule_playbook",
+        description=(
+            "Schedule a playbook to run automatically on a cron schedule. "
+            "Sets the playbook's schedule_config so it fires at the specified "
+            "times. Use platform_execute_playbook for immediate one-off runs."
+        ),
+        category="playbooks",
+        parameters={
+            "type": "object",
+            "properties": {
+                "playbook_id": {
+                    "type": "integer",
+                    "description": "ID of the playbook to schedule.",
+                },
+                "playbook_name": {
+                    "type": "string",
+                    "description": "Name of the playbook to schedule (alternative to ID).",
+                },
+                "cron_expression": {
+                    "type": "string",
+                    "description": "5-field cron expression (e.g. '0 9 * * 1' = every Monday at 09:00 UTC).",
+                },
+                "timezone": {
+                    "type": "string",
+                    "description": "Timezone for the schedule (e.g. 'UTC', 'Europe/Dublin'). Defaults to 'UTC'.",
+                },
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Whether to activate the schedule immediately. Defaults to true.",
+                },
+            },
+            "required": ["cron_expression"],
+        },
+        permission_level="write",
+        requires_confirmation=False,
+        tags=["playbooks", "schedule", "cron", "automate", "recurring"],
+        examples=[
+            "schedule the daily briefing playbook to run at 9am",
+            "set playbook 5 to run every Monday",
+            "schedule this playbook on a cron",
+            "automate the weekly review playbook",
+        ],
+    ))
+
     # ── Execution ────────────────────────────────────────────────────
 
     registry.register(ActionDefinition(

--- a/orchestrator/modules/tools/discovery/handlers_playbooks.py
+++ b/orchestrator/modules/tools/discovery/handlers_playbooks.py
@@ -339,6 +339,74 @@ async def delete_playbook_step(db: Session, workspace_id: UUID, params: Dict[str
     }
 
 
+async def schedule_playbook(db: Session, workspace_id: UUID, params: Dict[str, Any]) -> Dict[str, Any]:
+    """Set a cron schedule on a playbook so it runs automatically."""
+    from core.models.core import WorkflowTemplate
+
+    playbook_id = params.get("playbook_id")
+    playbook_name = params.get("playbook_name")
+    cron_expression = params.get("cron_expression")
+
+    if not cron_expression:
+        return {"success": False, "error": "Missing required parameter: cron_expression"}
+
+    # Validate cron expression
+    parts = cron_expression.strip().split()
+    if len(parts) != 5:
+        return {"success": False, "error": f"Invalid cron expression: expected 5 fields, got {len(parts)}. Format: minute hour day_of_month month day_of_week"}
+
+    # Resolve playbook
+    query = db.query(WorkflowTemplate).filter(
+        WorkflowTemplate.workspace_id == workspace_id
+    )
+    if playbook_id:
+        query = query.filter(WorkflowTemplate.id == playbook_id)
+    elif playbook_name:
+        query = query.filter(WorkflowTemplate.name.ilike(f"%{playbook_name}%"))
+    else:
+        return {"success": False, "error": "Provide playbook_id or playbook_name"}
+
+    playbook = query.first()
+    if not playbook:
+        return {"success": False, "error": "Playbook not found"}
+
+    timezone = params.get("timezone", "UTC")
+    enabled = params.get("enabled", True)
+
+    schedule_config = {
+        "type": "cron",
+        "cron_expression": cron_expression,
+        "timezone": timezone,
+        "enabled": enabled,
+    }
+    playbook.schedule_config = schedule_config
+    db.flush()
+
+    # Sync with APScheduler if available
+    try:
+        from services.playbook_scheduler import PlaybookSchedulerService
+        scheduler = PlaybookSchedulerService()
+        if enabled:
+            scheduler.schedule_playbook(playbook.id, cron_expression, timezone)
+        else:
+            scheduler.unschedule_playbook(playbook.id)
+    except Exception as e:
+        logger.warning("[PlatformExecutor] Scheduler sync failed for playbook %d: %s", playbook.id, e)
+
+    logger.info(
+        "[PlatformExecutor] Scheduled playbook '%s' (id=%d) with cron '%s' tz=%s enabled=%s",
+        playbook.name, playbook.id, cron_expression, timezone, enabled,
+    )
+
+    return {
+        "success": True,
+        "playbook_id": playbook.id,
+        "playbook_name": playbook.name,
+        "schedule_config": schedule_config,
+        "message": f"Playbook '{playbook.name}' scheduled: {cron_expression} ({timezone}). {'Active now.' if enabled else 'Paused — set enabled=true to activate.'}",
+    }
+
+
 async def execute_playbook(db: Session, workspace_id: UUID, params: Dict[str, Any]) -> Dict[str, Any]:
     """Trigger a playbook run asynchronously. Returns execution_id immediately."""
     from core.models.core import WorkflowTemplate, RecipeExecution

--- a/orchestrator/modules/tools/discovery/platform_executor.py
+++ b/orchestrator/modules/tools/discovery/platform_executor.py
@@ -31,6 +31,7 @@ from modules.tools.discovery.handlers_playbooks import (
     add_playbook_step,
     update_playbook_step,
     delete_playbook_step,
+    schedule_playbook,
     execute_playbook,
     get_playbook_execution,
     delete_playbook,
@@ -197,6 +198,7 @@ class PlatformActionExecutor:
             "platform_update_playbook_step": update_playbook_step,
             "platform_delete_recipe_step": delete_playbook_step,
             "platform_delete_playbook_step": delete_playbook_step,
+            "platform_schedule_playbook": schedule_playbook,
             "platform_store_memory": store_memory,
             "platform_delete_agent": delete_agent,
             # Infrastructure / observability


### PR DESCRIPTION
…ocked status

- Add platform_schedule_playbook to registry (action, handler, executor, keywords) so agents can schedule playbooks on a cron directly
- Fix board stats endpoint excluding "blocked" from all_statuses — was only returning 5 of 6 columns
- Add empty state to cost tracker widget when no data exists
- Add Tier 2 keywords for schedule playbook routing in Auto

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added empty state display to cost tracker widget showing "No cost data yet" message when no cost information is available.
  * Board statistics now include "blocked" task status tracking alongside existing statuses.
  * New playbook scheduling capability allowing recurring execution with customizable schedules and timezone support.
  * Chatbot enhanced to recognize and handle playbook scheduling requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->