### PR TITLE
feat(agents): add job_title field and surface team + role on roster card

### DIFF
--- a/frontend/components/agents/agent-configuration-modal.tsx
+++ b/frontend/components/agents/agent-configuration-modal.tsx
@@ -431,6 +431,7 @@ export function AgentConfigurationModal({
       setFormData({
         name: (agent as any).name || '',
         description: (agent as any).description || '',
+        job_title: (agent as any).job_title || '',
         tags: Array.isArray((agent as any).tags) ? ((agent as any).tags as string[]).join(', ') : '',
         agent_type: categoryName,
         priority_level: (agentConfig as any).priority_level || 'medium',
@@ -660,6 +661,7 @@ export function AgentConfigurationModal({
       const updatePayload = {
         name: formData.name,
         description: formData.description,
+        job_title: (formData.job_title || '').trim(),
         agent_type: dbAgentType,
         marketplace_category: selectedCategory,
         tags,
@@ -855,6 +857,21 @@ export function AgentConfigurationModal({
                           placeholder="Enter agent description"
                           rows={3}
                         />
+                      </div>
+
+                      <div className="space-y-2">
+                        <Label htmlFor="job_title">Job Title</Label>
+                        <Input
+                          id="job_title"
+                          value={formData.job_title || ''}
+                          onChange={(e) => updateFormData('job_title', e.target.value)}
+                          placeholder="e.g. Lead Intelligence, Code Watchdog, Memory Keeper"
+                          maxLength={120}
+                        />
+                        <p className="text-xs text-muted-foreground">
+                          Short role label shown under the agent&apos;s name on the roster card
+                          (e.g. &quot;Research &middot; Lead Intelligence&quot;).
+                        </p>
                       </div>
 
                       <div className="space-y-2">

--- a/frontend/components/agents/agent-roster.tsx
+++ b/frontend/components/agents/agent-roster.tsx
@@ -52,6 +52,7 @@ import { AgentConfigurationModal } from './agent-configuration-modal'
 import { AgentStatusControlModal } from './agent-status-control-modal'
 import { AgentConfirmDeleteModal } from './agent-confirm-delete-modal'
 import { ToolLogo } from '@/components/ui/tool-logo'
+import { getAgentRoleLine } from '@/lib/agent-constants'
 
 // Agent type/category icons mapping - SIMPLE clean icons only!
 const getAgentIcon = (agentType: string, category?: string) => {
@@ -136,6 +137,7 @@ interface AgentWithPerformance {
   agent_type: string
   status: string
   description?: string
+  job_title?: string
   created_at?: string
   skills?: Array<{ id: string; name: string }>
   plugins?: Array<{ plugin_id: string; slug: string; name: string; skills_count: number; commands_count: number }>
@@ -328,7 +330,7 @@ export function AgentRoster({
                       </StatusBadge>
                     </div>
                     <div className="flex items-center gap-2 text-xs text-muted-foreground mt-0.5">
-                      <span>{agent.agent_type ? agent.agent_type.replace('_', ' ') : 'Unknown'}</span>
+                      <span className="truncate">{getAgentRoleLine(agent)}</span>
                       <span>&middot;</span>
                       <span>{getModelDisplayName(agent.agent_model_config?.model_id)}</span>
                       <span>&middot;</span>
@@ -416,7 +418,7 @@ export function AgentRoster({
                     )}
                     <div>
                       <h3 className="font-semibold">{agent.name || 'Unknown Agent'}</h3>
-                      <p className="text-xs text-muted-foreground">{agent.agent_type ? agent.agent_type.replace('_', ' ') : 'Unknown Type'}</p>
+                      <p className="text-xs text-muted-foreground truncate">{getAgentRoleLine(agent)}</p>
                     </div>
                   </div>
 

--- a/frontend/lib/agent-constants.ts
+++ b/frontend/lib/agent-constants.ts
@@ -102,3 +102,40 @@ export const DB_TO_CATEGORY_MAP: Record<string, string> = {
   'document generator': 'writing',
   custom: 'custom',
 }
+
+/**
+ * Resolve an agent's user-facing category/team name (e.g. "Research", "Sales").
+ *
+ * Mirrors the precedence used by the Agent Configuration modal so the roster
+ * card and the modal stay in sync:
+ *   1. marketplace_category — set when the agent was installed from a template
+ *   2. configuration.category — set when an admin picks a category in Configure
+ *   3. DB_TO_CATEGORY_MAP[agent_type] — fallback for legacy agents
+ *
+ * The result is normalized to the title-case display name from
+ * AGENT_CATEGORIES when the value matches a known category id.
+ */
+export function getAgentCategoryDisplay(agent: any): string {
+  const raw =
+    agent?.marketplace_category ||
+    agent?.configuration?.category ||
+    DB_TO_CATEGORY_MAP[agent?.agent_type || ''] ||
+    agent?.agent_type ||
+    'Custom'
+
+  const known = AGENT_CATEGORIES.find(
+    (c) => c.id === String(raw).toLowerCase(),
+  )
+  return known ? known.name : String(raw)
+}
+
+/**
+ * Compose the card subtitle as `{Category} · {Job Title}`.
+ * Falls back to just the category when no job title has been set, so the
+ * card always tells the user which team the agent belongs to.
+ */
+export function getAgentRoleLine(agent: any): string {
+  const category = getAgentCategoryDisplay(agent)
+  const jobTitle = (agent?.job_title || '').trim()
+  return jobTitle ? `${category} · ${jobTitle}` : category
+}

--- a/orchestrator/alembic/versions/add_job_title_to_agents.py
+++ b/orchestrator/alembic/versions/add_job_title_to_agents.py
@@ -1,0 +1,29 @@
+"""Add job_title column to agents table
+
+Lets users give each agent a short role label (e.g. "Lead Intelligence",
+"Code Watchdog", "Memory Keeper") shown alongside their codename on the
+roster card. Keeps the codenames as identity while making the team's
+purpose scannable.
+
+Standalone migration (down_revision = None).
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "add_job_title_to_agents"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "agents",
+        sa.Column("job_title", sa.String(length=120), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("agents", "job_title")

--- a/orchestrator/api/agents.py
+++ b/orchestrator/api/agents.py
@@ -247,6 +247,7 @@ def _build_agent_response(agent: Agent, db: Session) -> AgentResponse:
         public_id=str(agent.public_id) if getattr(agent, 'public_id', None) else None,
         name=agent.name,
         description=agent.description,
+        job_title=getattr(agent, 'job_title', None),
         agent_type=agent.agent_type,
         status=agent.status,
         configuration=configuration,
@@ -422,6 +423,7 @@ async def create_agent(agent_data: AgentCreate, ctx: RequestContext = Depends(ge
             public_id=_uuid4(),
             name=agent_data.name,
             description=agent_data.description,
+            job_title=getattr(agent_data, 'job_title', None),
             agent_type=agent_data.agent_type,
             configuration=agent_data.configuration or {},
             marketplace_category=getattr(agent_data, 'marketplace_category', None),
@@ -824,7 +826,12 @@ async def update_agent(agent_id: int, agent_update: AgentUpdate, ctx: RequestCon
         
         if agent_update.description is not None:
             agent.description = agent_update.description
-        
+
+        if agent_update.job_title is not None:
+            # Empty string clears the job title; non-empty stores the trimmed value.
+            trimmed = agent_update.job_title.strip()
+            agent.job_title = trimmed if trimmed else None
+
         if agent_update.status is not None:
             agent.status = agent_update.status.value
 

--- a/orchestrator/core/models/core.py
+++ b/orchestrator/core/models/core.py
@@ -180,6 +180,7 @@ class Agent(Base):
     public_id = Column(UUID(as_uuid=True), default=uuid4, unique=True, nullable=True, index=True)
     name = Column(String(255), nullable=False)
     description = Column(Text)
+    job_title = Column(String(120), nullable=True)  # Short role label shown on cards (e.g. "Lead Intelligence")
     agent_type = Column(String(100), nullable=False)  # 'custom', 'system', 'specialized'
     status = Column(String(50), default='active')  # 'active', 'inactive', 'training'
     configuration = Column(JSON)  # Agent-specific config
@@ -633,6 +634,7 @@ class ExecutionStatus(str, Enum):
 class AgentCreate(BaseModel):
     name: str = Field(..., min_length=1, max_length=255)
     description: Optional[str] = None
+    job_title: Optional[str] = Field(None, max_length=120)
     agent_type: str  # Flexible agent type - no enum restriction
     configuration: Optional[Dict[str, Any]] = None
     skill_ids: Optional[List[int]] = []
@@ -643,6 +645,7 @@ class AgentCreate(BaseModel):
 class AgentUpdate(BaseModel):
     name: Optional[str] = None
     description: Optional[str] = None
+    job_title: Optional[str] = Field(None, max_length=120)
     agent_type: Optional[str] = None  # Allow updating agent type/category
     marketplace_category: Optional[str] = None  # UI category (Research, Marketing, etc.)
     status: Optional[AgentStatus] = None
@@ -657,6 +660,7 @@ class AgentResponse(BaseModel):
     public_id: Optional[str] = None  # UUID exposed externally (widgets, API); use this instead of id
     name: str
     description: Optional[str]
+    job_title: Optional[str] = None
     agent_type: str
     status: str
     configuration: Optional[Dict[str, Any]]


### PR DESCRIPTION
The roster card was hard to scan once you had 30+ agents — codenames like SCOUT/SENTINEL/ORACLE are great for identity but say nothing about what each agent actually does, and the only subtitle was the raw agent_type (usually "custom"). This change keeps the codenames and adds a real role line beneath them.

Backend:
- Agent.job_title — nullable VARCHAR(120) on the agents table
- AgentCreate / AgentUpdate / AgentResponse — accept and return job_title
- POST /agents and PATCH /agents/{id} persist it; empty string clears
- alembic/add_job_title_to_agents.py — standalone migration adding the column

Frontend:
- agent-constants.ts: new getAgentRoleLine(agent) returns "{Category} · {Job Title}" (or just the category when no title is set), built on top of getAgentCategoryDisplay() so the card resolves the team using the same precedence as the Configuration modal
- agent-roster.tsx: both list and grid views now render the role line under the agent name instead of agent_type ("custom")
- agent-configuration-modal.tsx: new Job Title input under Description with helper text and a 120-char cap; saves via the existing PATCH payload

Existing agents render "{Category}" until an admin sets a job title in Configure.