### PR TITLE
feat(reports): unified execution metrics for heartbeat / task / playbook

### DIFF
--- a/orchestrator/api/board_tasks.py
+++ b/orchestrator/api/board_tasks.py
@@ -51,7 +51,7 @@ async def _auto_create_task_report(
     Always non-blocking: never raises, just warns on failure.
     """
     try:
-        from services.report_service import ReportService
+        from services.report_service import ReportService, compute_execution_metrics
 
         agent_name = "Unknown Agent"
         if task.assigned_agent_id:
@@ -70,12 +70,31 @@ async def _auto_create_task_report(
             or ""
         )
 
-        usage = exec_result.get("usage") or {}
-        tokens = (
-            usage.get("total_tokens")
-            or exec_result.get("tokens_used")
-            or 0
+        # Pull cost/model/duration rollup from llm_usage (window = task started→completed)
+        exec_metrics = compute_execution_metrics(
+            db,
+            workspace_id,
+            agent_id=task.assigned_agent_id,
+            execution_id=getattr(task, "execution_id", None),
+            started_at=getattr(task, "started_at", None),
+            completed_at=getattr(task, "completed_at", None),
+            extra={
+                "task_id": task.id,
+                "task_status": task.status,
+                "trigger": "task",
+            },
         )
+
+        # Honour upstream-supplied tokens if the rollup found nothing
+        if not exec_metrics.get("tokens_used"):
+            usage = exec_result.get("usage") or {}
+            fallback_tokens = (
+                usage.get("total_tokens")
+                or exec_result.get("tokens_used")
+                or 0
+            )
+            if fallback_tokens:
+                exec_metrics["tokens_used"] = fallback_tokens
 
         report_status = "ok" if task.status in ("done", "review") else "warning"
         if task.error_message:
@@ -96,9 +115,16 @@ async def _auto_create_task_report(
             lines.append("## Result")
             lines.append(str(llm_text))
             lines.append("")
-        lines.append("## Metrics")
-        lines.append(f"- Tokens used: {tokens}")
-        lines.append(f"- Duration: {task.duration_seconds() if hasattr(task, 'duration_seconds') else 'n/a'}")
+        lines.append("## Execution Metrics")
+        lines.append(f"- Model: {exec_metrics.get('model') or 'unknown'}")
+        lines.append(f"- LLM calls: {exec_metrics.get('llm_calls', 0)}")
+        lines.append(f"- Tokens (in/out/total): "
+                     f"{exec_metrics.get('input_tokens', 0)} / "
+                     f"{exec_metrics.get('output_tokens', 0)} / "
+                     f"{exec_metrics.get('tokens_used', 0)}")
+        lines.append(f"- Cost: ${exec_metrics.get('cost_usd', 0):.4f}")
+        if exec_metrics.get("duration_ms") is not None:
+            lines.append(f"- Duration: {exec_metrics['duration_ms']} ms")
         content = "\n".join(lines)
 
         # Summary is the first non-empty body line — same convention as heartbeat reports.
@@ -118,11 +144,7 @@ async def _auto_create_task_report(
             report_type="task",
             status=report_status,
             summary=summary,
-            metrics={
-                "tokens_used": tokens,
-                "task_id": task.id,
-                "task_status": task.status,
-            },
+            metrics=exec_metrics,
         )
         if not report_result.get("success"):
             logger.warning(

--- a/orchestrator/api/recipe_executor.py
+++ b/orchestrator/api/recipe_executor.py
@@ -83,6 +83,146 @@ async def _dispatch_playbook_event(
 
 
 # ---------------------------------------------------------------------------
+# Auto-report on playbook completion (mirrors heartbeat & task auto-reports)
+# ---------------------------------------------------------------------------
+async def _auto_create_playbook_report(
+    *,
+    db: Session,
+    workspace_id: str,
+    recipe,
+    recipe_execution_id: str,
+    execution,
+    step_results: List[dict],
+    total_duration_ms: int,
+    total_tokens: int,
+    final_output: Any,
+    success: bool,
+) -> None:
+    """Persist an agent_reports row summarising a playbook execution.
+
+    File path: reports/playbook-{slug}/{date}_{exec_id}.md
+    Always non-blocking — never raises.
+    """
+    try:
+        from services.report_service import ReportService, compute_execution_metrics
+
+        recipe_name = getattr(recipe, "name", None) or f"playbook-{recipe.id}"
+        report_agent_name = f"playbook-{recipe_name}"
+
+        # Roll up cost/model/duration across every LLM call in this execution
+        exec_metrics = compute_execution_metrics(
+            db,
+            workspace_id,
+            execution_id=recipe_execution_id,
+            started_at=getattr(execution, "started_at", None),
+            completed_at=getattr(execution, "completed_at", None),
+            extra={
+                "recipe_id": getattr(recipe, "id", None),
+                "recipe_name": recipe_name,
+                "recipe_execution_id": recipe_execution_id,
+                "steps_count": len(step_results),
+                "trigger": "playbook",
+            },
+        )
+        # Honour totals computed by the executor when llm_usage rollup is sparse
+        if not exec_metrics.get("tokens_used"):
+            exec_metrics["tokens_used"] = total_tokens
+        if exec_metrics.get("duration_ms") is None:
+            exec_metrics["duration_ms"] = total_duration_ms
+
+        report_status = "ok" if success else ("warning" if step_results else "critical")
+        any_failed = any(
+            s.get("status") in ("failed", "error") for s in step_results
+        )
+        if any_failed and report_status == "ok":
+            report_status = "warning"
+
+        # Markdown body
+        lines = [
+            f"# {recipe_name} — Playbook Report",
+            f"**Execution:** {recipe_execution_id}",
+            f"**Status:** {'completed' if success else 'failed'}",
+            "",
+            "## Execution Metrics",
+            f"- Primary model: {exec_metrics.get('model') or 'unknown'}",
+            f"- LLM calls: {exec_metrics.get('llm_calls', 0)}",
+            f"- Tokens (in/out/total): "
+            f"{exec_metrics.get('input_tokens', 0)} / "
+            f"{exec_metrics.get('output_tokens', 0)} / "
+            f"{exec_metrics.get('tokens_used', 0)}",
+            f"- Cost: ${exec_metrics.get('cost_usd', 0):.4f}",
+            f"- Duration: {exec_metrics.get('duration_ms', 0)} ms",
+            f"- Steps: {len(step_results)}",
+            "",
+            "## Steps",
+        ]
+        for step in step_results:
+            order = step.get("order") or step.get("step_order") or "?"
+            name = step.get("name") or step.get("agent_name") or "(unnamed)"
+            status = step.get("status", "?")
+            duration = step.get("duration_ms")
+            tokens = step.get("tokens_used", 0)
+            duration_str = f"{duration} ms" if duration is not None else "n/a"
+            lines.append(
+                f"- **#{order} {name}** — {status} · {tokens} tokens · {duration_str}"
+            )
+
+        models_used = exec_metrics.get("models_used") or []
+        if models_used:
+            lines.append("")
+            lines.append("## Models Used")
+            for m in models_used:
+                lines.append(f"- {m}")
+
+        if final_output:
+            preview = str(final_output)[:500]
+            if len(str(final_output)) > 500:
+                preview += "…"
+            lines.append("")
+            lines.append("## Final Output (preview)")
+            lines.append("```")
+            lines.append(preview)
+            lines.append("```")
+
+        content = "\n".join(lines)
+
+        first_step_summary = next(
+            (s.get("output_preview") for s in step_results if s.get("output_preview")),
+            None,
+        )
+        summary = (
+            f"{len(step_results)} steps · "
+            f"${exec_metrics.get('cost_usd', 0):.4f} · "
+            f"{exec_metrics.get('duration_ms', 0)} ms"
+        )
+        if first_step_summary:
+            summary = f"{summary} · {str(first_step_summary)[:100]}"
+
+        svc = ReportService(db, workspace_id)
+        report_result = await svc.create_report(
+            agent_id=None,
+            agent_name=report_agent_name,
+            title=f"Playbook: {recipe_name}",
+            content=content,
+            report_type="summary",
+            status=report_status,
+            summary=summary,
+            metrics=exec_metrics,
+        )
+        if not report_result.get("success"):
+            logger.warning(
+                "[recipe_direct] Playbook auto-report DB insert failed for %s: %s",
+                recipe_execution_id, report_result.get("error"),
+            )
+    except Exception:
+        logger.error(
+            "[recipe_direct] _auto_create_playbook_report raised for %s",
+            recipe_execution_id,
+            exc_info=True,
+        )
+
+
+# ---------------------------------------------------------------------------
 # Per-workspace execution semaphore — allows bounded concurrent recipe
 # execution within a workspace.  Keys are workspace_id strings; values are
 # asyncio.Semaphores created on first access.  The dict itself is
@@ -1313,6 +1453,26 @@ async def _execute_recipe_inner(
             f"{len(step_results)} steps, {total_duration}ms, {total_tokens} tokens"
         )
 
+        # --- Auto-report (mirrors heartbeat / task auto-report) ---
+        try:
+            await _auto_create_playbook_report(
+                db=db,
+                workspace_id=workspace_id,
+                recipe=recipe,
+                recipe_execution_id=recipe_execution_id,
+                execution=execution,
+                step_results=step_results,
+                total_duration_ms=total_duration,
+                total_tokens=total_tokens,
+                final_output=final_output,
+                success=True,
+            )
+        except Exception as report_err:
+            logger.warning(
+                "[recipe_direct] Playbook auto-report failed (non-blocking) for %s: %s",
+                recipe_execution_id, report_err,
+            )
+
         # --- Post-execution: update agent performance_metrics ---
         _update_agent_performance_metrics(db, step_results, success=True)
 
@@ -1537,6 +1697,34 @@ async def _fail_execution(
             logger.info(f"[recipe_direct] Execution {execution_id} marked FAILED: {error_message}")
             # Update agent performance_metrics for failure
             _update_agent_performance_metrics(db, step_results or [], success=False)
+
+            # Auto-report on failure too — system admin needs to see these
+            try:
+                recipe = db.query(WorkflowRecipe).filter(WorkflowRecipe.id == execution.recipe_id).first()
+                if recipe:
+                    duration_ms = 0
+                    if execution.started_at and execution.completed_at:
+                        duration_ms = int(
+                            (execution.completed_at - execution.started_at).total_seconds() * 1000
+                        )
+                    total_tokens = sum((s.get("tokens_used", 0) for s in (step_results or [])))
+                    await _auto_create_playbook_report(
+                        db=db,
+                        workspace_id=str(execution.workspace_id),
+                        recipe=recipe,
+                        recipe_execution_id=execution_id,
+                        execution=execution,
+                        step_results=step_results or [],
+                        total_duration_ms=duration_ms,
+                        total_tokens=total_tokens,
+                        final_output=error_message,
+                        success=False,
+                    )
+            except Exception as rep_err:
+                logger.warning(
+                    "[recipe_direct] Failure auto-report skipped for %s: %s",
+                    execution_id, rep_err,
+                )
 
             # Capture failure context into memory so future runs can learn from it
             try:

--- a/orchestrator/modules/tools/discovery/actions_reports.py
+++ b/orchestrator/modules/tools/discovery/actions_reports.py
@@ -76,6 +76,68 @@ def register_report_actions(registry: ActionRegistry) -> None:
     ))
 
     registry.register(ActionDefinition(
+        name="platform_browse_reports",
+        description=(
+            "List agent reports across the workspace with optional filters. "
+            "Use this to analyse cost / model / duration patterns across agents, "
+            "tasks and playbooks — the system admin agent uses this to recommend "
+            "model swaps and cost savings. For a single agent's most-recent report, "
+            "use platform_get_latest_report instead."
+        ),
+        category="reports",
+        parameters={
+            "type": "object",
+            "properties": {
+                "agent_id": {
+                    "type": "integer",
+                    "description": "Optional agent filter.",
+                },
+                "agent_name": {
+                    "type": "string",
+                    "description": "Optional agent name filter (substring match).",
+                },
+                "report_type": {
+                    "type": "string",
+                    "enum": ["standup", "research", "incident", "summary", "delivery", "audit", "task"],
+                    "description": "Optional report type filter.",
+                },
+                "status": {
+                    "type": "string",
+                    "enum": ["ok", "warning", "critical", "info"],
+                    "description": "Optional status filter.",
+                },
+                "trigger": {
+                    "type": "string",
+                    "enum": ["heartbeat", "task", "playbook"],
+                    "description": "Optional trigger filter — matches metrics.trigger field.",
+                },
+                "model": {
+                    "type": "string",
+                    "description": "Optional model filter — matches metrics.model field (e.g. 'openai/gpt-5').",
+                },
+                "period": {
+                    "type": "string",
+                    "enum": ["1d", "7d", "30d", "90d", "all"],
+                    "description": "Time window. Default 7d.",
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Max rows to return (default 50, max 200).",
+                },
+            },
+            "required": [],
+        },
+        permission_level="read",
+        tags=["reports", "read", "analytics", "monitoring"],
+        examples=[
+            "list reports from the last 7 days",
+            "show me playbook reports that ran on opus-4.7",
+            "list critical reports across the workspace",
+            "show task reports for agent FORGE this month",
+        ],
+    ))
+
+    registry.register(ActionDefinition(
         name="platform_get_latest_report",
         description=(
             "Read the most recent report from a specific agent. Use to check another "

--- a/orchestrator/modules/tools/discovery/handlers_reports.py
+++ b/orchestrator/modules/tools/discovery/handlers_reports.py
@@ -5,6 +5,7 @@ import re
 from typing import Any, Dict, List
 from uuid import UUID
 
+from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 logger = logging.getLogger(__name__)
@@ -104,6 +105,149 @@ async def get_latest_report(db: Session, workspace_id: UUID, params: Dict[str, A
         agent_id=agent_id,
         report_type=report_type,
     )
+
+
+async def browse_reports(db: Session, workspace_id: UUID, params: Dict[str, Any]) -> Dict[str, Any]:
+    """List reports across the workspace with model/trigger/status filters.
+
+    Joins onto the metrics jsonb so callers can filter on `trigger` and `model`
+    (set by heartbeat / task / playbook auto-reports). Returns a compact rollup
+    with per-row cost/duration/model so the system admin agent can analyse.
+    """
+    from sqlalchemy import text
+
+    period = params.get("period", "7d")
+    period_map = {
+        "1d": "INTERVAL '1 day'",
+        "7d": "INTERVAL '7 days'",
+        "30d": "INTERVAL '30 days'",
+        "90d": "INTERVAL '90 days'",
+    }
+    interval_sql = period_map.get(period, "INTERVAL '7 days'")
+    has_period = period != "all"
+
+    try:
+        limit = max(1, min(int(params.get("limit", 50)), 200))
+    except (TypeError, ValueError):
+        limit = 50
+
+    conditions = ["r.workspace_id = :workspace_id"]
+    sql_params: Dict[str, Any] = {"workspace_id": str(workspace_id)}
+
+    if has_period:
+        conditions.append(f"r.created_at >= NOW() - {interval_sql}")
+
+    if params.get("agent_id"):
+        conditions.append("r.agent_id = :agent_id")
+        sql_params["agent_id"] = params["agent_id"]
+
+    if params.get("agent_name"):
+        conditions.append("r.agent_name ILIKE :agent_name")
+        sql_params["agent_name"] = f"%{params['agent_name']}%"
+
+    if params.get("report_type"):
+        conditions.append("r.report_type = :report_type")
+        sql_params["report_type"] = params["report_type"]
+
+    if params.get("status"):
+        conditions.append("r.status = :status")
+        sql_params["status"] = params["status"]
+
+    if params.get("trigger"):
+        conditions.append("r.metrics->>'trigger' = :trigger")
+        sql_params["trigger"] = params["trigger"]
+
+    if params.get("model"):
+        conditions.append("r.metrics->>'model' = :model")
+        sql_params["model"] = params["model"]
+
+    where = " AND ".join(conditions)
+
+    try:
+        rows = db.execute(
+            text(f"""
+                SELECT
+                    r.id,
+                    r.agent_id,
+                    r.agent_name,
+                    r.report_type,
+                    r.status,
+                    r.title,
+                    r.summary,
+                    r.created_at,
+                    r.metrics
+                FROM agent_reports r
+                WHERE {where}
+                ORDER BY r.created_at DESC
+                LIMIT :limit
+            """),
+            {**sql_params, "limit": limit},
+        ).fetchall()
+    except Exception as e:
+        logger.error("[browse_reports] query failed: %s", e, exc_info=True)
+        return {"success": False, "error": f"query failed: {e}"}
+
+    items: list = []
+    total_cost = 0.0
+    total_tokens = 0
+    total_duration_ms = 0
+    by_model: Dict[str, Dict[str, Any]] = {}
+    by_trigger: Dict[str, Dict[str, Any]] = {}
+
+    for row in rows:
+        m = row.metrics if isinstance(row.metrics, dict) else {}
+        cost = float(m.get("cost_usd") or 0)
+        tokens = int(m.get("tokens_used") or 0)
+        duration_ms = int(m.get("duration_ms") or 0)
+        model = m.get("model") or "unknown"
+        trigger = m.get("trigger") or row.report_type
+
+        items.append({
+            "id": str(row.id),
+            "agent_id": row.agent_id,
+            "agent_name": row.agent_name,
+            "report_type": row.report_type,
+            "status": row.status,
+            "title": row.title,
+            "summary": row.summary,
+            "created_at": row.created_at.isoformat() if row.created_at else None,
+            "model": model,
+            "trigger": trigger,
+            "tokens_used": tokens,
+            "cost_usd": cost,
+            "duration_ms": duration_ms,
+            "llm_calls": int(m.get("llm_calls") or 0),
+        })
+
+        total_cost += cost
+        total_tokens += tokens
+        total_duration_ms += duration_ms
+
+        bm = by_model.setdefault(model, {"reports": 0, "tokens": 0, "cost_usd": 0.0, "duration_ms": 0})
+        bm["reports"] += 1
+        bm["tokens"] += tokens
+        bm["cost_usd"] += cost
+        bm["duration_ms"] += duration_ms
+
+        bt = by_trigger.setdefault(trigger, {"reports": 0, "tokens": 0, "cost_usd": 0.0, "duration_ms": 0})
+        bt["reports"] += 1
+        bt["tokens"] += tokens
+        bt["cost_usd"] += cost
+        bt["duration_ms"] += duration_ms
+
+    return {
+        "success": True,
+        "period": period,
+        "count": len(items),
+        "totals": {
+            "cost_usd": round(total_cost, 6),
+            "tokens": total_tokens,
+            "duration_ms": total_duration_ms,
+        },
+        "by_model": by_model,
+        "by_trigger": by_trigger,
+        "items": items,
+    }
 
 
 def _check_required_sections(content: str, required_sections: List[str]) -> List[str]:

--- a/orchestrator/modules/tools/discovery/platform_executor.py
+++ b/orchestrator/modules/tools/discovery/platform_executor.py
@@ -99,6 +99,7 @@ from modules.tools.discovery.handlers_scheduling import (
 from modules.tools.discovery.handlers_reports import (
     submit_report,
     get_latest_report,
+    browse_reports,
 )
 from modules.tools.discovery.handlers_harness import (
     harness_status,
@@ -245,6 +246,7 @@ class PlatformActionExecutor:
             # PRD-76: Agent Reports
             "platform_submit_report": submit_report,
             "platform_get_latest_report": get_latest_report,
+            "platform_browse_reports": browse_reports,
             # PRD-72: Board Tasks
             "platform_create_task": create_board_task,
             "platform_list_tasks": list_board_tasks,

--- a/orchestrator/services/heartbeat_service.py
+++ b/orchestrator/services/heartbeat_service.py
@@ -676,6 +676,7 @@ class HeartbeatService:
             return {"status": "skipped", "reason": "already_ran_this_period"}
 
         self._running_ticks[tick_key] = True
+        run_started_at = datetime.utcnow()
         result: Dict[str, Any] = {
             "source_type": "agent",
             "source_id": str(agent_id),
@@ -684,6 +685,7 @@ class HeartbeatService:
             "findings": [],
             "actions_taken": [],
             "tokens_used": 0,
+            "_run_started_at": run_started_at,
         }
 
         try:
@@ -837,6 +839,7 @@ class HeartbeatService:
             finally:
                 db.close()
 
+            result["_run_completed_at"] = datetime.utcnow()
             await self._store_heartbeat_result(result)
             await self._dispatch_heartbeat_notification(result)
             await self._auto_create_report(agent_id, workspace_id, result)
@@ -850,6 +853,7 @@ class HeartbeatService:
             )
             result["status"] = "error"
             result["findings"].append({"check": "error", "detail": str(e)})
+            result["_run_completed_at"] = datetime.utcnow()
             await self._store_heartbeat_result(result)
             await self._dispatch_heartbeat_notification(result)
             await self._auto_create_report(agent_id, workspace_id, result)
@@ -1199,7 +1203,7 @@ class HeartbeatService:
         try:
             from core.database.database import SessionLocal
             from core.models import Agent
-            from services.report_service import ReportService
+            from services.report_service import ReportService, compute_execution_metrics
 
             db = SessionLocal()
             try:
@@ -1211,6 +1215,24 @@ class HeartbeatService:
                 actions = result.get("actions_taken", [])
                 hb_status = result.get("status", "success")
                 tokens = result.get("tokens_used", 0)
+                started_at = result.get("_run_started_at")
+                completed_at = result.get("_run_completed_at")
+
+                # Pull cost/model/duration rollup from llm_usage
+                exec_metrics = compute_execution_metrics(
+                    db,
+                    workspace_id,
+                    agent_id=agent_id,
+                    started_at=started_at,
+                    completed_at=completed_at,
+                    extra={
+                        "findings_count": len(findings),
+                        "actions_count": len(actions),
+                        "trigger": "heartbeat",
+                    },
+                )
+                if exec_metrics.get("tokens_used"):
+                    tokens = exec_metrics["tokens_used"]
 
                 lines = [
                     f"# {agent_name} — Heartbeat Report",
@@ -1235,8 +1257,17 @@ class HeartbeatService:
                             lines.append(f"- {a}")
                     lines.append("")
 
-                lines.append("## Metrics")
-                lines.append(f"- Tokens used: {tokens}")
+                lines.append("## Execution Metrics")
+                lines.append(f"- Model: {exec_metrics.get('model') or 'unknown'}")
+                lines.append(f"- LLM calls: {exec_metrics.get('llm_calls', 0)}")
+                lines.append(f"- Tokens (in/out/total): "
+                             f"{exec_metrics.get('input_tokens', 0)} / "
+                             f"{exec_metrics.get('output_tokens', 0)} / "
+                             f"{exec_metrics.get('tokens_used', tokens)}")
+                lines.append(f"- Cost: ${exec_metrics.get('cost_usd', 0):.4f}")
+                duration_ms = exec_metrics.get('duration_ms')
+                if duration_ms is not None:
+                    lines.append(f"- Duration: {duration_ms} ms")
                 lines.append(f"- Findings: {len(findings)}")
                 lines.append(f"- Actions: {len(actions)}")
 
@@ -1264,11 +1295,7 @@ class HeartbeatService:
                     report_type="standup",
                     status=report_status,
                     summary=summary,
-                    metrics={
-                        "tokens_used": tokens,
-                        "findings_count": len(findings),
-                        "actions_count": len(actions),
-                    },
+                    metrics=exec_metrics,
                     heartbeat_result_id=result.get("_heartbeat_result_id"),
                 )
 

--- a/orchestrator/services/report_service.py
+++ b/orchestrator/services/report_service.py
@@ -36,6 +36,116 @@ def _agent_slug(agent_name: str) -> str:
     return _slugify(agent_name)
 
 
+def compute_execution_metrics(
+    db: Session,
+    workspace_id: UUID,
+    *,
+    agent_id: Optional[int] = None,
+    execution_id: Optional[str] = None,
+    started_at: Optional[datetime] = None,
+    completed_at: Optional[datetime] = None,
+    extra: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Aggregate model/cost/duration from llm_usage for a report context.
+
+    Pass either execution_id (preferred — exact match on llm_usage.execution_id)
+    or agent_id + (started_at, completed_at) for a time-window aggregate.
+
+    Always returns a dict with the standard keys, even on no-match (zeros).
+    Caller merges the result into ReportService.create_report(metrics=...).
+    """
+    metrics: Dict[str, Any] = {
+        "model": None,
+        "models_used": [],
+        "llm_calls": 0,
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "tokens_used": 0,
+        "cost_usd": 0.0,
+        "duration_ms": None,
+        "started_at": started_at.isoformat() if started_at else None,
+        "completed_at": completed_at.isoformat() if completed_at else None,
+        "llm_errors": 0,
+    }
+
+    if started_at and completed_at:
+        metrics["duration_ms"] = int(
+            (completed_at - started_at).total_seconds() * 1000
+        )
+
+    conditions = ["workspace_id = :workspace_id"]
+    params: Dict[str, Any] = {"workspace_id": str(workspace_id)}
+
+    if execution_id:
+        conditions.append("execution_id = :execution_id")
+        params["execution_id"] = str(execution_id)
+    elif agent_id is not None:
+        conditions.append("agent_id = :agent_id")
+        params["agent_id"] = agent_id
+        if started_at and completed_at:
+            conditions.append("created_at BETWEEN :w_start AND :w_end")
+            params["w_start"] = started_at
+            params["w_end"] = completed_at
+    else:
+        if extra:
+            metrics.update(extra)
+        return metrics
+
+    try:
+        rollup = db.execute(
+            text(
+                f"""
+                SELECT
+                    COUNT(*) AS calls,
+                    COALESCE(SUM(input_tokens), 0) AS in_tok,
+                    COALESCE(SUM(output_tokens), 0) AS out_tok,
+                    COALESCE(SUM(total_tokens), 0) AS tot_tok,
+                    COALESCE(SUM(total_cost), 0) AS cost,
+                    COUNT(*) FILTER (WHERE status NOT IN ('success', NULL)) AS errors
+                FROM llm_usage
+                WHERE {' AND '.join(conditions)}
+                """
+            ),
+            params,
+        ).fetchone()
+
+        if rollup and rollup.calls:
+            metrics["llm_calls"] = int(rollup.calls)
+            metrics["input_tokens"] = int(rollup.in_tok)
+            metrics["output_tokens"] = int(rollup.out_tok)
+            metrics["tokens_used"] = int(rollup.tot_tok)
+            metrics["cost_usd"] = float(rollup.cost)
+            metrics["llm_errors"] = int(rollup.errors)
+
+        models = db.execute(
+            text(
+                f"""
+                SELECT model_id, SUM(total_tokens) AS tok
+                FROM llm_usage
+                WHERE {' AND '.join(conditions)}
+                GROUP BY model_id
+                ORDER BY tok DESC
+                """
+            ),
+            params,
+        ).fetchall()
+
+        if models:
+            metrics["models_used"] = [m.model_id for m in models]
+            metrics["model"] = models[0].model_id
+
+    except Exception as e:
+        logger.warning(
+            "[compute_execution_metrics] rollup failed for ws=%s exec=%s agent=%s: %s",
+            workspace_id, execution_id, agent_id, e,
+        )
+
+    if extra:
+        metrics.update(extra)
+
+    return metrics
+
+
 class ReportService:
     """Service for managing agent reports."""
 


### PR DESCRIPTION
Adds compute_execution_metrics() helper in ReportService that rolls up model, in/out tokens, cost_usd, duration_ms, llm_calls, llm_errors from the llm_usage table for a given execution_id or agent+window.

Wires the helper into all three auto-report paths so every report row in agent_reports.metrics now carries the full cost/model/duration block:

- heartbeat_service._auto_create_report: agent_id + run window
- board_tasks._auto_create_task_report: task.execution_id / started_at
- recipe_executor._auto_create_playbook_report (new): per playbook run, fires on both COMPLETED and _fail_execution paths. File at reports/playbook-{name}/{date}_{title}.md, includes per-step breakdown.

Adds platform_browse_reports action for the future system admin agent — returns items plus by_model and by_trigger rollups so it can recommend model swaps and cost savings off the existing two tables (agent_reports JOIN llm_usage). Zero new tables.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enriched task and playbook reports with detailed execution metrics (token usage, costs, model breakdown, duration).
  * Auto-generation of Markdown playbook reports upon completion and failure.
  * Added report browsing capability with filters by agent, type, status, trigger, and model across workspaces.
  * Enhanced heartbeat reports with aggregated LLM execution metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->