### PR TITLE
fix(composio): add LinkedIn image upload actions to FileUpload interc…

### DIFF
--- a/orchestrator/core/composio/tool_executor.py
+++ b/orchestrator/core/composio/tool_executor.py
@@ -148,6 +148,8 @@ class ComposioToolExecutor:
         "LINKEDIN_CREATE_LINKED_IN_POST",
         "LINKEDIN_CREATE_IMAGE_POST",
         "LINKEDIN_CREATE_SHARE",
+        "LINKEDIN_INITIALIZE_IMAGE_UPLOAD",
+        "LINKEDIN_REGISTER_IMAGE_UPLOAD",
     }
     _FILE_PARAM_NAMES = {"media", "media_data", "media_url", "media_urls", "file", "image", "video", "media_file"}
 


### PR DESCRIPTION
…eptor

LINKEDIN_INITIALIZE_IMAGE_UPLOAD and LINKEDIN_REGISTER_IMAGE_UPLOAD need the same FileUploadable conversion so Composio can handle the binary upload to LinkedIn's asset API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added file upload support for Composio actions, automatically converting workspace paths and URLs to file objects.
  * Implemented automatic action mapping with ranked suggestions for unmapped actions.
  * Added agent-specific action enablement/disablement capabilities.
  * Enhanced validation to verify agent app assignments and workspace connectivity.

* **Bug Fixes**
  * Improved error handling with structured execution errors and dependency detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->