### PR TITLE
feat(auto-wave1): schema completion — give Auto exposure to existing …

### DIFF
--- a/orchestrator/alembic/versions/wave1a_agent_responsibilities.py
+++ b/orchestrator/alembic/versions/wave1a_agent_responsibilities.py
@@ -1,0 +1,29 @@
+"""Wave 1.A — Agent organisation: responsibilities
+
+Adds the missing structured field that lets Auto reason about who owns what
+without having to grep an agent's persona text. ``team`` and ``reports_to_id``
+already exist (Mission Zero).
+
+Idempotent — safe to run anywhere.
+"""
+
+from alembic import op
+
+
+revision = "wave1a_agent_responsibilities"
+down_revision = "dedupe_skills_unique_workspace_name"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE agents
+        ADD COLUMN IF NOT EXISTS responsibilities JSONB NOT NULL DEFAULT '[]'::jsonb;
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE agents DROP COLUMN IF EXISTS responsibilities;")

--- a/orchestrator/alembic/versions/wave1b_heartbeat_completion.py
+++ b/orchestrator/alembic/versions/wave1b_heartbeat_completion.py
@@ -1,0 +1,44 @@
+"""Wave 1.B — Heartbeat completion semantics
+
+A heartbeat row today says "ran" with status + findings + actions. It does
+not say "did the agent actually do the thing it was supposed to do?". Adds
+two cheap fields:
+
+  - ``objective_met``  bool    — explicit yes/no/null outcome
+  - ``evidence_ref``   text    — pointer to the artefact that proves it
+                                  (workspace file path, report id, task id, etc.)
+
+The column is nullable so old rows stay valid; new ticks populate it where
+the heartbeat has a clear objective (e.g. "submit a daily report" → check
+report exists; "review failed tasks" → check actions_taken non-empty).
+
+Idempotent.
+"""
+
+from alembic import op
+
+
+revision = "wave1b_heartbeat_completion"
+down_revision = "wave1a_agent_responsibilities"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE heartbeat_results
+        ADD COLUMN IF NOT EXISTS objective_met BOOLEAN;
+        """
+    )
+    op.execute(
+        """
+        ALTER TABLE heartbeat_results
+        ADD COLUMN IF NOT EXISTS evidence_ref TEXT;
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE heartbeat_results DROP COLUMN IF EXISTS evidence_ref;")
+    op.execute("ALTER TABLE heartbeat_results DROP COLUMN IF EXISTS objective_met;")

--- a/orchestrator/alembic/versions/wave1c_report_signals.py
+++ b/orchestrator/alembic/versions/wave1c_report_signals.py
@@ -1,0 +1,64 @@
+"""Wave 1.C — Reports as operating signals
+
+Reports today are write-once narratives. To make them an operating layer
+Auto can act on, add the structured fields that turn a report into asks:
+
+  - ``recommendations``   jsonb   — list of recommended actions/changes
+  - ``action_items``       jsonb   — list of concrete next steps with owners
+  - ``linked_task_ids``    jsonb   — board task IDs this report references
+  - ``requires_approval``  bool    — does this need a Gerard call?
+  - ``acknowledged_by``    int FK  — user who acknowledged it
+  - ``acknowledged_at``    tstz    — when it was acknowledged
+
+All nullable / default-empty — existing rows stay valid.
+
+Idempotent.
+"""
+
+from alembic import op
+
+
+revision = "wave1c_report_signals"
+down_revision = "wave1b_heartbeat_completion"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE agent_reports
+        ADD COLUMN IF NOT EXISTS recommendations JSONB NOT NULL DEFAULT '[]'::jsonb,
+        ADD COLUMN IF NOT EXISTS action_items    JSONB NOT NULL DEFAULT '[]'::jsonb,
+        ADD COLUMN IF NOT EXISTS linked_task_ids JSONB NOT NULL DEFAULT '[]'::jsonb,
+        ADD COLUMN IF NOT EXISTS requires_approval BOOLEAN NOT NULL DEFAULT FALSE,
+        ADD COLUMN IF NOT EXISTS acknowledged_by   INTEGER REFERENCES users(id) ON DELETE SET NULL,
+        ADD COLUMN IF NOT EXISTS acknowledged_at   TIMESTAMPTZ;
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_agent_reports_requires_approval "
+        "ON agent_reports (workspace_id, requires_approval) "
+        "WHERE requires_approval = TRUE;"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_agent_reports_unacknowledged "
+        "ON agent_reports (workspace_id, acknowledged_at) "
+        "WHERE acknowledged_at IS NULL;"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_agent_reports_unacknowledged;")
+    op.execute("DROP INDEX IF EXISTS ix_agent_reports_requires_approval;")
+    op.execute(
+        """
+        ALTER TABLE agent_reports
+        DROP COLUMN IF EXISTS acknowledged_at,
+        DROP COLUMN IF EXISTS acknowledged_by,
+        DROP COLUMN IF EXISTS requires_approval,
+        DROP COLUMN IF EXISTS linked_task_ids,
+        DROP COLUMN IF EXISTS action_items,
+        DROP COLUMN IF EXISTS recommendations;
+        """
+    )

