### PR TITLE
feat: promote workspace_html_to_png to first-class tool

### DIFF
--- a/orchestrator/modules/tools/discovery/workspace_actions.py
+++ b/orchestrator/modules/tools/discovery/workspace_actions.py
@@ -265,6 +265,7 @@ def register_workspace_actions(registry: ActionRegistry) -> None:
             "required": ["url", "viewport", "output_path"],
         },
         permission_level="write",
+        promoted=True,
         tags=["workspace", "render", "html", "png", "screenshot", "social"],
         examples=[
             "render the definition template for instagram",


### PR DESCRIPTION
Set promoted=True on the workspace_html_to_png ActionDefinition so it gets its own OpenAI tool schema instead of being hidden behind the platform_execute dispatcher. Auto and any agent with this action enabled now sees workspace_html_to_png as a directly-callable tool in their tool list.

Behaviour unchanged — the executor path at exec_workspace.py already handles the promoted call shape via the same workspace_html_to_png branch.