### PR TITLE
feat(auto-wave2): auto_reporting prefs + dispatcher hooks + platform_…

### DIFF
--- a/orchestrator/core/services/auto_reporting.py
+++ b/orchestrator/core/services/auto_reporting.py
@@ -1,0 +1,190 @@
+"""Auto reporting preferences — Wave 2.
+
+Single canonical reader/writer for ``workspace.settings.auto_reporting`` and
+the helpers the NotificationDispatcher uses to honour those preferences.
+
+Settings shape (``workspace.settings.auto_reporting``):
+
+    {
+      "enabled": bool,
+      "primary_channel":   "telegram" | "slack" | "in_app" | "webhook",
+      "fallback_channel":  "in_app" | "webhook" | null,
+      "quiet_hours": {
+        "enabled":  bool,
+        "start":    "22:00",
+        "end":      "08:00",
+        "timezone": "Europe/Dublin"
+      },
+      "digest_frequency": "immediate" | "daily" | "weekly",
+      "digest_time":      "09:00",
+      "routes": {
+        "<event_type>": "<destination>"   # destination overrides workspace prefs
+      }
+    }
+
+Defaults are conservative — when the field is absent, behaviour falls back
+to the existing ``notification_preferences`` table (PRD-128).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, time as dtime
+from typing import Any, Dict, Optional
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+
+# Sensible defaults — workspaces inherit these unless they explicitly override.
+DEFAULTS: Dict[str, Any] = {
+    "enabled": True,
+    "primary_channel": "in_app",
+    "fallback_channel": "in_app",
+    "quiet_hours": {
+        "enabled": False,
+        "start": "22:00",
+        "end": "08:00",
+        "timezone": "UTC",
+    },
+    "digest_frequency": "immediate",
+    "digest_time": "09:00",
+    "routes": {},
+}
+
+
+def load_auto_reporting_settings(
+    db: Session, workspace_id: UUID | str
+) -> Dict[str, Any]:
+    """Return ``auto_reporting`` settings merged onto defaults."""
+    from core.models.workspaces import Workspace
+
+    ws = db.query(Workspace).filter(Workspace.id == workspace_id).first()
+    if ws is None:
+        return dict(DEFAULTS)
+
+    settings = ws.settings or {}
+    user_cfg = settings.get("auto_reporting", {}) or {}
+    return _merge_defaults(DEFAULTS, user_cfg)
+
+
+def update_auto_reporting_settings(
+    db: Session,
+    workspace_id: UUID | str,
+    partial: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Merge ``partial`` into ``workspace.settings.auto_reporting`` and persist.
+
+    Caller owns the transaction — this only stages the update and flushes.
+    Returns the resulting effective settings (defaults + stored override).
+    """
+    from core.models.workspaces import Workspace
+
+    ws = db.query(Workspace).filter(Workspace.id == workspace_id).first()
+    if ws is None:
+        raise ValueError(f"workspace {workspace_id} not found")
+
+    settings = dict(ws.settings or {})
+    current = dict(settings.get("auto_reporting") or {})
+    merged = _merge_dicts(current, partial)
+    settings["auto_reporting"] = merged
+    ws.settings = settings
+    db.flush()
+
+    return _merge_defaults(DEFAULTS, merged)
+
+
+def is_quiet_hours(
+    settings: Dict[str, Any], now: Optional[datetime] = None
+) -> bool:
+    """Return True when ``now`` falls inside the workspace's quiet window."""
+    qh = settings.get("quiet_hours") or {}
+    if not qh.get("enabled"):
+        return False
+
+    tz_name = qh.get("timezone") or "UTC"
+    try:
+        from zoneinfo import ZoneInfo
+        tz = ZoneInfo(tz_name)
+    except Exception:
+        from datetime import timezone as _tz
+        tz = _tz.utc
+
+    moment = (now or datetime.now(tz)).astimezone(tz).time()
+    start = _parse_hhmm(qh.get("start") or "22:00")
+    end = _parse_hhmm(qh.get("end") or "08:00")
+
+    if start == end:
+        return False
+    if start < end:
+        return start <= moment < end
+    # Window crosses midnight (e.g. 22:00 → 08:00)
+    return moment >= start or moment < end
+
+
+def route_for_event(
+    settings: Dict[str, Any],
+    event_type: str,
+    severity: Optional[str] = None,
+) -> Optional[str]:
+    """Resolve the destination for an event from auto_reporting.routes.
+
+    Lookup order:
+      1. ``routes[f"{event_type}:{severity}"]`` — most specific
+      2. ``routes[event_type]``
+      3. ``routes[severity]`` — severity-only fallback
+      4. None (caller falls back to workspace ``notification_preferences``)
+
+    Special destination ``"primary"`` resolves to ``primary_channel``;
+    ``"fallback"`` resolves to ``fallback_channel``.
+    """
+    routes = settings.get("routes") or {}
+    candidates = []
+    if severity:
+        candidates.append(f"{event_type}:{severity}")
+    candidates.append(event_type)
+    if severity:
+        candidates.append(severity)
+
+    for key in candidates:
+        if key in routes:
+            return _resolve_alias(settings, routes[key])
+    return None
+
+
+# ----------------------------------------------------------------- internals
+
+
+def _resolve_alias(settings: Dict[str, Any], destination: str) -> str:
+    """Map ``primary``/``fallback`` aliases onto the configured channels."""
+    if destination == "primary":
+        return settings.get("primary_channel") or "in_app"
+    if destination == "fallback":
+        return settings.get("fallback_channel") or "in_app"
+    return destination
+
+
+def _parse_hhmm(value: str) -> dtime:
+    try:
+        hh, mm = value.split(":", 1)
+        return dtime(hour=int(hh), minute=int(mm))
+    except Exception:
+        logger.warning("[auto_reporting] could not parse time %r — defaulting to 00:00", value)
+        return dtime(0, 0)
+
+
+def _merge_defaults(defaults: Dict[str, Any], override: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a deep-merged copy of defaults+override (override wins)."""
+    return _merge_dicts(defaults, override)
+
+
+def _merge_dicts(base: Dict[str, Any], override: Dict[str, Any]) -> Dict[str, Any]:
+    out = dict(base)
+    for k, v in (override or {}).items():
+        if isinstance(v, dict) and isinstance(out.get(k), dict):
+            out[k] = _merge_dicts(out[k], v)
+        else:
+            out[k] = v
+    return out

--- a/orchestrator/core/services/notification_dispatcher.py
+++ b/orchestrator/core/services/notification_dispatcher.py
@@ -95,18 +95,58 @@ class NotificationDispatcher:
         agent_name: Optional[str] = None,
         status: str = "ok",
         user_id: Optional[int] = None,
+        severity: Optional[str] = None,
     ) -> dict[str, Any]:
         """Raise ``event_type`` against the configured preferences.
+
+        Wave 2: when ``workspace.settings.auto_reporting`` is configured,
+        ``routes`` overrides the per-event prefs and ``quiet_hours`` forces
+        non-urgent traffic onto in_app. ``security`` and ``urgent`` severities
+        always go through, even during quiet hours.
 
         Returns a dict with a ``dispatched_to`` list naming every
         destination that was actually fired (``in_app``, ``telegram``,
         ``slack``, ``webhook``, ``channel:<uuid>``). Silent and failed
         destinations are not included.
         """
+        # Wave 2 — auto_reporting overrides
+        ar_settings = self._load_auto_reporting()
+        ar_enabled = bool(ar_settings.get("enabled", True))
+
+        override_destination: Optional[str] = None
+        if ar_enabled:
+            override_destination = self._auto_reporting_destination(
+                ar_settings, event_type, severity
+            )
+
         prefs = self._get_preferences(event_type, user_id)
 
-        # No preferences configured at all → default to a single in_app row.
-        if not prefs:
+        if override_destination:
+            prefs = [
+                {
+                    "destination": override_destination,
+                    "enabled": True,
+                    "channel_connection_id": None,
+                    "user_id": user_id,
+                }
+            ]
+        elif not prefs:
+            # No preferences configured at all → default to a single in_app row.
+            prefs = [
+                {
+                    "destination": "in_app",
+                    "enabled": True,
+                    "channel_connection_id": None,
+                    "user_id": user_id,
+                }
+            ]
+
+        # Quiet hours — funnel non-urgent traffic to in_app
+        if (
+            ar_enabled
+            and severity not in {"urgent", "security"}
+            and self._is_quiet_hours(ar_settings)
+        ):
             prefs = [
                 {
                     "destination": "in_app",
@@ -193,6 +233,32 @@ class NotificationDispatcher:
                 )
 
         return {"dispatched_to": dispatched}
+
+    # -------------------------------------------------------- auto_reporting
+
+    def _load_auto_reporting(self) -> dict[str, Any]:
+        """Return the workspace's effective auto_reporting settings (Wave 2)."""
+        try:
+            from core.services.auto_reporting import load_auto_reporting_settings
+            return load_auto_reporting_settings(self.db, self.workspace_id)
+        except Exception:
+            logger.warning(
+                "[Dispatcher] Failed to load auto_reporting for ws=%s — falling back to prefs only",
+                self.workspace_id, exc_info=True,
+            )
+            return {}
+
+    @staticmethod
+    def _auto_reporting_destination(
+        settings: dict[str, Any], event_type: str, severity: Optional[str]
+    ) -> Optional[str]:
+        from core.services.auto_reporting import route_for_event
+        return route_for_event(settings, event_type, severity)
+
+    @staticmethod
+    def _is_quiet_hours(settings: dict[str, Any]) -> bool:
+        from core.services.auto_reporting import is_quiet_hours
+        return is_quiet_hours(settings)
 
     # -------------------------------------------------------- preferences
 

--- a/orchestrator/modules/tools/discovery/actions_auto_reporting.py
+++ b/orchestrator/modules/tools/discovery/actions_auto_reporting.py
@@ -1,0 +1,154 @@
+"""Auto reporting platform tools — Wave 2.
+
+Three tools that let Auto (or any agent) read/write the workspace's
+auto_reporting preferences and emit notifications without going round
+the back of the platform.
+"""
+
+from .action_registry import ActionDefinition, ActionRegistry
+
+
+def register_auto_reporting_actions(registry: ActionRegistry) -> None:
+    """Register Auto-reporting + send-notification tools."""
+
+    registry.register(ActionDefinition(
+        name="platform_get_auto_reporting_prefs",
+        description=(
+            "Read this workspace's auto_reporting preferences — primary/fallback "
+            "channels, quiet hours, digest frequency, and per-event routing rules. "
+            "Use before deciding where to send a notification or before proposing "
+            "preference changes to the user."
+        ),
+        category="settings",
+        parameters={
+            "type": "object",
+            "properties": {},
+            "required": [],
+        },
+        permission_level="read",
+        tags=["settings", "auto-reporting", "notifications", "preferences"],
+        examples=[
+            "what are my notification preferences?",
+            "where do I send reports?",
+            "show auto reporting config",
+        ],
+    ))
+
+    registry.register(ActionDefinition(
+        name="platform_update_auto_reporting_prefs",
+        description=(
+            "Update the workspace's auto_reporting preferences. Accepts a partial "
+            "object — only the supplied keys are merged into the existing config. "
+            "Use this to set the primary channel (telegram/slack/in_app/webhook), "
+            "configure quiet hours, change digest cadence, or set per-event routes. "
+            "Always confirm with the user before changing the primary channel."
+        ),
+        category="settings",
+        parameters={
+            "type": "object",
+            "properties": {
+                "enabled": {"type": "boolean"},
+                "primary_channel": {
+                    "type": "string",
+                    "enum": ["telegram", "slack", "in_app", "webhook"],
+                },
+                "fallback_channel": {
+                    "type": "string",
+                    "enum": ["in_app", "webhook"],
+                },
+                "quiet_hours": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {"type": "boolean"},
+                        "start": {"type": "string", "description": "HH:MM 24-hour."},
+                        "end": {"type": "string", "description": "HH:MM 24-hour."},
+                        "timezone": {"type": "string", "description": "IANA tz name, e.g. Europe/Dublin."},
+                    },
+                },
+                "digest_frequency": {
+                    "type": "string",
+                    "enum": ["immediate", "daily", "weekly"],
+                },
+                "digest_time": {"type": "string", "description": "HH:MM the digest should fire."},
+                "routes": {
+                    "type": "object",
+                    "description": (
+                        "Map of event_type (or event_type:severity) to a destination. "
+                        "Destination may be a literal channel (telegram/slack/in_app/webhook/silent) "
+                        "or an alias ('primary'/'fallback'). Example: "
+                        "{\"agent_error\": \"primary\", \"task_complete:info\": \"silent\"}."
+                    ),
+                },
+            },
+            "required": [],
+        },
+        permission_level="write",
+        requires_confirmation=True,
+        tags=["settings", "auto-reporting", "notifications", "preferences"],
+        examples=[
+            "set telegram as the primary notification channel",
+            "enable quiet hours from 10pm to 8am",
+            "route urgent errors to telegram, info to in_app",
+        ],
+    ))
+
+    registry.register(ActionDefinition(
+        name="platform_send_notification",
+        description=(
+            "Send a notification through the workspace's configured channels. "
+            "Honours auto_reporting routes, quiet hours, and the existing "
+            "notification_preferences fan-out. Use for proactive Auto pings — "
+            "approval requests, urgent alerts, decision summaries — not for "
+            "every routine event (those auto-fire through the dispatcher)."
+        ),
+        category="notifications",
+        parameters={
+            "type": "object",
+            "properties": {
+                "event_type": {
+                    "type": "string",
+                    "enum": [
+                        "heartbeat_complete",
+                        "task_complete",
+                        "mission_step_complete",
+                        "mission_complete",
+                        "playbook_step_complete",
+                        "playbook_complete",
+                        "trigger_fired",
+                        "report_submitted",
+                        "agent_error",
+                    ],
+                    "description": "Platform event_type. Drives prefs lookup and routing.",
+                },
+                "title": {"type": "string"},
+                "message": {"type": "string"},
+                "severity": {
+                    "type": "string",
+                    "enum": ["info", "warning", "urgent", "security"],
+                    "description": "Routing hint. Maps onto auto_reporting.routes for severity-based delivery.",
+                },
+                "status": {
+                    "type": "string",
+                    "enum": ["ok", "warning", "error", "info"],
+                    "description": "Status icon used in formatted external messages.",
+                },
+                "link_type": {
+                    "type": "string",
+                    "description": "Optional link type, e.g. 'report' / 'task' / 'mission'.",
+                },
+                "link_id": {
+                    "type": "string",
+                    "description": "Optional link target id for in-app deep-link.",
+                },
+            },
+            "required": ["event_type", "title"],
+        },
+        permission_level="write",
+        requires_confirmation=False,
+        tags=["notifications", "send", "auto-reporting"],
+        examples=[
+            "ping me on telegram about the failing harness run",
+            "send an approval request notification",
+            "notify Gerard that the daily brief is ready",
+        ],
+    ))

