### PR TITLE
fix(platform): inject _agent_id/_agent_name into platform_execute params

### DIFF
--- a/orchestrator/modules/tools/execution/exec_platform.py
+++ b/orchestrator/modules/tools/execution/exec_platform.py
@@ -33,6 +33,7 @@ async def execute_platform_action(
     workspace_id: Optional[UUID] = None,
     trace_id: Optional[str] = None,
     caller_context: Optional[Dict[str, Any]] = None,
+    agent_id: Optional[int] = None,
 ) -> Dict[str, Any]:
     """Execute a platform action via PlatformActionExecutor.
 
@@ -42,6 +43,10 @@ async def execute_platform_action(
             If None, falls back to workspace-scoped check via
             _workspace_has_admin_owner() — admin workspace grants access,
             non-admin workspace denies.
+        agent_id: ID of the calling agent. Injected as ``_agent_id`` (and
+            ``_agent_name`` resolved from DB) into params so handlers like
+            ``platform_submit_report`` can attribute the call. Without this,
+            recipe-step calls failed with "Could not determine calling agent".
     """
     if not workspace_id:
         return {
@@ -49,6 +54,24 @@ async def execute_platform_action(
             "error": "workspace_id required for platform actions",
             "tool": tool_name,
         }
+
+    # Inject agent context into params so handlers (submit_report, blog,
+    # auto_reporting, board_tasks) can attribute the call. Don't overwrite
+    # if the LLM already supplied them.
+    if agent_id and isinstance(parameters, dict):
+        if "_agent_id" not in parameters:
+            parameters = {**parameters, "_agent_id": agent_id}
+        if "_agent_name" not in parameters:
+            try:
+                from core.models import Agent
+                agent = executor.db.query(Agent).filter(
+                    Agent.id == agent_id,
+                    Agent.workspace_id == workspace_id,
+                ).first()
+                if agent:
+                    parameters = {**parameters, "_agent_name": agent.name}
+            except Exception as e:
+                logger.debug("[exec_platform] _agent_name lookup failed: %s", e)
 
     try:
         from modules.tools.discovery.platform_executor import PlatformActionExecutor

--- a/orchestrator/modules/tools/execution/unified_executor.py
+++ b/orchestrator/modules/tools/execution/unified_executor.py
@@ -407,7 +407,7 @@ class UnifiedToolExecutor:
                     return result
                 result = await self._execute_platform_action(
                     action_name, action_params, workspace_id=workspace_id, trace_id=trace,
-                    caller_context=caller_context,
+                    caller_context=caller_context, agent_id=agent_id,
                 )
                 return result
 
@@ -416,7 +416,7 @@ class UnifiedToolExecutor:
                 logger.info(f"[tool-trace {trace}] Routing to PlatformActionExecutor: {tool_name}")
                 result = await self._execute_platform_action(
                     tool_name, parameters, workspace_id=workspace_id, trace_id=trace,
-                    caller_context=caller_context,
+                    caller_context=caller_context, agent_id=agent_id,
                 )
                 return result
 
@@ -531,8 +531,12 @@ class UnifiedToolExecutor:
     async def _execute_platform_tool(self, tool_name, parameters, agent_id, **kw):
         return await exec_platform.execute_platform_tool(self, tool_name, parameters, agent_id)
 
-    async def _execute_platform_action(self, tool_name, parameters, workspace_id=None, trace_id=None, caller_context=None):
-        return await exec_platform.execute_platform_action(self, tool_name, parameters, workspace_id=workspace_id, trace_id=trace_id, caller_context=caller_context)
+    async def _execute_platform_action(self, tool_name, parameters, workspace_id=None, trace_id=None, caller_context=None, agent_id=None):
+        return await exec_platform.execute_platform_action(
+            self, tool_name, parameters,
+            workspace_id=workspace_id, trace_id=trace_id, caller_context=caller_context,
+            agent_id=agent_id,
+        )
 
     async def _execute_database_tool(self, tool_name, parameters, agent_id, **kw):
         return await exec_research.execute_database_tool(self, tool_name, parameters, agent_id)


### PR DESCRIPTION
platform_submit_report (and other handlers that depend on caller attribution: handlers_blog, handlers_auto_reporting, handlers_board_tasks) were failing in recipe-step execution with "Could not determine calling agent". The unified_executor knew agent_id at the dispatch level but never threaded it through to the platform action handlers.

Repro: PULSE step in daily-social-analytics-report recipe, agent=189. Tool trace 3cc0c2236df3 — `platform_execute -> platform_submit_report` returned success=False, agent fell back to workspace_write_file with LLM-invented paths (repos/automatos-ai/analytics/...).

Fix:
  - exec_platform.execute_platform_action accepts optional agent_id, injects {_agent_id, _agent_name} into params before dispatch (without overwriting LLM-supplied values).
  - unified_executor passes agent_id through both platform_execute and direct platform_* call paths.

agent_name is resolved via a single Agent lookup. Failures in the lookup fall back to the handler's own DB query (handlers_reports.py:55), which is already there for legacy callers.

Closes the recipe-mode submit_report regression for PRD-76 reports.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced agent identification tracking during platform action execution with automatic metadata injection.
  * Added support for per-action tool integrations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AutomatosAI/automatos-ai/pull/302)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->