### PR TITLE
fix: escape literal curly braces in blog mission goal template

### DIFF
--- a/orchestrator/modules/tools/discovery/handlers_blog.py
+++ b/orchestrator/modules/tools/discovery/handlers_blog.py
@@ -250,11 +250,11 @@ _BLOG_MISSION_GOAL_TEMPLATE = (
     "5. Generate and attach a cover image: call "
     "platform_generate_cover_image(post_id=<from step 4>, prompt=<a vivid 16:9 "
     "abstract/conceptual image prompt based on the post topic>). The tool "
-    "generates the image via Gemini Nano Banana Pro, saves it, and attaches it "
-    "to the post — one tool call handles everything.\n"
+    "generates the image via the configured cover model, saves it, and attaches "
+    "it to the post — one tool call handles everything.\n"
     "6. Create a board task for human review via platform_create_task with "
     "title: 'Review & Publish: <post title>', approval_action: "
-    "{type: publish_blog, post_id: <post UUID>}, priority: high, "
+    "{{type: publish_blog, post_id: <post UUID>}}, priority: high, "
     "auto_approve: true, tags: ['blog', 'approval']."
 )
 


### PR DESCRIPTION
Auto's call to platform_create_blog_post failed with KeyError: 'type' because the goal template string had a literal JSON-like example "{type: publish_blog, post_id: <UUID>}" inside it, and Python's str.format() interprets every {...} as a placeholder. With only topic= and category= passed as kwargs, the format call hit the {type:...} fragment and raised KeyError.

Escaped to {{type: ...}} which str.format() emits as literal {type: ...} — the agent reading the goal sees the original example unchanged. Confirmed via standalone format test:
  template.format(topic=..., category=...) succeeds, last line reads
  approval_action: {type: publish_blog, post_id: <post UUID>}, ...

Also dropped the model-specific phrase "via Gemini Nano Banana Pro" from the cover step (matches the configurable BLOG_COVER_MODEL change elsewhere in this PR).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed hardcoded model reference from blog cover image generation; cover images now use the configured cover model as intended.

* **Chores**
  * Improved pipeline instruction template formatting for better rendering consistency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AutomatosAI/automatos-ai/pull/310)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->