--- a/orchestrator/alembic/versions/wave1d_mission_lifecycle.py
+++ b/orchestrator/alembic/versions/wave1d_mission_lifecycle.py
@@ -1,0 +1,53 @@
+"""Wave 1.D — Mission lifecycle fields
+
+OrchestrationRun has goal/state/plan/output_summary already. Auto needs four
+more fields to manage missions like a real CTO:
+
+  - ``linked_prd``         text   — PRD or issue reference, e.g. "PRD-121"
+  - ``completion_evidence`` jsonb  — proof of done (artefacts, links)
+  - ``deadline``            tstz   — target completion time
+  - ``risks``               jsonb  — recorded risk register
+
+Acceptance criteria already lives in ``OrchestrationTask.verification_criteria``;
+not duplicating it on the run.
+
+Idempotent.
+"""
+
+from alembic import op
+
+
+revision = "wave1d_mission_lifecycle"
+down_revision = "wave1c_report_signals"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE orchestration_runs
+        ADD COLUMN IF NOT EXISTS linked_prd          TEXT,
+        ADD COLUMN IF NOT EXISTS completion_evidence JSONB NOT NULL DEFAULT '[]'::jsonb,
+        ADD COLUMN IF NOT EXISTS deadline            TIMESTAMPTZ,
+        ADD COLUMN IF NOT EXISTS risks               JSONB NOT NULL DEFAULT '[]'::jsonb;
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_orchestration_runs_deadline "
+        "ON orchestration_runs (workspace_id, deadline) "
+        "WHERE deadline IS NOT NULL;"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_orchestration_runs_deadline;")
+    op.execute(
+        """
+        ALTER TABLE orchestration_runs
+        DROP COLUMN IF EXISTS risks,
+        DROP COLUMN IF EXISTS deadline,
+        DROP COLUMN IF EXISTS completion_evidence,
+        DROP COLUMN IF EXISTS linked_prd;
+        """
+    )

--- a/orchestrator/core/models/core.py
+++ b/orchestrator/core/models/core.py
@@ -180,7 +180,6 @@ class Agent(Base):
     public_id = Column(UUID(as_uuid=True), default=uuid4, unique=True, nullable=True, index=True)
     name = Column(String(255), nullable=False)
     description = Column(Text)
-    job_title = Column(String(120), nullable=True)  # Short role label shown on cards (e.g. "Lead Intelligence")
     agent_type = Column(String(100), nullable=False)  # 'custom', 'system', 'specialized'
     status = Column(String(50), default='active')  # 'active', 'inactive', 'training'
     configuration = Column(JSON)  # Agent-specific config
@@ -229,6 +228,7 @@ class Agent(Base):
     team = Column(String(100), nullable=True)       # Department/team name (e.g., "Engineering", "Marketing")
     job_title = Column(String(200), nullable=True)  # Human-readable role (e.g., "Lead Developer", "SEO Analyst")
     reports_to_id = Column(Integer, ForeignKey('agents.id', ondelete='SET NULL'), nullable=True)
+    responsibilities = Column(JSONB, default=list, server_default='[]', nullable=False)  # Wave 1.A: structured ownership list
 
     # PRD-64: Semantic routing embedding
     semantic_embedding = Column(JSONB, nullable=True)       # 2048-float vector for cosine similarity

--- a/orchestrator/core/models/orchestration.py
+++ b/orchestrator/core/models/orchestration.py
@@ -115,6 +115,12 @@ class OrchestrationRun(Base):
     budget_config = Column(JSONB, nullable=True)   # {max_cost, max_tokens, alert_at_pct}
     budget_spent = Column(JSONB, nullable=True, server_default=text("'{}'"))  # {cost, tokens, api_calls}
 
