### PR TITLE
fix(chat): widen message bubbles 85% → 92% to match composer

### DIFF
--- a/frontend/components/chatbot/message.tsx
+++ b/frontend/components/chatbot/message.tsx
@@ -329,7 +329,7 @@ export function Message({
       data-testid={isUser ? 'msg-user' : 'msg-assistant'}
       className={`group/msg flex ${isUser ? 'justify-end' : 'justify-start'}`}
     >
-      <div className={`flex items-start space-x-3 max-w-[85%] min-w-0 ${isUser ? 'flex-row-reverse space-x-reverse' : ''}`}>
+      <div className={`flex items-start space-x-3 max-w-[92%] min-w-0 ${isUser ? 'flex-row-reverse space-x-reverse' : ''}`}>
         {/* Avatar */}
         <div className={`w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 ${
           isUser


### PR DESCRIPTION
User feedback: chat transcript renders noticeably narrower than the composer input bar. Both wrappers (messages container and composer) use max-w-4xl, but each message bubble in message.tsx:332 was capped at max-w-[85%] of the inner content area, while the composer has no inner percentage cap.

At a 1024px container, that's ~144px (≈ 38mm) less horizontal text space than the composer below. Bumping to 92% recovers ~72px (≈ 19mm) — matches the user's 15–20mm request — and leaves a small visible gutter so messages still don't sit flush with the composer edge.

One-line change. Easy to dial back to 88%/90% if 92% feels too wide.