### PR TITLE
fix(channels): auto-start telegram adapter and persist chat_id for no…

### DIFF
--- a/orchestrator/api/channels.py
+++ b/orchestrator/api/channels.py
@@ -110,7 +110,24 @@ async def create_channel(
     db.commit()
 
     logger.info("Created channel connection %s (%s) for workspace %s", conn_id, platform, ctx.workspace_id)
-    return {"id": str(conn_id), "platform": platform, "status": "inactive"}
+
+    started = False
+    try:
+        from channels.manager import get_channel_manager
+        manager = get_channel_manager()
+        started = await manager.start_adapter(str(conn_id), str(ctx.workspace_id), platform, config)
+    except Exception as exc:
+        logger.warning("Failed to auto-start adapter for new channel %s: %s", conn_id, exc)
+
+    if started:
+        db.execute(
+            text("UPDATE channel_connections SET status = 'active', updated_at = NOW() WHERE id = :id"),
+            {"id": str(conn_id)},
+        )
+        db.commit()
+
+    final_status = "active" if started else "inactive"
+    return {"id": str(conn_id), "platform": platform, "status": final_status}
 
 
 @router.put("/{channel_id}")

--- a/orchestrator/channels/manager.py
+++ b/orchestrator/channels/manager.py
@@ -75,15 +75,14 @@ class ChannelManager:
         workspace_id: str,
         platform: str,
         config: dict,
-    ):
-        """Start (or restart) a specific adapter."""
-        # Stop existing instance if already running
+    ) -> bool:
+        """Start (or restart) a specific adapter. Returns True on success."""
         if connection_id in self._adapters:
             await self._adapters[connection_id].stop()
 
         adapter = self._create_adapter(connection_id, workspace_id, platform, config)
         if adapter is None:
-            return
+            return False
 
         try:
             await adapter.start()
@@ -93,8 +92,10 @@ class ChannelManager:
                 platform,
                 connection_id,
             )
+            return True
         except Exception as e:
             logger.error("[ChannelManager] Failed to start %s: %s", platform, e)
+            return False
 
     async def stop_adapter(self, connection_id: str):
         """Stop a specific adapter by connection ID."""

--- a/orchestrator/channels/telegram_adapter.py
+++ b/orchestrator/channels/telegram_adapter.py
@@ -27,7 +27,7 @@ class TelegramAdapter(BaseChannelAdapter):
     async def start(self):
         """Start the Telegram bot."""
         try:
-            from telegram.ext import ApplicationBuilder, MessageHandler, filters
+            from telegram.ext import ApplicationBuilder, CommandHandler, MessageHandler, filters
 
             token = self.config.get("bot_token", "")
             if not token:
@@ -35,7 +35,7 @@ class TelegramAdapter(BaseChannelAdapter):
 
             self._app = ApplicationBuilder().token(token).build()
 
-            # Register message handler — text, photos, and documents
+            self._app.add_handler(CommandHandler(["start", "help"], self._on_command))
             self._app.add_handler(
                 MessageHandler(
                     (filters.TEXT | filters.PHOTO | filters.Document.ALL) & ~filters.COMMAND,
@@ -43,7 +43,6 @@ class TelegramAdapter(BaseChannelAdapter):
                 )
             )
 
-            # Start polling in background
             await self._app.initialize()
             await self._app.start()
             self._task = asyncio.create_task(self._app.updater.start_polling())
@@ -99,12 +98,61 @@ class TelegramAdapter(BaseChannelAdapter):
         except Exception as e:
             return {"status": "error", "detail": str(e)}
 
+    async def _on_command(self, update, context):
+        """Handle /start and /help — captures chat_id and confirms wiring."""
+        if not update.effective_chat:
+            return
+        chat_id = str(update.effective_chat.id)
+        self._persist_default_chat_id(chat_id)
+        try:
+            await context.bot.send_message(
+                chat_id=update.effective_chat.id,
+                text=(
+                    "✅ Connected. This chat is now your default for Automatos "
+                    "notifications. Send any message to talk to your agents."
+                ),
+            )
+        except Exception as e:
+            logger.warning("[Telegram:%s] Failed to ack /start: %s", self.connection_id, e)
+
+    def _persist_default_chat_id(self, chat_id: str) -> None:
+        """Store chat_id in workspace.settings.integrations.telegram_default_chat_id."""
+        try:
+            from core.database.database import SessionLocal
+            from core.models.workspaces import Workspace
+            from sqlalchemy.orm.attributes import flag_modified
+
+            db = SessionLocal()
+            try:
+                ws = db.query(Workspace).get(self.workspace_id)
+                if not ws:
+                    return
+                settings = dict(ws.settings or {})
+                integrations = dict(settings.get("integrations", {}))
+                if integrations.get("telegram_default_chat_id") == chat_id:
+                    return
+                integrations["telegram_default_chat_id"] = chat_id
+                settings["integrations"] = integrations
+                ws.settings = settings
+                flag_modified(ws, "settings")
+                db.commit()
+                logger.info(
+                    "[Telegram:%s] Persisted telegram_default_chat_id=%s for ws=%s",
+                    self.connection_id, chat_id, self.workspace_id,
+                )
+            finally:
+                db.close()
+        except Exception as e:
+            logger.warning("[Telegram:%s] Failed to persist chat_id: %s", self.connection_id, e)
+
     async def _on_message(self, update, context):
         """Handle incoming Telegram message (text, photos, documents)."""
         if not update.message:
             return
 
-        # Must have text, photo, or document
+        if update.effective_chat:
+            self._persist_default_chat_id(str(update.effective_chat.id))
+
         has_text = bool(update.message.text or update.message.caption)
         has_photo = bool(update.message.photo)
         has_document = bool(update.message.document)
@@ -113,7 +161,6 @@ class TelegramAdapter(BaseChannelAdapter):
             return
 
         try:
-            # Send typing indicator
             await context.bot.send_chat_action(
                 chat_id=update.effective_chat.id, action="typing"
             )


### PR DESCRIPTION
…tifications

Three connected fixes so Telegram channels work end-to-end after Connect:

1. POST /api/channels now starts the adapter and flips status to 'active' on success. Previously the row was inserted as 'inactive' and the UI never followed up with /start, leaving the bot un-polled forever.

2. ChannelManager.start_adapter returns bool so callers can react to start failures (bad token, network) instead of optimistically marking the channel active.

3. TelegramAdapter persists effective_chat.id to workspace.settings.integrations.telegram_default_chat_id whenever it receives a /start, /help, or any normal message. This is the chat_id that NotificationDispatcher / send_workspace_notification needs to route external alerts. Previously only the /api/webhooks/ws/{key} path persisted it, so polling-based bots had no reliable target and notifications silently dropped.

Allowing /start and /help commands gives users a first-message handshake to capture chat_id before any conversation happens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Channel adapters now attempt to auto-start on creation, with the connection status accurately reflecting whether the adapter successfully activated.
  * Telegram bot now responds to `/start` and `/help` commands for improved user connection experience.
  * Telegram automatically persists the default chat destination when users interact with the bot, enabling seamless workspace messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->