### PR TITLE
fix: agent install button flashes all cards — use per-card loading state

### DIFF
--- a/frontend/components/marketplace/marketplace-agents-tab.tsx
+++ b/frontend/components/marketplace/marketplace-agents-tab.tsx
@@ -75,6 +75,7 @@ export function MarketplaceAgentsTab({ searchQuery }: MarketplaceAgentsTabProps)
   const [selectedAgentId, setSelectedAgentId] = useState<number | null>(null)
   const [approvingId, setApprovingId] = useState<number | null>(null)
   const [deletingId, setDeletingId] = useState<number | null>(null)
+  const [installingId, setInstallingId] = useState<number | null>(null)
 
   // Check if user is admin (you can adjust this check based on your admin logic)
   const isAdmin = user?.emailAddresses?.[0]?.emailAddress?.includes('automatos.app') || false
@@ -361,12 +362,15 @@ export function MarketplaceAgentsTab({ searchQuery }: MarketplaceAgentsTabProps)
                   Details
                 </Button>
                 <Button size="sm" variant="outline"
-                  disabled={installMutation.isLoading}
+                  disabled={installingId === agent.id}
                   onClick={(e) => {
                     e.stopPropagation()
-                    installMutation.mutate(agent.id)
+                    setInstallingId(agent.id)
+                    installMutation.mutate(agent.id, {
+                      onSettled: () => setInstallingId(null),
+                    })
                   }}>
-                  {installMutation.isLoading ? 'Adding...' : 'Add to Workspace'}
+                  {installingId === agent.id ? 'Adding...' : 'Add to Workspace'}
                 </Button>
               </div>
             </Card>


### PR DESCRIPTION
The install mutation's isLoading flag was shared across all agent cards, causing every button to show "Adding..." when any single agent was being installed. Switched to per-card installingId tracking (same pattern as approvingId/deletingId already in use).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the marketplace agent installation flow to independently track individual agent installation states, allowing users to interact with other agents while one is being installed, rather than blocking all interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->