### PR TITLE
feat(agents): full visibility into skills, tools, heartbeats for plat…

### DIFF
--- a/orchestrator/consumers/chatbot/auto.py
+++ b/orchestrator/consumers/chatbot/auto.py
@@ -329,6 +329,22 @@ _PLATFORM_KEYWORDS = {
         "disable heartbeat", "heartbeat interval", "set active hours",
         "heartbeat config",
     ],
+    "platform_get_agent_heartbeat": [
+        "show heartbeat", "read heartbeat", "view heartbeat",
+        "what's the heartbeat", "show agent heartbeat", "current heartbeat",
+        "heartbeat for agent", "is heartbeat enabled",
+    ],
+    "platform_unassign_skill_from_agent": [
+        "unassign skill from agent", "remove skill from agent",
+        "drop skill from agent", "detach skill from agent",
+        "take skill off agent", "delete skill assignment",
+    ],
+    "platform_unassign_tool_from_agent": [
+        "unassign tool from agent", "remove tool from agent",
+        "drop tool from agent", "detach tool from agent",
+        "take tool off agent", "deactivate tool on agent",
+        "remove app from agent", "unassign app from agent",
+    ],
     "platform_create_agent": [
         "create agent", "create an agent", "build agent", "build an agent",
         "make agent", "make an agent", "set up agent", "setup agent",

--- a/orchestrator/modules/tools/discovery/actions_agents.py
+++ b/orchestrator/modules/tools/discovery/actions_agents.py
@@ -332,3 +332,33 @@ def register_agents_actions(registry: ActionRegistry) -> None:
             "set active hours 9am to 6pm for the monitoring agent",
         ],
     ))
+
+    registry.register(ActionDefinition(
+        name="platform_get_agent_heartbeat",
+        description=(
+            "Read the heartbeat configuration for a specific agent. Returns "
+            "every field the configure endpoint accepts (enabled, interval, "
+            "prompt, checklist, auto_act, active hours, proactive_level, "
+            "notification_channel) plus an is_configured flag. Use this before "
+            "editing a heartbeat so the diff is informed — read current state, "
+            "decide what changes, then call platform_configure_agent_heartbeat "
+            "with only the fields you actually want to change."
+        ),
+        category="agents",
+        parameters={
+            "type": "object",
+            "properties": {
+                "agent_id": {"type": "integer", "description": "Agent id. Either agent_id or agent_name."},
+                "agent_name": {"type": "string", "description": "Agent name (case-insensitive partial match)."},
+            },
+            "required": [],
+        },
+        permission_level="read",
+        tags=["agents", "heartbeat", "read", "schedule"],
+        examples=[
+            "show me VECTOR's heartbeat config",
+            "what's SENTINEL's heartbeat schedule?",
+            "read the heartbeat for agent 188",
+            "is ATLAS heartbeat enabled?",
+        ],
+    ))

--- a/orchestrator/modules/tools/discovery/actions_assignments.py
+++ b/orchestrator/modules/tools/discovery/actions_assignments.py
@@ -119,3 +119,61 @@ def register_assignments_actions(registry: ActionRegistry) -> None:
             "give the devops plugin to the deployment agent",
         ],
     ))
+
+    registry.register(ActionDefinition(
+        name="platform_unassign_skill_from_agent",
+        description=(
+            "Remove a skill from an agent. Idempotent — no-op if the skill "
+            "wasn't assigned. Drops the row from agent_skills only; the skill "
+            "itself stays in the workspace and can be re-assigned later. Use "
+            "this when triaging agents that have stale or wrong skill picks."
+        ),
+        category="agents",
+        parameters={
+            "type": "object",
+            "properties": {
+                "agent_id": {"type": "integer", "description": "Agent id (or use agent_name)."},
+                "agent_name": {"type": "string", "description": "Agent name (case-insensitive partial match)."},
+                "skill_id": {"type": "integer", "description": "Skill id to unassign (or use skill_name)."},
+                "skill_name": {"type": "string", "description": "Skill name (case-insensitive partial match within the workspace)."},
+            },
+            "required": [],
+        },
+        permission_level="write",
+        tags=["agents", "skills", "unassign", "remove"],
+        examples=[
+            "unassign the code-review skill from VECTOR",
+            "remove skill 42 from agent 188",
+            "drop the growth-hacker skill from ATLAS",
+        ],
+    ))
+
+    registry.register(ActionDefinition(
+        name="platform_unassign_tool_from_agent",
+        description=(
+            "Remove a tool/app from an agent. Defaults to deactivating the "
+            "assignment (is_active=False) so the audit trail stays intact; "
+            "pass hard_delete=true to drop the row entirely. Use this to "
+            "tidy up agents with broad tool access they don't need."
+        ),
+        category="agents",
+        parameters={
+            "type": "object",
+            "properties": {
+                "agent_id": {"type": "integer", "description": "Agent id (or use agent_name)."},
+                "agent_name": {"type": "string", "description": "Agent name (case-insensitive partial match)."},
+                "app_name": {"type": "string", "description": "App/tool name to unassign (e.g. 'GMAIL', 'GITHUB'). Case-insensitive."},
+                "tool_name": {"type": "string", "description": "Alias for app_name."},
+                "assignment_id": {"type": "integer", "description": "Specific agent_app_assignment row id (used when app_name is ambiguous)."},
+                "hard_delete": {"type": "boolean", "description": "If true, drop the row instead of deactivating. Defaults to false."},
+            },
+            "required": [],
+        },
+        permission_level="write",
+        tags=["agents", "tools", "unassign", "remove"],
+        examples=[
+            "unassign GMAIL from agent 188",
+            "remove the github tool from VECTOR",
+            "deactivate composio_search on the marketing agent",
+        ],
+    ))

