### PR TITLE
fix(deliverables): shrink Created Today artwork to 64px centered tile

### DIFF
--- a/frontend/components/deliverables/created-today.tsx
+++ b/frontend/components/deliverables/created-today.tsx
@@ -93,7 +93,9 @@ function TodayCard({ deliverable, onClick }: TodayCardProps) {
             className="h-full w-full object-cover"
           />
         ) : (
-          <DeliverableArtwork type={artifact_type} className="absolute inset-0" />
+          <div className="h-16 w-16 overflow-hidden rounded-md">
+            <DeliverableArtwork type={artifact_type} />
+          </div>
         )}
         <Badge
           variant="secondary"


### PR DESCRIPTION
Hero artwork was full-bleed (224x112) which felt heavy and cropped the square SVG. Constrain to a 64x64 centered tile so the card breathes and the iconography reads cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined non-image thumbnail display in deliverables cards with improved sizing, rounded corners, and better overflow handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->