### PR TITLE
hotfix(prd140): restore TARGET_* constants — Auto is down

### DIFF
--- a/orchestrator/core/security/hierarchy_permissions.py
+++ b/orchestrator/core/security/hierarchy_permissions.py
@@ -30,6 +30,22 @@ logger = logging.getLogger(__name__)
 # ----------------------------------------------------------------- constants
 
 
+# Target-type string constants used by callers (platform_executor,
+# core.security.__init__, tests). These are the public API for the
+# ``target_type`` argument of :func:`can_actor_modify`. Kept as plain
+# strings so they survive JSON round-trips through the dispatcher.
+#
+# Currently can_actor_modify only enforces hierarchy on TARGET_AGENT;
+# the other target types fall through to default-deny (intentional —
+# tightening will land per-target in follow-ups).
+TARGET_AGENT          = "agent"
+TARGET_HEARTBEAT      = "heartbeat"
+TARGET_PLAYBOOK       = "playbook"
+TARGET_TASK           = "task"
+TARGET_SKILL          = "skill"
+TARGET_TOOL_ASSIGNMENT = "tool_assignment"
+
+
 # Narrowed bypass allowlist — these specific named actors may bypass the
 # hierarchy. Adding to this list is a security-sensitive change. ``Auto``
 # is the workspace orchestrator (slug auto-{workspace_id}); the others are


### PR DESCRIPTION
## Summary
- PR #296 rewrote `orchestrator/core/security/hierarchy_permissions.py` and dropped the `TARGET_*` string constants
- But `core/security/__init__.py`, `modules/tools/discovery/platform_executor.py`, and the test suite still import them
- Result: `ImportError: cannot import name 'TARGET_AGENT'` on uvicorn startup → container crashes → **Auto is currently down on prod**

## Fix
Restored the 6 constants as plain strings (same values from PR #295). `can_actor_modify` still only enforces hierarchy on `TARGET_AGENT`; the rest fall through to default-deny (no behaviour change from the PR #296 rewrite — only the import contract is restored).

## Why merge ASAP
Production is down. This is one file, 16 lines added, no semantic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)