### PR TITLE
fix(harness): use Agent.status='active' — Agent has no is_active column

### DIFF
--- a/orchestrator/services/harness_service.py
+++ b/orchestrator/services/harness_service.py
@@ -365,9 +365,11 @@ class HarnessService:
         from core.models import Agent
         from sqlalchemy import text
 
+        # Agent has no `is_active` column — use the canonical `status` field
+        # (matches semantic_indexer + AgentService throughout the codebase).
         agent_count = (
             db.query(Agent)
-            .filter(Agent.workspace_id == workspace_id, Agent.is_active.is_(True))
+            .filter(Agent.workspace_id == workspace_id, Agent.status == "active")
             .count()
         )
 


### PR DESCRIPTION
platform_harness_status was crashing with:
  type object 'Agent' has no attribute 'is_active'

The Agent model uses ``status: String(50)`` (default 'active') — not a boolean ``is_active`` column. semantic_indexer and AgentService already filter by ``Agent.status == 'active'`` throughout the codebase; HARNESS diverged.

The bug pre-dates the harness-stabilization patches but only became visible after Patch A flipped the default from disabled to enabled — nothing was hitting the broken filter before.

Live DB verification: workspace ae8320bc-95e1-4de1-bbe9-396bef19cbf8 returns 19 active agents under the corrected filter (well above _MIN_AGENTS=3 threshold), so dormancy classification will now work.