### PR TITLE
fix: import Dict, Any in board_tasks.py — was breaking app boot

### DIFF
--- a/orchestrator/api/board_tasks.py
+++ b/orchestrator/api/board_tasks.py
@@ -10,7 +10,7 @@ import asyncio
 import json
 import logging
 from datetime import datetime, timedelta, timezone
-from typing import Optional
+from typing import Any, Dict, Optional
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request


### PR DESCRIPTION
The _auto_create_task_report helper added in b15b0e9ca uses Dict[str, Any] in its signature but board_tasks.py only imported Optional. AST parse passed locally because annotations aren't resolved at parse time, but at module import the NameError took the entire app down.

Add Any and Dict to the existing typing import.