+    # Wave 1.D: Auto operating contract — mission lifecycle
+    linked_prd = Column(Text, nullable=True)  # e.g. "PRD-121"
+    completion_evidence = Column(JSONB, nullable=False, server_default=text("'[]'"))  # proof of done
+    deadline = Column(DateTime(timezone=True), nullable=True)
+    risks = Column(JSONB, nullable=False, server_default=text("'[]'"))
+
     # Timestamps
     started_at = Column(DateTime(timezone=True), nullable=True)
     completed_at = Column(DateTime(timezone=True), nullable=True)

--- a/orchestrator/modules/tools/discovery/actions_reports.py
+++ b/orchestrator/modules/tools/discovery/actions_reports.py
@@ -61,6 +61,40 @@ def register_report_actions(registry: ActionRegistry) -> None:
                     "items": {"type": "string"},
                     "description": "Optional list of section headings the report must contain (e.g. ['Summary', 'Metrics', 'Next Steps']). Submission fails if any are missing from the markdown content.",
                 },
+                "recommendations": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "title": {"type": "string"},
+                            "rationale": {"type": "string"},
+                            "impact": {"type": "string", "description": "Expected outcome if adopted."},
+                        },
+                    },
+                    "description": "Structured recommendations Auto can route or surface as decisions. Prefer these over burying recommendations in markdown — they make the report machine-readable.",
+                },
+                "action_items": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "title": {"type": "string"},
+                            "owner": {"type": "string", "description": "Agent or person who owns this action."},
+                            "due": {"type": "string", "description": "ISO timestamp or natural deadline."},
+                            "priority": {"type": "string", "enum": ["urgent", "high", "medium", "low"]},
+                        },
+                    },
+                    "description": "Concrete next steps. Auto can promote these into board tasks automatically.",
+                },
+                "linked_task_ids": {
+                    "type": "array",
+                    "items": {"type": "integer"},
+                    "description": "Board task IDs this report references (origin task, follow-up tasks, etc.).",
+                },
+                "requires_approval": {
+                    "type": "boolean",
+                    "description": "Set to true when the report's recommendations need a human decision before any action. Surfaces in the 'Decisions Needed' queue.",
+                },
             },
             "required": ["title", "content", "report_type", "status"],
         },

--- a/orchestrator/modules/tools/discovery/handlers_reports.py
+++ b/orchestrator/modules/tools/discovery/handlers_reports.py
@@ -73,6 +73,10 @@ async def submit_report(db: Session, workspace_id: UUID, params: Dict[str, Any])
         metrics=params.get("metrics"),
         attachments=params.get("attachments"),
         heartbeat_result_id=params.get("_heartbeat_result_id"),
+        recommendations=params.get("recommendations"),
+        action_items=params.get("action_items"),
+        linked_task_ids=params.get("linked_task_ids"),
+        requires_approval=bool(params.get("requires_approval", False)),
     )
 
     # PRD-126: Trigger knowledge graph update on report submission

--- a/orchestrator/services/heartbeat_service.py
+++ b/orchestrator/services/heartbeat_service.py
@@ -996,10 +996,12 @@ class HeartbeatService:
                         """
                         INSERT INTO heartbeat_results
                             (source_type, source_id, workspace_id, status,
-                             findings, actions_taken, tokens_used, created_at)
+                             findings, actions_taken, tokens_used,
+                             objective_met, evidence_ref, created_at)
                         VALUES
                             (:source_type, :source_id, :workspace_id, :status,
-                             :findings, :actions_taken, :tokens_used, NOW())
+                             :findings, :actions_taken, :tokens_used,
+                             :objective_met, :evidence_ref, NOW())
                         RETURNING id
                         """
                     ),
@@ -1011,6 +1013,8 @@ class HeartbeatService:
                         "findings": json.dumps(result["findings"]),
                         "actions_taken": json.dumps(result["actions_taken"]),
                         "tokens_used": result.get("tokens_used", 0),
+                        "objective_met": self._infer_objective_met(result),
+                        "evidence_ref": result.get("evidence_ref"),
                     },
                 ).fetchone()
                 db.commit()
@@ -1022,6 +1026,32 @@ class HeartbeatService:
         except Exception as e:
             logger.error("[Heartbeat] Failed to store result: %s", e)
             return None
+
+    @staticmethod
+    def _infer_objective_met(result: dict) -> Optional[bool]:
+        """Best-effort objective completion classifier — Wave 1.B.
+
+        ``True``  — status=success and there is observable output (actions
+                    taken, findings recorded, or an explicit evidence_ref).
+        ``False`` — status indicates failure (error / failed / timeout).
+        ``None``  — cannot be determined (silent success with no output).
+
+        Callers may override by setting ``result["objective_met"]`` directly
+        before persistence.
+        """
+        if "objective_met" in result:
+            return result.get("objective_met")
+        status = (result.get("status") or "").lower()
+        if status in {"error", "failed", "timeout"}:
+            return False
+        if status == "success":
+            has_output = bool(
+                result.get("actions_taken")
+                or result.get("findings")
+                or result.get("evidence_ref")
+            )
+            return True if has_output else None
+        return None
 
     # ------------------------------------------------------------------
     # Notification delivery (PRD-128: unified dispatcher)

