### PR TITLE
feat(prd140): hierarchy permission helper + queryable bypass audit log

### DIFF
--- a/orchestrator/alembic/versions/prd140_permission_bypass_log.py
+++ b/orchestrator/alembic/versions/prd140_permission_bypass_log.py
@@ -1,0 +1,58 @@
+"""PRD-140 — permission_bypass_log
+
+Queryable audit trail for every time the hierarchy permission system grants
+a bypass (e.g. Auto, HARNESS service actor, platform admin). Stored in its
+own table — not buried in app logs — so the workspace owner can answer
+"did anyone bypass anything in the last 7 days?" with one SQL query.
+
+Idempotent.
+"""
+
+from alembic import op
+
+
+revision = "prd140_permission_bypass_log"
+down_revision = "wave3_escalation_level"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS permission_bypass_log (
+            id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            workspace_id    UUID NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+            actor_agent_id  INTEGER REFERENCES agents(id) ON DELETE SET NULL,
+            actor_name      VARCHAR(255) NOT NULL,
+            actor_kind      VARCHAR(40)  NOT NULL,
+            target_type     VARCHAR(40)  NOT NULL,
+            target_id       VARCHAR(255),
+            change_type     VARCHAR(60)  NOT NULL,
+            reason          VARCHAR(80)  NOT NULL,
+            source          VARCHAR(120),
+            metadata        JSONB NOT NULL DEFAULT '{}'::jsonb,
+            created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        );
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_perm_bypass_workspace_created "
+        "ON permission_bypass_log (workspace_id, created_at DESC);"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_perm_bypass_actor "
+        "ON permission_bypass_log (workspace_id, actor_agent_id, created_at DESC) "
+        "WHERE actor_agent_id IS NOT NULL;"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_perm_bypass_target "
+        "ON permission_bypass_log (workspace_id, target_type, target_id);"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_perm_bypass_target;")
+    op.execute("DROP INDEX IF EXISTS ix_perm_bypass_actor;")
+    op.execute("DROP INDEX IF EXISTS ix_perm_bypass_workspace_created;")
+    op.execute("DROP TABLE IF EXISTS permission_bypass_log;")

