### PR TITLE
fix: agent install 500 — marketplace_installs.item_id NOT NULL violation

### DIFF
--- a/frontend/components/marketplace/marketplace-agents-tab.tsx
+++ b/frontend/components/marketplace/marketplace-agents-tab.tsx
@@ -76,6 +76,7 @@ export function MarketplaceAgentsTab({ searchQuery }: MarketplaceAgentsTabProps)
   const [approvingId, setApprovingId] = useState<number | null>(null)
   const [deletingId, setDeletingId] = useState<number | null>(null)
   const [installingId, setInstallingId] = useState<number | null>(null)
+  const [installedIds, setInstalledIds] = useState<Set<number>>(new Set())
 
   // Check if user is admin (you can adjust this check based on your admin logic)
   const isAdmin = user?.emailAddresses?.[0]?.emailAddress?.includes('automatos.app') || false
@@ -361,17 +362,26 @@ export function MarketplaceAgentsTab({ searchQuery }: MarketplaceAgentsTabProps)
                   className="text-muted-foreground hover:text-foreground p-0 h-auto">
                   Details
                 </Button>
-                <Button size="sm" variant="outline"
-                  disabled={installingId === agent.id}
-                  onClick={(e) => {
-                    e.stopPropagation()
-                    setInstallingId(agent.id)
-                    installMutation.mutate(agent.id, {
-                      onSettled: () => setInstallingId(null),
-                    })
-                  }}>
-                  {installingId === agent.id ? 'Adding...' : 'Add to Workspace'}
-                </Button>
+                {installedIds.has(agent.id) ? (
+                  <Button size="sm" variant="secondary"
+                    className="bg-secondary/50 hover:bg-secondary border border-white/10">
+                    <Check className="w-3 h-3 mr-2" />
+                    Added
+                  </Button>
+                ) : (
+                  <Button size="sm" variant="outline"
+                    disabled={installingId === agent.id}
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      setInstallingId(agent.id)
+                      installMutation.mutate(agent.id, {
+                        onSuccess: () => setInstalledIds(prev => new Set([...prev, agent.id])),
+                        onSettled: () => setInstallingId(null),
+                      })
+                    }}>
+                    {installingId === agent.id ? 'Adding...' : 'Add to Workspace'}
+                  </Button>
+                )}
               </div>
             </Card>
           ))}

