### PR TITLE
fix(activity): History page crash on task items

### DIFF
--- a/frontend/components/activity/execution-detail.tsx
+++ b/frontend/components/activity/execution-detail.tsx
@@ -20,6 +20,7 @@ import {
   User,
   ChevronDown,
   ChevronUp,
+  ListTodo,
 } from 'lucide-react'
 import { format, formatDistanceToNow } from 'date-fns'
 import { toast } from 'react-hot-toast'
@@ -56,7 +57,22 @@ const TYPE_CONFIG = {
     accentColor: 'text-[hsl(var(--success))]',
     borderColor: 'border-l-[hsl(var(--success))]',
   },
+  task: {
+    icon: ListTodo,
+    label: 'Task',
+    accentColor: 'text-[hsl(var(--info))]',
+    borderColor: 'border-l-[hsl(var(--info))]',
+  },
 } as const
+
+const TYPE_FALLBACK = {
+  icon: ListTodo,
+  label: 'Activity',
+  accentColor: 'text-muted-foreground',
+  borderColor: 'border-l-border',
+} as const
+
+const STATUS_FALLBACK = { label: 'Unknown', variant: 'neutral' as StatusVariant, dot: false }
 
 const STATUS_MAP: Record<ActivityFeedItem['status'], { label: string; variant: StatusVariant; dot: boolean }> = {
   pending: { label: 'Waiting', variant: 'neutral', dot: false },
@@ -274,8 +290,8 @@ export function ExecutionDetail({ item, onClose }: ExecutionDetailProps) {
   const prefersReducedMotion = useReducedMotion()
   const [logsExpanded, setLogsExpanded] = useState(true)
 
-  const typeConfig = TYPE_CONFIG[item.type]
-  const statusConfig = STATUS_MAP[item.status]
+  const typeConfig = TYPE_CONFIG[item.type as keyof typeof TYPE_CONFIG] ?? TYPE_FALLBACK
+  const statusConfig = STATUS_MAP[item.status] ?? STATUS_FALLBACK
   const TypeIcon = typeConfig.icon
   const logEntries = generateLogEntries(item)
 

--- a/frontend/hooks/use-activity-api.ts
+++ b/frontend/hooks/use-activity-api.ts
@@ -32,7 +32,7 @@ export interface ActivityFeedItem {
   id: string
   type: 'chat' | 'routine' | 'recipe' | 'mission' | 'task'
   name: string
-  status: 'pending' | 'running' | 'completed' | 'failed' | 'cancelled' | 'paused' | 'working' | 'attention'
+  status: 'pending' | 'running' | 'completed' | 'failed' | 'cancelled' | 'paused'
   started_at: string | null
   completed_at: string | null
   duration_seconds: number | null

--- a/orchestrator/services/activity_service.py
+++ b/orchestrator/services/activity_service.py
@@ -350,11 +350,15 @@ class ActivityService:
 
             items: List[Dict[str, Any]] = []
             for t in tasks:
+                # Map kanban statuses to the activity feed's internal status
+                # vocabulary (running/completed/failed/pending) — same shape
+                # heartbeats and recipes use, so STATUS_MAP / STATUS_VARIANT_MAP
+                # / _map_status_filter all work without special-casing.
                 feed_status = {
-                    "in_progress": "working",
-                    "review": "attention",
+                    "in_progress": "running",
+                    "review": "pending",
                     "done": "completed",
-                    "blocked": "attention",
+                    "blocked": "failed",
                 }.get(t.status, "completed")
 
                 agent = agents_by_id.get(t.assigned_agent_id) if t.assigned_agent_id else None


### PR DESCRIPTION
Two related bugs from b15b0e9ca (board tasks in activity feed):

1. _fetch_board_tasks emitted non-canonical statuses ('working', 'attention') instead of the internal vocabulary the rest of the feed uses ('running'/'completed'/'failed'/'pending'). _map_status_filter never matched, STATUS_MAP / STATUS_VARIANT_MAP fell through to neutral fallbacks, and the user-facing status filter chips broke for tasks. Fixed by mapping kanban → internal: in_progress→running, review→pending, done→completed, blocked→failed.

2. ExecutionDetail did `const TypeIcon = typeConfig.icon` with no fallback. When item.type === 'task' (now possible), TYPE_CONFIG returns undefined and the icon access throws — a client-side exception that took the History page down. Added a 'task' entry to TYPE_CONFIG plus generic TYPE_FALLBACK / STATUS_FALLBACK objects so future item types or statuses degrade gracefully instead of crashing.

Reverted my earlier ActivityFeedItem.status union widening since the backend now stays inside the canonical vocabulary.