### PR TITLE
feat(heartbeat): wire report_to=auto via board task; surface Auto in …

### DIFF
--- a/frontend/components/activity/board/board-agent-sidebar.tsx
+++ b/frontend/components/activity/board/board-agent-sidebar.tsx
@@ -2,7 +2,7 @@
 
 import { Bot } from 'lucide-react'
 import { PremiumIcon } from '@/components/shared'
-import { useAgents } from '@/hooks/use-agent-api'
+import { useAssignableAgents } from '@/hooks/use-agent-api'
 import { cn } from '@/lib/utils'
 
 interface BoardAgentSidebarProps {
@@ -28,7 +28,7 @@ function getRoleBadge(role: string | undefined): { label: string; color: string 
 }
 
 export function BoardAgentSidebar({ selectedAgentId, onSelectAgent, className }: BoardAgentSidebarProps) {
-  const { data: rawAgents, isLoading } = useAgents()
+  const { data: rawAgents, isLoading } = useAssignableAgents()
   const agents = (rawAgents as any[]) ?? []
 
   return (

--- a/frontend/components/activity/board/board-filters.tsx
+++ b/frontend/components/activity/board/board-filters.tsx
@@ -11,7 +11,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
-import { useAgents } from '@/hooks/use-agent-api'
+import { useAssignableAgents } from '@/hooks/use-agent-api'
 import type { BoardFilters } from '@/hooks/use-board-tasks'
 import { cn } from '@/lib/utils'
 
@@ -35,7 +35,7 @@ export function BoardFiltersBar({
   className,
 }: BoardFiltersBarProps) {
   const [searchValue, setSearchValue] = useState(filters.search ?? '')
-  const { data: rawAgents } = useAgents()
+  const { data: rawAgents } = useAssignableAgents()
   const agents = (rawAgents as any[]) ?? []
 
   const handleSearch = (value: string) => {

--- a/frontend/components/activity/board/create-task-dialog.tsx
+++ b/frontend/components/activity/board/create-task-dialog.tsx
@@ -13,7 +13,7 @@ import {
   DialogDescription,
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
-import { useAgents } from '@/hooks/use-agent-api'
+import { useAssignableAgents } from '@/hooks/use-agent-api'
 import { useCreateTask, usePlanTask, useRefineTask } from '@/hooks/use-board-tasks-api'
 import type { CreateTaskPayload, PlanResponse, RefineResponse } from '@/hooks/use-board-tasks-api'
 import type { TaskPriority, ReviewMode } from '@/types/board'
@@ -59,7 +59,7 @@ export function CreateTaskDialog({ open, onOpenChange }: CreateTaskDialogProps) 
   const [answers, setAnswers] = useState<Record<string, number>>({})
   const [refinedData, setRefinedData] = useState<RefineResponse | null>(null)
 
-  const { data: agents = [] } = useAgents()
+  const { data: agents = [] } = useAssignableAgents()
   const createTask = useCreateTask()
   const planTask = usePlanTask()
   const refineTask = useRefineTask()

--- a/frontend/components/agents/agent-configuration-modal.tsx
+++ b/frontend/components/agents/agent-configuration-modal.tsx
@@ -1818,8 +1818,8 @@ export function AgentConfigurationModal({
                             >
                               <SelectTrigger><SelectValue /></SelectTrigger>
                               <SelectContent>
-                                <SelectItem value="orchestrator">Orchestrator (DB only)</SelectItem>
-                                <SelectItem value="direct">Direct (Chat)</SelectItem>
+                                <SelectItem value="orchestrator">DB only</SelectItem>
+                                <SelectItem value="auto">Auto (assign task)</SelectItem>
                                 {connectedIntegrations.map((i) => (
                                   <SelectItem key={i.key} value={i.platform}>
                                     {i.platform.charAt(0).toUpperCase() + i.platform.slice(1)}
@@ -1829,8 +1829,8 @@ export function AgentConfigurationModal({
                               </SelectContent>
                             </Select>
                             <p className="text-xs text-muted-foreground">
-                              {heartbeatConfig.report_to === 'orchestrator' && 'Results stored in database, visible in analytics'}
-                              {heartbeatConfig.report_to === 'direct' && 'Results appear in agent chat'}
+                              {heartbeatConfig.report_to === 'orchestrator' && 'Results stored in DB. Auto only sees them if asked.'}
+                              {heartbeatConfig.report_to === 'auto' && 'Creates a board task assigned to Auto. Auto picks it up on its next tick.'}
                               {heartbeatConfig.report_to === 'telegram' && 'Results sent to your Telegram chat'}
                               {heartbeatConfig.report_to === 'slack' && 'Results sent to your Slack channel'}
                               {heartbeatConfig.report_to === 'webhook' && 'Results POSTed as JSON to your URL'}

--- a/frontend/hooks/use-agent-api.ts
+++ b/frontend/hooks/use-agent-api.ts
@@ -86,15 +86,24 @@ export const agentQueryKeys = {
 import { useSystemIcons } from './use-system-config-api'
 import { LEGACY_CATEGORY_MAP } from '@/lib/agent-constants'
 
+interface UseAgentsOptions {
+  /** Include the workspace's system agents (e.g. Auto). Used by assignee
+   *  pickers — the Roster never sets this. */
+  includeWorkspaceSystem?: boolean
+}
+
 // Get all agents
-export function useAgents() {
+export function useAgents(options: UseAgentsOptions = {}) {
   const { data: iconMappings = {} } = useSystemIcons();
   const iconKeys = Object.keys(iconMappings).sort().join(',')
+  const includeSystem = options.includeWorkspaceSystem === true
 
   return useQuery({
-    queryKey: [...agentQueryKeys.agents, iconKeys],
+    queryKey: [...agentQueryKeys.agents, iconKeys, includeSystem ? 'sys' : 'noSys'],
     queryFn: async () => {
-      const agents = await agentApiClient.getAgents();
+      const agents = (await apiClient.getAgents(0, 100, {
+        includeWorkspaceSystem: includeSystem,
+      })) as any[];
       // Inject icon mapping based on category (normalize legacy Title Case categories)
       return agents.map((agent: any) => {
         const cat = agent.marketplace_category || agent.configuration?.category || agent.agent_type
@@ -109,6 +118,16 @@ export function useAgents() {
     staleTime: 30000, // Cache for 30 seconds, allows manual refresh
     refetchOnWindowFocus: false, // Don't refetch on window focus
   })
+}
+
+/**
+ * Variant of useAgents() that includes the workspace's hidden Auto so it
+ * can be selected as a task assignee. Use this in board pickers, task
+ * dialogs, and agent dropdowns where Auto should appear; never in the
+ * Roster (which deliberately hides it).
+ */
+export function useAssignableAgents() {
+  return useAgents({ includeWorkspaceSystem: true })
 }
 
 // Get single agent

--- a/frontend/lib/api-client.ts
+++ b/frontend/lib/api-client.ts
@@ -1075,8 +1075,14 @@ class ApiClient {
   }
 
   // ===== AGENT ENDPOINTS =====
-  async getAgents(skip = 0, limit = 100) {
-    return this.request(`/api/agents/?skip=${skip}&limit=${limit}`)
+  async getAgents(
+    skip = 0,
+    limit = 100,
+    options: { includeWorkspaceSystem?: boolean } = {},
+  ) {
+    const params = new URLSearchParams({ skip: String(skip), limit: String(limit) })
+    if (options.includeWorkspaceSystem) params.set('include_workspace_system', 'true')
+    return this.request(`/api/agents/?${params.toString()}`)
   }
 
   async getAgent(id: string) {

--- a/orchestrator/api/agents.py
+++ b/orchestrator/api/agents.py
@@ -495,6 +495,14 @@ async def list_agents(
     agent_type: Optional[AgentType] = None,
     priority_level: Optional[PriorityLevel] = None,
     search: Optional[str] = None,
+    include_workspace_system: bool = Query(
+        False,
+        description=(
+            "When true, include the workspace's system agents (e.g. Auto) in "
+            "the result set. Used by task assignee pickers so Auto can be "
+            "assigned work without being shown in the main Roster."
+        ),
+    ),
     ctx: RequestContext = Depends(get_request_context_hybrid),
     db: Session = Depends(get_db)
 ):
@@ -522,12 +530,17 @@ async def list_agents(
             db.query(Agent)
             .options(joinedload(Agent.skills), subqueryload(Agent.assigned_plugins))
             .filter(scope_filter)
-            # Hide per-workspace Auto agents from the Roster — they are managed
-            # in Settings > Orchestrator, not in the agent list.  Global system
-            # agents (CTO, workspace_id=None) remain visible to admins.
-            .filter(~and_(Agent.is_system_agent.is_(True), Agent.workspace_id.isnot(None)))
             .filter(Agent.agent_type != "ephemeral")  # Hide Mission Zero ephemeral clones
         )
+
+        # By default hide per-workspace system agents (Auto) from the Roster —
+        # they are managed in Settings > Orchestrator. Assignee pickers pass
+        # ``include_workspace_system=true`` so Auto is selectable as a task
+        # owner without being listed alongside regular agents.
+        if not include_workspace_system:
+            query = query.filter(
+                ~and_(Agent.is_system_agent.is_(True), Agent.workspace_id.isnot(None))
+            )
 
         # Apply filters uniformly to all agents (workspace + system)
         if status:

--- a/orchestrator/services/heartbeat_service.py
+++ b/orchestrator/services/heartbeat_service.py
@@ -1105,9 +1105,10 @@ class HeartbeatService:
                 ]
                 message_body = "\n".join(details) if details else "No findings."
 
-            # Resolve agent metadata (agent tick only)
+            # Resolve agent metadata + per-agent report_to override (agent tick only)
             agent_id: Optional[int] = None
             agent_name: Optional[str] = None
+            agent_hb_config: dict = {}
             if source_type == "agent":
                 try:
                     agent_id = int(result.get("source_id"))
@@ -1120,6 +1121,8 @@ class HeartbeatService:
 
                         agent = db_lookup.query(Agent).get(agent_id)
                         agent_name = agent.name if agent else f"agent-{agent_id}"
+                        if agent and agent.configuration:
+                            agent_hb_config = (agent.configuration or {}).get("heartbeat", {}) or {}
                     finally:
                         db_lookup.close()
                 title = f"{agent_name or 'Agent'} Heartbeat"
@@ -1128,6 +1131,39 @@ class HeartbeatService:
                 title = "Orchestrator Heartbeat"
 
             link_id = result.get("_heartbeat_result_id")
+
+            # Per-agent ``report_to`` overrides the workspace dispatch path.
+            #   - "auto"     → assign a board task to the workspace's Auto, so
+            #                  Auto picks it up on its next tick (PRD-72 loop).
+            #   - "webhook"  → POST directly to the agent's stored webhook_url,
+            #                  bypassing workspace prefs.
+            #   - anything else (orchestrator/telegram/slack/empty) falls
+            #                  through to the workspace-level NotificationDispatcher.
+            report_to = (agent_hb_config.get("report_to") or "").strip().lower()
+
+            if report_to == "auto" and source_type == "agent":
+                await self._route_heartbeat_to_auto(
+                    workspace_id=workspace_id,
+                    source_agent_id=agent_id,
+                    source_agent_name=agent_name,
+                    title=title,
+                    message=message_body,
+                    link_id=link_id,
+                    status=dispatch_status,
+                )
+                return
+
+            if report_to == "webhook" and agent_hb_config.get("webhook_url"):
+                await self._route_heartbeat_to_webhook(
+                    webhook_url=agent_hb_config["webhook_url"],
+                    title=title,
+                    message=message_body,
+                    agent_id=agent_id,
+                    agent_name=agent_name,
+                    link_id=link_id,
+                    status=dispatch_status,
+                )
+                return
 
             db = SessionLocal()
             try:
@@ -1157,6 +1193,131 @@ class HeartbeatService:
             logger.error(
                 "[Heartbeat] Notification dispatch failed for ws=%s: %s",
                 workspace_id, e, exc_info=True,
+            )
+
+    # ------------------------------------------------------------------
+    # report_to routing — per-agent overrides (PRD-72 follow-up)
+    # ------------------------------------------------------------------
+
+    async def _route_heartbeat_to_auto(
+        self,
+        *,
+        workspace_id: str,
+        source_agent_id: Optional[int],
+        source_agent_name: Optional[str],
+        title: str,
+        message: str,
+        link_id: Optional[Any],
+        status: str,
+    ) -> None:
+        """Create a BoardTask for Auto to pick up on its next tick.
+
+        ``report_to=auto`` means "the manager should look at this." Auto's
+        heartbeat already scans assigned board tasks
+        (heartbeat_service:730-765) and ingests them as priority work, so
+        creating a task here is enough — no new scheduler, no notification.
+        """
+        from core.database.database import SessionLocal
+        from core.models import Agent
+        from core.models.core import BoardTask
+
+        db = SessionLocal()
+        try:
+            auto = (
+                db.query(Agent)
+                .filter(
+                    Agent.workspace_id == workspace_id,
+                    Agent.is_system_agent.is_(True),
+                    Agent.name == "Auto",
+                )
+                .first()
+            )
+            if not auto:
+                logger.warning(
+                    "[Heartbeat] report_to=auto but no canonical Auto found for ws=%s — "
+                    "falling back to silent (DB only).",
+                    workspace_id,
+                )
+                return
+
+            summary_line = (message or "").strip().splitlines()[0] if message else ""
+            summary_line = summary_line[:200] or "no findings"
+
+            description = (
+                f"{source_agent_name or 'Agent'} heartbeat completed (status={status}).\n\n"
+                f"Findings:\n{(message or '(no findings)')[:2000]}\n\n"
+                f"Read the full report with `platform_get_latest_report` "
+                f"(agent_name=\"{source_agent_name}\")."
+            )
+
+            priority = "high" if status in ("error", "critical") else "medium"
+
+            task = BoardTask(
+                workspace_id=workspace_id,
+                title=f"Review {source_agent_name or 'agent'} heartbeat — {summary_line}"[:500],
+                description=description,
+                status="assigned",
+                priority=priority,
+                assigned_agent_id=auto.id,
+                created_by_type="agent",
+                created_by_id=str(source_agent_id) if source_agent_id else None,
+                source_type="heartbeat",
+                source_id=str(link_id) if link_id is not None else None,
+            )
+            db.add(task)
+            db.commit()
+            logger.info(
+                "[Heartbeat] report_to=auto: created BoardTask id=%s assigned to Auto "
+                "(agent_id=%s) for source_agent=%s",
+                task.id, auto.id, source_agent_id,
+            )
+        except Exception as e:
+            db.rollback()
+            logger.error(
+                "[Heartbeat] _route_heartbeat_to_auto failed for ws=%s: %s",
+                workspace_id, e, exc_info=True,
+            )
+        finally:
+            db.close()
+
+    async def _route_heartbeat_to_webhook(
+        self,
+        *,
+        webhook_url: str,
+        title: str,
+        message: str,
+        agent_id: Optional[int],
+        agent_name: Optional[str],
+        link_id: Optional[Any],
+        status: str,
+    ) -> None:
+        """POST the heartbeat result directly to a per-agent webhook URL.
+
+        Bypasses the workspace-level NotificationDispatcher because the
+        agent has its own destination. Failure is logged but never raised
+        — heartbeat completion isn't blocked by a flaky downstream URL.
+        """
+        try:
+            import httpx
+            payload = {
+                "event": "heartbeat_complete",
+                "title": title,
+                "message": (message or "")[:4000],
+                "agent_id": agent_id,
+                "agent_name": agent_name,
+                "status": status,
+                "report_id": str(link_id) if link_id is not None else None,
+            }
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                resp = await client.post(webhook_url, json=payload)
+                logger.info(
+                    "[Heartbeat] report_to=webhook: POST %s → %s (agent=%s)",
+                    webhook_url, resp.status_code, agent_id,
+                )
+        except Exception as e:
+            logger.warning(
+                "[Heartbeat] Per-agent webhook delivery failed for agent=%s: %s",
+                agent_id, e,
             )
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
…assignee picker

Three connected changes — couldn't ship one without the others:

1. **Auto becomes assignable.** /api/agents accepts a new ?include_workspace_system=true flag that flips off the per-workspace-system filter (agents.py:528). Frontend gets a new useAssignableAgents() hook that always passes the flag; the Roster keeps using useAgents() so Auto stays hidden there. Board sidebar, filters, and create-task dialog switch to the new hook so canonical Auto appears in task assignee dropdowns.

2. **Heartbeat 'Report To' dropdown rework.**
   - Drop the dead "Direct (Chat)" option — never wired in any code path.
   - Add "Auto (assign task)" — the new high-value behaviour. Tooltip copy clarified for "DB only" too: it doesn't push to Auto, it just sits there until something asks.

3. **Backend wiring of report_to.** _dispatch_heartbeat_notification now reads agent.configuration .heartbeat.report_to and branches:
   - "auto"    → _route_heartbeat_to_auto creates a BoardTask
                 (status=assigned, priority=high|medium, source_type=
                 heartbeat) for the workspace's canonical Auto. Auto's
                 existing PRD-72 task pickup loop ingests it on the
                 next tick — no new scheduler.
   - "webhook" → POST directly to agent.configuration.heartbeat
                 .webhook_url, bypassing workspace prefs (so per-agent
                 endpoints actually work). Failure logged, never raised.
   - else      → existing workspace NotificationDispatcher path
                 (telegram/slack/in-app stay workspace-scoped for now).

Per-agent telegram/slack overrides are deferred — they need overrides plumbed into send_workspace_notification, which is a bigger refactor. Workspace-level prefs still work for those destinations.

Closes the path "Vector heartbeats → DB → invisible to Auto". Auto now sees them as priority work.