### PR TITLE
fix: rewrite SKILL.md three-layer model — marketplace is optional, no…

### DIFF
--- a/orchestrator/core/seeds/platform-management-skill.md
+++ b/orchestrator/core/seeds/platform-management-skill.md
@@ -185,7 +185,27 @@ When using platform tools, know which concept you're operating on:
 
 ---
 
-## 1. Understanding the Workspace Model
+## 1. Understanding the Three Layers
+
+There are three distinct layers. You MUST keep them separate in your thinking.
+
+### Layer 1: Marketplace (the catalog)
+The marketplace is a **catalog of available items** — agent templates, skills, plugins, tools, models. If something is in the marketplace, it is **possible to install**, not active. The marketplace is there to save time. It is NOT a limitation — if the user needs something that isn't in the marketplace, you build it custom.
+
+### Layer 2: Workspace (what's enabled)
+The workspace is what's **actually installed and active** for this specific workspace. Before anything can be used, it must be installed, enabled, or connected inside the workspace. If it's not in the workspace, treat it as unavailable to agents in this workspace.
+
+### Layer 3: Agent (what's specifically equipped)
+Even if something is installed in the workspace, an agent still may not have it. Tools, skills, and plugins must be **assigned to a specific agent** before that agent can use them.
+
+**Agent capability is not:**
+- "exists in marketplace" ← just means it's available to install
+- "exists in workspace" ← means it's enabled but agent might not have it
+
+**Agent capability IS:**
+- "installed in workspace **AND** assigned to this agent" ← confirmed usable
+
+### What This Means in Practice
 
 A workspace starts **blank**. Nothing is installed. The owner decides what goes in:
 - Which LLM models to install (cost control — only pay for what you use)
@@ -196,17 +216,36 @@ A workspace starts **blank**. Nothing is installed. The owner decides what goes 
 
 **Principle:** Keep it clean. Only install what the business actually needs. A Shopify store doesn't need GitHub tools. A dev team doesn't need Shopify plugins.
 
+### WHAT YOU SHOULD NEVER SAY
+
+Never say "the agent has it", "the tool is ready", or "it can use web access" unless you have confirmed:
+1. It is installed in the workspace
+2. It is assigned to the agent
+3. Ideally, it works in a real test
+
+### THE MARKETPLACE IS OPTIONAL
+
+The marketplace exists to save time — browse, find something close, install it. But:
+- The user might not want anything from the marketplace
+- They might have a very custom or unique requirement
+- They might want to build from scratch using the APIs
+- They might build it themselves without asking you
+
+**If the marketplace doesn't have what the user needs, offer to build it custom.** Don't say "unavailable" — say "I don't see that in the marketplace, but I can build it for you."
+
+---
+
 ### THE INSTALL CHAIN
 
-Nothing from the marketplace is usable until it is installed in the workspace.
-
-**For individual items (single plugin, skill, or model) — three manual steps:**
+**For individual items (single plugin, skill, or model) — three steps:**
 
 | Step | Action | Tool | What It Does |
 |------|--------|------|-------------|
-| 1. **Find** | Browse the marketplace | `platform_browse_marketplace_*` | Discovers what exists — does NOT make it usable |
+| 1. **Find** | Browse the marketplace (optional) | `platform_browse_marketplace_*` | Discovers what exists — does NOT make it usable |
 | 2. **Install** | Add to workspace | `platform_install_plugin`, `platform_install_skill`, `platform_install_model` | Makes it available workspace-wide |
 | 3. **Assign** | Wire to a specific agent | `platform_assign_tool_to_agent`, `platform_assign_skill_to_agent`, `platform_assign_plugin_to_agent` | Agent can now actually use it |
+
+**The safe sequence is always:** browse → install in workspace → assign to agent → verify → test
 
 ### CASCADING INSTALLS — Agents & Playbooks
 
@@ -250,17 +289,12 @@ Check the response shows the tool/skill/plugin in the agent's assignments. If it
 
 **NEVER claim an agent has a capability unless you have verified it with `platform_get_agent`.** Browsing the marketplace or knowing a tool exists is NOT the same as it being installed and assigned.
 
-**Standard for ALL marketplace items — agents, skills, plugins, tools, models:**
-- "Add to Workspace" = install at workspace level
-- "Assign to Agent" = wire to a specific agent
-- Both steps required for individual items. Agent/playbook installs handle this automatically.
-
 **When a user asks for an agent with specific capabilities:**
-1. Search the marketplace for matching agent templates
-2. Install the agent template (dependencies cascade automatically)
-3. Verify the agent's final configuration with `platform_get_agent`
-4. Report what was installed and what OAuth connections are needed
-5. If no matching template exists, build manually: install items, create agent, assign tools, verify
+1. Check the marketplace for matching agent templates — if found, install (dependencies cascade automatically)
+2. If no matching template exists, build custom: create agent, install items, assign tools
+3. Either way: verify the agent's final configuration with `platform_get_agent`
+4. Report what was installed, what was assigned, and what OAuth connections are needed
+5. If you can't find or build what they need, ask them what they want — don't assume limitations
 
 ---
 


### PR DESCRIPTION
…t a limitation

Clarifies: marketplace = catalog (optional), workspace = enabled, agent = equipped. Marketplace absence doesn't mean unavailable — Auto should offer to build custom. Adds explicit "never say" rules and safe sequence for capability claims.