### PR TITLE
fix: Clerk redirecting new users to its own welcome page

### DIFF
--- a/frontend/app/sso-callback/page.tsx
+++ b/frontend/app/sso-callback/page.tsx
@@ -3,5 +3,11 @@
 import { AuthenticateWithRedirectCallback } from '@clerk/nextjs'
 
 export default function SSOCallbackPage() {
-  return <AuthenticateWithRedirectCallback />
+  return (
+    <AuthenticateWithRedirectCallback
+      afterSignInUrl="/"
+      afterSignUpUrl="/"
+      redirectUrl="/"
+    />
+  )
 }

--- a/frontend/components/providers.tsx
+++ b/frontend/components/providers.tsx
@@ -25,6 +25,10 @@ export function Providers({ children }: { children: React.ReactNode }) {
 
   return (
     <ClerkProvider
+      afterSignInUrl="/"
+      afterSignUpUrl="/"
+      signInForceRedirectUrl="/"
+      signUpForceRedirectUrl="/"
       appearance={{
         baseTheme: undefined,
         variables: {


### PR DESCRIPTION
- ClerkProvider: add afterSignUpUrl="/", signUpForceRedirectUrl="/"
- SSO callback: add explicit afterSignUpUrl="/" redirect
- Railway env: NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL changed /dashboard → /

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed authentication redirect flow to properly redirect users to the home page after sign-in and sign-up actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->