### PR TITLE
fix(heartbeat): Run Now bypasses interval cooldown via force_run flag

### DIFF
--- a/orchestrator/services/heartbeat_service.py
+++ b/orchestrator/services/heartbeat_service.py
@@ -384,7 +384,11 @@ class HeartbeatService:
             return {"status": "skipped", "reason": "outside_active_hours"}
 
         interval_minutes = hb_config.get("interval_minutes", 30)
-        if await self._was_recently_executed("orchestrator", workspace_id, interval_minutes):
+        # Manual UI triggers (run_orchestrator_heartbeat) set force_run=True to
+        # bypass the cooldown — clicking "Run Now" should always execute.
+        if not hb_config.get("force_run") and await self._was_recently_executed(
+            "orchestrator", workspace_id, interval_minutes
+        ):
             return {"status": "skipped", "reason": "already_ran_this_period"}
 
         self._running_ticks[tick_key] = True
@@ -687,7 +691,12 @@ class HeartbeatService:
             return {"status": "skipped", "reason": "outside_active_hours"}
 
         interval_minutes = hb_config.get("interval_minutes", 60)
-        if await self._was_recently_executed("agent", str(agent_id), interval_minutes):
+        # Manual UI triggers (run_agent_heartbeat) set force_run=True to bypass
+        # the cooldown — without this, daily-interval agents could only be
+        # tested once a day. Scheduled ticks never set force_run.
+        if not hb_config.get("force_run") and await self._was_recently_executed(
+            "agent", str(agent_id), interval_minutes
+        ):
             return {"status": "skipped", "reason": "already_ran_this_period"}
 
         self._running_ticks[tick_key] = True
@@ -1342,12 +1351,14 @@ class HeartbeatService:
         finally:
             db.close()
 
-        # Force run regardless of active hours
+        # Force run regardless of active hours AND cooldown — clicking Run
+        # Now from the UI should always trigger a tick.
         hb_config_override = {
             **hb_config,
             "active_hours_start": "00:00",
             "active_hours_end": "23:59",
             "inherit_active_hours": False,  # manual runs always execute
+            "force_run": True,
         }
         return await self._orchestrator_tick(workspace_id, hb_config_override)
 
@@ -1371,6 +1382,7 @@ class HeartbeatService:
             "active_hours_start": "00:00",
             "active_hours_end": "23:59",
             "inherit_active_hours": False,  # manual runs always execute
+            "force_run": True,             # bypass cooldown so daily agents are testable
         }
         return await self._agent_tick(agent_id, workspace_id, hb_config_override)
 


### PR DESCRIPTION
Clicking "Run Now" on an agent or orchestrator heartbeat returned 200 OK but silently skipped the tick when the agent had run within its interval. For daily-cadence agents (interval_minutes=1440) this meant exactly one run per ~24 hours — testing config changes was impossible without waiting overnight.

Repro: Vector heartbeat (1440 min interval) ran at 12:01. User updated report_to=auto, saved, hit Run Now at 12:25.
  → POST /api/heartbeat/agents/577/run → 200 OK
  → "[Heartbeat] Skipping agent 577 — last successful run 24 min ago
     (interval=1440 min, cooldown=1435 min)"
The new code path (_route_heartbeat_to_auto) never fired because the tick itself was suppressed.

Fix: add a force_run flag honoured by both _agent_tick and _orchestrator_tick. The two manual-trigger entrypoints (run_agent_heartbeat, run_orchestrator_heartbeat) set force_run=True in their config override; scheduled cron ticks never set it, so the interval-based dedup still protects against duplicate scheduled runs.

Active-hours override was already in place for manual triggers; this extends the same "manual = always run" principle to cooldown.