--- a/orchestrator/services/report_service.py
+++ b/orchestrator/services/report_service.py
@@ -165,6 +165,10 @@ class ReportService:
         metrics: Optional[Dict[str, Any]] = None,
         attachments: Optional[List[Dict[str, Any]]] = None,
         heartbeat_result_id: Optional[int] = None,
+        recommendations: Optional[List[Dict[str, Any]]] = None,
+        action_items: Optional[List[Dict[str, Any]]] = None,
+        linked_task_ids: Optional[List[int]] = None,
+        requires_approval: bool = False,
     ) -> Dict[str, Any]:
         """Create a report: write file to workspace + insert DB row."""
 
@@ -212,12 +216,18 @@ class ReportService:
                         (workspace_id, agent_id, agent_name, heartbeat_result_id,
                          report_type, title, summary, status,
                          file_path, file_type, file_size_bytes,
-                         metrics, attachments, created_at, updated_at)
+                         metrics, attachments,
+                         recommendations, action_items, linked_task_ids,
+                         requires_approval,
+                         created_at, updated_at)
                     VALUES
                         (:workspace_id, :agent_id, :agent_name, :heartbeat_result_id,
                          :report_type, :title, :summary, :status,
                          :file_path, :file_type, :file_size_bytes,
-                         :metrics, :attachments, NOW(), NOW())
+                         :metrics, :attachments,
+                         :recommendations, :action_items, :linked_task_ids,
+                         :requires_approval,
+                         NOW(), NOW())
                     RETURNING id
                 """),
                 {
@@ -234,6 +244,10 @@ class ReportService:
                     "file_size_bytes": file_size,
                     "metrics": json.dumps(metrics or {}),
                     "attachments": json.dumps(attachments or []),
+                    "recommendations": json.dumps(recommendations or []),
+                    "action_items": json.dumps(action_items or []),
+                    "linked_task_ids": json.dumps(linked_task_ids or []),
+                    "requires_approval": bool(requires_approval),
                 },
             )
             row = result.fetchone()


### PR DESCRIPTION
…surfaces

Wave 1 of the Auto operating contract. Pure additive — no new tables, no new orchestration, no new flows. Just the columns and tool params that let Auto reason about and write back to surfaces the platform already has.

W1.A — Agent organisation
  + agents.responsibilities JSONB DEFAULT '[]'  (structured ownership list; team and reports_to_id already shipped in Mission Zero)
  - Drops a duplicate Agent.job_title declaration (lines 183 was overridden by 230 anyway; kept the 200-char Mission Zero version)

W1.B — Heartbeat completion semantics
  + heartbeat_results.objective_met BOOLEAN
  + heartbeat_results.evidence_ref TEXT Service inference: success+output → True, error/failed/timeout → False, silent success → None. Callers can override by setting result["objective_met"].

W1.C — Reports as operating signals
  + agent_reports.recommendations JSONB
  + agent_reports.action_items JSONB
  + agent_reports.linked_task_ids JSONB
  + agent_reports.requires_approval BOOLEAN
  + agent_reports.acknowledged_by FK users.id
  + agent_reports.acknowledged_at TIMESTAMPTZ Plus partial indexes for "needs approval" and "unacknowledged" queues. platform_submit_report tool gains the four authoring params.

W1.D — Mission lifecycle
  + orchestration_runs.linked_prd TEXT
  + orchestration_runs.completion_evidence JSONB
  + orchestration_runs.deadline TIMESTAMPTZ
  + orchestration_runs.risks JSONB Acceptance criteria already lives in OrchestrationTask.verification_criteria — not duplicating on the run.

All migrations are idempotent (IF NOT EXISTS) and chain cleanly: dedupe_skills_unique_workspace_name → wave1a → wave1b → wave1c → wave1d.

Compile-clean. No behaviour change to existing rows. Waves 2-6 build on this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Agents can now define and track their responsibilities
  * Heartbeat monitoring enhanced with objective completion tracking and supporting evidence references
  * Reports now support recommendations, action items, task linking, and approval workflows
  * Mission tracking expanded with deadline management, PRD references, completion evidence, and risk documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->