### PR TITLE
feat(agents): workspace Skills tab with fork-on-edit + scanner-backed…

### DIFF
--- a/frontend/components/activity/activity-feed-item.tsx
+++ b/frontend/components/activity/activity-feed-item.tsx
@@ -112,7 +112,7 @@ function getConfigureUrl(item: ActivityFeedItem): string | null {
     case 'routine':
       return item.agent?.id ? `/agents?agent=${item.agent.id}` : null
     case 'recipe':
-      return item.source_id ? `/agents?tab=recipes&recipe=${item.source_id}` : null
+      return item.source_id ? `/assignments?tab=playbooks&recipe=${item.source_id}` : null
     case 'mission':
       return null
     default:

--- a/frontend/components/agents/agent-management.tsx
+++ b/frontend/components/agents/agent-management.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect } from 'react'
 import { motion } from 'framer-motion'
 import { useInView } from 'react-intersection-observer'
 import { Badge } from '@/components/ui/badge'
@@ -12,10 +12,10 @@ import {
   Users,
   Zap,
   AlertTriangle,
-  ChefHat,
   RefreshCw,
   Network,
   Activity,
+  Brain,
 } from 'lucide-react'
 
 // Shared components
@@ -30,8 +30,7 @@ import { useViewMode } from '@/hooks/use-view-mode'
 import { AgentRoster } from './agent-roster'
 
 import { AgentConfiguration } from './agent-configuration'
-import { AgentCoordination } from './agent-coordination'
-import { PlaybooksTab } from '@/components/workflows/playbooks-tab'
+import { WorkspaceSkillsTab } from './skills/workspace-skills-tab'
 import { CreateAgentModal } from './create-agent-modal'
 import { AgentDetailsModal } from './agent-details-modal'
 import { OrgChartTab } from './org-chart-tab'
@@ -128,19 +127,11 @@ export function AgentManagement() {
     }
   }
 