--- a/orchestrator/core/security/bypass_audit.py
+++ b/orchestrator/core/security/bypass_audit.py
@@ -1,0 +1,78 @@
+"""PRD-140 — bypass audit writer.
+
+Records every system-agent / workspace-owner permission bypass into a
+queryable table so the workspace owner can answer "did anyone bypass
+anything in the last 7 days?" without grepping logs.
+
+The writer is fail-soft: if the audit insert fails, the caller still
+proceeds (permission is already granted) but a warning is logged. We
+never block a legitimate bypass on audit-storage failure.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict, Optional
+from uuid import UUID
+
+from sqlalchemy import text
+
+from core.security.hierarchy_permissions import PermissionDecision
+
+logger = logging.getLogger(__name__)
+
+
+def record_bypass(
+    db,
+    *,
+    decision: PermissionDecision,
+    workspace_id: UUID | str,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> None:
+    """Insert one row into ``permission_bypass_log`` for a granted bypass.
+
+    No-op when ``decision.bypass`` is False. Caller owns the transaction —
+    we do not commit here, matching the pattern used by NotificationDispatcher
+    and ReportService.
+    """
+    if not decision.bypass:
+        return
+
+    try:
+        db.execute(
+            text(
+                """
+                INSERT INTO permission_bypass_log
+                    (workspace_id, actor_agent_id, actor_name, actor_kind,
+                     target_type, target_id, change_type, reason, source, metadata)
+                VALUES
+                    (:workspace_id, :actor_agent_id, :actor_name, :actor_kind,
+                     :target_type, :target_id, :change_type, :reason, :source, :metadata)
+                """
+            ),
+            {
+                "workspace_id": str(workspace_id),
+                "actor_agent_id": decision.actor_agent_id,
+                "actor_name": decision.actor_name or "unknown",
+                "actor_kind": decision.bypass_kind or "unknown",
+                "target_type": decision.target_type or "unknown",
+                "target_id": decision.target_id,
+                "change_type": decision.change_type or "unknown",
+                "reason": decision.reason,
+                "source": decision.source,
+                "metadata": json.dumps(metadata or {}),
+            },
+        )
+    except Exception as exc:
+        # Never block a legitimate bypass on audit failure — but make the
+        # gap visible so the operator knows audit coverage degraded.
+        logger.error(
+            "[bypass_audit] failed to record bypass actor=%s target=%s/%s change=%s: %s",
+            decision.actor_name,
+            decision.target_type,
+            decision.target_id,
+            decision.change_type,
+            exc,
+            exc_info=True,
+        )

--- a/orchestrator/core/security/hierarchy_permissions.py
+++ b/orchestrator/core/security/hierarchy_permissions.py
@@ -1,0 +1,336 @@
+"""PRD-140 — hierarchy permission helper.
+
+Single chokepoint that says yes/no/why for "actor X wants to make change C
+on target T". Designed to be called from service-layer mutations (the only
+correct enforcement point) and from tool wrappers as a defence in depth.
+
+Defaults are conservative:
+
+  * Default DENY on broken state — missing manager, cycle in reports_to_id
+    chain, unknown target, deleted/inactive actor.
+  * Default DENY on ambiguity — if the helper cannot decide, the caller
+    must NOT proceed. No "fail open" path.
+
+System-agent bypass is **narrowed**: not every ``is_system_agent=True``
+record gets a free pass. Only the specific named system actors registered
+in :data:`SYSTEM_BYPASS_ALLOWLIST` may bypass, and every bypass is recorded
+to ``permission_bypass_log`` (see :mod:`core.security.bypass_audit`).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Iterable, Optional, Set
+from uuid import UUID
+
+logger = logging.getLogger(__name__)
+
+
+# ----------------------------------------------------------------- constants
+
+
+# Narrowed bypass allowlist — these specific named actors may bypass the
+# hierarchy. Adding to this list is a security-sensitive change. ``Auto``
+# is the workspace orchestrator (slug auto-{workspace_id}); the others are
+# platform service actors.
+SYSTEM_BYPASS_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        "Auto",                   # workspace orchestrator
+        "HARNESS",                # weekly self-optimisation service actor
+        "platform-admin",         # explicit admin agent
+        "platform-system",        # internal service actor
+    }
+)
+
+# Maximum subtree depth before we treat the chain as broken. Real org
+# trees rarely exceed 6 levels; anything deeper is almost certainly a
+# cycle the visited-set didn't catch (defence in depth).
+MAX_SUBTREE_DEPTH: int = 16
+
+
+# ----------------------------------------------------------------- types
+
+
+@dataclass(frozen=True)
+class PermissionDecision:
+    """Result of a permission check. Always inspect ``allowed`` first."""
+
+    allowed: bool
+    reason: str
+    bypass: bool = False
+    bypass_kind: Optional[str] = None  # 'system_actor' | 'workspace_owner' | None
+    actor_agent_id: Optional[int] = None
+    actor_name: Optional[str] = None
+    target_type: Optional[str] = None
+    target_id: Optional[str] = None
+    change_type: Optional[str] = None
+    source: Optional[str] = None
+
+
+# ----------------------------------------------------------------- main API
+
+
+def can_actor_modify(
+    db,
+    *,
+    actor_agent_id: Optional[int],
+    target_type: str,
+    target_id: Optional[str],
+    change_type: str,
+    workspace_id: UUID | str,
+    source: Optional[str] = None,
+) -> PermissionDecision:
+    """Decide whether ``actor`` may apply ``change_type`` to ``target``.
+
+    Parameters
+    ----------
+    db                : SQLAlchemy session.
+    actor_agent_id    : ID of the agent attempting the change. ``None`` is
+                        treated as an anonymous caller and almost always
+                        denied (only the explicit platform-system flow may
+                        pass with ``None``).
+    target_type       : 'agent' | 'playbook' | 'task' | 'skill' | 'tool' | ...
+    target_id         : ID of the target row (string for UUID tables, int as
+                        string for integer PKs).
+    change_type       : Free-form short verb e.g. 'update', 'delete',
+                        'assign_skill', 'configure_heartbeat'.
+    workspace_id      : Workspace scope — every check is workspace-bound.
+                        Cross-workspace mutations are always denied here.
+    source            : Optional caller identifier for audit ('platform_tool',
+                        'api/agents', 'heartbeat_tick', etc.).
+
+    Returns
+    -------
+    PermissionDecision (always non-None — never raises for permission state).
+    """
+    from core.models import Agent
+
+    workspace_id_str = str(workspace_id)
+
+    # --- Anonymous / missing actor: always deny (no ambient authority) ---
+    if actor_agent_id is None:
+        return PermissionDecision(
+            allowed=False,
+            reason="anonymous_actor",
+            actor_agent_id=None,
+            target_type=target_type,
+            target_id=str(target_id) if target_id is not None else None,
+            change_type=change_type,
+            source=source,
+        )
+
+    actor = db.query(Agent).filter(Agent.id == actor_agent_id).first()
+    if actor is None:
+        return PermissionDecision(
+            allowed=False,
+            reason="actor_not_found",
+            actor_agent_id=actor_agent_id,
+            target_type=target_type,
+            target_id=str(target_id) if target_id is not None else None,
+            change_type=change_type,
+            source=source,
+        )
+
+    # --- Workspace boundary check (cross-tenant attack surface) ---
+    if str(actor.workspace_id) != workspace_id_str:
+        return PermissionDecision(
+            allowed=False,
+            reason="cross_workspace_actor",
+            actor_agent_id=actor.id,
+            actor_name=actor.name,
+            target_type=target_type,
+            target_id=str(target_id) if target_id is not None else None,
+            change_type=change_type,
+            source=source,
+        )
+
+    # --- Inactive actor cannot mutate ---
+    if (actor.status or "").lower() != "active":
+        return PermissionDecision(
+            allowed=False,
+            reason="actor_inactive",
+            actor_agent_id=actor.id,
+            actor_name=actor.name,
+            target_type=target_type,
+            target_id=str(target_id) if target_id is not None else None,
+            change_type=change_type,
+            source=source,
+        )
+
+    # --- Narrowed system-agent bypass ---
+    # Bypass is only granted when BOTH conditions hold: ``is_system_agent``
+    # is set AND the agent's name is on the explicit allowlist. The flag
+    # alone is not a golden key.
+    if (
+        bool(getattr(actor, "is_system_agent", False))
+        and (actor.name or "") in SYSTEM_BYPASS_ALLOWLIST
+    ):
+        return PermissionDecision(
+            allowed=True,
+            reason="system_actor_bypass",
+            bypass=True,
+            bypass_kind="system_actor",
+            actor_agent_id=actor.id,
+            actor_name=actor.name,
+            target_type=target_type,
+            target_id=str(target_id) if target_id is not None else None,
+            change_type=change_type,
+            source=source,
+        )
+
+    # --- Subtree authority (team-lead path) ---
+    # The actor may modify any agent in their reports-to subtree, plus
+    # workspace-owned playbooks and board tasks they (or their reports)
+    # own. Cross-team and shared-resource mutations are denied at this layer.
+    if target_type == "agent":
+        if target_id is None:
+            return _deny(actor, target_type, target_id, change_type, source, "missing_target")
+        try:
+            target_int = int(target_id)
+        except (TypeError, ValueError):
+            return _deny(actor, target_type, target_id, change_type, source, "invalid_target_id")
+
+        if target_int == actor.id:
+            return PermissionDecision(
+                allowed=True,
+                reason="self_mutation",
+                actor_agent_id=actor.id,
+                actor_name=actor.name,
+                target_type=target_type,
+                target_id=str(target_id),
+                change_type=change_type,
+                source=source,
+            )
+
+        target = db.query(Agent).filter(Agent.id == target_int).first()
+        if target is None:
+            return _deny(actor, target_type, target_id, change_type, source, "target_not_found")
+        if str(target.workspace_id) != workspace_id_str:
+            return _deny(actor, target_type, target_id, change_type, source, "cross_workspace_target")
+
+        in_subtree = _agent_in_subtree(db, root_id=actor.id, candidate_id=target_int)
+        if in_subtree is None:
+            # Cycle detected or chain too deep — default DENY.
+            return _deny(actor, target_type, target_id, change_type, source, "broken_hierarchy")
+        if in_subtree:
+            return PermissionDecision(
+                allowed=True,
+                reason="subtree_authority",
+                actor_agent_id=actor.id,
+                actor_name=actor.name,
+                target_type=target_type,
+                target_id=str(target_id),
+                change_type=change_type,
+                source=source,
+            )
+        return _deny(actor, target_type, target_id, change_type, source, "out_of_subtree")
+
+    # Other target_types fall through to default-deny here — wiring for
+    # playbook / skill / tool / task is added per resource as the chokepoint
+    # rolls out (Ticket 2). Default-deny means a new tool added before its
+    # permission rules are coded gets blocked, not silently allowed.
+    return _deny(
+        actor,
+        target_type,
+        target_id,
+        change_type,
+        source,
+        f"unsupported_target_type:{target_type}",
+    )
+
+
+# ----------------------------------------------------------------- helpers
+
+
+def subtree_of(db, root_agent_id: int) -> Set[int]:
+    """Return every agent id reachable via reports_to_id from ``root``.
+
+    Cycle-safe (visited set + depth cap). Returns at minimum ``{root_id}``
+    even when the agent has no direct reports. Returns an empty set when
+    the chain is broken or the depth cap is exceeded.
+    """
+    from core.models import Agent
+
+    out: Set[int] = {root_agent_id}
+    frontier: Set[int] = {root_agent_id}
+
+    for _ in range(MAX_SUBTREE_DEPTH):
+        if not frontier:
+            return out
+        rows = (
+            db.query(Agent.id)
+            .filter(Agent.reports_to_id.in_(frontier))
+            .all()
+        )
+        next_frontier: Set[int] = {row.id for row in rows} - out
+        out.update(next_frontier)
+        frontier = next_frontier
+
+    # Hit depth cap — chain is suspect. Default deny by returning empty.
+    logger.warning(
+        "[hierarchy] subtree_of(%s) exceeded MAX_SUBTREE_DEPTH=%d — defaulting deny",
+        root_agent_id,
+        MAX_SUBTREE_DEPTH,
+    )
+    return set()
+
+
+def _agent_in_subtree(db, root_id: int, candidate_id: int) -> Optional[bool]:
+    """Return True / False / None.
+
+    None signals broken hierarchy (cycle, depth cap, missing manager) so
+    the caller can choose default deny.
+    """
+    from core.models import Agent
+
+    # Walk UP from candidate toward root with cycle detection. This is
+    # cheaper than expanding the full subtree of root when the tree is
+    # wide — we only ever load the actor's reporting chain.
+    visited: Set[int] = set()
+    cursor: Optional[int] = candidate_id
+    depth = 0
+
+    while cursor is not None:
+        if cursor in visited:
+            logger.warning(
+                "[hierarchy] cycle detected at agent_id=%s while walking from %s",
+                cursor,
+                candidate_id,
+            )
+            return None
+        if depth >= MAX_SUBTREE_DEPTH:
+            logger.warning(
+                "[hierarchy] depth cap exceeded walking from %s",
+                candidate_id,
+            )
+            return None
+        visited.add(cursor)
+        if cursor == root_id:
+            return True
+        row = (
+            db.query(Agent.reports_to_id)
+            .filter(Agent.id == cursor)
+            .first()
+        )
+        if row is None:
+            # candidate row vanished mid-walk — treat as broken
+            return None
+        # SQLAlchemy Row supports attribute access by column label.
+        cursor = getattr(row, "reports_to_id", None)
+        depth += 1
+
+    return False
+
+
+def _deny(actor, target_type, target_id, change_type, source, reason) -> PermissionDecision:
+    return PermissionDecision(
+        allowed=False,
+        reason=reason,
+        actor_agent_id=getattr(actor, "id", None),
+        actor_name=getattr(actor, "name", None),
+        target_type=target_type,
+        target_id=str(target_id) if target_id is not None else None,
+        change_type=change_type,
+        source=source,
+    )


