### PR TITLE
feat(org-chart): include system agent (Auto/CTO) as root

### DIFF
--- a/orchestrator/api/agents.py
+++ b/orchestrator/api/agents.py
@@ -571,12 +571,13 @@ async def get_org_chart(
     try:
         from core.models.composio_cache import AgentAppAssignment
 
-        # Fetch active workspace agents (inactive and system agents don't belong on the org chart)
+        # Fetch active workspace agents — the system agent (Auto / CTO) is
+        # included so the chart has a single root; the regular Roster page
+        # keeps its own is_system_agent filter so Auto stays hidden there.
         agents = (
             db.query(Agent)
             .filter(Agent.workspace_id == ctx.workspace_id)
             .filter(Agent.status == "active")
-            .filter(Agent.is_system_agent == False)
             .all()
         )
 


### PR DESCRIPTION
The /api/agents/org-chart endpoint filtered out is_system_agent=True, which hid Auto from the chart even though the auto-orphan logic already pointed every parentless agent at him. Result: a forest of floating roots in the UI with no visible head.

Drop the is_system_agent filter on this endpoint only — the regular Roster page still filters them out (different query). Auto now appears as the chart root and the existing orphan-reparenting logic stitches every other top-level agent (VECTOR, SCRIBE, ORACLE, etc.) underneath.

The frontend already receives is_system_agent on each node payload (line 30 of org-chart-canvas.tsx) — node renderer can style Auto distinctly if desired in a follow-up.