### PR TITLE
fix(skills): stop marketplace surfacing workspace forks; dedupe + enf…

### DIFF
--- a/orchestrator/alembic/versions/dedupe_skills_unique_workspace_name.py
+++ b/orchestrator/alembic/versions/dedupe_skills_unique_workspace_name.py
@@ -1,0 +1,139 @@
+"""Dedupe skills and enforce uniqueness on (workspace_id, name).
+
+After fork-on-edit shipped (commit 7ea2ff274), workspace forks of marketplace
+skills started surfacing in the marketplace tab alongside the originals. The
+GET /api/v1/skills endpoint was filtering with `workspace_id IS NULL OR
+workspace_id == ctx.workspace_id`, so each fork appeared as a duplicate.
+
+This migration:
+  1. For each (workspace_id, name) group with multiple rows, picks the oldest
+     (lowest id) as the survivor.
+  2. Re-points agent_skills.skill_id from dupes to the survivor, handling
+     existing-link conflicts by deleting the redundant dupe link.
+  3. Re-points workspace_enabled_skills.skill_id similarly.
+  4. Sets skill_audit_logs.skill_id to NULL on dupes (its FK is already
+     ondelete=SET NULL but doing it explicitly avoids relying on that).
+  5. Deletes the dupe rows. CASCADE removes skill_files and skill_versions.
+  6. Adds UNIQUE (workspace_id, name) so this can never recur.
+
+Standalone migration — safe to run anytime.
+"""
+
+from alembic import op
+
+
+revision = "dedupe_skills_unique_workspace_name"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    bind = op.get_bind()
+
+    # 1. Identify dupes: same (workspace_id, name), keep the lowest id as survivor.
+    bind.execute(
+        """
+        CREATE TEMPORARY TABLE skill_dedupe_map AS
+        WITH ranked AS (
+            SELECT
+                id,
+                workspace_id,
+                name,
+                MIN(id) OVER (PARTITION BY workspace_id, name) AS survivor_id
+            FROM skills
+        )
+        SELECT id AS dupe_id, survivor_id
+        FROM ranked
+        WHERE id <> survivor_id;
+        """
+    )
+
+    # 2. Re-point agent_skills. Junction has implicit unique (agent_id, skill_id);
+    #    if the agent is already linked to the survivor, drop the dupe link instead.
+    bind.execute(
+        """
+        DELETE FROM agent_skills a
+        USING skill_dedupe_map m
+        WHERE a.skill_id = m.dupe_id
+          AND EXISTS (
+              SELECT 1 FROM agent_skills b
+              WHERE b.agent_id = a.agent_id
+                AND b.skill_id = m.survivor_id
+          );
+        """
+    )
+    bind.execute(
+        """
+        UPDATE agent_skills a
+        SET skill_id = m.survivor_id
+        FROM skill_dedupe_map m
+        WHERE a.skill_id = m.dupe_id;
+        """
+    )
+
+    # 3. Re-point workspace_enabled_skills. Same conflict handling.
+    bind.execute(
+        """
+        DELETE FROM workspace_enabled_skills w
+        USING skill_dedupe_map m
+        WHERE w.skill_id = m.dupe_id
+          AND EXISTS (
+              SELECT 1 FROM workspace_enabled_skills v
+              WHERE v.workspace_id = w.workspace_id
+                AND v.skill_id = m.survivor_id
+          );
+        """
+    )
+    bind.execute(
+        """
+        UPDATE workspace_enabled_skills w
+        SET skill_id = m.survivor_id
+        FROM skill_dedupe_map m
+        WHERE w.skill_id = m.dupe_id;
+        """
+    )
+
+    # 4. Detach audit logs from dupes (FK is already SET NULL on delete, but explicit is safer).
+    bind.execute(
+        """
+        UPDATE skill_audit_logs
+        SET skill_id = NULL
+        WHERE skill_id IN (SELECT dupe_id FROM skill_dedupe_map);
+        """
+    )
+
+    # 5. Delete dupes. skill_files / skill_versions / workspace_enabled_skills cascade.
+    bind.execute(
+        """
+        DELETE FROM skills
+        WHERE id IN (SELECT dupe_id FROM skill_dedupe_map);
+        """
+    )
+
+    bind.execute("DROP TABLE IF EXISTS skill_dedupe_map;")
+
+    # 6. Enforce uniqueness going forward. Postgres treats NULL workspace_id as
+    #    distinct in a plain UNIQUE, which is exactly what we want — but we also
+    #    need marketplace skills (workspace_id IS NULL) to be unique by name. Add
+    #    two constraints: a regular UNIQUE for workspace-owned, and a partial
+    #    unique index for marketplace skills.
+    op.create_unique_constraint(
+        "uq_skills_workspace_id_name",
+        "skills",
+        ["workspace_id", "name"],
+    )
+    bind.execute(
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS uq_skills_marketplace_name
+        ON skills (name)
+        WHERE workspace_id IS NULL;
+        """
+    )
+
+
+def downgrade():
+    bind = op.get_bind()
+    bind.execute("DROP INDEX IF EXISTS uq_skills_marketplace_name;")
+    op.drop_constraint("uq_skills_workspace_id_name", "skills", type_="unique")
+    # Dedupe is not reversible — dupe rows are gone.

--- a/orchestrator/api/skills.py
+++ b/orchestrator/api/skills.py
@@ -473,15 +473,13 @@ async def list_skills(
         GET /api/v1/skills?search=security&tags=authentication,authorization
     """
     try:
-        # Workspace isolation: a caller may only see marketplace skills (workspace_id IS NULL)
-        # plus skills owned by their own workspace. Admins see everything.
+        # Marketplace endpoint: only surface system-owned skills (workspace_id IS NULL).
+        # Workspace-owned skills (forks, custom) are listed via /workspaces/{id}/skills,
+        # which already shadows marketplace originals when a fork exists. Admins see all.
         is_admin = getattr(ctx.user, "system_role", "user") == "admin"
         query = db.query(Skill).filter(Skill.is_active == True)
         if not is_admin:
-            query = query.filter(
-                (Skill.workspace_id.is_(None)) |
-                (Skill.workspace_id == ctx.workspace_id)
-            )
+            query = query.filter(Skill.workspace_id.is_(None))
 
         # Apply filters
         if category:

--- a/orchestrator/modules/agents/services/skill_loader.py
+++ b/orchestrator/modules/agents/services/skill_loader.py
@@ -730,10 +730,13 @@ class SkillLoader:
                     logger.warning(f"Skipping {skill_name} - contains dangerous patterns: {dangerous_matches}")
                     continue
                 
-                # Check if skill exists
+                # Check if skill exists. Git-imported skills are marketplace-only
+                # (workspace_id IS NULL); without this scope a re-import would match
+                # workspace forks of the same name and corrupt them.
                 existing_skill = db.query(Skill).filter(
                     Skill.name == skill_name,
-                    Skill.skill_source == str(source_id)
+                    Skill.skill_source == str(source_id),
+                    Skill.workspace_id.is_(None),
                 ).first()
                 
                 if existing_skill:


### PR DESCRIPTION
…orce uniqueness

Four connected fixes after fork-on-edit (commit 7ea2ff274) caused the Skills Marketplace tab to show workspace forks alongside their originals.

1. api/skills.py — GET /api/v1/skills now returns only marketplace skills (workspace_id IS NULL) for non-admins. The workspace tab already has its own endpoint at /workspaces/{id}/skills which shadows originals when a fork exists, so this won't break it. Admins still see all.

2. alembic — new migration dedupes existing duplicate skill rows. For each (workspace_id, name) group it keeps the oldest id as survivor, re-points agent_skills and workspace_enabled_skills to the survivor (handling unique-link conflicts by deleting the redundant dupe link), detaches audit logs, then deletes the dupes. CASCADE handles skill_files / skill_versions.

3. alembic — same migration adds uniqueness:
   - UNIQUE (workspace_id, name) for workspace-owned skills
   - partial UNIQUE INDEX on name WHERE workspace_id IS NULL for marketplace skills (so two marketplace rows with the same name can never coexist either)

4. skill_loader.py — _index_repository's existence check now also filters on workspace_id IS NULL. Git-imported skills are marketplace-only; without this scope a re-import that hits a workspace fork of the same name would silently corrupt the fork.