-  // Navigate to ExecutionKitchen when a recipe is cooked
-  const handleExecuteRecipe = useCallback((_workflowId: number, info?: { recipeExecutionId: string; recipeId: string }) => {
-    if (info) {
-      window.location.href = `/activity/execution?id=${info.recipeExecutionId}&recipeId=${info.recipeId}`
-    }
-  }, [])
-
   const tabDefs = [
     { value: 'roster', label: 'Agent Roster', icon: Users },
     { value: 'org-chart', label: 'Org Chart', icon: Network },
     { value: 'configuration', label: 'Configuration', icon: Settings },
-    { value: 'coordination', label: 'Coordination', icon: Users },
-    { value: 'recipes', label: 'Playbooks', icon: ChefHat },
+    { value: 'skills', label: 'Skills', icon: Brain },
   ]
 
   return (
@@ -150,7 +141,7 @@ export function AgentManagement() {
       <PageHeader
         title="Agent"
         titleAccent="Management"
-        subtitle="Manage your AI agents, capabilities, and coordination strategies"
+        subtitle="Manage your AI agents and their capabilities"
         actions={
           <>
             {!!agentsError && (
@@ -275,15 +266,8 @@ export function AgentManagement() {
             />
           </TabsContent>
 
-          <TabsContent value="coordination" className="space-y-6">
-            <AgentCoordination
-              agents={agents as any[]}
-              selectedAgentId={selectedAgentId}
-            />
-          </TabsContent>
-
-          <TabsContent value="recipes" className="space-y-6">
-            <PlaybooksTab onUseRecipe={() => {}} onExecuteRecipe={handleExecuteRecipe} />
+          <TabsContent value="skills" className="space-y-6">
+            <WorkspaceSkillsTab />
           </TabsContent>
         </FilterTabs>
       </motion.div>

--- a/frontend/components/agents/skills/skill-editor-modal.tsx
+++ b/frontend/components/agents/skills/skill-editor-modal.tsx
@@ -1,0 +1,598 @@
+/**
+ * Skill Editor Modal — view / edit / new modes in one component.
+ *
+ * - 'view'  : read-only render of an existing skill
+ * - 'edit'  : edit a workspace-owned skill, OR fork-on-save for marketplace skills
+ * - 'new'   : create a workspace skill from pasted content or a dropped .md file
+ *
+ * Save runs through the workspace skills API which calls plugin_security_scanner.
+ * Critical findings hard-block; high findings show inline warnings + an
+ * "I understand, save anyway" toggle.
+ */
+
+'use client'
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  AlertTriangle,
+  Brain,
+  Eye,
+  GitBranch,
+  Loader2,
+  Pencil,
+  Plus,
+  Save,
+  ShieldAlert,
+  Trash2,
+  Upload,
+  UserPlus,
+} from 'lucide-react'
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Badge } from '@/components/ui/badge'
+import { Textarea } from '@/components/ui/textarea'
+import { Checkbox } from '@/components/ui/checkbox'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { useToast } from '@/hooks/use-toast'
+import { useWorkspace } from '@/components/workspace-provider'
+import { useAgents } from '@/hooks/use-agent-api'
+import {
+  useSkillsApi,
+  SkillScanError,
+  type ScannerFinding,
+  type WorkspaceSkillContent,
+} from '@/hooks/use-skills-api'
+
+export type SkillEditorMode = 'view' | 'edit' | 'new'
+
+interface Props {
+  open: boolean
+  mode: SkillEditorMode
+  skillId: number | null
+  onClose: (didChange: boolean) => void
+}
+
+const MAX_UPLOAD_BYTES = 256 * 1024 // 256KB — plenty for SKILL.md
+
+const SAMPLE_SKELETON = `---
+name: my-new-skill
+description: One-line summary of what this skill does
+category: marketing
+tags:
+  - example
+version: 1.0.0
+---
+
+# My New Skill
+
+## When to use
+Describe the situations where the agent should reach for this skill.
+
+## How it works
+Step-by-step instructions the agent should follow.
+
+## Example
+A concrete worked example so the agent can pattern-match.
+`
+
+export function SkillEditorModal({ open, mode: initialMode, skillId, onClose }: Props) {
+  const { workspace } = useWorkspace()
+  const { toast } = useToast()
+  const { data: agents = [] } = useAgents()
+  const {
+    getWorkspaceSkillContent,
+    createWorkspaceSkill,
+    updateWorkspaceSkill,
+    deleteWorkspaceSkill,
+    assignSkillsToAgent,
+  } = useSkillsApi()
+
+  const [mode, setMode] = useState<SkillEditorMode>(initialMode)
+  const [skill, setSkill] = useState<WorkspaceSkillContent | null>(null)
+  const [name, setName] = useState('')
+  const [description, setDescription] = useState('')
+  const [category, setCategory] = useState('')
+  const [tagsCsv, setTagsCsv] = useState('')
+  const [content, setContent] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [findings, setFindings] = useState<ScannerFinding[]>([])
+  const [acknowledgeWarnings, setAcknowledgeWarnings] = useState(false)
+  const [confirmDelete, setConfirmDelete] = useState(false)
+  const [assignAgentId, setAssignAgentId] = useState<string>('')
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  const isView = mode === 'view'
+  const isNew = mode === 'new'
+  const willFork = mode === 'edit' && skill?.origin === 'marketplace'
+
+  // Load when opened
+  useEffect(() => {
+    if (!open) return
+    setMode(initialMode)
+    setFindings([])
+    setAcknowledgeWarnings(false)
+    setConfirmDelete(false)
+    setAssignAgentId('')
+
+    if (initialMode === 'new' || skillId === null) {
+      setSkill(null)
+      setName('')
+      setDescription('')
+      setCategory('')
+      setTagsCsv('')
+      setContent(SAMPLE_SKELETON)
+      return
+    }
+
+    if (!workspace?.id) return
+    setLoading(true)
+    getWorkspaceSkillContent(workspace.id, skillId)
+      .then((data) => {
+        setSkill(data)
+        setName(data.name)
+        setDescription(data.description ?? '')
+        setCategory(data.category ?? '')
+        setTagsCsv((data.tags ?? []).join(', '))
+        setContent(data.content ?? '')
+      })
+      .catch((err) => {
+        toast({ title: 'Failed to load skill', description: err.message, variant: 'destructive' })
+        onClose(false)
+      })
+      .finally(() => setLoading(false))
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, initialMode, skillId, workspace?.id])
+
+  const tagList = useMemo(
+    () => tagsCsv.split(',').map((t) => t.trim()).filter(Boolean),
+    [tagsCsv],
+  )
+
+  const tokenEstimate = useMemo(() => Math.ceil(content.length / 4), [content])
+
+  const handleFilePick = useCallback((files: FileList | null) => {
+    const file = files?.[0]
+    if (!file) return
+    if (file.size > MAX_UPLOAD_BYTES) {
+      toast({
+        title: 'File too large',
+        description: `Max ${MAX_UPLOAD_BYTES / 1024} KB. Got ${(file.size / 1024).toFixed(1)} KB.`,
+        variant: 'destructive',
+      })
+      return
+    }
+    if (!/\.(md|markdown|txt)$/i.test(file.name)) {
+      toast({
+        title: 'Unsupported file type',
+        description: 'Only .md, .markdown, or .txt files are accepted.',
+        variant: 'destructive',
+      })
+      return
+    }
+    const reader = new FileReader()
+    reader.onload = () => {
+      const text = typeof reader.result === 'string' ? reader.result : ''
+      setContent(text)
+    }
+    reader.onerror = () => {
+      toast({ title: 'Read failed', description: 'Could not read the file.', variant: 'destructive' })
+    }
+    reader.readAsText(file)
+  }, [toast])
+
+  const handleSave = useCallback(async () => {
+    if (!workspace?.id) return
+    setSaving(true)
+    setFindings([])
+    try {
+      if (isNew) {
+        if (!name.trim()) {
+          toast({ title: 'Name required', variant: 'destructive' })
+          setSaving(false)
+          return
+        }
+        const result = await createWorkspaceSkill(workspace.id, {
+          name: name.trim(),
+          content,
+          description: description.trim() || undefined,
+          category: category.trim() || undefined,
+          tags: tagList.length ? tagList : undefined,
+          acknowledge_warnings: acknowledgeWarnings,
+        })
+        setFindings(result.warnings ?? [])
+        onClose(true)
+        return
+      }
+
+      if (skillId === null) return
+      const result = await updateWorkspaceSkill(workspace.id, skillId, {
+        content,
+        description: description.trim() || undefined,
+        category: category.trim() || undefined,
+        tags: tagList.length ? tagList : undefined,
+        acknowledge_warnings: acknowledgeWarnings,
+      })
+      setFindings(result.warnings ?? [])
+      onClose(true)
+    } catch (err: any) {
+      if (err instanceof SkillScanError) {
+        setFindings(err.findings)
+        if (err.status === 'warnings') {
+          // High-severity — let the user toggle the acknowledge box and retry
+          toast({
+            title: 'Review warnings',
+            description: 'High-severity findings — confirm and save again to proceed.',
+          })
+        } else {
+          toast({
+            title: 'Skill blocked',
+            description: 'Critical security findings must be removed before saving.',
+            variant: 'destructive',
+          })
+        }
+      }
+      // Non-scan errors already toasted by the hook
+    } finally {
+      setSaving(false)
+    }
+  }, [workspace?.id, isNew, skillId, name, content, description, category, tagList, acknowledgeWarnings, createWorkspaceSkill, updateWorkspaceSkill, onClose, toast])
+
+  const handleDelete = useCallback(async () => {
+    if (!workspace?.id || skillId === null) return
+    setSaving(true)
+    const ok = await deleteWorkspaceSkill(workspace.id, skillId)
+    setSaving(false)
+    if (ok) onClose(true)
+  }, [workspace?.id, skillId, deleteWorkspaceSkill, onClose])
+
+  const handleAssign = useCallback(async () => {
+    if (!assignAgentId || skillId === null) return
+    const agentIdNum = parseInt(assignAgentId, 10)
+    if (Number.isNaN(agentIdNum)) return
+    const ok = await assignSkillsToAgent(agentIdNum, [skillId], false)
+    if (ok) {
+      setAssignAgentId('')
+    }
+  }, [assignAgentId, skillId, assignSkillsToAgent])
+
+  const blocking = findings.filter((f) => f.severity === 'critical')
+  const warnings = findings.filter((f) => f.severity === 'high')
+
+  return (
+    <>
+      <Dialog open={open} onOpenChange={(o) => !o && onClose(false)}>
+        <DialogContent className="max-w-4xl max-h-[92vh] overflow-hidden flex flex-col">
+          <DialogHeader className="space-y-2">
+            <div className="flex items-start justify-between gap-3">
+              <div className="flex items-center gap-3">
+                <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 text-primary">
+                  <Brain className="h-5 w-5" />
+                </div>
+                <div>
+                  <DialogTitle className="text-xl">
+                    {isNew ? 'New Skill' : (skill?.name || 'Skill')}
+                  </DialogTitle>
+                  <DialogDescription className="mt-0.5 text-xs flex flex-wrap items-center gap-1.5">
+                    {isView && (
+                      <Badge variant="outline" className="text-[10px]">
+                        <Eye className="mr-1 h-3 w-3" /> View
+                      </Badge>
+                    )}
+                    {!isView && !isNew && (
+                      <Badge variant="outline" className="text-[10px]">
+                        <Pencil className="mr-1 h-3 w-3" /> Edit
+                      </Badge>
+                    )}
+                    {isNew && (
+                      <Badge variant="outline" className="text-[10px]">
+                        <Plus className="mr-1 h-3 w-3" /> New
+                      </Badge>
+                    )}
+                    {skill?.origin === 'marketplace' && (
+                      <Badge variant="secondary" className="text-[10px]">Marketplace</Badge>
+                    )}
+                    {skill?.origin === 'workspace' && skill?.forked_from_skill_id && (
+                      <Badge variant="secondary" className="text-[10px]">
+                        <GitBranch className="mr-1 h-3 w-3" />
+                        Forked from #{skill.forked_from_skill_id}
+                      </Badge>
+                    )}
+                    {willFork && (
+                      <span className="text-amber-500">
+                        Saving will fork this marketplace skill into your workspace.
+                      </span>
+                    )}
+                  </DialogDescription>
+                </div>
+              </div>
+
+              {!isNew && skill && !isView && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setMode('view')}
+                >
+                  <Eye className="mr-1.5 h-3.5 w-3.5" />
+                  View
+                </Button>
+              )}
+              {isView && skill && (
+                <Button size="sm" onClick={() => setMode('edit')}>
+                  <Pencil className="mr-1.5 h-3.5 w-3.5" />
+                  {skill.origin === 'marketplace' ? 'Fork & edit' : 'Edit'}
+                </Button>
+              )}
+            </div>
+          </DialogHeader>
+
+          {/* Body */}
+          <div className="flex-1 overflow-y-auto space-y-4 pr-1">
+            {loading ? (
+              <div className="flex items-center justify-center py-16">
+                <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+              </div>
+            ) : (
+              <>
+                {/* Metadata fields (hidden in view mode for marketplace, shown for owned) */}
+                {!isView && (
+                  <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                    {isNew && (
+                      <div className="sm:col-span-2">
+                        <label className="text-xs font-medium text-muted-foreground">Name *</label>
+                        <Input
+                          value={name}
+                          onChange={(e) => setName(e.target.value)}
+                          placeholder="my-skill-slug"
+                          className="mt-1"
+                        />
+                      </div>
+                    )}
+                    <div>
+                      <label className="text-xs font-medium text-muted-foreground">Category</label>
+                      <Input
+                        value={category}
+                        onChange={(e) => setCategory(e.target.value)}
+                        placeholder="e.g. marketing"
+                        className="mt-1"
+                      />
+                    </div>
+                    <div>
+                      <label className="text-xs font-medium text-muted-foreground">Tags (comma-separated)</label>
+                      <Input
+                        value={tagsCsv}
+                        onChange={(e) => setTagsCsv(e.target.value)}
+                        placeholder="e.g. social, copy, instagram"
+                        className="mt-1"
+                      />
+                    </div>
+                    <div className="sm:col-span-2">
+                      <label className="text-xs font-medium text-muted-foreground">Description</label>
+                      <Input
+                        value={description}
+                        onChange={(e) => setDescription(e.target.value)}
+                        placeholder="One-line summary"
+                        className="mt-1"
+                      />
+                    </div>
+                  </div>
+                )}
+
+                {/* Findings panel */}
+                {findings.length > 0 && (
+                  <FindingsPanel
+                    blocking={blocking}
+                    warnings={warnings}
+                    acknowledged={acknowledgeWarnings}
+                    onAcknowledge={setAcknowledgeWarnings}
+                    showAcknowledge={blocking.length === 0 && warnings.length > 0}
+                  />
+                )}
+
+                {/* Editor / Viewer */}
+                <div>
+                  <div className="flex items-center justify-between mb-1.5">
+                    <label className="text-xs font-medium text-muted-foreground">
+                      SKILL.md content
+                    </label>
+                    <div className="flex items-center gap-3 text-xs text-muted-foreground">
+                      <span className="tabular-nums">~{tokenEstimate.toLocaleString()} tokens</span>
+                      {!isView && (
+                        <button
+                          type="button"
+                          onClick={() => fileInputRef.current?.click()}
+                          className="inline-flex items-center gap-1 hover:text-foreground"
+                        >
+                          <Upload className="h-3 w-3" />
+                          Upload .md
+                        </button>
+                      )}
+                      <input
+                        ref={fileInputRef}
+                        type="file"
+                        accept=".md,.markdown,.txt,text/markdown,text/plain"
+                        className="hidden"
+                        onChange={(e) => {
+                          handleFilePick(e.target.files)
+                          e.target.value = ''
+                        }}
+                      />
+                    </div>
+                  </div>
+                  <Textarea
+                    value={content}
+                    onChange={(e) => setContent(e.target.value)}
+                    readOnly={isView}
+                    className="font-mono text-sm min-h-[420px] resize-y"
+                    placeholder="---&#10;name: my-skill&#10;description: …&#10;---&#10;&#10;# Skill body"
+                  />
+                </div>
+              </>
+            )}
+          </div>
+
+          {/* Footer */}
+          <div className="border-t pt-3 mt-3 flex flex-wrap items-center gap-2">
+            {!isNew && skill && (
+              <div className="flex items-center gap-2">
+                <Select value={assignAgentId} onValueChange={setAssignAgentId}>
+                  <SelectTrigger className="w-[200px] h-9">
+                    <SelectValue placeholder="Assign to agent…" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {(agents as any[]).map((agent) => (
+                      <SelectItem key={agent.id} value={String(agent.id)}>
+                        {agent.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={handleAssign}
+                  disabled={!assignAgentId}
+                >
+                  <UserPlus className="mr-1.5 h-3.5 w-3.5" />
+                  Assign
+                </Button>
+              </div>
+            )}
+
+            <div className="ml-auto flex items-center gap-2">
+              {skill?.origin === 'workspace' && !isNew && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="text-destructive hover:text-destructive"
+                  onClick={() => setConfirmDelete(true)}
+                  disabled={saving}
+                >
+                  <Trash2 className="mr-1.5 h-3.5 w-3.5" />
+                  Delete
+                </Button>
+              )}
+              <Button variant="ghost" onClick={() => onClose(false)} disabled={saving}>
+                {isView ? 'Close' : 'Cancel'}
+              </Button>
+              {!isView && (
+                <Button onClick={handleSave} disabled={saving || (warnings.length > 0 && !acknowledgeWarnings && blocking.length === 0)}>
+                  {saving ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Save className="mr-2 h-4 w-4" />}
+                  {isNew ? 'Create' : willFork ? 'Fork & save' : 'Save'}
+                </Button>
+              )}
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      <AlertDialog open={confirmDelete} onOpenChange={setConfirmDelete}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete this skill?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This permanently removes the skill from your workspace and unassigns it from any agents.
+              {skill?.forked_from_skill_id && ' The original marketplace skill will still be available to re-install.'}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDelete}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  )
+}
+
+function FindingsPanel({
+  blocking,
+  warnings,
+  acknowledged,
+  onAcknowledge,
+  showAcknowledge,
+}: {
+  blocking: ScannerFinding[]
+  warnings: ScannerFinding[]
+  acknowledged: boolean
+  onAcknowledge: (v: boolean) => void
+  showAcknowledge: boolean
+}) {
+  return (
+    <div className="space-y-2">
+      {blocking.length > 0 && (
+        <div className="rounded-md border border-destructive/40 bg-destructive/5 p-3">
+          <div className="flex items-center gap-2 text-destructive font-medium text-sm">
+            <ShieldAlert className="h-4 w-4" />
+            {blocking.length} critical issue{blocking.length === 1 ? '' : 's'} — save blocked
+          </div>
+          <ul className="mt-2 space-y-1 text-xs text-destructive/90">
+            {blocking.map((f, i) => (
+              <li key={i} className="font-mono">
+                <span className="text-destructive">L{f.line}</span> · {f.description}
+                {f.matched_text && <span className="opacity-70"> — “{f.matched_text}”</span>}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {warnings.length > 0 && (
+        <div className="rounded-md border border-amber-500/40 bg-amber-500/5 p-3">
+          <div className="flex items-center gap-2 text-amber-500 font-medium text-sm">
+            <AlertTriangle className="h-4 w-4" />
+            {warnings.length} warning{warnings.length === 1 ? '' : 's'}
+          </div>
+          <ul className="mt-2 space-y-1 text-xs text-amber-200">
+            {warnings.map((f, i) => (
+              <li key={i} className="font-mono">
+                <span className="text-amber-400">L{f.line}</span> · {f.description}
+                {f.matched_text && <span className="opacity-70"> — “{f.matched_text}”</span>}
+              </li>
+            ))}
+          </ul>
+          {showAcknowledge && (
+            <label className="mt-3 flex items-start gap-2 text-xs cursor-pointer">
+              <Checkbox
+                checked={acknowledged}
+                onCheckedChange={(checked) => onAcknowledge(checked === true)}
+                className="mt-0.5"
+              />
+              <span>
+                I&rsquo;ve reviewed these warnings and want to save anyway. (You can resolve them later — they don&rsquo;t block agent execution.)
+              </span>
+            </label>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/components/agents/skills/workspace-skills-tab.tsx
+++ b/frontend/components/agents/skills/workspace-skills-tab.tsx
@@ -1,0 +1,295 @@
+/**
+ * Workspace Skills Tab — user-local skills library on the Agents page.
+ *
+ * Shows the workspace's enabled marketplace skills + workspace-owned (forked or
+ * user-created) skills. Click a card to view; edit forks marketplace skills on
+ * first save. "+ New Skill" opens a paste/upload editor.
+ */
+
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Brain, Plus, Search, Pencil, Eye, GitBranch, ShoppingBag } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Card, CardContent } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { useToast } from '@/hooks/use-toast'
+import { useWorkspace } from '@/components/workspace-provider'
+import { useSkillsApi } from '@/hooks/use-skills-api'
+
+import { SkillEditorModal, type SkillEditorMode } from './skill-editor-modal'
+
+interface WorkspaceSkillRow {
+  skill_id: number
+  name: string
+  description: string | null
+  category: string | null
+  skill_version: string | null
+  tags: string[] | null
+  estimated_tokens: number
+  skill_source: string | null
+  enabled_at: string | null
+  origin: 'marketplace' | 'workspace'
+  forked_from_skill_id: number | null
+}
+
+export function WorkspaceSkillsTab() {
+  const { workspace } = useWorkspace()
+  const { toast } = useToast()
+  const { listWorkspaceSkills } = useSkillsApi()
+
+  const [skills, setSkills] = useState<WorkspaceSkillRow[]>([])
+  const [search, setSearch] = useState('')
+  const [originFilter, setOriginFilter] = useState<'all' | 'workspace' | 'marketplace'>('all')
+  const [loading, setLoading] = useState(true)
+
+  const [editorOpen, setEditorOpen] = useState(false)
+  const [editorMode, setEditorMode] = useState<SkillEditorMode>('view')
+  const [editorSkillId, setEditorSkillId] = useState<number | null>(null)
+
+  const loadSkills = useCallback(async () => {
+    if (!workspace?.id) return
+    setLoading(true)
+    try {
+      const items = await listWorkspaceSkills(workspace.id)
+      setSkills(items as WorkspaceSkillRow[])
+    } catch (err: any) {
+      toast({ title: 'Failed to load skills', description: err.message, variant: 'destructive' })
+    } finally {
+      setLoading(false)
+    }
+  }, [workspace?.id, listWorkspaceSkills, toast])
+
+  useEffect(() => {
+    loadSkills()
+  }, [loadSkills])
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase()
+    return skills.filter((s) => {
+      if (originFilter !== 'all' && s.origin !== originFilter) return false
+      if (!q) return true
+      return (
+        s.name.toLowerCase().includes(q) ||
+        (s.description || '').toLowerCase().includes(q) ||
+        (s.tags || []).some((t) => t.toLowerCase().includes(q))
+      )
+    })
+  }, [skills, search, originFilter])
+
+  const openViewer = useCallback((skillId: number, mode: SkillEditorMode) => {
+    setEditorSkillId(skillId)
+    setEditorMode(mode)
+    setEditorOpen(true)
+  }, [])
+
+  const openNew = useCallback(() => {
+    setEditorSkillId(null)
+    setEditorMode('new')
+    setEditorOpen(true)
+  }, [])
+
+  const handleEditorClose = useCallback((didChange: boolean) => {
+    setEditorOpen(false)
+    if (didChange) {
+      loadSkills()
+    }
+  }, [loadSkills])
+
+  const ownedCount = useMemo(() => skills.filter((s) => s.origin === 'workspace').length, [skills])
+  const marketplaceCount = useMemo(() => skills.filter((s) => s.origin === 'marketplace').length, [skills])
+
+  return (
+    <div className="space-y-4">
+      {/* Header row */}
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+        <div className="relative flex-1 min-w-[220px] max-w-md">
+          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search skills…"
+            className="pl-9"
+          />
+        </div>
+
+        <div className="flex gap-2">
+          <Button
+            variant={originFilter === 'all' ? 'default' : 'outline'}
+            size="sm"
+            onClick={() => setOriginFilter('all')}
+          >
+            All <span className="ml-1.5 text-xs text-muted-foreground">{skills.length}</span>
+          </Button>
+          <Button
+            variant={originFilter === 'workspace' ? 'default' : 'outline'}
+            size="sm"
+            onClick={() => setOriginFilter('workspace')}
+          >
+            <GitBranch className="mr-1.5 h-3.5 w-3.5" />
+            Yours <span className="ml-1.5 text-xs text-muted-foreground">{ownedCount}</span>
+          </Button>
+          <Button
+            variant={originFilter === 'marketplace' ? 'default' : 'outline'}
+            size="sm"
+            onClick={() => setOriginFilter('marketplace')}
+          >
+            <ShoppingBag className="mr-1.5 h-3.5 w-3.5" />
+            Marketplace <span className="ml-1.5 text-xs text-muted-foreground">{marketplaceCount}</span>
+          </Button>
+        </div>
+
+        <div className="ml-auto">
+          <Button onClick={openNew}>
+            <Plus className="mr-2 h-4 w-4" />
+            New Skill
+          </Button>
+        </div>
+      </div>
+
+      {/* Cards */}
+      {loading ? (
+        <SkillCardsSkeleton />
+      ) : filtered.length === 0 ? (
+        <EmptyState
+          hasAny={skills.length > 0}
+          onCreate={openNew}
+          searching={search.trim().length > 0 || originFilter !== 'all'}
+        />
+      ) : (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {filtered.map((skill) => (
+            <SkillCard
+              key={skill.skill_id}
+              skill={skill}
+              onView={() => openViewer(skill.skill_id, 'view')}
+              onEdit={() => openViewer(skill.skill_id, 'edit')}
+            />
+          ))}
+        </div>
+      )}
+
+      <SkillEditorModal
+        open={editorOpen}
+        mode={editorMode}
+        skillId={editorSkillId}
+        onClose={handleEditorClose}
+      />
+    </div>
+  )
+}
+
+function SkillCard({
+  skill,
+  onView,
+  onEdit,
+}: {
+  skill: WorkspaceSkillRow
+  onView: () => void
+  onEdit: () => void
+}) {
+  const isWorkspace = skill.origin === 'workspace'
+  return (
+    <Card className="glass-card group transition-all hover:border-primary/40">
+      <CardContent className="p-5 space-y-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+            <Brain className="h-5 w-5" />
+          </div>
+          <div className="flex flex-wrap justify-end gap-1.5">
+            {isWorkspace ? (
+              <Badge variant="secondary" className="text-[10px]">
+                <GitBranch className="mr-1 h-3 w-3" />
+                {skill.forked_from_skill_id ? 'Forked' : 'Yours'}
+              </Badge>
+            ) : (
+              <Badge variant="outline" className="text-[10px]">
+                <ShoppingBag className="mr-1 h-3 w-3" />
+                Marketplace
+              </Badge>
+            )}
+            {skill.skill_version && (
+              <Badge variant="outline" className="text-[10px]">v{skill.skill_version}</Badge>
+            )}
+          </div>
+        </div>
+
+        <div>
+          <h3 className="font-semibold text-base line-clamp-1">{skill.name}</h3>
+          {skill.description && (
+            <p className="mt-1 text-sm text-muted-foreground line-clamp-2">{skill.description}</p>
+          )}
+        </div>
+
+        <div className="flex items-center justify-between text-xs text-muted-foreground">
+          <span>{skill.category ?? 'Uncategorised'}</span>
+          <span className="tabular-nums">~{skill.estimated_tokens.toLocaleString()} tok</span>
+        </div>
+
+        <div className="flex gap-2 pt-1">
+          <Button variant="outline" size="sm" className="flex-1" onClick={onView}>
+            <Eye className="mr-1.5 h-3.5 w-3.5" />
+            View
+          </Button>
+          <Button variant="outline" size="sm" className="flex-1" onClick={onEdit}>
+            <Pencil className="mr-1.5 h-3.5 w-3.5" />
+            {isWorkspace ? 'Edit' : 'Fork & edit'}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+function SkillCardsSkeleton() {
+  return (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {[0, 1, 2, 3, 4, 5].map((i) => (
+        <Card key={i} className="glass-card">
+          <CardContent className="p-5 space-y-3">
+            <div className="h-10 w-10 rounded-lg bg-secondary/50" />
+            <div className="h-4 w-2/3 rounded bg-secondary/50" />
+            <div className="h-3 w-full rounded bg-secondary/30" />
+            <div className="h-3 w-4/5 rounded bg-secondary/30" />
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  )
+}
+
+function EmptyState({
+  hasAny,
+  onCreate,
+  searching,
+}: {
+  hasAny: boolean
+  onCreate: () => void
+  searching: boolean
+}) {
+  if (searching) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-3 py-16 text-center text-muted-foreground">
+        <Search className="h-10 w-10" strokeWidth={1.5} />
+        <div className="text-sm">No skills match your filters.</div>
+      </div>
+    )
+  }
+  return (
+    <div className="flex flex-col items-center justify-center gap-3 py-16 text-center">
+      <Brain className="h-10 w-10 text-muted-foreground" strokeWidth={1.5} />
+      <div className="text-base font-medium">
+        {hasAny ? 'No skills in this view' : 'No skills yet'}
+      </div>
+      <div className="max-w-sm text-sm text-muted-foreground">
+        Skills give your agents repeatable how-tos. Install one from the Marketplace, or paste a SKILL.md to author your own.
+      </div>
+      <Button onClick={onCreate} className="mt-2">
+        <Plus className="mr-2 h-4 w-4" />
+        New Skill
+      </Button>
+    </div>
+  )
+}

--- a/frontend/components/documents/document-management.tsx
+++ b/frontend/components/documents/document-management.tsx
@@ -40,6 +40,7 @@ import { PageHeader } from '@/components/shared/page-header'
 import { StatsBar } from '@/components/shared/stats-bar'
 import { CodeGraphPanel } from '@/components/knowledge/CodeGraphPanel'
 import { BusinessGraphPanel } from '@/components/knowledge/BusinessGraphPanel'
+import { MemoryTab } from '@/components/knowledge/memory-tab'
 import { GraphDiffBanner } from '@/components/knowledge/GraphDiffBanner'
 import { MultimodalKnowledgePanel } from '@/components/knowledge/MultimodalKnowledgePanel'
 import { DatabaseQueryExplorer } from '@/components/knowledge/DatabaseQueryExplorer'
@@ -645,6 +646,10 @@ export function DocumentManagement() {
               <Network className="w-4 h-4" />
               <span>Business Graph</span>
             </TabsTrigger>
+            <TabsTrigger value="memory" className="flex items-center space-x-2">
+              <Brain className="w-4 h-4" />
+              <span>Memory</span>
+            </TabsTrigger>
             {/* Analytics tab removed — see /analytics */}
           </TabsList>
 
@@ -1097,6 +1102,10 @@ export function DocumentManagement() {
           <TabsContent value="businessgraph" className="space-y-6">
             <GraphDiffBanner />
             <BusinessGraphPanel />
+          </TabsContent>
+
+          <TabsContent value="memory" className="space-y-6">
+            <MemoryTab />
           </TabsContent>
         </Tabs>
       </motion.div>

--- a/frontend/components/knowledge/memory-tab.tsx
+++ b/frontend/components/knowledge/memory-tab.tsx
@@ -1,0 +1,219 @@
+'use client'
+
+import { useState, useCallback, useMemo } from 'react'
+import { ArrowLeft } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import {
+  useMemoryBrowse,
+  useDeleteMemory,
+  useConsolidateMemories,
+} from '@/hooks/use-memory-explorer-api'
+import type { MemoryFilters } from '@/hooks/use-memory-explorer-api'
+import { HealthBanner, MemorySidebar, MemoryViewer } from '@/components/activity/memory'
+
+type MemoryFilterKey =
+  | 'all'
+  | 'transcript'
+  | 'mission_summary'
+  | 'task_failure'
+  | 'retry_recovery'
+  | 'facts'
+
+export function MemoryTab() {
+  const [filters, setFilters] = useState<MemoryFilters>({ limit: 50 })
+  const [activeFilter, setActiveFilter] = useState<MemoryFilterKey>('all')
+  const [searchInput, setSearchInput] = useState('')
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
+  const [deleteTarget, setDeleteTarget] = useState<string | null>(null)
+  const [showConsolidate, setShowConsolidate] = useState(false)
+  const [mobileShowViewer, setMobileShowViewer] = useState(false)
+
+  const { data, isLoading } = useMemoryBrowse(filters)
+  const deleteMemory = useDeleteMemory()
+  const consolidate = useConsolidateMemories()
+
+  const memories = data?.memories ?? []
+  const total = data?.total ?? 0
+  const activeMemory = useMemo(
+    () => memories.find((m) => m.id === selectedId) ?? null,
+    [memories, selectedId]
+  )
+
+  const handleSearch = useCallback(() => {
+    setFilters((prev) => ({ ...prev, query: searchInput.trim() || undefined }))
+  }, [searchInput])
+
+  const handleClearSearch = useCallback(() => {
+    setSearchInput('')
+    setFilters((prev) => ({ ...prev, query: undefined }))
+  }, [])
+
+  const handleSelectMemory = useCallback((id: string) => {
+    setSelectedId(id)
+    setMobileShowViewer(true)
+  }, [])
+
+  const handleToggleSelect = useCallback((id: string, checked: boolean) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev)
+      if (checked) next.add(id)
+      else next.delete(id)
+      return next
+    })
+  }, [])
+
+  const handleDeleteConfirm = useCallback(() => {
+    if (!deleteTarget) return
+    deleteMemory.mutate({ memoryId: deleteTarget })
+    setDeleteTarget(null)
+    setSelectedIds((prev) => {
+      const next = new Set(prev)
+      next.delete(deleteTarget)
+      return next
+    })
+    if (selectedId === deleteTarget) setSelectedId(null)
+  }, [deleteTarget, deleteMemory, selectedId])
+
+  const handleBulkDelete = useCallback(() => {
+    selectedIds.forEach((id) => deleteMemory.mutate({ memoryId: id }))
+    if (selectedId && selectedIds.has(selectedId)) setSelectedId(null)
+    setSelectedIds(new Set())
+  }, [selectedIds, deleteMemory, selectedId])
+
+  const handleConsolidate = useCallback(
+    (strategy: 'merge' | 'summarise') => {
+      consolidate.mutate({ memory_ids: Array.from(selectedIds), strategy })
+      setSelectedIds(new Set())
+      setShowConsolidate(false)
+    },
+    [selectedIds, consolidate]
+  )
+
+  const handleFilterChange = useCallback((next: MemoryFilterKey) => {
+    setActiveFilter(next)
+    setSelectedId(null)
+    setFilters((prev) => {
+      const { content_type, tier, ...rest } = prev
+      switch (next) {
+        case 'all':
+          return { ...rest }
+        case 'facts':
+          return { ...rest, tier: 'l3' }
+        default:
+          return { ...rest, tier: 'l2', content_type: next }
+      }
+    })
+  }, [])
+
+  return (
+    <div className="space-y-4">
+      <HealthBanner />
+
+      <div className="glass-card overflow-hidden" style={{ height: 'calc(100vh - 260px)', minHeight: 480 }}>
+        <div className="flex h-full">
+          <div className={cn(
+            'w-full lg:w-[340px] lg:min-w-[280px] border-r border-border/40 flex-shrink-0',
+            mobileShowViewer ? 'hidden lg:flex lg:flex-col' : 'flex flex-col'
+          )}>
+            <MemorySidebar
+              memories={memories}
+              selectedId={selectedId}
+              onSelect={handleSelectMemory}
+              searchInput={searchInput}
+              onSearchChange={setSearchInput}
+              onSearchSubmit={handleSearch}
+              onClearSearch={handleClearSearch}
+              hasActiveQuery={!!filters.query}
+              total={total}
+              isLoading={isLoading}
+              activeFilter={activeFilter}
+              onFilterChange={handleFilterChange}
+            />
+          </div>
+
+          <div className={cn(
+            'flex-1 flex flex-col min-w-0',
+            mobileShowViewer ? 'flex' : 'hidden lg:flex'
+          )}>
+            {mobileShowViewer && (
+              <div className="lg:hidden px-3 py-2 border-b border-border/40">
+                <Button variant="ghost" size="sm" className="h-7 text-xs gap-1" onClick={() => setMobileShowViewer(false)}>
+                  <ArrowLeft className="w-3.5 h-3.5" />
+                  Back to list
+                </Button>
+              </div>
+            )}
+            <MemoryViewer
+              memory={activeMemory}
+              isSelected={selectedId ? selectedIds.has(selectedId) : false}
+              onToggleSelect={handleToggleSelect}
+              onDelete={setDeleteTarget}
+              selectedCount={selectedIds.size}
+              onMerge={() => setShowConsolidate(true)}
+              onBulkDelete={handleBulkDelete}
+            />
+          </div>
+        </div>
+      </div>
+
+      {memories.length > 0 && memories.length < total && (
+        <div className="text-center">
+          <Button variant="outline" size="sm" onClick={() => setFilters((prev) => ({ ...prev, limit: (prev.limit || 50) + 50 }))}>
+            Load More ({total - memories.length} remaining)
+          </Button>
+        </div>
+      )}
+
+      <AlertDialog open={!!deleteTarget} onOpenChange={() => setDeleteTarget(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete Memory</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will permanently remove this memory. Your agents will no longer recall this information.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={handleDeleteConfirm} className="bg-destructive text-destructive-foreground hover:bg-destructive/90">
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog open={showConsolidate} onOpenChange={setShowConsolidate}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Consolidate {selectedIds.size} Memories</AlertDialogTitle>
+            <AlertDialogDescription>Choose how to combine these memories into a single entry.</AlertDialogDescription>
+          </AlertDialogHeader>
+          <div className="grid grid-cols-2 gap-3 py-4">
+            <button onClick={() => handleConsolidate('merge')} className="glass-card p-4 text-left hover:bg-secondary/40 transition-colors">
+              <p className="font-medium text-sm">Merge</p>
+              <p className="text-xs text-muted-foreground mt-1">Combine content into one memory, keeping the latest metadata.</p>
+            </button>
+            <button onClick={() => handleConsolidate('summarise')} className="glass-card p-4 text-left hover:bg-secondary/40 transition-colors">
+              <p className="font-medium text-sm">Summarise</p>
+              <p className="text-xs text-muted-foreground mt-1">AI generates a concise summary replacing all selected memories.</p>
+            </button>
+          </div>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  )
+}

--- a/frontend/components/tools/tools-dashboard.tsx
+++ b/frontend/components/tools/tools-dashboard.tsx
@@ -346,10 +346,6 @@ export function ToolsDashboard() {
       switch (sortBy) {
         case 'name':
           return (a?.name || '').localeCompare(b?.name || '')
-        case 'rating':
-          return (b?.rating || 0) - (a?.rating || 0)
-        case 'usage':
-          return (b?.usageCount || 0) - (a?.usageCount || 0)
         case 'updated':
           return new Date(b?.lastUpdated || 0).getTime() - new Date(a?.lastUpdated || 0).getTime()
         default:
@@ -603,10 +599,22 @@ export function ToolsDashboard() {
   const handleRemoveFromWorkspace = async (tool: Tool) => {
     setLoading(true)
     try {
-      const appName = tool.name
+      // Resolve the canonical Composio app name (e.g. "GOOGLEDRIVE"), not the
+      // display name ("Google Drive") — backend looks up by ComposioConnection.app_name.
+      const integrationUrl = (tool as any).integration_url || tool.metadata?.integration_url
+      const composioFromUrl = integrationUrl?.startsWith('composio://')
+        ? integrationUrl.replace('composio://', '').split('/')[0]
+        : null
+      const appName =
+        tool.composio_app_name ||
+        tool.metadata?.composio_app_name ||
+        tool.metadata?.app_name ||
+        composioFromUrl ||
+        tool.name
+
       console.log(`Removing ${appName} from workspace`)
 
-      await apiClient.delete(`/api/tools/remove-from-workspace/${appName}`)
+      await apiClient.delete(`/api/tools/remove-from-workspace/${encodeURIComponent(appName)}`)
 
       // Close modal and refresh tools list
       setDetailsModalOpen(false)
@@ -615,7 +623,7 @@ export function ToolsDashboard() {
 
       toast({
         title: 'Removed from Workspace',
-        description: `${appName} has been removed from your workspace.`,
+        description: `${tool.name} has been removed from your workspace.`,
       })
     } catch (error) {
       console.error('Failed to remove from workspace:', error)
@@ -712,8 +720,6 @@ export function ToolsDashboard() {
                 </SelectTrigger>
                 <SelectContent>
                   <SelectItem value="name">Name</SelectItem>
-                  <SelectItem value="rating">Rating</SelectItem>
-                  <SelectItem value="usage">Usage</SelectItem>
                   <SelectItem value="updated">Updated</SelectItem>
                 </SelectContent>
               </Select>

--- a/frontend/hooks/use-skills-api.ts
+++ b/frontend/hooks/use-skills-api.ts
@@ -25,6 +25,72 @@ function getSkillsApiBase(): string {
   return base ? `${base}/api/v1/skills` : '/api/v1/skills';
 }
 
+function getWorkspaceSkillsBase(workspaceId: string): string {
+  const base = apiClient.getBaseUrl();
+  const root = base ? `${base}/api/workspaces` : '/api/workspaces';
+  return `${root}/${workspaceId}/skills`;
+}
+
+export interface ScannerFinding {
+  type: string;
+  severity: 'critical' | 'high' | 'medium' | 'low' | string;
+  line: number;
+  description: string;
+  matched_text: string;
+}
+
+export interface WorkspaceSkillContent {
+  skill_id: number;
+  name: string;
+  description: string | null;
+  category: string | null;
+  tags: string[];
+  skill_version: string | null;
+  skill_source: string | null;
+  content: string;
+  origin: 'workspace' | 'marketplace';
+  forked_from_skill_id: number | null;
+  editable: boolean;
+}
+
+export interface CreateSkillPayload {
+  name: string;
+  content: string;
+  description?: string;
+  category?: string;
+  tags?: string[];
+  skill_type?: string;
+  acknowledge_warnings?: boolean;
+}
+
+export interface UpdateSkillPayload {
+  content: string;
+  description?: string;
+  category?: string;
+  tags?: string[];
+  acknowledge_warnings?: boolean;
+}
+
+export interface SkillSaveResult {
+  success: true;
+  skill_id: number;
+  forked?: boolean;
+  forked_from_skill_id?: number;
+  agents_migrated?: number;
+  warnings: ScannerFinding[];
+}
+
+export class SkillScanError extends Error {
+  status: 'blocked' | 'warnings';
+  findings: ScannerFinding[];
+  constructor(status: 'blocked' | 'warnings', message: string, findings: ScannerFinding[]) {
+    super(message);
+    this.name = 'SkillScanError';
+    this.status = status;
+    this.findings = findings;
+  }
+}
+
 async function fetchWithAuth(url: string, init?: RequestInit): Promise<Response> {
   const auth = await apiClient.getAuthHeaders();
   return fetch(url, {
@@ -524,6 +590,148 @@ export function useSkillsApi() {
     }
   }, []);
 
+  // =========================================================================
+  // Workspace Skill Editor (PRD: User-editable workspace skills)
+  // =========================================================================
+
+  const listWorkspaceSkills = useCallback(async (workspaceId: string) => {
+    setError(null);
+    const response = await fetchWithAuth(`${getWorkspaceSkillsBase(workspaceId)}`);
+    if (!response.ok) {
+      const detail = await response.text();
+      throw new Error(detail || 'Failed to load workspace skills');
+    }
+    const json = await response.json();
+    return (json.items ?? []) as Array<{
+      skill_id: number;
+      name: string;
+      description: string | null;
+      category: string | null;
+      skill_version: string | null;
+      tags: string[] | null;
+      estimated_tokens: number;
+      skill_source: string | null;
+      enabled_at: string | null;
+      origin: 'marketplace' | 'workspace';
+      forked_from_skill_id: number | null;
+    }>;
+  }, []);
+
+  const getWorkspaceSkillContent = useCallback(async (
+    workspaceId: string,
+    skillId: number,
+  ): Promise<WorkspaceSkillContent> => {
+    setError(null);
+    const response = await fetchWithAuth(`${getWorkspaceSkillsBase(workspaceId)}/${skillId}/content`);
+    if (!response.ok) {
+      const detail = await response.text();
+      throw new Error(detail || 'Failed to load skill content');
+    }
+    return response.json();
+  }, []);
+
+  const _parseSaveResponse = async (response: Response): Promise<SkillSaveResult> => {
+    if (response.ok) {
+      return response.json();
+    }
+    const text = await response.text();
+    let parsed: any = null;
+    try { parsed = JSON.parse(text); } catch { /* not JSON */ }
+    const detail = parsed?.detail;
+    if (response.status === 422 && detail && typeof detail === 'object' && 'status' in detail) {
+      throw new SkillScanError(
+        detail.status,
+        detail.message || 'Skill failed security scan',
+        detail.findings || [],
+      );
+    }
+    throw new Error(typeof detail === 'string' ? detail : (parsed?.message || 'Failed to save skill'));
+  };
+
+  const createWorkspaceSkill = useCallback(async (
+    workspaceId: string,
+    payload: CreateSkillPayload,
+  ): Promise<SkillSaveResult> => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetchWithAuth(`${getWorkspaceSkillsBase(workspaceId)}/create`, {
+        method: 'POST',
+        body: JSON.stringify(payload),
+      });
+      const result = await _parseSaveResponse(response);
+      toast({
+        title: 'Skill created',
+        description: `'${payload.name}' added to your workspace.`,
+      });
+      return result;
+    } catch (err: any) {
+      if (!(err instanceof SkillScanError)) {
+        setError(err.message);
+        toast({ title: 'Save failed', description: err.message, variant: 'destructive' });
+      }
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  }, [toast]);
+
+  const updateWorkspaceSkill = useCallback(async (
+    workspaceId: string,
+    skillId: number,
+    payload: UpdateSkillPayload,
+  ): Promise<SkillSaveResult> => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetchWithAuth(`${getWorkspaceSkillsBase(workspaceId)}/${skillId}`, {
+        method: 'PATCH',
+        body: JSON.stringify(payload),
+      });
+      const result = await _parseSaveResponse(response);
+      toast({
+        title: result.forked ? 'Skill forked & saved' : 'Skill saved',
+        description: result.forked
+          ? `Created your workspace copy. ${result.agents_migrated ?? 0} agent assignment(s) migrated.`
+          : 'Your changes are live.',
+      });
+      return result;
+    } catch (err: any) {
+      if (!(err instanceof SkillScanError)) {
+        setError(err.message);
+        toast({ title: 'Save failed', description: err.message, variant: 'destructive' });
+      }
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  }, [toast]);
+
+  const deleteWorkspaceSkill = useCallback(async (
+    workspaceId: string,
+    skillId: number,
+  ): Promise<boolean> => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetchWithAuth(`${getWorkspaceSkillsBase(workspaceId)}/${skillId}/owned`, {
+        method: 'DELETE',
+      });
+      if (!response.ok) {
+        const text = await response.text();
+        throw new Error(text || 'Failed to delete skill');
+      }
+      toast({ title: 'Skill deleted' });
+      return true;
+    } catch (err: any) {
+      setError(err.message);
+      toast({ title: 'Delete failed', description: err.message, variant: 'destructive' });
+      return false;
+    } finally {
+      setLoading(false);
+    }
+  }, [toast]);
+
   return {
     loading,
     error,
@@ -544,6 +752,12 @@ export function useSkillsApi() {
     assignSkillsToAgent,
     removeSkillsFromAgent,
     // Recommendations
-    recommendSkills
+    recommendSkills,
+    // Workspace skill editor
+    listWorkspaceSkills,
+    getWorkspaceSkillContent,
+    createWorkspaceSkill,
+    updateWorkspaceSkill,
+    deleteWorkspaceSkill,
   };
 }

--- a/frontend/lib/shepherd/tours/agents-tour.ts
+++ b/frontend/lib/shepherd/tours/agents-tour.ts
@@ -34,14 +34,12 @@ export function createAgentsTour(userId: string) {
   // Step 2: Tabs
   tour.addStep({
     id: 'agents-tabs',
-    title: title('Five', 'Agent Views'),
+    title: title('Three', 'Agent Views'),
     text: `
       ${tabList([
         ['Roster', 'The full list of agents as cards or rows — create, edit, start/pause, delete.'],
-        ['Org Chart', 'Visualise reporting lines and coordination hierarchy between agents.'],
+        ['Org Chart', 'Visualise reporting lines and hierarchy between agents.'],
         ['Configuration', 'Deep settings — model, system prompt, memory, guardrails.'],
-        ['Coordination', 'Rules for how agents hand off work to each other and share context.'],
-        ['Playbooks', 'Reusable playbooks assigned to an agent — the jobs they know how to run.'],
       ])}
       ${stepProgress(2, TOTAL)}
     `,

--- a/frontend/lib/shepherd/tours/documents-tour.ts
+++ b/frontend/lib/shepherd/tours/documents-tour.ts
@@ -45,9 +45,9 @@ export function createDocumentsTour(userId: string) {
       ${tabList([
         ['Documents', 'Upload PDFs, Word, Markdown, images. Auto-chunked, embedded, and searchable via RAG.'],
         ['Database', 'Connect Postgres, MySQL, Snowflake and let agents query them in natural language with a semantic layer on top.'],
-        ['Templates', 'Reusable document templates agents can fill in — proposals, reports, briefs.'],
         ['CodeGraph', 'Index a repo into a graph of files, symbols and calls so agents can reason about code structure.'],
         ['Business Graph', 'Your org modelled as entities — customers, products, processes — agents can traverse.'],
+        ['Memory', 'Browse and prune the long-term memories your agents have stored — short-term and Mem0 facts.'],
       ])}
       ${stepProgress(2, TOTAL)}
     `,

--- a/orchestrator/api/skills.py
+++ b/orchestrator/api/skills.py
@@ -473,8 +473,16 @@ async def list_skills(
         GET /api/v1/skills?search=security&tags=authentication,authorization
     """
     try:
+        # Workspace isolation: a caller may only see marketplace skills (workspace_id IS NULL)
+        # plus skills owned by their own workspace. Admins see everything.
+        is_admin = getattr(ctx.user, "system_role", "user") == "admin"
         query = db.query(Skill).filter(Skill.is_active == True)
-        
+        if not is_admin:
+            query = query.filter(
+                (Skill.workspace_id.is_(None)) |
+                (Skill.workspace_id == ctx.workspace_id)
+            )
+
         # Apply filters
         if category:
             query = query.filter(Skill.category == category)

--- a/orchestrator/api/workspace_skills.py
+++ b/orchestrator/api/workspace_skills.py
@@ -2,19 +2,23 @@
 Workspace Skill Enablement API Endpoints (PRD-71)
 ==================================================
 
-Provides REST APIs for workspace owners to enable/disable marketplace skills:
-- List enabled skills for a workspace
-- Enable a skill for a workspace
+Provides REST APIs for workspace owners to manage skills:
+- List skills available to a workspace (forked + enabled marketplace)
+- Enable a marketplace skill for a workspace
 - Disable a skill for a workspace (cascades to agent assignments)
-- List all available marketplace skills (for browsing)
+- Browse all marketplace skills (for adding)
+- Create a workspace-owned skill from pasted/uploaded content
+- Edit a workspace skill (forks marketplace skills on first edit)
+- Delete a workspace-owned skill
 
-Mirrors workspace_plugins.py — same pattern for skills.
+All edits run plugin_security_scanner.quick_scan() — critical findings block,
+high findings warn-and-confirm.
 """
 
 from __future__ import annotations
 
 import logging
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -28,6 +32,10 @@ from core.database.database import get_db
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/workspaces", tags=["Workspace Skills"])
+
+# Severity levels that block save unless explicitly acknowledged.
+_BLOCKING_SEVERITIES = {"critical"}
+_WARNING_SEVERITIES = {"high"}
 
 
 def _is_admin(ctx: RequestContext) -> bool:
@@ -59,9 +67,41 @@ class WorkspaceSkillOut(BaseModel):
     estimated_tokens: int = 0
     skill_source: Optional[str] = None
     enabled_at: Optional[str] = None
+    # Origin: 'marketplace' = enabled via junction (read-only original),
+    # 'workspace' = workspace-owned (forked or user-created, editable).
+    origin: str = "marketplace"
+    # If origin='workspace' and this skill was forked, the marketplace id it came from.
+    forked_from_skill_id: Optional[int] = None
 
     class Config:
         from_attributes = True
+
+
+class ScannerFinding(BaseModel):
+    """A single security finding surfaced to the UI."""
+    type: str
+    severity: str
+    line: int
+    description: str
+    matched_text: str
+
+
+class CreateSkillBody(BaseModel):
+    name: str = Field(..., min_length=1, max_length=255)
+    content: str = Field(..., min_length=1, description="SKILL.md content (frontmatter + body)")
+    description: Optional[str] = None
+    category: Optional[str] = None
+    tags: Optional[List[str]] = None
+    skill_type: Optional[str] = Field(None, description="cognitive | technical | communication")
+    acknowledge_warnings: bool = Field(False, description="Allow save when only 'high'-severity findings exist.")
+
+
+class UpdateSkillBody(BaseModel):
+    content: str = Field(..., min_length=1)
+    description: Optional[str] = None
+    category: Optional[str] = None
+    tags: Optional[List[str]] = None
+    acknowledge_warnings: bool = False
 
 
 class MarketplaceSkillOut(BaseModel):
@@ -90,23 +130,63 @@ async def list_workspace_skills(
     ctx: RequestContext = Depends(get_request_context_hybrid),
     db: Session = Depends(get_db),
 ):
-    """List skills enabled for a workspace."""
+    """
+    List all skills available to a workspace:
+    - Marketplace skills enabled via junction (origin='marketplace', read-only)
+    - Workspace-owned skills (origin='workspace', editable — forked or user-created)
+    """
     _assert_workspace_access(ctx, workspace_id)
 
     try:
         from core.models.core import Skill
         from core.models.marketplace_plugins import WorkspaceEnabledSkill
 
+        items: List[WorkspaceSkillOut] = []
+        seen_skill_ids: set[int] = set()
+
+        # Workspace-owned skills (forked or user-created)
+        owned_skills = (
+            db.query(Skill)
+            .filter(
+                Skill.workspace_id == workspace_id,
+                Skill.is_active == True,
+            )
+            .order_by(Skill.name)
+            .all()
+        )
+        for skill in owned_skills:
+            tokens = (len(skill.prompt_template) // 4) if skill.prompt_template else 0
+            metadata = skill.skill_metadata if isinstance(skill.skill_metadata, dict) else {}
+            items.append(WorkspaceSkillOut(
+                skill_id=skill.id,
+                name=skill.name,
+                description=skill.description,
+                category=skill.category,
+                skill_version=skill.skill_version,
+                tags=skill.tags,
+                estimated_tokens=tokens,
+                skill_source=skill.skill_source,
+                enabled_at=skill.created_at.isoformat() if skill.created_at else None,
+                origin="workspace",
+                forked_from_skill_id=metadata.get("forked_from_skill_id"),
+            ))
+            seen_skill_ids.add(skill.id)
+
+        # Marketplace skills enabled via junction (skip any already shadowed by a fork
+        # that points back at the same marketplace id — see PATCH/fork below)
+        forked_origin_ids = {
+            i.forked_from_skill_id for i in items if i.forked_from_skill_id is not None
+        }
         rows = (
             db.query(WorkspaceEnabledSkill, Skill)
             .join(Skill, Skill.id == WorkspaceEnabledSkill.skill_id)
             .filter(WorkspaceEnabledSkill.workspace_id == workspace_id)
             .all()
         )
-
-        items = []
         for wes, skill in rows:
-            tokens = len(skill.prompt_template or "") // 4 if skill.prompt_template else 0
+            if skill.id in seen_skill_ids or skill.id in forked_origin_ids:
+                continue
+            tokens = (len(skill.prompt_template) // 4) if skill.prompt_template else 0
             items.append(WorkspaceSkillOut(
                 skill_id=skill.id,
                 name=skill.name,
@@ -117,6 +197,7 @@ async def list_workspace_skills(
                 estimated_tokens=tokens,
                 skill_source=skill.skill_source,
                 enabled_at=wes.enabled_at.isoformat() if wes.enabled_at else None,
+                origin="marketplace",
             ))
 
         return {"items": [item.model_dump() for item in items]}
@@ -275,7 +356,7 @@ async def disable_skill(
     _assert_workspace_access(ctx, workspace_id)
 
     try:
-        from core.models.core import Agent, agent_skills_table
+        from core.models.core import Agent, agent_skills as agent_skills_table
         from core.models.marketplace_plugins import WorkspaceEnabledSkill
 
         junction = db.query(WorkspaceEnabledSkill).filter(
@@ -322,3 +403,421 @@ async def disable_skill(
         logger.error("Error disabling skill %s for workspace %s: %s", skill_id, workspace_id, e)
         db.rollback()
         raise HTTPException(status_code=500, detail="Internal server error")
+
+
+# ===================================================================
+# Workspace Skill Editor: View / Create / Update (fork-on-edit) / Delete
+# ===================================================================
+
+def _classify_findings(findings: list) -> Dict[str, Any]:
+    """Bucket scanner findings by severity and decide whether to block."""
+    blocking = [f for f in findings if f.severity in _BLOCKING_SEVERITIES]
+    warnings = [f for f in findings if f.severity in _WARNING_SEVERITIES]
+    return {
+        "blocking": blocking,
+        "warnings": warnings,
+        "all": findings,
+    }
+
+
+def _findings_to_payload(findings: list) -> List[Dict[str, Any]]:
+    """Serialize StaticFinding list to the UI-facing shape."""
+    return [
+        {
+            "type": f.type,
+            "severity": f.severity,
+            "line": f.line,
+            "description": f.description,
+            "matched_text": f.matched_text,
+        }
+        for f in findings
+    ]
+
+
+def _resolve_user_id(ctx: RequestContext, db: Session) -> Optional[int]:
+    """Look up the integer users.id for the current Clerk user (or None)."""
+    from core.models.core import User as UserModel
+
+    clerk_id = getattr(ctx.user, "id", None)
+    if not clerk_id:
+        return None
+
+    # ctx.user.id may itself already be a numeric DB id depending on auth path
+    try:
+        return int(clerk_id)
+    except (TypeError, ValueError):
+        pass
+
+    user = db.query(UserModel).filter(UserModel.clerk_user_id == clerk_id).first()
+    if not user and getattr(ctx.user, "email", None):
+        user = db.query(UserModel).filter(UserModel.email == ctx.user.email).first()
+    return user.id if user else None
+
+
+def _invalidate_skill_cache(skill_name: str, db: Session) -> None:
+    """Clear SkillLoader caches so updated content is served immediately."""
+    try:
+        from modules.agents.services.skill_loader import get_skill_loader
+        loader = get_skill_loader(db)
+        loader.metadata_cache.pop(skill_name, None)
+        loader.core_content_cache.pop(skill_name, None)
+    except Exception:  # SkillLoader not initialized — nothing to clear
+        pass
+
+
+def _scan_or_raise(content: str, filename: str, acknowledge_warnings: bool) -> List[Any]:
+    """
+    Run the static scanner. Raises 422 with findings on critical issues, or on
+    high-severity issues unless the caller has acknowledged them.
+    """
+    from core.services.plugin_security_scanner import quick_scan
+
+    findings = quick_scan(content, filename=filename)
+    bucketed = _classify_findings(findings)
+
+    if bucketed["blocking"]:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "status": "blocked",
+                "message": "Skill contains critical security issues. Please remove the flagged patterns and try again.",
+                "findings": _findings_to_payload(findings),
+            },
+        )
+
+    if bucketed["warnings"] and not acknowledge_warnings:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "status": "warnings",
+                "message": "Skill contains high-severity findings. Review and resubmit with acknowledge_warnings=true to save anyway.",
+                "findings": _findings_to_payload(findings),
+            },
+        )
+
+    return findings
+
+
+def _apply_frontmatter(skill, content: str, body: Any) -> str:
+    """
+    Parse SKILL.md frontmatter and overlay onto the skill record.
+    Body fields (description / category / tags) override frontmatter when set.
+    Returns the raw markdown body to store in prompt_template.
+    """
+    from modules.agents.services.skill_loader import parse_yaml_frontmatter
+
+    yaml_data, markdown_body = parse_yaml_frontmatter(content)
+    yaml_data = yaml_data or {}
+
+    # Frontmatter sets defaults; explicit body fields win.
+    skill.description = body.description or yaml_data.get("description") or skill.description
+    skill.category = body.category or yaml_data.get("category") or skill.category
+    incoming_tags = body.tags if body.tags is not None else yaml_data.get("tags")
+    if incoming_tags is not None:
+        skill.tags = incoming_tags
+
+    if yaml_data.get("version"):
+        skill.skill_version = str(yaml_data["version"])
+
+    # Persist parsed metadata for downstream consumers (skill_loader.load_skill_metadata)
+    existing_metadata = skill.skill_metadata if isinstance(skill.skill_metadata, dict) else {}
+    skill.skill_metadata = {**existing_metadata, **{k: v for k, v in yaml_data.items() if k != "forked_from_skill_id"}}
+    # Restore lineage if it was already there
+    if "forked_from_skill_id" in existing_metadata:
+        skill.skill_metadata["forked_from_skill_id"] = existing_metadata["forked_from_skill_id"]
+
+    # Store the full SKILL.md (frontmatter + body) — that's what skill_loader expects
+    return content
+
+
+@router.get("/{workspace_id}/skills/{skill_id}/content")
+async def get_workspace_skill_content(
+    workspace_id: UUID,
+    skill_id: int,
+    ctx: RequestContext = Depends(get_request_context_hybrid),
+    db: Session = Depends(get_db),
+):
+    """
+    Return the raw SKILL.md content for a workspace skill (forked or enabled marketplace).
+    Used by the editor modal to populate the textarea.
+    """
+    _assert_workspace_access(ctx, workspace_id)
+
+    from core.models.core import Skill
+    from core.models.marketplace_plugins import WorkspaceEnabledSkill
+
+    skill = db.query(Skill).filter(Skill.id == skill_id, Skill.is_active == True).first()
+    if not skill:
+        raise HTTPException(status_code=404, detail="Skill not found")
+
+    # Authorization: workspace can read its own skill, or any marketplace skill it has enabled.
+    if skill.workspace_id is not None and skill.workspace_id != workspace_id:
+        raise HTTPException(status_code=403, detail="Skill does not belong to this workspace")
+
+    if skill.workspace_id is None:
+        enabled = db.query(WorkspaceEnabledSkill).filter(
+            WorkspaceEnabledSkill.workspace_id == workspace_id,
+            WorkspaceEnabledSkill.skill_id == skill_id,
+        ).first()
+        if not enabled:
+            raise HTTPException(status_code=403, detail="Skill is not enabled for this workspace")
+
+    metadata = skill.skill_metadata if isinstance(skill.skill_metadata, dict) else {}
+    return {
+        "skill_id": skill.id,
+        "name": skill.name,
+        "description": skill.description,
+        "category": skill.category,
+        "tags": skill.tags or [],
+        "skill_version": skill.skill_version,
+        "skill_source": skill.skill_source,
+        "content": skill.prompt_template or "",
+        "origin": "workspace" if skill.workspace_id is not None else "marketplace",
+        "forked_from_skill_id": metadata.get("forked_from_skill_id"),
+        "editable": skill.workspace_id is not None,
+    }
+
+
+@router.post("/{workspace_id}/skills/create", status_code=201)
+async def create_workspace_skill(
+    workspace_id: UUID,
+    body: CreateSkillBody,
+    ctx: RequestContext = Depends(get_request_context_hybrid),
+    db: Session = Depends(get_db),
+):
+    """
+    Create a new workspace-owned skill from pasted or uploaded SKILL.md content.
+    Runs the security scanner; 422 if blocked.
+    """
+    _assert_workspace_access(ctx, workspace_id)
+
+    from core.models.core import Skill
+    from core.models.marketplace_plugins import WorkspaceEnabledSkill
+
+    findings = _scan_or_raise(body.content, filename=f"{body.name}.md", acknowledge_warnings=body.acknowledge_warnings)
+
+    # Reject duplicate names within the same workspace
+    duplicate = db.query(Skill).filter(
+        Skill.workspace_id == workspace_id,
+        Skill.name == body.name,
+        Skill.is_active == True,
+    ).first()
+    if duplicate:
+        raise HTTPException(status_code=409, detail=f"A skill named '{body.name}' already exists in this workspace")
+
+    user_id = _resolve_user_id(ctx, db)
+
+    skill = Skill(
+        name=body.name,
+        description=body.description or "",
+        skill_type=body.skill_type or "cognitive",
+        category=body.category,
+        tags=body.tags,
+        prompt_template=body.content,
+        skill_source="workspace-user",
+        skill_version="1.0.0",
+        workspace_id=workspace_id,
+        is_active=True,
+        created_by=str(user_id) if user_id else None,
+        skill_metadata={},
+    )
+    _apply_frontmatter(skill, body.content, body)
+
+    db.add(skill)
+    db.flush()
+
+    # Auto-enable for the workspace so it shows up in the listing immediately
+    db.add(WorkspaceEnabledSkill(
+        workspace_id=workspace_id,
+        skill_id=skill.id,
+        enabled_by=user_id,
+    ))
+    db.commit()
+
+    logger.info("Created workspace skill '%s' (id=%d) for workspace %s", skill.name, skill.id, workspace_id)
+
+    return {
+        "success": True,
+        "skill_id": skill.id,
+        "name": skill.name,
+        "warnings": _findings_to_payload([f for f in findings if f.severity in _WARNING_SEVERITIES]),
+    }
+
+
+@router.patch("/{workspace_id}/skills/{skill_id}")
+async def update_workspace_skill(
+    workspace_id: UUID,
+    skill_id: int,
+    body: UpdateSkillBody,
+    ctx: RequestContext = Depends(get_request_context_hybrid),
+    db: Session = Depends(get_db),
+):
+    """
+    Update a workspace skill's content.
+
+    If the target is a marketplace skill (workspace_id IS NULL), this performs
+    fork-on-edit: clones the skill into the workspace, records lineage in
+    skill_metadata.forked_from_skill_id, migrates any existing agent_skills
+    assignments to the fork, and disables the marketplace junction.
+
+    Returns the (possibly new) skill_id of the workspace-owned record.
+    """
+    _assert_workspace_access(ctx, workspace_id)
+
+    from core.models.core import Agent, Skill, agent_skills as agent_skills_table
+    from core.models.marketplace_plugins import WorkspaceEnabledSkill
+
+    target = db.query(Skill).filter(Skill.id == skill_id, Skill.is_active == True).first()
+    if not target:
+        raise HTTPException(status_code=404, detail="Skill not found")
+
+    # Authorization
+    if target.workspace_id is not None and target.workspace_id != workspace_id:
+        raise HTTPException(status_code=403, detail="Skill does not belong to this workspace")
+
+    if target.workspace_id is None:
+        # Must be enabled for this workspace to be forkable
+        enabled = db.query(WorkspaceEnabledSkill).filter(
+            WorkspaceEnabledSkill.workspace_id == workspace_id,
+            WorkspaceEnabledSkill.skill_id == skill_id,
+        ).first()
+        if not enabled:
+            raise HTTPException(status_code=403, detail="Skill is not enabled for this workspace")
+
+    findings = _scan_or_raise(body.content, filename=f"{target.name}.md", acknowledge_warnings=body.acknowledge_warnings)
+
+    user_id = _resolve_user_id(ctx, db)
+
+    if target.workspace_id is None:
+        # Fork-on-edit
+        fork = Skill(
+            name=target.name,
+            description=target.description,
+            skill_type=target.skill_type,
+            category=target.category,
+            tags=list(target.tags) if target.tags else None,
+            prompt_template=body.content,
+            skill_source="workspace-fork",
+            skill_version=target.skill_version,
+            workspace_id=workspace_id,
+            is_active=True,
+            created_by=str(user_id) if user_id else None,
+            skill_metadata={"forked_from_skill_id": target.id},
+        )
+        _apply_frontmatter(fork, body.content, body)
+        db.add(fork)
+        db.flush()
+
+        # Migrate existing agent_skills assignments to the fork (within this workspace)
+        from sqlalchemy import and_
+        workspace_agent_ids = [
+            a.id for a in db.query(Agent.id).filter(Agent.workspace_id == workspace_id).all()
+        ]
+        migrated = 0
+        if workspace_agent_ids:
+            existing = db.execute(
+                agent_skills_table.select().where(
+                    and_(
+                        agent_skills_table.c.agent_id.in_(workspace_agent_ids),
+                        agent_skills_table.c.skill_id == target.id,
+                    )
+                )
+            ).fetchall()
+            for row in existing:
+                db.execute(agent_skills_table.delete().where(
+                    and_(
+                        agent_skills_table.c.agent_id == row.agent_id,
+                        agent_skills_table.c.skill_id == target.id,
+                    )
+                ))
+                db.execute(agent_skills_table.insert().values(
+                    agent_id=row.agent_id, skill_id=fork.id,
+                ))
+                migrated += 1
+
+        # Replace marketplace junction with fork-aware view: drop the old junction so
+        # listing surfaces the fork instead. (Listing already hides marketplace skills
+        # whose ids are forked_from_skill_id of a workspace skill — but dropping the
+        # junction is cleaner and ensures the user can re-enable the original later.)
+        db.query(WorkspaceEnabledSkill).filter(
+            WorkspaceEnabledSkill.workspace_id == workspace_id,
+            WorkspaceEnabledSkill.skill_id == target.id,
+        ).delete()
+
+        db.commit()
+        _invalidate_skill_cache(fork.name, db)
+        logger.info(
+            "Forked marketplace skill %d -> workspace skill %d (name=%s, %d agent assignments migrated)",
+            target.id, fork.id, fork.name, migrated,
+        )
+        return {
+            "success": True,
+            "skill_id": fork.id,
+            "forked": True,
+            "forked_from_skill_id": target.id,
+            "agents_migrated": migrated,
+            "warnings": _findings_to_payload([f for f in findings if f.severity in _WARNING_SEVERITIES]),
+        }
+
+    # In-place update (already workspace-owned)
+    target.prompt_template = body.content
+    _apply_frontmatter(target, body.content, body)
+    db.commit()
+    _invalidate_skill_cache(target.name, db)
+    logger.info("Updated workspace skill %d (name=%s)", target.id, target.name)
+    return {
+        "success": True,
+        "skill_id": target.id,
+        "forked": False,
+        "warnings": _findings_to_payload([f for f in findings if f.severity in _WARNING_SEVERITIES]),
+    }
+
+
+@router.delete("/{workspace_id}/skills/{skill_id}/owned")
+async def delete_workspace_owned_skill(
+    workspace_id: UUID,
+    skill_id: int,
+    ctx: RequestContext = Depends(get_request_context_hybrid),
+    db: Session = Depends(get_db),
+):
+    """
+    Delete a workspace-owned skill (forked or user-created). Refuses to delete
+    marketplace skills — use the existing DELETE /skills/{skill_id} (disable) for those.
+    """
+    _assert_workspace_access(ctx, workspace_id)
+
+    from core.models.core import Agent, Skill, agent_skills as agent_skills_table
+    from core.models.marketplace_plugins import WorkspaceEnabledSkill
+    from sqlalchemy import and_, delete
+
+    skill = db.query(Skill).filter(Skill.id == skill_id).first()
+    if not skill:
+        raise HTTPException(status_code=404, detail="Skill not found")
+    if skill.workspace_id != workspace_id:
+        raise HTTPException(status_code=403, detail="Skill is not workspace-owned")
+
+    # Drop agent assignments first (FK)
+    workspace_agent_ids = [
+        a.id for a in db.query(Agent.id).filter(Agent.workspace_id == workspace_id).all()
+    ]
+    if workspace_agent_ids:
+        db.execute(delete(agent_skills_table).where(
+            and_(
+                agent_skills_table.c.agent_id.in_(workspace_agent_ids),
+                agent_skills_table.c.skill_id == skill_id,
+            )
+        ))
+
+    # Drop junction (auto-enabled on create)
+    db.query(WorkspaceEnabledSkill).filter(
+        WorkspaceEnabledSkill.workspace_id == workspace_id,
+        WorkspaceEnabledSkill.skill_id == skill_id,
+    ).delete()
+
+    name = skill.name
+    db.delete(skill)
+    db.commit()
+    _invalidate_skill_cache(name, db)
+
+    logger.info("Deleted workspace-owned skill %d (name=%s) for workspace %s", skill_id, name, workspace_id)
+    return {"success": True, "skill_id": skill_id}


### PR DESCRIPTION
… save

Agents now has a Skills tab where users view, edit, and create skills scoped to their workspace. Editing a marketplace skill forks it (lineage stored in skill_metadata.forked_from_skill_id, agent_skills assignments migrated). New skills support paste or .md drop. Every save runs plugin_security_scanner quick_scan; critical findings hard-block, high findings warn-and-confirm. Quick-assign-to-agent dropdown reuses existing assignSkillsToAgent.

Backend:
- workspace_skills.py: GET content, POST create, PATCH update (fork-on-edit), DELETE owned. Listing now unions marketplace junctions + workspace-owned skills, hiding marketplace originals shadowed by a fork.
- skills.py: list_skills filtered by workspace (was leaking other tenants).
- Fixed pre-existing agent_skills_table import bug in disable_skill.

Frontend:
- workspace-skills-tab.tsx: card grid, search, origin filter, counts.
- skill-editor-modal.tsx: one component, view/edit/new modes, findings panel, quick-assign dropdown, .md upload.
- New hooks in use-skills-api.ts + SkillScanError type.

Plus the page cleanup work bundled with this session:
- Agents: removed Coordination + Playbooks tabs (per VISION.md).
- Tools: dropped Rating/Usage sort options (untracked); fixed delete-from- workspace to send the canonical Composio app name, not display name.
- Knowledge Bases: restored Memory tab (deleted with Command Center cleanup).
- Shepherd tours updated to match new tab sets.
- Stale /agents?tab=recipes link retargeted to /assignments?tab=playbooks.