### PR TITLE
feat(activity): board tasks surface in feed + auto-create reports lik…

### DIFF
--- a/frontend/components/activity/activity-feed.tsx
+++ b/frontend/components/activity/activity-feed.tsx
@@ -14,6 +14,7 @@ import {
   Zap,
   Eye,
   MessageCircle,
+  CheckSquare,
 } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { formatDistanceToNow } from 'date-fns'
@@ -235,6 +236,11 @@ export function ActivityFeed({ period = '1d', openExecution, deepLinkRecipeId }:
       router.push(`/chat/${item.source_id}`)
       return
     }
+    // For tasks, jump to the kanban board with the task highlighted
+    if (item.type === 'task' && item.source_id) {
+      router.push(`/command-center?tab=board&task=${item.source_id}` as any)
+      return
+    }
     // Fallback to inline detail for routines
     setSelectedItem(item)
   }, [router])
@@ -429,6 +435,12 @@ function FeedRow({ item, index, isNew, onView }: FeedRowProps) {
               <Badge className="text-xs bg-cyan-500/20 text-cyan-300 border-cyan-500/30 shrink-0">
                 <Rocket className="w-3 h-3 mr-1" />
                 Mission
+              </Badge>
+            )}
+            {item.type === 'task' && (
+              <Badge className="text-xs bg-purple-500/20 text-purple-300 border-purple-500/30 shrink-0">
+                <CheckSquare className="w-3 h-3 mr-1" />
+                Task
               </Badge>
             )}
             <Badge className={cn('text-xs shrink-0', statusBadge.className)}>

