### PR TITLE
feat: workspace_html_to_png — headless Chromium renderer in worker

### DIFF
--- a/orchestrator/consumers/chatbot/auto.py
+++ b/orchestrator/consumers/chatbot/auto.py
@@ -343,6 +343,13 @@ _PLATFORM_KEYWORDS = {
         "git log", "git pull", "check git", "commit changes",
         "push changes",
     ],
+    "workspace_html_to_png": [
+        "render html", "html to png", "html to image",
+        "screenshot the page", "screenshot template",
+        "render the template", "render social card",
+        "generate social post", "render social post",
+        "make a social card", "render to png", "html screenshot",
+    ],
     # PRD-76: Agent Reports
     "platform_submit_report": [
         "submit report", "file report", "create report",

--- a/orchestrator/core/workspace_client.py
+++ b/orchestrator/core/workspace_client.py
@@ -170,6 +170,47 @@ class WorkspaceClient:
         except (httpx.ConnectError, httpx.TimeoutException) as err:
             return _connection_error("exec_command", err)
 
+    # ── Headless rendering ────────────────────────────────────────
+
+    async def html_to_png(
+        self,
+        url: str,
+        viewport_w: int,
+        viewport_h: int,
+        output_path: str,
+        wait_for: str = "[data-render-ready='true']",
+        full_page: bool = False,
+    ) -> Dict[str, Any]:
+        """Render an HTML page to a PNG in the workspace via headless Chromium.
+
+        Args mirror ``WorkspaceToolExecutor.html_to_png``. ``output_path`` is
+        workspace-relative (e.g. ``deliverables/social/2026-04-29/foo.png``).
+        Returns the worker's response dict; success path includes
+        ``file_path``, ``file_size_bytes``, ``w``, ``h``, ``ms``.
+        """
+        client = _get_client()
+        url_endpoint = _worker_url(self.workspace_id, "/html-to-png")
+        body: Dict[str, Any] = {
+            "url": url,
+            "viewport": {"w": int(viewport_w), "h": int(viewport_h)},
+            "output_path": output_path,
+            "wait_for": wait_for,
+            "full_page": bool(full_page),
+        }
+        try:
+            resp = await client.post(url_endpoint, json=body)
+            if resp.status_code != 200:
+                return {
+                    "success": False,
+                    "error": _parse_error(resp),
+                    "status_code": resp.status_code,
+                }
+            data = resp.json()
+            data.setdefault("success", True)
+            return data
+        except (httpx.ConnectError, httpx.TimeoutException) as err:
+            return _connection_error("html_to_png", err)
+
     # ── Git ────────────────────────────────────────────────────────
 
     async def git(

--- a/orchestrator/modules/tools/discovery/workspace_actions.py
+++ b/orchestrator/modules/tools/discovery/workspace_actions.py
@@ -200,6 +200,81 @@ def register_workspace_actions(registry: ActionRegistry) -> None:
     ))
 
     registry.register(ActionDefinition(
+        name="workspace_html_to_png",
+        description=(
+            "Render an HTML page to a PNG image inside the workspace using "
+            "headless Chromium. Use to turn templated HTML (e.g. social card "
+            "templates from a cloned repo) into shareable PNGs. The output file "
+            "is automatically registered as a deliverable and shows up in the "
+            "Deliverables Gallery, Workspace Explorer, and Mission Outputs."
+        ),
+        category="workspace_render",
+        parameters={
+            "type": "object",
+            "properties": {
+                "url": {
+                    "type": "string",
+                    "description": (
+                        "Absolute URL to render. Must be either: "
+                        "(a) a 'file://' URL pointing INSIDE this workspace "
+                        "(e.g. 'file:///workspaces/<id>/repos/automatos-social/render/index.html?template=definition&size=ig_post&...'), "
+                        "or (b) an 'http(s)://' URL. Other schemes are rejected."
+                    ),
+                },
+                "viewport": {
+                    "type": "object",
+                    "description": (
+                        "Browser viewport in pixels. Set to the exact final "
+                        "image dimensions — e.g. Instagram 4:5 = {w:1080,h:1350}, "
+                        "LinkedIn = {w:1200,h:628}, IG Story = {w:1080,h:1920}, "
+                        "Twitter/YouTube = {w:1600,h:900}."
+                    ),
+                    "properties": {
+                        "w": {"type": "integer", "description": "Width in px (max 4096)."},
+                        "h": {"type": "integer", "description": "Height in px (max 4096)."},
+                    },
+                    "required": ["w", "h"],
+                },
+                "output_path": {
+                    "type": "string",
+                    "description": (
+                        "Workspace-relative path for the PNG. Must end in '.png'. "
+                        "Convention: 'deliverables/social/{YYYY-MM-DD}/{template}_{size}.png' "
+                        "(e.g. 'deliverables/social/2026-04-29/definition_ig_post.png'). "
+                        "Parent directories are created automatically."
+                    ),
+                },
+                "wait_for": {
+                    "type": "string",
+                    "description": (
+                        "CSS selector to await before screenshotting. Default "
+                        "'[data-render-ready=\\'true\\']' matches the Automatos "
+                        "render protocol — pages set this attribute on body once "
+                        "fonts have loaded and layout has settled."
+                    ),
+                },
+                "full_page": {
+                    "type": "boolean",
+                    "description": (
+                        "When true, capture the full scrollable height. Default "
+                        "false — social cards are sized to the viewport, so a "
+                        "viewport screenshot is what you want."
+                    ),
+                },
+            },
+            "required": ["url", "viewport", "output_path"],
+        },
+        permission_level="write",
+        tags=["workspace", "render", "html", "png", "screenshot", "social"],
+        examples=[
+            "render the definition template for instagram",
+            "screenshot the html page to a png",
+            "generate a social card png from the template",
+            "produce a 1080x1350 instagram post from the html",
+        ],
+    ))
+
+    registry.register(ActionDefinition(
         name="workspace_git",
         description=(
             "Execute a git operation in the workspace repository. Allowed operations: "

--- a/orchestrator/modules/tools/execution/exec_workspace.py
+++ b/orchestrator/modules/tools/execution/exec_workspace.py
@@ -232,6 +232,35 @@ async def execute_workspace_action(
                 args=parameters.get("args", ""),
             )
 
+        elif tool_name == "workspace_html_to_png":
+            # Render an HTML page to a PNG inside the workspace. The resulting
+            # file is auto-registered as a deliverable below (artifact_type
+            # 'image' — inferred from .png).
+            url = parameters.get("url", "")
+            output_path = parameters.get("output_path", "")
+            viewport = parameters.get("viewport") or {}
+            if not url:
+                return {"success": False, "error": "url is required", "tool": tool_name}
+            if not output_path:
+                return {"success": False, "error": "output_path is required", "tool": tool_name}
+            try:
+                viewport_w = int(viewport.get("w", 0))
+                viewport_h = int(viewport.get("h", 0))
+            except (TypeError, ValueError):
+                return {
+                    "success": False,
+                    "error": "viewport.w and viewport.h must be integers",
+                    "tool": tool_name,
+                }
+            result = await client.html_to_png(
+                url=url,
+                viewport_w=viewport_w,
+                viewport_h=viewport_h,
+                output_path=output_path,
+                wait_for=parameters.get("wait_for", "[data-render-ready='true']"),
+                full_page=bool(parameters.get("full_page", False)),
+            )
+
         else:
             return {"success": False, "error": f"Unknown workspace tool: {tool_name}", "tool": tool_name}
 
@@ -261,6 +290,21 @@ async def execute_workspace_action(
                 caller_context=caller_context,
                 trace_id=trace_id,
             )
+
+        # workspace_html_to_png writes a PNG into the workspace; register it as
+        # a deliverable using the path the worker actually wrote (post-validation).
+        # Same contract as workspace_write_file — failure must not break the render.
+        if tool_name == "workspace_html_to_png" and workspace_id:
+            written_path = result.get("file_path")
+            if written_path:
+                _auto_register_deliverable(
+                    workspace_id=workspace_id,
+                    file_path=written_path,
+                    write_result=result,
+                    agent_id=agent_id,
+                    caller_context=caller_context,
+                    trace_id=trace_id,
+                )
 
         return result
 

--- a/services/workspace-worker/Dockerfile
+++ b/services/workspace-worker/Dockerfile
@@ -26,6 +26,11 @@ RUN pip install --no-cache-dir \
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
+# Headless Chromium for workspace_html_to_png tool (PRD-social-render).
+# Installed AFTER pip so the playwright CLI is on PATH; --with-deps pulls
+# the Debian libs Chromium needs (libnss3, libatk1.0-0, libxkbcommon0, etc).
+RUN playwright install --with-deps chromium
+
 # Worker code (includes automatos_logging.py + automatos_metrics.py for observability)
 COPY . .
 

--- a/services/workspace-worker/executor.py
+++ b/services/workspace-worker/executor.py
@@ -324,6 +324,201 @@ class WorkspaceToolExecutor:
             return {"error": f"Create directory error: {e}"}
 
     # =========================================================================
+    # Headless rendering — HTML → PNG
+    # =========================================================================
+    #
+    # Powers the `workspace_html_to_png` tool. Renders an arbitrary URL (file://
+    # or http(s)://) to a PNG inside the workspace, then returns the relative
+    # path. The orchestrator's exec_workspace layer auto-registers the resulting
+    # PNG as a deliverable (artifact_type='image') so it appears in the
+    # Deliverables Gallery, Workspace Explorer, and Mission Outputs view.
+    #
+    # Designed for the daily-social-post playbook: an agent writes
+    # `repos/automatos-social/render/index.html` parameters, calls this tool,
+    # and gets back a path it can hand to a Composio poster.
+
+    # Hard cap on render time. Pages with no animation should be done in <2s.
+    _RENDER_TIMEOUT_MS = 30_000
+    # Cap viewport so an agent can't request a 32k×32k canvas and OOM the worker.
+    _MAX_VIEWPORT_DIM = 4096
+
+    async def html_to_png(
+        self,
+        url: str,
+        viewport_w: int,
+        viewport_h: int,
+        output_path: str,
+        wait_for: str = "[data-render-ready='true']",
+        full_page: bool = False,
+    ) -> Dict[str, Any]:
+        """Render an HTML page to a PNG file inside the workspace.
+
+        Args:
+            url: Absolute URL to render. Either ``file://`` (must resolve to a
+                path inside this workspace) or ``http(s)://``. Anything else is
+                rejected.
+            viewport_w / viewport_h: Browser viewport in pixels. Capped at
+                ``_MAX_VIEWPORT_DIM`` per side.
+            output_path: Workspace-relative path for the PNG. Parents are
+                created. Must end in ``.png``.
+            wait_for: CSS selector to await before screenshotting. Default
+                matches the Automatos render protocol — pages set
+                ``document.body[data-render-ready="true"]`` once fonts load
+                and layout settles.
+            full_page: When True, capture the entire scroll height instead of
+                just the viewport. Default False — social cards are designed
+                to the viewport so a viewport screenshot is what we want.
+
+        Returns:
+            On success::
+
+                {
+                    "success": True,
+                    "file_path": "deliverables/social/2026-04-29/definition_ig_post.png",
+                    "file_size_bytes": 187432,
+                    "w": 1080, "h": 1350,
+                    "ms": 1842,
+                    "url": "<the input url>",
+                }
+
+            On failure, ``{"success": False, "error": "..."}`` — caller
+            (worker HTTP handler) translates to a 4xx response.
+        """
+        import time
+
+        # ── Validate output path ──────────────────────────────────────
+        if not output_path or not output_path.lower().endswith(".png"):
+            return {"success": False, "error": "output_path must end in .png"}
+
+        try:
+            safe_output = self.ws.resolve_safe_path(output_path)
+        except SecurityError as e:
+            return {"success": False, "error": f"Invalid output_path: {e}"}
+
+        # ── Validate viewport ─────────────────────────────────────────
+        if viewport_w <= 0 or viewport_h <= 0:
+            return {"success": False, "error": "viewport dimensions must be positive"}
+        if viewport_w > self._MAX_VIEWPORT_DIM or viewport_h > self._MAX_VIEWPORT_DIM:
+            return {
+                "success": False,
+                "error": (
+                    f"viewport exceeds max dimension {self._MAX_VIEWPORT_DIM}px "
+                    f"(got {viewport_w}×{viewport_h})"
+                ),
+            }
+
+        # ── Validate URL scheme ──────────────────────────────────────
+        # file:// must point inside this workspace. http(s):// is fine because
+        # the worker container has no inbound network path back to the
+        # orchestrator; outbound HTTPS to render templates from CDNs is OK.
+        if url.startswith("file://"):
+            file_path = url[len("file://"):]
+            # file:// URLs may have an empty host before the path; strip a
+            # leading slash if the path looks absolute.
+            try:
+                resolved_target = Path(file_path).resolve()
+                # Containment check: the target file must live inside this
+                # workspace's root (so an agent cannot screenshot, say,
+                # /etc/passwd via file:///etc/passwd).
+                ws_root = self.ws.root.resolve()
+                resolved_target.relative_to(ws_root)
+            except (ValueError, OSError) as e:
+                return {
+                    "success": False,
+                    "error": f"file:// URL must point inside the workspace: {e}",
+                }
+            if not resolved_target.exists():
+                return {
+                    "success": False,
+                    "error": f"file:// target does not exist: {file_path}",
+                }
+        elif not (url.startswith("http://") or url.startswith("https://")):
+            return {
+                "success": False,
+                "error": "url must be file://, http://, or https://",
+            }
+
+        # ── Render ────────────────────────────────────────────────────
+        try:
+            from playwright.async_api import async_playwright, TimeoutError as PWTimeout
+        except ImportError:
+            return {
+                "success": False,
+                "error": "playwright not installed in worker — check requirements.txt",
+            }
+
+        start = time.monotonic()
+        safe_output.parent.mkdir(parents=True, exist_ok=True)
+
+        try:
+            async with async_playwright() as pw:
+                # `--no-sandbox` because the worker container runs as a non-root
+                # user without the kernel capabilities Chromium's sandbox needs.
+                # Acceptable here: we already validated URL containment, and
+                # the worker is itself the sandbox boundary.
+                browser = await pw.chromium.launch(
+                    args=["--no-sandbox", "--disable-dev-shm-usage"],
+                )
+                try:
+                    context = await browser.new_context(
+                        viewport={"width": int(viewport_w), "height": int(viewport_h)},
+                        device_scale_factor=1,
+                    )
+                    page = await context.new_page()
+                    try:
+                        await page.goto(url, wait_until="load", timeout=self._RENDER_TIMEOUT_MS)
+                        if wait_for:
+                            await page.wait_for_selector(
+                                wait_for, timeout=self._RENDER_TIMEOUT_MS
+                            )
+                        await page.screenshot(
+                            path=str(safe_output),
+                            type="png",
+                            full_page=bool(full_page),
+                            omit_background=False,
+                        )
+                    finally:
+                        await context.close()
+                finally:
+                    await browser.close()
+        except PWTimeout as e:
+            return {
+                "success": False,
+                "error": f"render timed out waiting for '{wait_for}': {e}",
+            }
+        except Exception as e:
+            logger.error(
+                "html_to_png failed in %s: %s", self.ws.workspace_id[:8], e,
+                exc_info=True,
+            )
+            return {"success": False, "error": f"render error: {e}"}
+
+        elapsed_ms = int((time.monotonic() - start) * 1000)
+
+        try:
+            file_size = safe_output.stat().st_size
+        except OSError:
+            file_size = 0
+
+        rel_path = str(safe_output.relative_to(self.ws.root))
+
+        logger.info(
+            "html_to_png ok ws=%s path=%s %dx%d %dms %dB",
+            self.ws.workspace_id[:8], rel_path,
+            viewport_w, viewport_h, elapsed_ms, file_size,
+        )
+
+        return {
+            "success": True,
+            "file_path": rel_path,
+            "file_size_bytes": file_size,
+            "w": int(viewport_w),
+            "h": int(viewport_h),
+            "ms": elapsed_ms,
+            "url": url,
+        }
+
+    # =========================================================================
     # High-level task steps (called by worker main)
     # =========================================================================
 

--- a/services/workspace-worker/main.py
+++ b/services/workspace-worker/main.py
@@ -798,6 +798,68 @@ class WorkspaceWorker:
             result = await executor.execute_command(command, timeout=120, cwd=cwd)
             return web.json_response(result)
 
+        async def html_to_png_handler(request):
+            """POST /workspaces/{workspace_id}/html-to-png — render HTML → PNG.
+
+            Body:
+                {
+                  "url": "file:///workspaces/{id}/repos/automatos-social/render/index.html?...",
+                  "viewport": {"w": 1080, "h": 1350},
+                  "output_path": "deliverables/social/2026-04-29/definition_ig_post.png",
+                  "wait_for": "[data-render-ready='true']",   # optional
+                  "full_page": false                            # optional
+                }
+
+            Response: see WorkspaceToolExecutor.html_to_png().
+            """
+            from executor import WorkspaceToolExecutor
+            from pathlib import Path as P
+
+            workspace_id = request.match_info["workspace_id"]
+            ws_dir = P(volume_path) / workspace_id
+            if not ws_dir.is_dir():
+                return web.json_response({"error": "Workspace not found"}, status=404)
+
+            try:
+                body = await request.json()
+            except Exception:
+                return web.json_response({"error": "Invalid JSON body"}, status=400)
+
+            url = (body.get("url") or "").strip()
+            output_path = (body.get("output_path") or "").strip()
+            viewport = body.get("viewport") or {}
+            wait_for = body.get("wait_for", "[data-render-ready='true']")
+            full_page = bool(body.get("full_page", False))
+
+            if not url:
+                return web.json_response({"error": "url is required"}, status=400)
+            if not output_path:
+                return web.json_response({"error": "output_path is required"}, status=400)
+
+            try:
+                viewport_w = int(viewport.get("w", 0))
+                viewport_h = int(viewport.get("h", 0))
+            except (TypeError, ValueError):
+                return web.json_response(
+                    {"error": "viewport.w and viewport.h must be integers"}, status=400,
+                )
+
+            ws_manager = WorkspaceManager(workspace_id, volume_path)
+            executor = WorkspaceToolExecutor(ws_manager)
+            result = await executor.html_to_png(
+                url=url,
+                viewport_w=viewport_w,
+                viewport_h=viewport_h,
+                output_path=output_path,
+                wait_for=wait_for,
+                full_page=full_page,
+            )
+            if not result.get("success"):
+                # Validation errors → 400. Render errors (timeout, browser
+                # crash) also → 400 since they're caller-fixable in practice.
+                return web.json_response(result, status=400)
+            return web.json_response(result)
+
         async def download_file_handler(request):
             """GET /workspaces/{workspace_id}/files/download — raw binary download."""
             from pathlib import Path as P
@@ -842,6 +904,7 @@ class WorkspaceWorker:
         app.router.add_get("/workspaces/{workspace_id}/files/grep", grep_handler)
         app.router.add_get("/workspaces/{workspace_id}/files/download", download_file_handler)
         app.router.add_post("/workspaces/{workspace_id}/git", git_handler)
+        app.router.add_post("/workspaces/{workspace_id}/html-to-png", html_to_png_handler)
 
         runner = web.AppRunner(app)
         await runner.setup()

--- a/services/workspace-worker/requirements.txt
+++ b/services/workspace-worker/requirements.txt
@@ -17,3 +17,6 @@ psycopg2-binary>=2.9.0,<3.0.0
 
 # Observability
 prometheus_client>=0.20.0,<1.0.0
+
+# Headless browser rendering (workspace_html_to_png tool)
+playwright>=1.45.0,<2.0.0


### PR DESCRIPTION
Add a workspace tool that renders HTML pages (file:// inside the workspace, or http(s)://) to PNG via Playwright + Chromium running in the workspace worker. Output PNGs are written to disk and auto-registered as deliverables (artifact_type=image) using the same path as workspace_write_file, so they appear in Deliverables Gallery / Workspace Explorer / Mission Outputs with no extra plumbing.

Designed for the daily-social-post playbook: an agent calls this with a file:// URL pointing at repos/automatos-social/render/index.html?... and gets back a workspace-relative PNG path it can hand to a Composio poster.

Worker (services/workspace-worker/):
  - requirements.txt: playwright>=1.45,<2
  - Dockerfile: playwright install --with-deps chromium
  - executor.py: WorkspaceToolExecutor.html_to_png() — validates output_path via resolve_safe_path, caps viewport at 4096px, enforces file:// URLs stay inside the workspace root, 30s timeout, --no-sandbox (worker is the sandbox boundary)
  - main.py: POST /workspaces/{id}/html-to-png handler + route

Orchestrator:
  - core/workspace_client.py: WorkspaceClient.html_to_png() proxy
  - modules/tools/execution/exec_workspace.py: route the action and call _auto_register_deliverable() on success using the worker-returned path
  - modules/tools/discovery/workspace_actions.py: ActionDefinition with full input schema (url, viewport.{w,h}, output_path, wait_for, full_page)
  - consumers/chatbot/auto.py: Tier 2 keywords for routing