--- a/orchestrator/modules/tools/discovery/handlers_agents.py
+++ b/orchestrator/modules/tools/discovery/handlers_agents.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 
 async def list_agents(db: Session, workspace_id: UUID, params: Dict[str, Any]) -> Dict[str, Any]:
-    from core.models import Agent
+    from core.models import Agent, agent_skills
     from core.models.composio_cache import AgentAppAssignment
 
     query = db.query(Agent).filter(Agent.workspace_id == workspace_id)
@@ -21,20 +21,39 @@ async def list_agents(db: Session, workspace_id: UUID, params: Dict[str, Any]) -
         query = query.filter(Agent.status == status_filter)
 
     agents = query.order_by(Agent.id).all()
+    agent_ids = [a.id for a in agents]
 
-    # Batch-load tool counts for all agents in one query
-    tool_counts = {}
+    # Batch-load tool counts (active assignments only) and skill counts in two grouped queries.
+    tool_counts: Dict[int, int] = {}
+    skill_counts: Dict[int, int] = {}
     try:
-        rows = (
+        tool_rows = (
             db.query(
                 AgentAppAssignment.agent_id,
                 func.count(AgentAppAssignment.id).label("cnt"),
             )
-            .filter(AgentAppAssignment.is_active == True)
+            .filter(
+                AgentAppAssignment.agent_id.in_(agent_ids) if agent_ids else False,
+                AgentAppAssignment.is_active == True,
+            )
             .group_by(AgentAppAssignment.agent_id)
             .all()
         )
-        tool_counts = {r.agent_id: r.cnt for r in rows}
+        tool_counts = {r.agent_id: r.cnt for r in tool_rows}
+    except Exception:
+        pass
+    try:
+        if agent_ids:
+            skill_rows = (
+                db.query(
+                    agent_skills.c.agent_id,
+                    func.count(agent_skills.c.skill_id).label("cnt"),
+                )
+                .filter(agent_skills.c.agent_id.in_(agent_ids))
+                .group_by(agent_skills.c.agent_id)
+                .all()
+            )
+            skill_counts = {r.agent_id: r.cnt for r in skill_rows}
     except Exception:
         pass
 
@@ -42,6 +61,7 @@ async def list_agents(db: Session, workspace_id: UUID, params: Dict[str, Any]) -
     for a in agents:
         mc = a.model_config or {}
         cfg = a.configuration or {}
+        hb = (cfg.get("heartbeat") or {}) if isinstance(cfg, dict) else {}
         agent_list.append({
             "id": a.id,
             "name": a.name,
@@ -52,8 +72,12 @@ async def list_agents(db: Session, workspace_id: UUID, params: Dict[str, Any]) -
             "provider": mc.get("provider") or cfg.get("provider"),
             "temperature": mc.get("temperature"),
             "tools_count": tool_counts.get(a.id, 0),
+            "skills_count": skill_counts.get(a.id, 0),
+            "heartbeat_enabled": bool(hb.get("enabled")),
             "has_persona": bool(a.custom_persona_prompt),
             "tags": a.tags or [],
+            "team": getattr(a, "team", None),
+            "job_title": getattr(a, "job_title", None),
             "created_at": a.created_at.isoformat() if a.created_at else None,
         })
 
@@ -65,7 +89,8 @@ async def list_agents(db: Session, workspace_id: UUID, params: Dict[str, Any]) -
 
 
 async def get_agent(db: Session, workspace_id: UUID, params: Dict[str, Any]) -> Dict[str, Any]:
-    from core.models import Agent
+    from core.models import Agent, Skill, agent_skills
+    from core.models.composio_cache import AgentAppAssignment
 
     agent_id = params.get("agent_id")
     agent_name = params.get("agent_name")
@@ -82,20 +107,60 @@ async def get_agent(db: Session, workspace_id: UUID, params: Dict[str, Any]) -> 
     if not agent:
         return {"success": False, "error": "Agent not found"}
 
-    # Get assigned tools count
-    tool_count = 0
+    # Full assigned tool list — names, app type, active state, dates, priority.
+    tool_list = []
     try:
-        from core.models.composio_cache import AgentAppAssignment
-        tool_count = (
+        tool_rows = (
             db.query(AgentAppAssignment)
-            .filter(AgentAppAssignment.agent_id == agent.id, AgentAppAssignment.is_active == True)
-            .count()
+            .filter(AgentAppAssignment.agent_id == agent.id)
+            .order_by(AgentAppAssignment.priority.desc(), AgentAppAssignment.assigned_at.desc())
+            .all()
         )
-    except Exception:
-        pass
+        tool_list = [
+            {
+                "id": t.id,
+                "name": t.app_name,
+                "app_type": t.app_type,
+                "is_active": bool(t.is_active),
+                "priority": t.priority or 0,
+                "assigned_at": t.assigned_at.isoformat() if t.assigned_at else None,
+            }
+            for t in tool_rows
+        ]
+    except Exception as e:
+        logger.warning("[get_agent] Failed to load tool assignments: %s", e)
+
+    # Full assigned skill list — joins agent_skills → skills for name, description,
+    # category, version, origin (marketplace vs workspace), active state.
+    skill_list = []
+    try:
+        skill_rows = (
+            db.query(Skill)
+            .join(agent_skills, agent_skills.c.skill_id == Skill.id)
+            .filter(agent_skills.c.agent_id == agent.id)
+            .order_by(Skill.name)
+            .all()
+        )
+        for s in skill_rows:
+            metadata = s.skill_metadata if isinstance(s.skill_metadata, dict) else {}
+            skill_list.append({
+                "id": s.id,
+                "name": s.name,
+                "description": (s.description or "")[:200],
+                "category": s.category,
+                "skill_version": s.skill_version,
+                "skill_source": s.skill_source,
+                "origin": "workspace" if s.workspace_id is not None else "marketplace",
+                "forked_from_skill_id": metadata.get("forked_from_skill_id"),
+                "is_active": bool(s.is_active),
+            })
+    except Exception as e:
+        logger.warning("[get_agent] Failed to load skill assignments: %s", e)
 
     mc = agent.model_config or {}
     config = agent.configuration or {}
+    heartbeat = config.get("heartbeat") if isinstance(config, dict) else None
+
     return {
         "success": True,
         "agent": {
@@ -107,10 +172,20 @@ async def get_agent(db: Session, workspace_id: UUID, params: Dict[str, Any]) -> 
             "model_id": mc.get("model_id") or config.get("model") or config.get("llm_model"),
             "provider": mc.get("provider") or config.get("provider") or config.get("llm_provider"),
             "temperature": mc.get("temperature"),
+            "max_tokens": mc.get("max_tokens"),
             "has_system_prompt": bool(agent.custom_persona_prompt),
             "system_prompt_preview": (agent.custom_persona_prompt or "")[:200] or None,
-            "assigned_tools": tool_count,
+            # Full lists (callers that just want counts can read len()):
+            "assigned_tools": tool_list,
+            "assigned_tools_count": len(tool_list),
+            "active_tools_count": sum(1 for t in tool_list if t["is_active"]),
+            "assigned_skills": skill_list,
+            "assigned_skills_count": len(skill_list),
+            "heartbeat": heartbeat,
             "tags": agent.tags or [],
+            "team": getattr(agent, "team", None),
+            "job_title": getattr(agent, "job_title", None),
+            "reports_to_id": getattr(agent, "reports_to_id", None),
             "created_at": agent.created_at.isoformat() if agent.created_at else None,
             "updated_at": agent.updated_at.isoformat() if agent.updated_at else None,
         },
@@ -326,4 +401,174 @@ async def delete_agent(db: Session, workspace_id: UUID, params: Dict[str, Any]) 
         "success": True,
         "deleted_agent": agent_info,
         "message": f"Agent '{agent_info['name']}' (ID {agent_info['id']}) has been deleted.",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Focused agent visibility handlers — heartbeat read, unassign tool, unassign skill
+# ---------------------------------------------------------------------------
+
+
+def _resolve_agent(db, workspace_id, params):
+    """Resolve an agent by id or name within the workspace. Returns (agent, error_dict)."""
+    from core.models import Agent
+
+    agent_id = params.get("agent_id")
+    agent_name = params.get("agent_name")
+
+    query = db.query(Agent).filter(Agent.workspace_id == workspace_id)
+    if agent_id:
+        query = query.filter(Agent.id == agent_id)
+    elif agent_name:
+        query = query.filter(Agent.name.ilike(f"%{agent_name}%"))
+    else:
+        return None, {"success": False, "error": "Provide agent_name or agent_id"}
+
+    agent = query.first()
+    if not agent:
+        return None, {"success": False, "error": "Agent not found"}
+    return agent, None
+
+
+async def get_agent_heartbeat(db: Session, workspace_id: UUID, params: Dict[str, Any]) -> Dict[str, Any]:
+    """Read the heartbeat configuration for an agent.
+
+    Heartbeat config lives in agent.configuration['heartbeat']. Surfaces every
+    field the configure handler accepts so an editing agent can read current
+    state, decide what to change, and submit the diff via
+    platform_configure_agent_heartbeat.
+    """
+    agent, err = _resolve_agent(db, workspace_id, params)
+    if err:
+        return err
+
+    config = agent.configuration if isinstance(agent.configuration, dict) else {}
+    hb = config.get("heartbeat") if isinstance(config.get("heartbeat"), dict) else {}
+
+    return {
+        "success": True,
+        "agent": {"id": agent.id, "name": agent.name},
+        "heartbeat": {
+            "enabled": bool(hb.get("enabled", False)),
+            "interval_minutes": hb.get("interval_minutes"),
+            "prompt": hb.get("prompt"),
+            "checklist": hb.get("checklist"),
+            "auto_act": hb.get("auto_act"),
+            "active_hours_start": hb.get("active_hours_start"),
+            "active_hours_end": hb.get("active_hours_end"),
+            "proactive_level": hb.get("proactive_level"),
+            "notification_channel": hb.get("notification_channel"),
+        },
+        "is_configured": bool(hb),
+    }
+
+
+async def unassign_skill_from_agent(db: Session, workspace_id: UUID, params: Dict[str, Any]) -> Dict[str, Any]:
+    """Remove a skill assignment from an agent. Idempotent — no-op if not assigned."""
+    from sqlalchemy import and_
+    from core.models import Skill, agent_skills
+
+    agent, err = _resolve_agent(db, workspace_id, params)
+    if err:
+        return err
+
+    skill_id = params.get("skill_id")
+    skill_name = params.get("skill_name")
+    if not skill_id and not skill_name:
+        return {"success": False, "error": "Provide skill_id or skill_name"}
+
+    if skill_name and not skill_id:
+        skill = (
+            db.query(Skill)
+            .filter(
+                Skill.name.ilike(f"%{skill_name}%"),
+                (Skill.workspace_id.is_(None)) | (Skill.workspace_id == workspace_id),
+            )
+            .first()
+        )
+        if not skill:
+            return {"success": False, "error": f"Skill '{skill_name}' not found in this workspace"}
+        skill_id = skill.id
+
+    result = db.execute(
+        agent_skills.delete().where(
+            and_(
+                agent_skills.c.agent_id == agent.id,
+                agent_skills.c.skill_id == skill_id,
+            )
+        )
+    )
+    removed = result.rowcount or 0
+    db.flush()
+
+    logger.info(
+        "[unassign_skill_from_agent] agent=%s skill_id=%s removed=%d",
+        agent.name, skill_id, removed,
+    )
+
+    return {
+        "success": True,
+        "agent": {"id": agent.id, "name": agent.name},
+        "skill_id": skill_id,
+        "removed": removed,
+        "message": (
+            f"Removed skill {skill_id} from agent '{agent.name}'."
+            if removed else
+            f"Skill {skill_id} was not assigned to agent '{agent.name}' (no-op)."
+        ),
+    }
+
+
+async def unassign_tool_from_agent(db: Session, workspace_id: UUID, params: Dict[str, Any]) -> Dict[str, Any]:
+    """Remove a tool/app assignment from an agent.
+
+    Default behaviour deactivates (sets is_active=False) so the audit trail
+    is preserved. Pass hard_delete=true to drop the row entirely.
+    """
+    from core.models.composio_cache import AgentAppAssignment
+
+    agent, err = _resolve_agent(db, workspace_id, params)
+    if err:
+        return err
+
+    app_name = params.get("app_name") or params.get("tool_name")
+    assignment_id = params.get("assignment_id")
+    hard_delete = bool(params.get("hard_delete", False))
+
+    if not app_name and not assignment_id:
+        return {"success": False, "error": "Provide app_name or assignment_id"}
+
+    query = db.query(AgentAppAssignment).filter(AgentAppAssignment.agent_id == agent.id)
+    if assignment_id:
+        query = query.filter(AgentAppAssignment.id == assignment_id)
+    else:
+        query = query.filter(AgentAppAssignment.app_name == str(app_name).upper())
+
+    assignment = query.first()
+    if not assignment:
+        return {
+            "success": False,
+            "error": f"No assignment found on agent '{agent.name}' for {app_name or assignment_id}",
+        }
+
+    target_label = assignment.app_name
+    if hard_delete:
+        db.delete(assignment)
+        action = "deleted"
+    else:
+        assignment.is_active = False
+        action = "deactivated"
+    db.flush()
+
+    logger.info(
+        "[unassign_tool_from_agent] agent=%s app=%s action=%s",
+        agent.name, target_label, action,
+    )
+
+    return {
+        "success": True,
+        "agent": {"id": agent.id, "name": agent.name},
+        "tool": target_label,
+        "action": action,
+        "message": f"Tool '{target_label}' {action} on agent '{agent.name}'.",
     }

--- a/orchestrator/modules/tools/discovery/platform_executor.py
+++ b/orchestrator/modules/tools/discovery/platform_executor.py
@@ -22,6 +22,9 @@ from modules.tools.discovery.handlers_agents import (
     create_agent,
     update_agent,
     delete_agent,
+    get_agent_heartbeat,
+    unassign_skill_from_agent,
+    unassign_tool_from_agent,
 )
 from modules.tools.discovery.handlers_playbooks import (
     list_playbooks,
@@ -254,6 +257,9 @@ class PlatformActionExecutor:
             "platform_assign_skill_to_agent": assign_skill_to_agent,
             "platform_assign_plugin_to_agent": assign_plugin_to_agent,
             "platform_configure_agent_heartbeat": configure_agent_heartbeat,
+            "platform_get_agent_heartbeat": get_agent_heartbeat,
+            "platform_unassign_skill_from_agent": unassign_skill_from_agent,
+            "platform_unassign_tool_from_agent": unassign_tool_from_agent,
             # PRD-76: Agent Reports
             "platform_submit_report": submit_report,
             "platform_get_latest_report": get_latest_report,


### PR DESCRIPTION
…form tools

Auto could see "ATLAS has 1 tool assigned" but not which tool, no skills list, no heartbeat config. That makes audits and remediation impossible without dropping into raw SQL. This expands the agent platform-tool surface so any agent (Auto, ATLAS, FIXER, etc.) can read full assignment state and unassign cleanly.

handlers_agents.get_agent — replaces "assigned_tools: <count>" with the full picture:
  - assigned_tools: [{ id, name, app_type, is_active, priority, assigned_at }, …]
  - assigned_tools_count, active_tools_count
  - assigned_skills: [{ id, name, description, category, skill_version, skill_source, origin (marketplace|workspace), forked_from_skill_id, is_active }, …]
  - assigned_skills_count
  - heartbeat: full block from agent.configuration.heartbeat (or null)
  - team, job_title, reports_to_id (org-chart context)

handlers_agents.list_agents — adds skills_count, heartbeat_enabled, team, job_title to the per-agent summary so the listing is enough to spot which agents are wired up vs idle without an extra get_agent call.

Three new platform tools (3-file pattern):

  platform_get_agent_heartbeat (read)
    Focused read of one agent's heartbeat block. Returns every field
    configure_agent_heartbeat accepts (enabled, interval_minutes,
    prompt, checklist, auto_act, active hours, proactive_level,
    notification_channel) plus is_configured. Use before editing so
    the diff is informed.

  platform_unassign_skill_from_agent (write)
    Drops a row from agent_skills. Idempotent — no-op if not assigned.
    Resolves skill by id or name (within workspace scope).

  platform_unassign_tool_from_agent (write)
    Defaults to deactivating (is_active=False) so audit trail stays
    intact. Pass hard_delete=true to drop the row entirely. Resolves
    tool by app_name (case-insensitive) or assignment_id.

Wired into platform_executor._handlers and auto.py Tier-2 keyword router. Three ActionDefinitions registered with category="agents", full descriptions / tags / examples for the PRD-138 semantic ranker.