--- a/frontend/hooks/use-activity-api.ts
+++ b/frontend/hooks/use-activity-api.ts
@@ -30,9 +30,9 @@ export interface ActivityChannel {
 
 export interface ActivityFeedItem {
   id: string
-  type: 'chat' | 'routine' | 'recipe' | 'mission'
+  type: 'chat' | 'routine' | 'recipe' | 'mission' | 'task'
   name: string
-  status: 'pending' | 'running' | 'completed' | 'failed' | 'cancelled' | 'paused'
+  status: 'pending' | 'running' | 'completed' | 'failed' | 'cancelled' | 'paused' | 'working' | 'attention'
   started_at: string | null
   completed_at: string | null
   duration_seconds: number | null
@@ -41,7 +41,7 @@ export interface ActivityFeedItem {
   summary: string
   source_id: string | null
   source_url: string | null
-  trigger: 'manual' | 'scheduled' | 'event' | 'webhook' | 'heartbeat' | null
+  trigger: 'manual' | 'scheduled' | 'event' | 'webhook' | 'heartbeat' | string | null
   channel?: ActivityChannel | null
   step_progress?: ActivityStepProgress | null
   error_message: string | null

--- a/orchestrator/api/board_tasks.py
+++ b/orchestrator/api/board_tasks.py
@@ -38,6 +38,105 @@ _PRIORITY_SLA_HOURS: dict[str, int] = {
 }
 
 
+# ── Auto-report creation (mirrors heartbeat_service._auto_create_report) ───
+async def _auto_create_task_report(
+    db: Session,
+    workspace_id: str,
+    task: BoardTask,
+    exec_result: Dict[str, Any],
+) -> None:
+    """
+    Persist an agent_reports row for a completed task so it shows up in
+    Reports / Deliverables / Activity Feed — same pattern heartbeats use.
+    Always non-blocking: never raises, just warns on failure.
+    """
+    try:
+        from services.report_service import ReportService
+
+        agent_name = "Unknown Agent"
+        if task.assigned_agent_id:
+            agent = db.query(Agent).filter(Agent.id == task.assigned_agent_id).first()
+            if agent:
+                agent_name = agent.name
+
+        # Source the body from the agent's actual response, falling back to whatever
+        # text was captured in task.result.
+        llm_text = (
+            exec_result.get("result")
+            or exec_result.get("response")
+            or exec_result.get("output")
+            or exec_result.get("content")
+            or task.result
+            or ""
+        )
+
+        usage = exec_result.get("usage") or {}
+        tokens = (
+            usage.get("total_tokens")
+            or exec_result.get("tokens_used")
+            or 0
+        )
+
+        report_status = "ok" if task.status in ("done", "review") else "warning"
+        if task.error_message:
+            report_status = "critical"
+
+        # Render the same shape heartbeat reports use so consumers stay uniform.
+        lines = [
+            f"# {agent_name} — Task Report",
+            f"**Task:** {task.title}",
+            f"**Status:** {task.status}",
+            "",
+        ]
+        if task.error_message:
+            lines.append("## Error")
+            lines.append(str(task.error_message))
+            lines.append("")
+        if llm_text:
+            lines.append("## Result")
+            lines.append(str(llm_text))
+            lines.append("")
+        lines.append("## Metrics")
+        lines.append(f"- Tokens used: {tokens}")
+        lines.append(f"- Duration: {task.duration_seconds() if hasattr(task, 'duration_seconds') else 'n/a'}")
+        content = "\n".join(lines)
+
+        # Summary is the first non-empty body line — same convention as heartbeat reports.
+        summary = None
+        for line in str(llm_text).split("\n"):
+            stripped = line.strip().lstrip("#").strip()
+            if stripped:
+                summary = (stripped[:497] + "...") if len(stripped) > 497 else stripped
+                break
+
+        svc = ReportService(db, workspace_id)
+        report_result = await svc.create_report(
+            agent_id=task.assigned_agent_id,
+            agent_name=agent_name,
+            title=f"Task: {task.title}",
+            content=content,
+            report_type="task",
+            status=report_status,
+            summary=summary,
+            metrics={
+                "tokens_used": tokens,
+                "task_id": task.id,
+                "task_status": task.status,
+            },
+        )
+        if not report_result.get("success"):
+            logger.warning(
+                "[BoardTasks] Auto-report creation failed for task=%s: %s",
+                task.id, report_result.get("error"),
+            )
+    except Exception:
+        logger.error(
+            "[BoardTasks] _auto_create_task_report raised for task=%s",
+            getattr(task, "id", "?"),
+            exc_info=True,
+        )
+
+
 # ── PRD-128: Unified notification dispatch ─────────────────────────
 async def _dispatch_task_complete(db: Session, workspace_id, task: BoardTask) -> None:
     """Fire a ``task_complete`` event through NotificationDispatcher.
@@ -601,6 +700,9 @@ def _launch_task_execution(
                 # PRD-128: dispatch task_complete only on terminal 'done'
                 if task.status == "done":
                     await _dispatch_task_complete(db, workspace_id, task)
+                # Persist a report row for every completed task so it surfaces
+                # in Reports / Deliverables / Activity Feed (mirrors heartbeats).
+                await _auto_create_task_report(db, workspace_id, task, exec_result)
                 db.commit()
 
             logger.info(
@@ -617,6 +719,12 @@ def _launch_task_execution(
                     task.status = "inbox"
                     task.error_message = str(e)[:500]
                     task.started_at = None
+                    db.commit()
+                    # Surface failures the same way successes are surfaced.
+                    await _auto_create_task_report(
+                        db, workspace_id, task,
+                        {"result": "", "tokens_used": 0},
+                    )
                     db.commit()
             except Exception:
                 db.rollback()

--- a/orchestrator/services/activity_service.py
+++ b/orchestrator/services/activity_service.py
@@ -18,6 +18,7 @@ from sqlalchemy.orm import Session
 
 from core.models.core import (
     Agent,
+    BoardTask,
     Chat,
     Message,
     RecipeExecution,
@@ -72,6 +73,9 @@ class ActivityService:
 
         if want_all or "recipe" in want_types:
             items.extend(self._fetch_recipes(since, limit + offset))
+
+        if want_all or "task" in want_types:
+            items.extend(self._fetch_board_tasks(since, limit + offset))
 
         # Apply status filter after merge
         if status:
@@ -307,6 +311,88 @@ class ActivityService:
             return items
         except Exception as e:
             logger.error("Failed to fetch recipes for activity feed: %s", e, exc_info=True)
+            self.db.rollback()
+            return []
+
+    # ── Board Task Fetching ───────────────────────────────────────
+
+    def _fetch_board_tasks(self, since: datetime, max_rows: int) -> List[Dict[str, Any]]:
+        """
+        Fetch recent board tasks (kanban) as activity items so completions and
+        in-flight work surface alongside heartbeats and chats.
+        """
+        try:
+            tasks = (
+                self.db.query(BoardTask)
+                .filter(
+                    BoardTask.workspace_id == self.workspace_id,
+                    # started_at OR completed_at OR created_at within window;
+                    # we use the most-recent of those for ordering downstream.
+                    (
+                        (BoardTask.started_at >= since) |
+                        (BoardTask.completed_at >= since) |
+                        (BoardTask.updated_at >= since)
+                    ),
+                    # Only show tasks an agent has actually touched. inbox/assigned
+                    # tasks aren't "activity" yet — they're queued.
+                    BoardTask.status.in_(("in_progress", "review", "done", "blocked")),
+                )
+                .order_by(desc(BoardTask.updated_at))
+                .limit(max_rows)
+                .all()
+            )
+
+            agent_ids = {t.assigned_agent_id for t in tasks if t.assigned_agent_id}
+            agents_by_id: Dict[int, Agent] = {}
+            if agent_ids:
+                rows = self.db.query(Agent).filter(Agent.id.in_(agent_ids)).all()
+                agents_by_id = {a.id: a for a in rows}
+
+            items: List[Dict[str, Any]] = []
+            for t in tasks:
+                feed_status = {
+                    "in_progress": "working",
+                    "review": "attention",
+                    "done": "completed",
+                    "blocked": "attention",
+                }.get(t.status, "completed")
+
+                agent = agents_by_id.get(t.assigned_agent_id) if t.assigned_agent_id else None
+                agent_info = None
+                if agent:
+                    agent_info = {
+                        "id": agent.id,
+                        "name": agent.name,
+                        "avatar_url": getattr(agent, "marketplace_icon", None),
+                    }
+
+                summary = ""
+                if t.error_message:
+                    summary = str(t.error_message)
+                elif t.result:
+                    summary = str(t.result)
+                elif t.description:
+                    summary = str(t.description)
+
+                items.append(
+                    self._build_feed_item(
+                        id=f"task-{t.id}",
+                        item_type="task",
+                        name=t.title or f"Task #{t.id}",
+                        status=feed_status,
+                        started_at=t.started_at or t.created_at,
+                        completed_at=t.completed_at,
+                        agent=agent_info,
+                        summary=summary,
+                        source_id=str(t.id),
+                        source_url=f"/command-center?tab=board&task={t.id}",
+                        trigger=t.source_type,
+                        error_message=t.error_message,
+                    )
+                )
+            return items
+        except Exception as e:
+            logger.error("Failed to fetch board tasks for activity feed: %s", e, exc_info=True)
             self.db.rollback()
             return []
 


### PR DESCRIPTION
…e heartbeats

Two parallel gaps closed:

1. Board task execution didn't write a report — heartbeats do via _auto_create_report. Added _auto_create_task_report in board_tasks.py that calls ReportService.create_report on completion (and on failure), so every task now lands as an agent_reports row + dispatches report_submitted (which feeds notifications).

2. ActivityService never queried board_tasks at all — only chats, heartbeats, recipes. Added _fetch_board_tasks pulling tasks in in_progress/review/done/blocked states (queued tasks aren't "activity" yet). Items get a /command-center?tab=board&task=N source_url so clicking through the feed lands on the kanban.

Frontend:
- ActivityFeedItem.type extended with 'task'.
- Purple Task badge in the feed row, CheckSquare icon.
- handleViewItem routes task clicks to the board.