### PR TITLE
fix(recipe): cancel kills in-flight LLM call ASAP via task signal

### DIFF
--- a/orchestrator/api/recipe_executor.py
+++ b/orchestrator/api/recipe_executor.py
@@ -230,6 +230,23 @@ async def _auto_create_playbook_report(
 # ---------------------------------------------------------------------------
 _workspace_semaphores: Dict[str, asyncio.Semaphore] = {}
 
+# Process-local registry of currently running execution tasks. Lets the cancel
+# endpoint signal the in-flight LLM call to abort immediately (httpx propagates
+# CancelledError, which closes the TCP connection mid-request — no more cost
+# burn). Cross-replica cancels are handled by the DB-poll fallback inside
+# _execute_step.
+_running_executions: Dict[str, asyncio.Task] = {}
+
+
+def request_execution_cancel(execution_id: str) -> bool:
+    """Signal a cancel to a locally-running execution. Returns True if the
+    task was found and cancelled on this replica, False otherwise."""
+    task = _running_executions.get(execution_id)
+    if task is None or task.done():
+        return False
+    task.cancel()
+    return True
+
 
 def _get_workspace_semaphore(workspace_id: str, max_concurrent: int = 3) -> asyncio.Semaphore:
     """Return (or create) an asyncio.Semaphore for the given workspace.
@@ -871,6 +888,11 @@ async def execute_recipe_direct(
             "[recipe_direct] QUEUED — waiting for workspace semaphore %s (execution=%s, recipe=%s)",
             workspace_id, recipe_execution_id, recipe_id,
         )
+
+    current_task = asyncio.current_task()
+    if current_task is not None:
+        _running_executions[recipe_execution_id] = current_task
+
     async with semaphore:
         logger.info(
             "[recipe_direct] Semaphore ACQUIRED for %s (execution=%s, recipe=%s, was_waiting=%s)",
@@ -880,11 +902,49 @@ async def execute_recipe_direct(
             await _execute_recipe_inner(
                 recipe_execution_id, recipe_id, workspace_id, input_data, db_url,
             )
+        except asyncio.CancelledError:
+            logger.info(
+                "[recipe_direct] CancelledError received — execution %s aborted mid-flight",
+                recipe_execution_id,
+            )
+            await _mark_execution_cancelled(recipe_execution_id, db_url)
+            # Do not re-raise — we've handled it cleanly. Task can complete.
         finally:
+            _running_executions.pop(recipe_execution_id, None)
             logger.info(
                 "[recipe_direct] Semaphore RELEASED for %s (execution=%s)",
                 workspace_id, recipe_execution_id,
             )
+
+
+async def _mark_execution_cancelled(execution_id: str, db_url: Optional[str]) -> None:
+    """Ensure the execution row reflects cancellation. The cancel endpoint
+    already writes status='cancelled', but if the kill came via task.cancel()
+    without going through the endpoint (or the endpoint hasn't committed yet),
+    we patch it here defensively."""
+    try:
+        if db_url:
+            _engine = create_engine(db_url)
+            _SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=_engine)
+            db = _SessionLocal()
+        else:
+            db = SessionLocal()
+        try:
+            execution = db.query(RecipeExecution).filter(
+                RecipeExecution.execution_id == execution_id
+            ).first()
+            if execution and execution.status not in ("completed", "failed", "cancelled"):
+                execution.status = "cancelled"
+                execution.error_message = execution.error_message or "Cancelled by user"
+                execution.completed_at = sa_func.now()
+                db.commit()
+        finally:
+            db.close()
+    except Exception:
+        logger.warning(
+            "[recipe_direct] Failed to mark execution %s cancelled (best-effort)",
+            execution_id, exc_info=True,
+        )
 
 
 async def _execute_recipe_inner(

--- a/orchestrator/api/workflow_recipes.py
+++ b/orchestrator/api/workflow_recipes.py
@@ -1043,7 +1043,24 @@ async def cancel_execution(
         except Exception:
             logger.warning("Board task update on cancel failed (non-blocking)", exc_info=True)
 
-        logger.info(f"[cancel_execution] {execution_id} cancelled by user")
+        # Signal the running task to abort the in-flight LLM call immediately.
+        # If the task is on this replica, httpx propagates CancelledError and
+        # closes the TCP connection mid-request — no more cost burn. If the
+        # task is on a different replica, it'll catch the status flip on its
+        # next DB poll inside _execute_step.
+        try:
+            from api.recipe_executor import request_execution_cancel
+            killed_locally = request_execution_cancel(execution_id)
+            logger.info(
+                "[cancel_execution] %s cancelled (local_kill=%s)",
+                execution_id, killed_locally,
+            )
+        except Exception:
+            logger.warning(
+                "[cancel_execution] Failed to signal task — DB poll will pick it up next iteration",
+                exc_info=True,
+            )
+
         return {"status": "cancelled", "execution_id": execution_id}
 
     except HTTPException:


### PR DESCRIPTION
Previous fix (PR #306) only checked the cancel flag BETWEEN iterations, which still let an in-flight 50s LLM call complete and bill before bailing — at $0.20/call, that's $0.20 of waste per cancel.

This adds a process-local task registry. When the cancel endpoint fires:
- Same replica: looks up the running asyncio.Task in _running_executions, calls task.cancel() — httpx propagates CancelledError, closes the TCP connection mid-request, no more LLM tokens billed.
- Different replica: registry miss, falls through to the existing DB-poll fallback (next iteration boundary, ~5–60s delay).

CancelledError is BaseException (not Exception), so it skips past every existing 'except Exception' handler and propagates cleanly through _execute_recipe_inner's try/finally (db.close, engine.dispose). The outer except in execute_recipe_direct catches it, defensively patches the execution row in case the cancel signal beat the endpoint's commit, and exits without re-raising.