### PR TITLE
fix(recipe): cancel button kills in-flight executions ASAP

### DIFF
--- a/orchestrator/api/recipe_executor.py
+++ b/orchestrator/api/recipe_executor.py
@@ -436,6 +436,23 @@ async def _execute_step(
     response = None
 
     for iteration in range(max_iterations):
+        if recipe_execution_id:
+            db.expire_all()
+            cancel_status = db.query(RecipeExecution.status).filter(
+                RecipeExecution.execution_id == recipe_execution_id
+            ).scalar()
+            if cancel_status == "cancelled":
+                logger.info(
+                    "[recipe_direct] Step %d cancelled mid-flight at iteration %d (execution=%s)",
+                    step_order, iteration, recipe_execution_id,
+                )
+                return {
+                    "status": "cancelled",
+                    "result": "Cancelled by user",
+                    "error": "Cancelled by user",
+                    "execution": {"tool_calls": all_tool_calls, "messages": messages, "tokens_used": 0},
+                }
+
         response = await llm.generate_response(messages=messages, tools=tools)
 
         if not response or not response.tool_calls:
@@ -1017,6 +1034,17 @@ async def _execute_recipe_inner(
         execution_start = time.time()
 
         for idx, step in enumerate(steps):
+            # Cancellation check — re-read execution row to detect external cancel
+            db.expire(execution)
+            db.refresh(execution)
+            if execution.status == "cancelled":
+                logger.info(
+                    "[recipe_direct] Cancelled before step %d (execution=%s)",
+                    idx + 1, recipe_execution_id,
+                )
+                _persist_step_results(db, execution, step_results)
+                return
+
             # Total timeout check
             elapsed = time.time() - execution_start
             if elapsed > total_timeout_sec:
@@ -1332,6 +1360,20 @@ async def _execute_recipe_inner(
                         ),
                         timeout=step_timeout_sec,
                     )
+
+                    if result.get("status") == "cancelled":
+                        logger.info(
+                            "[recipe_direct] Step %d returned cancelled — halting execution %s",
+                            step_order, recipe_execution_id,
+                        )
+                        step_result["status"] = "cancelled"
+                        step_result["error"] = "Cancelled by user"
+                        step_result["duration_ms"] = int((time.time() - step_start) * 1000)
+                        step_result["completed_at"] = datetime.now(timezone.utc).isoformat()
+                        step_results.append(_build_compact_step_result(step_result))
+                        _persist_step_results(db, execution, step_results)
+                        # Cancel endpoint already wrote status='cancelled' + completed_at
+                        return
 
                     if result.get("status") == "success":
                         step_result["status"] = "completed"


### PR DESCRIPTION
## The bug

When you hit Cancel on a running playbook execution, the UI flipped `RecipeExecution.status='cancelled'` in the DB — but the running async task **never read it back**. So the executor kept burning LLM cycles for up to `step_timeout_sec × max_retries` after the click. Vector's weekly memo kept retrying for ~10 min after cancel, billing ~\$1.80.

## The fix — two-tier kill

### Tier 1: Same-replica instant kill (commit 2)
A process-local `_running_executions` registry maps `execution_id → asyncio.Task`. When the cancel endpoint fires, it calls `request_execution_cancel(execution_id)` which does `task.cancel()`. Since `httpx` honours `asyncio.CancelledError`, the TCP connection to OpenRouter closes mid-request — **no more tokens billed for the in-flight call**.

`CancelledError` is `BaseException` (not `Exception`) so it skips past every existing `except Exception` handler and propagates cleanly:
- through `_execute_step`
- through `asyncio.wait_for` in the retry loop
- through `_execute_recipe_inner`'s `try/finally` (db.close, engine.dispose)
- into the outer `except asyncio.CancelledError` in `execute_recipe_direct`

The outer handler defensively patches the row in case the cancel signal beat the endpoint's commit, then exits without re-raising.

### Tier 2: Cross-replica DB poll (commit 1)
If the cancel endpoint hits a different replica than the running task, the registry miss returns `False` — but three DB-status checks pick it up at the next iteration boundary:

1. **`_execute_step` tool loop** — re-reads `RecipeExecution.status` before every LLM call
2. **Retry loop** — short-circuits on a `cancelled` return without retrying
3. **Main step loop** — refreshes the execution row between steps

## Cost saved per cancel

- **Before**: up to `2 × 300s × $0.20/iter = ~$1.80` waste
- **Tier 1 kill**: in-flight LLM call dies mid-request, ~0 waste
- **Tier 2 fallback**: next iteration boundary, ~5–60s of waste max

## Test plan
- [ ] Trigger a long playbook (e.g. Vector weekly), hit Cancel mid-LLM-call
- [ ] Confirm `[cancel_execution] ... cancelled (local_kill=True)` in logs
- [ ] Confirm `[recipe_direct] CancelledError received` immediately after
- [ ] No further `LLM_CALL` log entries for that `execution_id`
- [ ] Execution row stays at `status='cancelled'` (not overwritten by `_fail_execution`)
- [ ] Cross-replica path: harder to test locally, but DB poll behaviour preserved