### PR TITLE
fix(agents): show team/category on roster card instead of raw agent_type

### DIFF
--- a/frontend/components/agents/agent-roster.tsx
+++ b/frontend/components/agents/agent-roster.tsx
@@ -52,6 +52,7 @@ import { AgentConfigurationModal } from './agent-configuration-modal'
 import { AgentStatusControlModal } from './agent-status-control-modal'
 import { AgentConfirmDeleteModal } from './agent-confirm-delete-modal'
 import { ToolLogo } from '@/components/ui/tool-logo'
+import { getAgentCategoryDisplay } from '@/lib/agent-constants'
 
 // Agent type/category icons mapping - SIMPLE clean icons only!
 const getAgentIcon = (agentType: string, category?: string) => {
@@ -328,7 +329,7 @@ export function AgentRoster({
                       </StatusBadge>
                     </div>
                     <div className="flex items-center gap-2 text-xs text-muted-foreground mt-0.5">
-                      <span>{agent.agent_type ? agent.agent_type.replace('_', ' ') : 'Unknown'}</span>
+                      <span>{getAgentCategoryDisplay(agent)}</span>
                       <span>&middot;</span>
                       <span>{getModelDisplayName(agent.agent_model_config?.model_id)}</span>
                       <span>&middot;</span>
@@ -416,7 +417,7 @@ export function AgentRoster({
                     )}
                     <div>
                       <h3 className="font-semibold">{agent.name || 'Unknown Agent'}</h3>
-                      <p className="text-xs text-muted-foreground">{agent.agent_type ? agent.agent_type.replace('_', ' ') : 'Unknown Type'}</p>
+                      <p className="text-xs text-muted-foreground">{getAgentCategoryDisplay(agent)}</p>
                     </div>
                   </div>
 

--- a/frontend/lib/agent-constants.ts
+++ b/frontend/lib/agent-constants.ts
@@ -102,3 +102,29 @@ export const DB_TO_CATEGORY_MAP: Record<string, string> = {
   'document generator': 'writing',
   custom: 'custom',
 }
+
+/**
+ * Resolve an agent's user-facing category/team name (e.g. "Research", "Sales").
+ *
+ * Mirrors the precedence used by the Agent Configuration modal so the roster
+ * card and the modal stay in sync:
+ *   1. marketplace_category — set when the agent was installed from a template
+ *   2. configuration.category — set when an admin picks a category in Configure
+ *   3. DB_TO_CATEGORY_MAP[agent_type] — fallback for legacy agents
+ *
+ * The result is normalized to the title-case display name from
+ * AGENT_CATEGORIES when the value matches a known category id.
+ */
+export function getAgentCategoryDisplay(agent: any): string {
+  const raw =
+    agent?.marketplace_category ||
+    agent?.configuration?.category ||
+    DB_TO_CATEGORY_MAP[agent?.agent_type || ''] ||
+    agent?.agent_type ||
+    'Custom'
+
+  const known = AGENT_CATEGORIES.find(
+    (c) => c.id === String(raw).toLowerCase(),
+  )
+  return known ? known.name : String(raw)
+}


### PR DESCRIPTION
The roster card subtitle was rendering agent.agent_type directly, so a custom-typed agent like SCOUT (configured into the Research team) showed "custom" on its card while the Configure tab correctly showed "Research".

Add getAgentCategoryDisplay() helper to agent-constants.ts that resolves the category using the same precedence as the Configuration modal — marketplace_category → configuration.category → DB_TO_CATEGORY_MAP[agent_type] — and normalizes to the title-case display name from AGENT_CATEGORIES.

Use it in both the list and grid views of agent-roster.tsx so the card subtitle now matches the team you see in Configure (e.g. "Research" for SCOUT, "Sales" for marketplace sales agents, etc.).