### PR DESCRIPTION
PRD-140 foundation. Builds the security primitive that gates every mutation in the platform onto a single chokepoint Auto can reason about.

What ships
- core/security/hierarchy_permissions.py — can_actor_modify(...) returns a frozen PermissionDecision (allowed/reason/bypass/bypass_kind/...). Walks the reports_to_id chain UP from the candidate toward the actor with cycle detection (visited set + MAX_SUBTREE_DEPTH=16) so circular org charts and broken chains default deny.
- subtree_of(...) helper for callers that need the full descendant set (e.g. team-review playbooks) — same cycle/depth protections.
- core/security/bypass_audit.py — record_bypass(...) inserts into a new queryable table on every granted bypass. Fail-soft: if the audit insert errors we log + continue (never block a legitimate bypass on storage).
- alembic/versions/prd140_permission_bypass_log.py — new audit table with indexes for "what bypasses happened in workspace X this week" queries.

Tighten-ups baked in (per Auto's review)
- Default DENY on every ambiguous path: anonymous actor, missing actor, cross-workspace actor, inactive actor, missing target, broken chain, cycle, depth cap, unsupported target_type.
- System-agent bypass NARROWED: requires BOTH ``is_system_agent=True`` AND agent name in SYSTEM_BYPASS_ALLOWLIST = {Auto, HARNESS, platform-admin, platform-system}. The is_system flag alone is not a golden key.
- Bypass audit is queryable, not buried in app logs (workspace_id + created_at index, plus actor and target indexes).

Tests (15/15 passing)
- Auto bypass granted; RogueAuto (is_system but not allowlisted) denied
- VECTOR → PULSE subtree authority; VECTOR → ATLAS peer denied; PULSE → VECTOR upward denied; self-mutation allowed
- Anonymous denied; inactive actor denied; cross-workspace denied
- Orphan cycle defaults deny (broken_hierarchy); self-loop where root is reachable still resolves correctly (subtree_authority); depth cap defaults deny
- Decision is frozen (immutable); subtree_of returns expected ids
- Unsupported target_type defaults deny

What is NOT in this branch (deliberately)
- Wiring to mutation paths (platform_update_agent, heartbeat config, playbook tools, etc.) — that's Ticket 2 and gets reviewed per resource. Default-deny on unknown target_types means new tools added before their rules are coded get blocked, not silently allowed.
- team_lead_enabled flag (suggest derived is_team_lead instead).
- Decorator pattern + CI registry — designed but not built; same branch as the wiring work.

Migration applied on live DB (verified 12 columns + 3 indexes present).