--- a/orchestrator/modules/tools/discovery/handlers_auto_reporting.py
+++ b/orchestrator/modules/tools/discovery/handlers_auto_reporting.py
@@ -1,0 +1,88 @@
+"""Auto reporting handlers — Wave 2."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+
+async def get_auto_reporting_prefs(
+    db: Session, workspace_id: UUID, params: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Return effective auto_reporting settings (defaults merged with overrides)."""
+    from core.services.auto_reporting import load_auto_reporting_settings
+
+    try:
+        settings = load_auto_reporting_settings(db, workspace_id)
+        return {"success": True, "data": settings}
+    except Exception as exc:
+        logger.error("[auto_reporting] get prefs failed: %s", exc, exc_info=True)
+        return {"success": False, "error": str(exc)}
+
+
+async def update_auto_reporting_prefs(
+    db: Session, workspace_id: UUID, params: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Merge ``params`` into ``workspace.settings.auto_reporting`` and commit."""
+    from core.services.auto_reporting import update_auto_reporting_settings
+
+    # Drop bookkeeping params that the executor injects (_agent_id, etc.)
+    partial = {k: v for k, v in params.items() if not k.startswith("_")}
+    if not partial:
+        return {"success": False, "error": "no settings keys provided"}
+
+    try:
+        merged = update_auto_reporting_settings(db, workspace_id, partial)
+        db.commit()
+        return {"success": True, "data": merged}
+    except ValueError as exc:
+        return {"success": False, "error": str(exc)}
+    except Exception as exc:
+        logger.error("[auto_reporting] update prefs failed: %s", exc, exc_info=True)
+        db.rollback()
+        return {"success": False, "error": str(exc)}
+
+
+async def send_notification(
+    db: Session, workspace_id: UUID, params: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Fire an event through the unified NotificationDispatcher."""
+    from core.services.notification_dispatcher import (
+        NotificationDispatcher,
+        VALID_EVENT_TYPES,
+    )
+
+    event_type = params.get("event_type")
+    title = params.get("title")
+    if not event_type or not title:
+        return {"success": False, "error": "event_type and title are required"}
+    if event_type not in VALID_EVENT_TYPES:
+        return {
+            "success": False,
+            "error": f"event_type must be one of: {', '.join(sorted(VALID_EVENT_TYPES))}",
+        }
+
+    dispatcher = NotificationDispatcher(db, workspace_id)
+    try:
+        result = await dispatcher.dispatch(
+            event_type=event_type,
+            title=title,
+            message=params.get("message"),
+            link_type=params.get("link_type"),
+            link_id=params.get("link_id"),
+            agent_id=params.get("_agent_id"),
+            agent_name=params.get("_agent_name"),
+            status=params.get("status", "ok"),
+            severity=params.get("severity"),
+        )
+        db.commit()
+        return {"success": True, "data": result}
+    except Exception as exc:
+        logger.error("[auto_reporting] send_notification failed: %s", exc, exc_info=True)
+        db.rollback()
+        return {"success": False, "error": str(exc)}

--- a/orchestrator/modules/tools/discovery/platform_actions.py
+++ b/orchestrator/modules/tools/discovery/platform_actions.py
@@ -32,6 +32,7 @@ from .actions_analytics_enhanced import register_analytics_enhanced_actions
 from .actions_governance import register_governance_actions
 from .actions_harness import register_harness_actions
 from .actions_graph import register_graph_actions
+from .actions_auto_reporting import register_auto_reporting_actions
 
 
 def register_all_actions(registry: ActionRegistry) -> None:
@@ -57,6 +58,7 @@ def register_all_actions(registry: ActionRegistry) -> None:
     register_governance_actions(registry)
     register_harness_actions(registry)
     register_graph_actions(registry)
+    register_auto_reporting_actions(registry)
 
     # Workspace tools (file I/O, grep, exec, git)
     from .workspace_actions import register_workspace_actions

--- a/orchestrator/modules/tools/discovery/platform_executor.py
+++ b/orchestrator/modules/tools/discovery/platform_executor.py
@@ -115,6 +115,11 @@ from modules.tools.discovery.handlers_harness import (
     harness_trigger,
     harness_history,
 )
+from modules.tools.discovery.handlers_auto_reporting import (
+    get_auto_reporting_prefs,
+    update_auto_reporting_prefs,
+    send_notification,
+)
 from modules.tools.discovery.handlers_assignments import (
     assign_tool_to_agent,
     assign_skill_to_agent,
@@ -316,6 +321,10 @@ class PlatformActionExecutor:
             "platform_harness_status": harness_status,
             "platform_harness_trigger": harness_trigger,
             "platform_harness_history": harness_history,
+            # Wave 2: Auto reporting preferences + send-notification wrapper
+            "platform_get_auto_reporting_prefs": get_auto_reporting_prefs,
+            "platform_update_auto_reporting_prefs": update_auto_reporting_prefs,
+            "platform_send_notification": send_notification,
             # PRD-126: Knowledge Graph
             "platform_query_graph": handle_query_graph,
             "platform_graph_neighbors": handle_graph_neighbors,


### PR DESCRIPTION
…send_notification

Wave 2 of the Auto operating contract. Closes the "where do I report to" gap from Auto's own runbook by giving the workspace a single canonical ``auto_reporting`` settings shape and three platform tools, then wires the existing NotificationDispatcher to honour it.

New
- core/services/auto_reporting.py — settings reader/writer with deep merge, defaults, severity routing helper, and quiet-hours window check that handles midnight-crossing windows and timezone-aware moments.
- modules/tools/discovery/actions_auto_reporting.py — three ActionDefinitions: platform_get_auto_reporting_prefs (read), platform_update_auto_reporting_prefs (write, requires_confirmation=True), platform_send_notification (wraps the dispatcher so Auto can fire events programmatically).
- modules/tools/discovery/handlers_auto_reporting.py — handlers that call the service + the dispatcher with proper transaction semantics.

Modified
- core/services/notification_dispatcher.py — dispatch() now accepts ``severity`` and consults ``auto_reporting``:
    1. routes lookup wins over notification_preferences (event:severity → event → severity → none).
    2. ``primary``/``fallback`` aliases resolve against configured channels.
    3. Quiet hours funnel non-urgent traffic to in_app (urgent + security always pass through). Existing callers continue to work — severity defaults to None and routes is empty by default, so behaviour is unchanged for unconfigured workspaces.
- modules/tools/discovery/platform_actions.py — registers new actions.
- modules/tools/discovery/platform_executor.py — dispatches new handlers.

Settings are pure JSONB on workspace.settings.auto_reporting. No new tables. Defaults preserve current behaviour; quiet hours and routes only kick in once a workspace opts in via platform_update_auto_reporting_prefs.

Smoke tests pass (route lookup, severity overrides, alias resolution, midnight-crossing quiet windows, deep merge).