--- a/frontend/components/tools/tool-details-modal.tsx
+++ b/frontend/components/tools/tool-details-modal.tsx
@@ -251,6 +251,23 @@ export function ToolDetailsModal({
                                 className="pl-9"
                               />
                             </div>
+                            {actions.length > 0 && (() => {
+                              const allEnabled = actions.every(a => a.enabled)
+                              const noneEnabled = actions.every(a => !a.enabled)
+                              return (
+                                <Button
+                                  size="sm"
+                                  variant="outline"
+                                  className="shrink-0 text-xs"
+                                  onClick={() => {
+                                    const enableAll = !allEnabled
+                                    setActions(prev => prev.map(a => ({ ...a, enabled: enableAll })))
+                                  }}
+                                >
+                                  {allEnabled ? 'Disable All' : noneEnabled ? 'Enable All' : 'Enable All'}
+                                </Button>
+                              )
+                            })()}
                           </div>
 
                           <div className="space-y-2 mb-4">

--- a/orchestrator/api/marketplace.py
+++ b/orchestrator/api/marketplace.py
@@ -522,18 +522,27 @@ async def install_item(
         # Increment marketplace agent install count
         marketplace_agent.install_count = (marketplace_agent.install_count or 0) + 1
 
-        # Record installation in marketplace_installs
+        # Record installation in marketplace_installs using a savepoint so
+        # failures don't roll back the main agent install.
+        # item_id is NOT NULL in production (migration 20260326 was never applied),
+        # so we populate it with the marketplace agent's id.
         install_query = text("""
-            INSERT INTO marketplace_installs (user_id, marketplace_agent_id, cloned_agent_id, version, installed_at)
-            VALUES (:user_id, :marketplace_agent_id, :cloned_agent_id, :version, NOW())
+            INSERT INTO marketplace_installs (item_id, user_id, marketplace_agent_id, cloned_agent_id, version, installed_at)
+            VALUES (:item_id, :user_id, :marketplace_agent_id, :cloned_agent_id, :version, NOW())
+            ON CONFLICT DO NOTHING
         """)
 
-        db.execute(install_query, {
-            "user_id": user_id_int,
-            "marketplace_agent_id": marketplace_agent.id,
-            "cloned_agent_id": cloned_agent.id,
-            "version": marketplace_agent.version
-        })
+        try:
+            with db.begin_nested():
+                db.execute(install_query, {
+                    "item_id": marketplace_agent.id,
+                    "user_id": user_id_int,
+                    "marketplace_agent_id": marketplace_agent.id,
+                    "cloned_agent_id": cloned_agent.id,
+                    "version": marketplace_agent.version
+                })
+        except Exception as e:
+            logger.warning(f"Could not record agent install in marketplace_installs: {e}")
 
         db.commit()
 

--- a/orchestrator/api/workflow_recipes.py
+++ b/orchestrator/api/workflow_recipes.py
@@ -1619,14 +1619,15 @@ async def install_recipe_from_marketplace(
         # failures don't roll back the main recipe install.
         from sqlalchemy import text
         install_query = text("""
-            INSERT INTO marketplace_installs (user_id, marketplace_recipe_id, cloned_recipe_id, version, installed_at)
-            VALUES (:user_id, :marketplace_recipe_id, :cloned_recipe_id, :version, NOW())
+            INSERT INTO marketplace_installs (item_id, user_id, marketplace_recipe_id, cloned_recipe_id, version, installed_at)
+            VALUES (:item_id, :user_id, :marketplace_recipe_id, :cloned_recipe_id, :version, NOW())
             ON CONFLICT DO NOTHING
         """)
 
         try:
             with db.begin_nested():
                 db.execute(install_query, {
+                    "item_id": marketplace_recipe.id,
                     "user_id": user_id_int,
                     "marketplace_recipe_id": marketplace_recipe.id,
                     "cloned_recipe_id": cloned_recipe.id,

--- a/orchestrator/scripts/seed_marketplace_agents_v2.py
+++ b/orchestrator/scripts/seed_marketplace_agents_v2.py
@@ -1,5 +1,5 @@
 """
-Seed marketplace with 18 NEW professional agents (v2).
+Seed marketplace with 22 professional agents (v2).
 
 Expands the marketplace with real-world use cases across sales, finance,
 recruiting, security, marketing, and operations. Tools map to real Composio
@@ -221,12 +221,54 @@ MARKETPLACE_AGENTS_V2 = [
         "model_id": "llama-3.1-8b-instruct",
         "skills": ["Data Analysis", "task_decomposition"],
     },
+
+    # ─── E-COMMERCE / SHOPIFY ───────────────────────────────────
+    {
+        "name": "E-commerce Manager",
+        "agent_type": "custom",
+        "description": "Manages your online store operations end-to-end. Monitors Shopify for new orders and inventory levels, tracks payment analytics via Stripe, and logs sales data in Google Sheets. Alerts on low stock, identifies best-selling products, and helps optimize pricing strategies. Perfect for e-commerce businesses scaling their operations. Uses Llama 3.3 70B for analyzing sales patterns and customer behavior.",
+        "category": "E-commerce",
+        "tags": ["ecommerce", "shopify", "stripe", "sales", "inventory", "payments", "orders"],
+        "tools": ["SHOPIFY", "STRIPE", "GOOGLESHEETS"],
+        "model_id": "llama-3.3-70b-instruct",
+        "skills": ["Data Analysis", "pattern_recognition"],
+    },
+    {
+        "name": "Shopify Product Optimizer",
+        "agent_type": "custom",
+        "description": "Optimizes your Shopify product listings for maximum conversion. Analyzes product performance data, rewrites descriptions for SEO, monitors competitor pricing, and tracks A/B test results in Google Sheets. Generates weekly product performance reports and suggests inventory reorder points. Uses Llama 3.3 70B for data-driven product optimization without premium LLM costs.",
+        "category": "E-commerce",
+        "tags": ["shopify", "products", "seo", "optimization", "conversion", "ecommerce"],
+        "tools": ["SHOPIFY", "GOOGLESHEETS", "GOOGLEDOCS"],
+        "model_id": "llama-3.3-70b-instruct",
+        "skills": ["Data Analysis", "pattern_recognition"],
+    },
+    {
+        "name": "Shopify Customer Engagement",
+        "agent_type": "custom",
+        "description": "Drives customer retention and repeat purchases for your Shopify store. Monitors order history for VIP customers, sends personalized follow-up emails via Gmail, tracks customer segments in Google Sheets, and posts engagement campaigns to Slack for team review. Identifies churn risks and automates win-back sequences. Uses Llama 3.3 70B for personalized customer communication at scale.",
+        "category": "E-commerce",
+        "tags": ["shopify", "customer engagement", "retention", "email", "ecommerce", "crm"],
+        "tools": ["SHOPIFY", "GMAIL", "GOOGLESHEETS", "SLACK"],
+        "model_id": "llama-3.3-70b-instruct",
+        "skills": ["Data Analysis", "pattern_recognition"],
+    },
+    {
+        "name": "Shopify Analytics & Reporting",
+        "agent_type": "custom",
+        "description": "Your e-commerce data analyst. Pulls sales, traffic, and conversion data from Shopify, enriches with payment data from Stripe, and builds automated dashboards in Google Sheets. Generates daily revenue summaries, weekly trend reports, and monthly business reviews. Spots anomalies in real-time and alerts via Slack. Powered by DeepSeek R1 for deep analytical reasoning on complex e-commerce datasets.",
+        "category": "E-commerce",
+        "tags": ["shopify", "analytics", "reporting", "stripe", "dashboards", "ecommerce", "data"],
+        "tools": ["SHOPIFY", "STRIPE", "GOOGLESHEETS", "SLACK"],
+        "model_id": "deepseek-ai/DeepSeek-R1",
+        "skills": ["Data Analysis", "pattern_recognition"],
+    },
 ]
 
 
 def seed_marketplace_agents_v2():
-    """Seed the marketplace with 18 new professional agents (v2 expansion)."""
-    print("🌱 Seeding marketplace with v2 agents (18 new agent types)...")
+    """Seed the marketplace with 22 professional agents (v2 expansion)."""
+    print("🌱 Seeding marketplace with v2 agents (22 agent types)...")
 
     database_url = get_database_url()
     engine = create_engine(database_url)


### PR DESCRIPTION
The marketplace_installs INSERT was missing the item_id column which is NOT NULL in production (migration 20260326 was standalone, never applied). Every agent install attempt hit a psycopg2 NotNullViolation and returned 500.

Fix: populate item_id with the marketplace agent/recipe id. Also wrap the install tracking in a savepoint (like recipes already do) so tracking failures can't kill the main install transaction.