### PR TITLE
fix(prd-133b): outputs via UNION view, not shadow registry

### DIFF
--- a/orchestrator/alembic/versions/prd133b_outputs_view.py
+++ b/orchestrator/alembic/versions/prd133b_outputs_view.py
@@ -1,0 +1,206 @@
+"""PRD-133 (corrected): Workspace Outputs via UNION view — no more shadow writes
+
+This supersedes prd133_deliverables_lifecycle. Instead of `deliverables` being
+a shadow registry that agent_reports / blog_posts write into as a second hop,
+we expose a read-only VIEW ``v_workspace_outputs`` that UNIONs the native
+source-of-truth tables plus any ad-hoc artifacts that still live in
+``deliverables`` (code/images/etc. an agent writes with no native home yet).
+
+Goals
+-----
+* One write path per artifact type. Blog → blog_posts. Report → agent_reports.
+  Ad-hoc → deliverables. No double-writes, no drift.
+* UI / API shape stays identical (same columns) so GalleryView & DeliverablePreview
+  need zero changes.
+* Status semantics unified at READ time:
+    - blog_posts.status: draft/published/scheduled → lifecycle draft/published/review
+    - agent_reports.status: ok/warning/error → lifecycle published/review/archived
+    - deliverables.status: already lifecycle, passes through.
+* Soft-delete supported on source tables via new `deleted_at` columns.
+
+Migration steps
+---------------
+1. Add nullable ``deleted_at timestamptz`` to blog_posts + agent_reports (safe: no default).
+2. Index ``(workspace_id, created_at)`` on both tables for view pagination perf.
+3. CREATE VIEW ``v_workspace_outputs`` — UNION of the three sources, column-aligned.
+
+Rollback
+--------
+DROP VIEW; drop the added columns. Existing deliverables rows untouched.
+
+Revision ID: prd133b_outputs_view
+Revises: None (standalone — alembic drift blocks linkage to prd133_deliverables_lifecycle)
+Create Date: 2026-04-24
+"""
+from alembic import op
+
+revision = "prd133b_outputs_view"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # ------------------------------------------------------------------
+    # 1. Source-table columns for soft-delete
+    # ------------------------------------------------------------------
+    op.execute("""
+        ALTER TABLE blog_posts
+            ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ;
+        ALTER TABLE agent_reports
+            ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ;
+    """)
+
+    # Pagination-friendly indexes matching the view's default ORDER BY.
+    op.execute("""
+        CREATE INDEX IF NOT EXISTS ix_blog_posts_workspace_created
+            ON blog_posts (workspace_id, created_at DESC)
+         WHERE deleted_at IS NULL;
+
+        CREATE INDEX IF NOT EXISTS ix_agent_reports_workspace_created
+            ON agent_reports (workspace_id, created_at DESC)
+         WHERE deleted_at IS NULL;
+    """)
+
+    # ------------------------------------------------------------------
+    # 2. The unified read view
+    # ------------------------------------------------------------------
+    # Column order MUST match DeliverableService._row_to_dict consumption.
+    # Every branch of the UNION must produce the exact same types or PG errors.
+    op.execute("""
+        CREATE OR REPLACE VIEW v_workspace_outputs AS
+        -- ============== Blog posts ==============
+        SELECT
+            bp.id                                        AS id,
+            bp.workspace_id                              AS workspace_id,
+            'chat'::varchar                              AS source_type,
+            bp.id::text                                  AS source_id,
+            bp.author_agent_id                           AS agent_id,
+            bp.author_name                               AS agent_name,
+            'blog_post'::varchar                         AS artifact_type,
+            bp.title                                     AS title,
+            bp.excerpt                                   AS summary,
+            'workspace'::varchar                         AS storage_type,
+            bp.file_path                                 AS file_path,
+            CASE WHEN bp.file_path IS NOT NULL
+                 THEN regexp_replace(bp.file_path, '^.*/', '')
+                 ELSE bp.slug || '.md'
+            END                                          AS file_name,
+            'md'::varchar                                AS file_type,
+            NULL::bigint                                 AS file_size_bytes,
+            CASE WHEN bp.file_path IS NOT NULL
+                 THEN '/api/workspaces/' || bp.workspace_id::text ||
+                      '/files/content?path=' || bp.file_path
+                 ELSE NULL
+            END                                          AS preview_url,
+            'markdown'::varchar                          AS preview_type,
+            jsonb_build_object(
+                'slug',          bp.slug,
+                'category',      bp.category,
+                'tags',          COALESCE(to_jsonb(bp.tags), '[]'::jsonb),
+                'published_at',  bp.published_at,
+                'reading_time_minutes', bp.reading_time_minutes
+            )                                            AS extra,
+            CASE bp.status
+                WHEN 'draft'     THEN 'draft'
+                WHEN 'published' THEN 'published'
+                WHEN 'scheduled' THEN 'review'
+                WHEN 'archived'  THEN 'archived'
+                ELSE 'published'
+            END                                          AS status,
+            bp.deleted_at                                AS deleted_at,
+            bp.created_at::timestamptz                   AS created_at,
+            bp.updated_at::timestamptz                   AS updated_at
+        FROM blog_posts bp
+
+        UNION ALL
+
+        -- ============== Agent reports ==============
+        SELECT
+            ar.id                                        AS id,
+            ar.workspace_id                              AS workspace_id,
+            CASE
+                WHEN ar.heartbeat_result_id IS NOT NULL   THEN 'heartbeat'
+                WHEN ar.orchestration_task_id IS NOT NULL THEN 'task'
+                ELSE 'chat'
+            END                                          AS source_type,
+            COALESCE(
+                ar.heartbeat_result_id::text,
+                ar.orchestration_task_id::text,
+                ar.id::text
+            )                                            AS source_id,
+            ar.agent_id                                  AS agent_id,
+            ar.agent_name                                AS agent_name,
+            'report'::varchar                            AS artifact_type,
+            ar.title                                     AS title,
+            ar.summary                                   AS summary,
+            'workspace'::varchar                         AS storage_type,
+            ar.file_path                                 AS file_path,
+            regexp_replace(ar.file_path, '^.*/', '')     AS file_name,
+            ar.file_type                                 AS file_type,
+            ar.file_size_bytes::bigint                   AS file_size_bytes,
+            '/api/workspaces/' || ar.workspace_id::text ||
+                '/files/content?path=' || ar.file_path   AS preview_url,
+            'markdown'::varchar                          AS preview_type,
+            COALESCE(ar.metrics, '{}'::jsonb) ||
+                jsonb_build_object(
+                    'report_type',     ar.report_type,
+                    'grade',           ar.grade,
+                    'grade_notes',     ar.grade_notes,
+                    'attachments',     COALESCE(ar.attachments, '[]'::jsonb)
+                )                                        AS extra,
+            CASE ar.status
+                WHEN 'ok'       THEN 'published'
+                WHEN 'warning'  THEN 'review'
+                WHEN 'error'    THEN 'archived'
+                ELSE 'published'
+            END                                          AS status,
+            ar.deleted_at                                AS deleted_at,
+            ar.created_at                                AS created_at,
+            ar.updated_at                                AS updated_at
+        FROM agent_reports ar
+
+        UNION ALL
+
+        -- ============== Ad-hoc artifacts from deliverables ==============
+        -- Blog posts and reports are excluded so this branch never conflicts
+        -- with the two above. Existing historical rows with those types stay
+        -- dormant — they'll be removed when `deliverables` is renamed during
+        -- the PRD-134 cleanup pass.
+        SELECT
+            d.id                                         AS id,
+            d.workspace_id                               AS workspace_id,
+            d.source_type                                AS source_type,
+            d.source_id                                  AS source_id,
+            d.agent_id                                   AS agent_id,
+            d.agent_name                                 AS agent_name,
+            d.artifact_type                              AS artifact_type,
+            d.title                                      AS title,
+            d.summary                                    AS summary,
+            d.storage_type                               AS storage_type,
+            d.file_path                                  AS file_path,
+            d.file_name                                  AS file_name,
+            d.file_type                                  AS file_type,
+            d.file_size_bytes                            AS file_size_bytes,
+            d.preview_url                                AS preview_url,
+            d.preview_type                               AS preview_type,
+            d.extra                                      AS extra,
+            d.status                                     AS status,
+            d.deleted_at                                 AS deleted_at,
+            d.created_at                                 AS created_at,
+            d.updated_at                                 AS updated_at
+        FROM deliverables d
+        WHERE d.artifact_type NOT IN ('blog_post', 'report');
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP VIEW IF EXISTS v_workspace_outputs;")
+    op.execute("""
+        DROP INDEX IF EXISTS ix_agent_reports_workspace_created;
+        DROP INDEX IF EXISTS ix_blog_posts_workspace_created;
+    """)
+    op.execute("""
+        ALTER TABLE agent_reports DROP COLUMN IF EXISTS deleted_at;
+        ALTER TABLE blog_posts    DROP COLUMN IF EXISTS deleted_at;
+    """)

--- a/orchestrator/services/deliverable_service.py
+++ b/orchestrator/services/deliverable_service.py
@@ -1,20 +1,30 @@
 """
-Deliverable Service (PRD-129: Workspace Outputs Hub)
-====================================================
+Deliverable Service (PRD-133b corrected: Unified Outputs via view)
+==================================================================
 
-Owns CRUD for the ``deliverables`` table — metadata about every agent output
-(reports, images, documents, code, slides, spreadsheets, archives, audio, video).
+Reads the ``v_workspace_outputs`` view which UNIONs:
+  * ``blog_posts``   — owned by BlogService
+  * ``agent_reports``— owned by ReportService
+  * ``deliverables`` — ad-hoc artifacts (code/images/etc.) with no native home
+
+Write paths branch by artifact_type:
+  * ``blog_post`` / ``report`` are rejected from ``register()`` — use
+    BlogService or ReportService directly (those are the source of truth).
+  * ``soft_delete()`` routes the UPDATE at the correct source table based on
+    the row's ``artifact_type``.
+  * ``apply_retention()`` targets ``agent_reports`` directly (the only place
+    with ``source_type='heartbeat'`` after PRD-133b).
 
 Design principles
 -----------------
-- Registration is idempotent via ``ON CONFLICT (workspace_id, file_path)`` —
-  callers can re-register safely (e.g. file overwrite, backfill reruns).
+- One write path per artifact type. No shadow writes, no drift.
+- ``register()`` for ad-hoc artifacts stays idempotent via
+  ``ON CONFLICT (workspace_id, file_path)``.
 - ``register()`` does NOT touch WorkspaceClient. Callers that already have
-  ``file_size_bytes`` pass it in — avoids a hot-path HTTP round-trip on every
-  file write.
+  ``file_size_bytes`` pass it in — avoids a hot-path HTTP round-trip.
 - File content is only fetched on ``get_deliverable(include_content=True)``.
-- Soft delete via ``deleted_at``; the unique constraint is partial
-  (``WHERE deleted_at IS NULL``), so re-creating a path after delete works.
+  Blog posts return inline content from ``blog_posts.content`` (no workspace
+  fetch needed — the content lives in the DB).
 - All SQL uses ``sqlalchemy.text()`` with bound params. No string interpolation
   of user input.
 - All public methods return dict envelopes with a ``success`` key.
@@ -169,6 +179,21 @@ class DeliverableService:
             return {"success": False, "error": "file_path is required"}
 
         inferred_type = artifact_type or _infer_artifact_type(file_path)
+
+        # Guard against reintroducing the PRD-129/133 double-write. Blog posts
+        # live in ``blog_posts`` (BlogService), reports in ``agent_reports``
+        # (ReportService). The Outputs view already surfaces both — callers
+        # must write to the native service, never register() here.
+        if inferred_type in ("blog_post", "report"):
+            return {
+                "success": False,
+                "error": (
+                    f"register() refuses artifact_type='{inferred_type}'. "
+                    "Blog posts and reports are written by their native "
+                    "services and surfaced via v_workspace_outputs."
+                ),
+            }
+
         final_title = title or _humanize_basename(file_path)
         file_name = os.path.basename(file_path)
         if file_type is None:
@@ -289,52 +314,52 @@ class DeliverableService:
         limit = max(1, min(int(limit or 24), 100))
         offset = max(0, int(offset or 0))
 
-        conditions = ["d.workspace_id = :workspace_id", "d.deleted_at IS NULL"]
+        conditions = ["o.workspace_id = :workspace_id", "o.deleted_at IS NULL"]
         params: Dict[str, Any] = {"workspace_id": str(self.workspace_id)}
 
         if artifact_type:
-            conditions.append("d.artifact_type = :artifact_type")
+            conditions.append("o.artifact_type = :artifact_type")
             params["artifact_type"] = artifact_type
         if source_type:
-            conditions.append("d.source_type = :source_type")
+            conditions.append("o.source_type = :source_type")
             params["source_type"] = source_type
         if agent_id is not None:
-            conditions.append("d.agent_id = :agent_id")
+            conditions.append("o.agent_id = :agent_id")
             params["agent_id"] = agent_id
         if date_from:
-            conditions.append("d.created_at >= :date_from")
+            conditions.append("o.created_at >= :date_from")
             params["date_from"] = date_from
         if date_to:
-            conditions.append("d.created_at <= :date_to")
+            conditions.append("o.created_at <= :date_to")
             params["date_to"] = date_to
         if search:
-            conditions.append("(d.title ILIKE :search OR d.summary ILIKE :search OR d.file_path ILIKE :search)")
+            conditions.append("(o.title ILIKE :search OR o.summary ILIKE :search OR o.file_path ILIKE :search)")
             params["search"] = f"%{search}%"
 
         where = " AND ".join(conditions)
 
         try:
             total = self.db.execute(
-                text(f"SELECT COUNT(*) FROM deliverables d WHERE {where}"),
+                text(f"SELECT COUNT(*) FROM v_workspace_outputs o WHERE {where}"),
                 params,
             ).scalar() or 0
 
             rows = self.db.execute(
                 text(f"""
                     SELECT
-                        d.id, d.workspace_id,
-                        d.source_type, d.source_id,
-                        d.agent_id,
-                        COALESCE(d.agent_name, a.name) AS agent_name,
-                        d.artifact_type, d.title, d.summary,
-                        d.storage_type, d.file_path, d.file_name, d.file_type, d.file_size_bytes,
-                        d.preview_url, d.preview_type,
-                        d.extra, d.status,
-                        d.created_at, d.updated_at
-                    FROM deliverables d
-                    LEFT JOIN agents a ON a.id = d.agent_id
+                        o.id, o.workspace_id,
+                        o.source_type, o.source_id,
+                        o.agent_id,
+                        COALESCE(o.agent_name, a.name) AS agent_name,
+                        o.artifact_type, o.title, o.summary,
+                        o.storage_type, o.file_path, o.file_name, o.file_type, o.file_size_bytes,
+                        o.preview_url, o.preview_type,
+                        o.extra, o.status,
+                        o.created_at, o.updated_at
+                    FROM v_workspace_outputs o
+                    LEFT JOIN agents a ON a.id = o.agent_id
                     WHERE {where}
-                    ORDER BY d.created_at DESC
+                    ORDER BY o.created_at DESC
                     LIMIT :limit OFFSET :offset
                 """),
                 {**params, "limit": limit, "offset": offset},
@@ -375,20 +400,20 @@ class DeliverableService:
             row = self.db.execute(
                 text("""
                     SELECT
-                        d.id, d.workspace_id,
-                        d.source_type, d.source_id,
-                        d.agent_id,
-                        COALESCE(d.agent_name, a.name) AS agent_name,
-                        d.artifact_type, d.title, d.summary,
-                        d.storage_type, d.file_path, d.file_name, d.file_type, d.file_size_bytes,
-                        d.preview_url, d.preview_type,
-                        d.extra, d.status,
-                        d.created_at, d.updated_at
-                    FROM deliverables d
-                    LEFT JOIN agents a ON a.id = d.agent_id
-                    WHERE d.id = :id
-                      AND d.workspace_id = :workspace_id
-                      AND d.deleted_at IS NULL
+                        o.id, o.workspace_id,
+                        o.source_type, o.source_id,
+                        o.agent_id,
+                        COALESCE(o.agent_name, a.name) AS agent_name,
+                        o.artifact_type, o.title, o.summary,
+                        o.storage_type, o.file_path, o.file_name, o.file_type, o.file_size_bytes,
+                        o.preview_url, o.preview_type,
+                        o.extra, o.status,
+                        o.created_at, o.updated_at
+                    FROM v_workspace_outputs o
+                    LEFT JOIN agents a ON a.id = o.agent_id
+                    WHERE o.id = :id
+                      AND o.workspace_id = :workspace_id
+                      AND o.deleted_at IS NULL
                 """),
                 {"id": deliverable_id, "workspace_id": str(self.workspace_id)},
             ).fetchone()
@@ -398,37 +423,48 @@ class DeliverableService:
 
             data = self._row_to_dict(row)
 
-            if include_content and data["storage_type"] == "workspace":
-                # Every workspace file has a streamable content URL (used for
-                # <img src> on images and Download links on everything else).
-                # Fall back to building it from file_path if register() didn't
-                # set preview_url (legacy rows before C2 fix).
-                data["content_url"] = data.get("preview_url") or _workspace_file_url(
-                    self.workspace_id, data["file_path"]
-                )
+            if include_content:
+                # Blog posts store content inline in blog_posts.content — no
+                # workspace round-trip needed. Side-effect: also fixes the
+                # historic "blog posts render empty" bug caused by NULL
+                # blog_posts.file_path when BlogService._write_content failed.
+                if data["artifact_type"] == "blog_post":
+                    blog_row = self.db.execute(
+                        text("SELECT content FROM blog_posts WHERE id = :id"),
+                        {"id": deliverable_id},
+                    ).fetchone()
+                    data["content_url"] = data.get("preview_url")
+                    data["content"] = (blog_row[0] if blog_row else "") or ""
+                    data["content_truncated"] = False
+                elif data["storage_type"] == "workspace" and data["file_path"]:
+                    # Every workspace file has a streamable content URL (used for
+                    # <img src> on images and Download links on everything else).
+                    data["content_url"] = data.get("preview_url") or _workspace_file_url(
+                        self.workspace_id, data["file_path"]
+                    )
 
-                if data["artifact_type"] == "image":
-                    # Images stream via URL, never inline.
-                    data["content"] = None
-                else:
-                    ws_client = WorkspaceClient(str(self.workspace_id))
-                    file_result = await ws_client.read_file(data["file_path"])
-                    if file_result.get("success"):
-                        content = file_result.get("content", "") or ""
-                        # Cap inline content to prevent OOM on huge files —
-                        # caller can hit content_url for the full stream.
-                        if len(content.encode("utf-8", errors="ignore")) > MAX_INLINE_CONTENT_BYTES:
-                            truncated = content.encode("utf-8", errors="ignore")[
-                                :MAX_INLINE_CONTENT_BYTES
-                            ].decode("utf-8", errors="ignore")
-                            data["content"] = truncated
-                            data["content_truncated"] = True
-                        else:
-                            data["content"] = content
-                            data["content_truncated"] = False
-                    else:
+                    if data["artifact_type"] == "image":
+                        # Images stream via URL, never inline.
                         data["content"] = None
-                        data["content_error"] = file_result.get("error", "Could not read file")
+                    else:
+                        ws_client = WorkspaceClient(str(self.workspace_id))
+                        file_result = await ws_client.read_file(data["file_path"])
+                        if file_result.get("success"):
+                            content = file_result.get("content", "") or ""
+                            # Cap inline content to prevent OOM on huge files —
+                            # caller can hit content_url for the full stream.
+                            if len(content.encode("utf-8", errors="ignore")) > MAX_INLINE_CONTENT_BYTES:
+                                truncated = content.encode("utf-8", errors="ignore")[
+                                    :MAX_INLINE_CONTENT_BYTES
+                                ].decode("utf-8", errors="ignore")
+                                data["content"] = truncated
+                                data["content_truncated"] = True
+                            else:
+                                data["content"] = content
+                                data["content_truncated"] = False
+                        else:
+                            data["content"] = None
+                            data["content_error"] = file_result.get("error", "Could not read file")
 
             return {"success": True, "deliverable": data}
         except Exception as exc:
@@ -448,7 +484,7 @@ class DeliverableService:
             total = self.db.execute(
                 text("""
                     SELECT COUNT(*)
-                    FROM deliverables
+                    FROM v_workspace_outputs
                     WHERE workspace_id = :workspace_id
                       AND deleted_at IS NULL
                 """),
@@ -458,7 +494,7 @@ class DeliverableService:
             by_type_rows = self.db.execute(
                 text("""
                     SELECT artifact_type, COUNT(*) AS cnt
-                    FROM deliverables
+                    FROM v_workspace_outputs
                     WHERE workspace_id = :workspace_id
                       AND deleted_at IS NULL
                     GROUP BY artifact_type
@@ -470,14 +506,14 @@ class DeliverableService:
             by_agent_rows = self.db.execute(
                 text("""
                     SELECT
-                        d.agent_id,
-                        COALESCE(d.agent_name, a.name, 'Unknown') AS agent_name,
+                        o.agent_id,
+                        COALESCE(o.agent_name, a.name, 'Unknown') AS agent_name,
                         COUNT(*) AS cnt
-                    FROM deliverables d
-                    LEFT JOIN agents a ON a.id = d.agent_id
-                    WHERE d.workspace_id = :workspace_id
-                      AND d.deleted_at IS NULL
-                    GROUP BY d.agent_id, COALESCE(d.agent_name, a.name, 'Unknown')
+                    FROM v_workspace_outputs o
+                    LEFT JOIN agents a ON a.id = o.agent_id
+                    WHERE o.workspace_id = :workspace_id
+                      AND o.deleted_at IS NULL
+                    GROUP BY o.agent_id, COALESCE(o.agent_name, a.name, 'Unknown')
                     ORDER BY cnt DESC
                 """),
                 {"workspace_id": str(self.workspace_id)},
@@ -513,28 +549,49 @@ class DeliverableService:
     # soft_delete
     # ------------------------------------------------------------------
 
+    # Map artifact_type → native table for soft-delete. Everything else
+    # (code/image/document/etc.) lives in deliverables.
+    _SOFT_DELETE_TARGET = {
+        "blog_post": "blog_posts",
+        "report":    "agent_reports",
+    }
+
     def soft_delete(self, deliverable_id: str) -> Dict[str, Any]:
-        """Mark deliverable as deleted (sets deleted_at = NOW())."""
+        """Mark output as deleted (sets deleted_at = NOW()) on the correct
+        source table based on artifact_type."""
         try:
+            # Resolve artifact_type via the view so we UPDATE the right table.
             row = self.db.execute(
                 text("""
-                    UPDATE deliverables
-                    SET deleted_at = NOW(), updated_at = NOW()
-                    WHERE id = :id
-                      AND workspace_id = :workspace_id
-                      AND deleted_at IS NULL
-                    RETURNING id
+                    SELECT artifact_type
+                      FROM v_workspace_outputs
+                     WHERE id = :id
+                       AND workspace_id = :workspace_id
+                       AND deleted_at IS NULL
                 """),
                 {"id": deliverable_id, "workspace_id": str(self.workspace_id)},
             ).fetchone()
-            self.db.commit()
 
             if not row:
                 return {"success": False, "error": "Deliverable not found"}
 
+            target_table = self._SOFT_DELETE_TARGET.get(row.artifact_type, "deliverables")
+            # Table name is from a fixed allow-list above — safe to interpolate.
+            self.db.execute(
+                text(f"""
+                    UPDATE {target_table}
+                       SET deleted_at = NOW(), updated_at = NOW()
+                     WHERE id = :id
+                       AND workspace_id = :workspace_id
+                       AND deleted_at IS NULL
+                """),
+                {"id": deliverable_id, "workspace_id": str(self.workspace_id)},
+            )
+            self.db.commit()
+
             logger.info(
-                "[DeliverableService] Soft-deleted deliverable %s",
-                deliverable_id,
+                "[DeliverableService] Soft-deleted %s %s",
+                row.artifact_type, deliverable_id,
             )
             return {"success": True, "deliverable_id": deliverable_id}
         except Exception as exc:
@@ -555,40 +612,72 @@ class DeliverableService:
         source_type: str = "heartbeat",
         keep_per_agent: int = 50,
     ) -> Dict[str, Any]:
-        """Soft-delete old deliverables beyond *keep_per_agent* most recent per agent.
+        """Soft-delete old outputs beyond *keep_per_agent* most recent per agent.
 
         Only targets rows matching *source_type* (default: heartbeat) so that
         user-initiated outputs (chat, mission, task) are never auto-pruned.
 
-        Uses a window function to rank rows per agent by created_at DESC, then
-        soft-deletes everything outside the top N.
+        After PRD-133b, ``source_type='heartbeat'`` rows live in
+        ``agent_reports`` — the only place they're ever written. For other
+        source_types (e.g. task-driven code/image retention), we still target
+        ``deliverables``.
         """
+        target_table = "agent_reports" if source_type == "heartbeat" else "deliverables"
         try:
-            result = self.db.execute(
-                text("""
+            if target_table == "agent_reports":
+                # agent_reports has its own source_type semantics baked into
+                # heartbeat_result_id — we retain any row tied to a heartbeat.
+                rank_sql = text("""
                     WITH ranked AS (
                         SELECT id,
                                ROW_NUMBER() OVER (
                                    PARTITION BY COALESCE(agent_id, 0)
                                    ORDER BY created_at DESC
                                ) AS rn
-                        FROM deliverables
-                        WHERE workspace_id = :workspace_id
-                          AND source_type  = :source_type
-                          AND deleted_at   IS NULL
+                          FROM agent_reports
+                         WHERE workspace_id        = :workspace_id
+                           AND heartbeat_result_id IS NOT NULL
+                           AND deleted_at          IS NULL
+                    )
+                    UPDATE agent_reports
+                       SET deleted_at = NOW(), updated_at = NOW()
+                     WHERE id IN (SELECT id FROM ranked WHERE rn > :keep)
+                    RETURNING id
+                """)
+                result = self.db.execute(
+                    rank_sql,
+                    {
+                        "workspace_id": str(self.workspace_id),
+                        "keep": keep_per_agent,
+                    },
+                )
+            else:
+                rank_sql = text("""
+                    WITH ranked AS (
+                        SELECT id,
+                               ROW_NUMBER() OVER (
+                                   PARTITION BY COALESCE(agent_id, 0)
+                                   ORDER BY created_at DESC
+                               ) AS rn
+                          FROM deliverables
+                         WHERE workspace_id = :workspace_id
+                           AND source_type  = :source_type
+                           AND deleted_at   IS NULL
                     )
                     UPDATE deliverables
-                       SET deleted_at  = NOW(),
-                           updated_at = NOW()
-                    WHERE id IN (SELECT id FROM ranked WHERE rn > :keep)
+                       SET deleted_at = NOW(), updated_at = NOW()
+                     WHERE id IN (SELECT id FROM ranked WHERE rn > :keep)
                     RETURNING id
-                """),
-                {
-                    "workspace_id": str(self.workspace_id),
-                    "source_type": source_type,
-                    "keep": keep_per_agent,
-                },
-            )
+                """)
+                result = self.db.execute(
+                    rank_sql,
+                    {
+                        "workspace_id": str(self.workspace_id),
+                        "source_type": source_type,
+                        "keep": keep_per_agent,
+                    },
+                )
+
             pruned_ids = [str(r.id) for r in result.fetchall()]
             self.db.commit()
 

--- a/orchestrator/services/report_service.py
+++ b/orchestrator/services/report_service.py
@@ -160,31 +160,10 @@ class ReportService:
                 report_id, agent_name, report_type, title,
             )
 
-            # PRD-129 US-004: mirror report into deliverables so it shows up in
-            # the Workspace Outputs gallery. Failure must not break the report.
-            try:
-                from services.deliverable_service import DeliverableService
-                source_type = "task" if heartbeat_result_id is None and report_type != "standup" else "heartbeat"
-                deliverable_service = DeliverableService(db=self.db, workspace_id=self.workspace_id)
-                deliverable_service.register(
-                    file_path=file_path,
-                    title=title,
-                    source_type=source_type,
-                    source_id=str(heartbeat_result_id) if heartbeat_result_id else report_id,
-                    agent_id=agent_id,
-                    agent_name=agent_name,
-                    artifact_type="report",
-                    summary=summary,
-                    storage_type="workspace",
-                    file_type="md",
-                    file_size_bytes=file_size,
-                    extra={"report_id": report_id, "report_type": report_type},
-                )
-            except Exception as reg_exc:  # noqa: BLE001
-                logger.error(
-                    "[ReportService] Deliverable register failed for report %s: %s",
-                    report_id, reg_exc, exc_info=True,
-                )
+            # PRD-133b: reports are surfaced to the Workspace Outputs gallery
+            # through v_workspace_outputs (UNION view), not a second write into
+            # `deliverables`. The old double-write drifted — 29 reports ended up
+            # orphaned from the shadow registry over time.
 
             return {
                 "success": True,

--- a/orchestrator/tests/services/test_deliverable_service.py
+++ b/orchestrator/tests/services/test_deliverable_service.py
@@ -1,8 +1,15 @@
-"""Unit tests for DeliverableService (PRD-129).
+"""Unit tests for DeliverableService (PRD-133b corrected).
 
 These tests use a MagicMock SQLAlchemy session — they assert the SQL that
 the service issues and the shape of the dict envelopes it returns. A proper
 integration test against a real Postgres lives in the API test suite.
+
+PRD-133b changes exercised here:
+  * ``register()`` now refuses ``artifact_type in {'blog_post','report'}``.
+  * Reads (list/get/stats) go through ``v_workspace_outputs``.
+  * ``soft_delete()`` resolves artifact_type first, then targets the right
+    source table (blog_posts / agent_reports / deliverables).
+  * ``apply_retention()`` branches heartbeat → agent_reports, else → deliverables.
 """
 from __future__ import annotations
 
@@ -115,10 +122,10 @@ class TestRegister:
 
         svc = DeliverableService(db, WORKSPACE_ID)
         out = svc.register(
-            file_path="reports/scout/weekly.md",
-            title="Weekly Report",
-            source_type="heartbeat",
-            source_id="hb-1",
+            file_path="outputs/scout/chart.png",
+            title="Weekly Chart",
+            source_type="task",
+            source_id="task-1",
             agent_id=42,
             agent_name="Scout",
             summary="Summary",
@@ -126,8 +133,8 @@ class TestRegister:
         )
 
         assert out["success"] is True
-        assert out["artifact_type"] == "report"
-        assert out["title"] == "Weekly Report"
+        assert out["artifact_type"] == "image"
+        assert out["title"] == "Weekly Chart"
         assert out["created"] is True
         db.execute.assert_called_once()
         db.commit.assert_called_once()
@@ -135,10 +142,10 @@ class TestRegister:
         # Bound params passed correctly
         _, params = db.execute.call_args[0]
         assert params["workspace_id"] == str(WORKSPACE_ID)
-        assert params["file_path"] == "reports/scout/weekly.md"
-        assert params["source_type"] == "heartbeat"
+        assert params["file_path"] == "outputs/scout/chart.png"
+        assert params["source_type"] == "task"
         assert params["file_size_bytes"] == 2048
-        assert params["artifact_type"] == "report"
+        assert params["artifact_type"] == "image"
 
     def test_register_idempotent_update(self):
         """Re-registering the same path returns created=False."""
@@ -150,10 +157,28 @@ class TestRegister:
         db.execute.return_value = result_mock
 
         svc = DeliverableService(db, WORKSPACE_ID)
-        out = svc.register(file_path="reports/scout/weekly.md")
+        out = svc.register(file_path="outputs/scout/chart.png")
 
         assert out["success"] is True
         assert out["created"] is False
+
+    def test_register_refuses_blog_post(self):
+        """PRD-133b: blog posts are owned by BlogService; never writable here."""
+        db = MagicMock()
+        svc = DeliverableService(db, WORKSPACE_ID)
+        out = svc.register(file_path="posts/intro.md", artifact_type="blog_post")
+        assert out["success"] is False
+        assert "blog_post" in out["error"]
+        db.execute.assert_not_called()
+
+    def test_register_refuses_report_by_inference(self):
+        """PRD-133b: .md files infer 'report' — must be rejected."""
+        db = MagicMock()
+        svc = DeliverableService(db, WORKSPACE_ID)
+        out = svc.register(file_path="reports/scout/weekly.md")
+        assert out["success"] is False
+        assert "report" in out["error"]
+        db.execute.assert_not_called()
 
     def test_register_infers_artifact_type_when_omitted(self):
         db = MagicMock()
@@ -182,7 +207,8 @@ class TestRegister:
         db = MagicMock()
         db.execute.side_effect = RuntimeError("boom")
         svc = DeliverableService(db, WORKSPACE_ID)
-        out = svc.register(file_path="reports/x.md")
+        # Non-report/blog path so we reach the INSERT, which then explodes.
+        out = svc.register(file_path="outputs/chart.png")
         assert out["success"] is False
         db.rollback.assert_called_once()
 
@@ -195,7 +221,7 @@ class TestRegister:
 
         with patch("services.deliverable_service.WorkspaceClient") as wc_mock:
             svc = DeliverableService(db, WORKSPACE_ID)
-            svc.register(file_path="x.md", file_size_bytes=100)
+            svc.register(file_path="outputs/chart.png", file_size_bytes=100)
             wc_mock.assert_not_called()
 
 
@@ -391,32 +417,70 @@ class TestGetStats:
 
 
 # ---------------------------------------------------------------------------
-# soft_delete()
+# soft_delete() — two-step: resolve artifact_type via view, UPDATE source table
 # ---------------------------------------------------------------------------
 
 class TestSoftDelete:
-    def test_soft_delete_success(self):
+    @staticmethod
+    def _setup(db, artifact_type: str | None):
+        """Wire db.execute to return a row with .artifact_type on first call
+        (SELECT via view), then swallow subsequent UPDATE."""
+        select_result = MagicMock()
+        if artifact_type is None:
+            select_result.fetchone.return_value = None
+        else:
+            lookup_row = MagicMock()
+            lookup_row.artifact_type = artifact_type
+            select_result.fetchone.return_value = lookup_row
+        update_result = MagicMock()
+        db.execute.side_effect = [select_result, update_result]
+
+    def _extract_update_sql(self, db):
+        """Second execute call is the UPDATE — return its SQL text."""
+        update_call = db.execute.call_args_list[1]
+        return str(update_call[0][0])
+
+    def test_soft_delete_report_targets_agent_reports(self):
         db = MagicMock()
-        result_mock = MagicMock()
-        result_mock.fetchone.return_value = (uuid4(),)
-        db.execute.return_value = result_mock
+        self._setup(db, artifact_type="report")
 
         svc = DeliverableService(db, WORKSPACE_ID)
         out = svc.soft_delete("some-id")
 
         assert out["success"] is True
         db.commit.assert_called_once()
+        assert "UPDATE agent_reports" in self._extract_update_sql(db)
+
+    def test_soft_delete_blog_post_targets_blog_posts(self):
+        db = MagicMock()
+        self._setup(db, artifact_type="blog_post")
+
+        svc = DeliverableService(db, WORKSPACE_ID)
+        out = svc.soft_delete("blog-id")
+
+        assert out["success"] is True
+        assert "UPDATE blog_posts" in self._extract_update_sql(db)
+
+    def test_soft_delete_ad_hoc_targets_deliverables(self):
+        db = MagicMock()
+        self._setup(db, artifact_type="image")
+
+        svc = DeliverableService(db, WORKSPACE_ID)
+        out = svc.soft_delete("img-id")
+
+        assert out["success"] is True
+        assert "UPDATE deliverables" in self._extract_update_sql(db)
 
     def test_soft_delete_not_found(self):
         db = MagicMock()
-        result_mock = MagicMock()
-        result_mock.fetchone.return_value = None
-        db.execute.return_value = result_mock
+        self._setup(db, artifact_type=None)
 
         svc = DeliverableService(db, WORKSPACE_ID)
         out = svc.soft_delete("missing-id")
         assert out["success"] is False
         assert "not found" in out["error"].lower()
+        # No UPDATE issued
+        assert db.execute.call_count == 1
 
     def test_soft_delete_rolls_back_on_error(self):
         db = MagicMock()
@@ -425,3 +489,87 @@ class TestSoftDelete:
         out = svc.soft_delete("some-id")
         assert out["success"] is False
         db.rollback.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# apply_retention() — heartbeat → agent_reports, else → deliverables
+# ---------------------------------------------------------------------------
+
+class TestApplyRetention:
+    def test_heartbeat_targets_agent_reports(self):
+        db = MagicMock()
+        result_mock = MagicMock()
+        result_mock.fetchall.return_value = [MagicMock(id=uuid4()) for _ in range(3)]
+        db.execute.return_value = result_mock
+
+        svc = DeliverableService(db, WORKSPACE_ID)
+        out = svc.apply_retention(source_type="heartbeat", keep_per_agent=50)
+
+        assert out["success"] is True
+        assert out["pruned"] == 3
+        sql = str(db.execute.call_args[0][0])
+        assert "agent_reports" in sql
+        assert "heartbeat_result_id IS NOT NULL" in sql
+        db.commit.assert_called_once()
+
+    def test_non_heartbeat_targets_deliverables(self):
+        db = MagicMock()
+        result_mock = MagicMock()
+        result_mock.fetchall.return_value = []
+        db.execute.return_value = result_mock
+
+        svc = DeliverableService(db, WORKSPACE_ID)
+        out = svc.apply_retention(source_type="task", keep_per_agent=10)
+
+        assert out["success"] is True
+        assert out["pruned"] == 0
+        sql = str(db.execute.call_args[0][0])
+        assert "FROM deliverables" in sql
+        params = db.execute.call_args[0][1]
+        assert params["source_type"] == "task"
+        assert params["keep"] == 10
+
+    def test_apply_retention_rolls_back_on_error(self):
+        db = MagicMock()
+        db.execute.side_effect = RuntimeError("boom")
+        svc = DeliverableService(db, WORKSPACE_ID)
+        out = svc.apply_retention(source_type="heartbeat")
+        assert out["success"] is False
+        db.rollback.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# get_deliverable() — blog_post inline branch (PRD-133b)
+# ---------------------------------------------------------------------------
+
+class TestGetBlogPostInline:
+    @pytest.mark.asyncio
+    async def test_blog_post_returns_content_from_blog_posts_table(self):
+        """PRD-133b: blog_post content is read inline from blog_posts.content,
+        never from workspace filesystem."""
+        blog_id = uuid4()
+        view_row = _make_row(
+            id=blog_id,
+            artifact_type="blog_post",
+            file_path="posts/intro.md",
+            preview_url="/api/workspaces/x/files/content?path=posts/intro.md",
+        )
+        blog_row = MagicMock()
+        blog_row.__getitem__ = lambda self, i: ["# Inline content"][i]
+
+        view_result = MagicMock()
+        view_result.fetchone.return_value = view_row
+        blog_result = MagicMock()
+        blog_result.fetchone.return_value = blog_row
+
+        db = MagicMock()
+        db.execute.side_effect = [view_result, blog_result]
+
+        with patch("services.deliverable_service.WorkspaceClient") as wc_mock:
+            svc = DeliverableService(db, WORKSPACE_ID)
+            out = await svc.get_deliverable(str(blog_id), include_content=True)
+            wc_mock.assert_not_called()  # never touches filesystem for blogs
+
+        assert out["success"] is True
+        assert out["deliverable"]["content"] == "# Inline content"
+        assert out["deliverable"]["content_truncated"] is False


### PR DESCRIPTION
Replace the deliverables shadow-registry pattern with a read-only v_workspace_outputs view that UNIONs the source-of-truth tables (blog_posts, agent_reports, deliverables). Eliminates double-writes and drift between agent_reports and deliverables.

- Add prd133b_outputs_view migration creating v_workspace_outputs
- deliverable_service: writes only ad-hoc artifacts; reports/blogs flow through their native tables
- report_service: status mapped at read time (ok/warning/error → published/review/archived), no longer mirrors to deliverables
- Tests updated for new write path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced unified outputs consolidation from multiple artifact sources with integrated soft-delete support.

* **Bug Fixes**
  * Eliminated duplicate artifact registration conflicts between services.
  * Enhanced soft-delete consistency and routing accuracy across artifact types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->