### PR TITLE
fix(prd-108): field memory recovery + viz panel actually shows what's happening

### DIFF
--- a/frontend/components/missions/mission-field-panel.tsx
+++ b/frontend/components/missions/mission-field-panel.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useMemo } from 'react'
-import { Brain, Zap, TrendingDown, Eye, Users, Activity, Clock, BarChart3 } from 'lucide-react'
+import { Brain, Zap, TrendingDown, Eye, Users, Activity, Clock, BarChart3, AlertTriangle, ServerCrash } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { useMissionField } from '@/hooks/use-missions-api'
 import type { FieldPattern } from '@/hooks/use-missions-api'
@@ -134,7 +134,11 @@ export function MissionFieldPanel({ missionId, className }: MissionFieldPanelPro
     )
   }
 
-  if (!data?.field_id) {
+  // Derive a fallback status if the API didn't return one (back-compat)
+  const status = data?.status
+    ?? (!data?.field_id ? 'not_created' : (data.patterns?.length ? 'active' : 'empty'))
+
+  if (status === 'not_created') {
     return (
       <div className={cn('flex flex-col items-center justify-center h-full gap-3 p-6', className)}>
         <Brain className="w-10 h-10 text-muted-foreground/30" />
@@ -145,6 +149,40 @@ export function MissionFieldPanel({ missionId, className }: MissionFieldPanelPro
         </div>
       </div>
     )
+  }
+
+  if (status === 'missing') {
+    return (
+      <div className={cn('flex flex-col items-center justify-center h-full gap-3 p-6', className)}>
+        <AlertTriangle className="w-10 h-10 text-warning/60" />
+        <div className="text-sm text-foreground text-center font-medium">
+          Field collection missing
+        </div>
+        <div className="text-xs text-muted-foreground text-center max-w-xs leading-relaxed">
+          The mission references field <code className="text-[10px] font-mono">{data?.field_id?.slice(0, 8)}…</code> but the underlying collection was destroyed.
+          <br />
+          <span className="text-warning/80">The coordinator will recreate it on the next tick.</span>
+        </div>
+      </div>
+    )
+  }
+
+  if (status === 'unavailable') {
+    return (
+      <div className={cn('flex flex-col items-center justify-center h-full gap-3 p-6', className)}>
+        <ServerCrash className="w-10 h-10 text-destructive/60" />
+        <div className="text-sm text-foreground text-center font-medium">
+          Field backend unavailable
+        </div>
+        <div className="text-xs text-muted-foreground text-center max-w-xs">
+          The shared-context backend (Qdrant) is unreachable.
+        </div>
+      </div>
+    )
+  }
+
+  if (!data) {
+    return null
   }
 
   const { patterns, stability, metrics } = data

--- a/frontend/hooks/use-missions-api.ts
+++ b/frontend/hooks/use-missions-api.ts
@@ -101,7 +101,15 @@ export interface FieldMetrics {
   queries_by_agent: Record<number, number>
 }
 
+export type MissionFieldStatus =
+  | 'not_created'
+  | 'missing'
+  | 'empty'
+  | 'active'
+  | 'unavailable'
+
 export interface MissionFieldResponse {
+  status?: MissionFieldStatus
   field_id: string | null
   backend: string | null
   patterns: FieldPattern[]

--- a/orchestrator/api/missions.py
+++ b/orchestrator/api/missions.py
@@ -993,6 +993,17 @@ async def get_mission_field(
 
     Returns all patterns with decayed strengths, stability metrics,
     and instrumentation data for the field visualizer.
+
+    `status` values:
+      - `not_created` — mission has no field_id (mission is queued or
+        was created before PRD-108 shipped)
+      - `missing` — field_id present but the underlying Qdrant
+        collection is gone (stale id; coordinator will recreate on
+        next tick if mission is still running — see PR #312)
+      - `empty` — collection exists but no patterns injected yet
+      - `active` — collection exists with patterns
+      - `unavailable` — shared context backend is down (Qdrant
+        unreachable, etc)
     """
     try:
         run = _get_run_for_workspace(db, mission_id, ctx.workspace_id)
@@ -1000,6 +1011,7 @@ async def get_mission_field(
 
         if not field_id:
             return {
+                "status": "not_created",
                 "field_id": None,
                 "backend": None,
                 "patterns": [],
@@ -1011,7 +1023,23 @@ async def get_mission_field(
 
         field = get_shared_context()
         if not field:
-            raise HTTPException(status_code=503, detail="Shared context backend unavailable")
+            return {
+                "status": "unavailable",
+                "field_id": field_id,
+                "backend": None,
+                "patterns": [],
+                "stability": {"stability": 0.0, "pattern_count": 0},
+                "metrics": None,
+            }
+
+        # Detect stale field_id (collection destroyed). PR #312 auto-heals
+        # on next coordinator tick; the panel surfaces this state in the UI.
+        collection_missing = False
+        if hasattr(field, "context_exists"):
+            try:
+                collection_missing = not await field.context_exists(field_id)
+            except Exception:
+                pass
 
         # Get patterns and stability from the inner (unwrapped) backend
         inner = field._inner
@@ -1023,6 +1051,17 @@ async def get_mission_field(
         if hasattr(inner, "measure_stability"):
             stability = await inner.measure_stability(field_id)
 
+        # measure_stability marks {"missing": True} on collection 404.
+        if stability.get("missing"):
+            collection_missing = True
+
+        if collection_missing:
+            status = "missing"
+        elif patterns:
+            status = "active"
+        else:
+            status = "empty"
+
         # Get instrumentation metrics if available
         metrics_data = None
         metrics = field.get_metrics(field_id)
@@ -1030,6 +1069,7 @@ async def get_mission_field(
             metrics_data = metrics.to_dict()
 
         return {
+            "status": status,
             "field_id": field_id,
             "backend": field._backend_name,
             "patterns": patterns,

--- a/orchestrator/modules/context/adapters/vector_field.py
+++ b/orchestrator/modules/context/adapters/vector_field.py
@@ -245,7 +245,13 @@ class VectorFieldSharedContext(SharedContextPort):
         organization = 1 - (stddev / mean) if mean > 0
         """
         collection = f"field_{context_id}"
-        points, _ = await self._client.scroll(collection, limit=10000)
+        try:
+            points, _ = await self._client.scroll(collection, limit=10000)
+        except Exception:
+            # Missing collection → return zero stats rather than crashing
+            # the field-viewer endpoint. PR #312 covers automatic recovery.
+            logger.debug("[Field] measure_stability: collection %s missing", collection, exc_info=True)
+            return {"stability": 0.0, "pattern_count": 0, "avg_strength": 0.0, "missing": True}
 
         if not points:
             return {"stability": 0.0, "pattern_count": 0, "avg_strength": 0.0}
@@ -289,6 +295,7 @@ class VectorFieldSharedContext(SharedContextPort):
         try:
             points, _ = await self._client.scroll(collection, limit=10000)
         except Exception:
+            logger.debug("[Field] get_patterns: collection %s missing or unreachable", collection, exc_info=True)
             return []
 
         now = datetime.now(timezone.utc)

--- a/orchestrator/modules/context/adapters/vector_field.py
+++ b/orchestrator/modules/context/adapters/vector_field.py
@@ -114,6 +114,19 @@ class VectorFieldSharedContext(SharedContextPort):
         except Exception:
             logger.warning("[Field] Failed to delete collection %s", collection, exc_info=True)
 
+    async def context_exists(self, context_id: str) -> bool:
+        """Check whether the underlying Qdrant collection still exists.
+
+        Used by the coordinator to detect stale field_ids inherited from
+        a parent/template mission whose collection has already been
+        destroyed by _cleanup_terminal_fields.
+        """
+        try:
+            return await self._client.collection_exists(f"field_{context_id}")
+        except Exception:
+            logger.debug("[Field] collection_exists check failed for %s", context_id, exc_info=True)
+            return False
+
     # ── Inject ──────────────────────────────────────────────────
 
     async def inject(

--- a/orchestrator/modules/context/instrumentation.py
+++ b/orchestrator/modules/context/instrumentation.py
@@ -190,6 +190,12 @@ class InstrumentedSharedContext(SharedContextPort):
         )
         return results
 
+    async def context_exists(self, context_id: str) -> bool:
+        """Pass through to inner adapter's existence check (no metric)."""
+        if hasattr(self._inner, "context_exists"):
+            return await self._inner.context_exists(context_id)
+        return True  # Backends without exists check assume valid
+
     async def destroy_context(self, context_id: str) -> None:
         start = time.monotonic()
         await self._inner.destroy_context(context_id)

--- a/orchestrator/services/coordinator_service.py
+++ b/orchestrator/services/coordinator_service.py
@@ -908,7 +908,31 @@ class CoordinatorService:
         workspace_id = run.workspace_id
 
         # --- PRD-108: Ensure field exists (lazy create for manual-approve path) ---
-        if not (run.config or {}).get("field_id"):
+        # Validates the underlying Qdrant collection still exists — a stale
+        # field_id can survive in run.config if it was inherited from a parent
+        # mission whose collection was destroyed by _cleanup_terminal_fields.
+        existing_field_id = (run.config or {}).get("field_id")
+        needs_field = not existing_field_id
+
+        if existing_field_id and not needs_field:
+            field = self._get_field()
+            if field and hasattr(field, "context_exists"):
+                try:
+                    if not await field.context_exists(existing_field_id):
+                        logger.warning(
+                            "[PRD-108] Stale field_id %s on mission %s — collection missing, recreating",
+                            existing_field_id, run.id,
+                        )
+                        # Clear the stale id so _create_mission_field assigns a fresh one
+                        updated_config = {**(run.config or {})}
+                        updated_config.pop("field_id", None)
+                        run.config = updated_config
+                        db.flush()
+                        needs_field = True
+                except Exception as e:
+                    logger.debug("[PRD-108] field exists-check raised: %s", e)
+
+        if needs_field:
             field_id = await self._create_mission_field(db, run)
             # Seed field with uploaded document references
             if field_id:


### PR DESCRIPTION
## The bugs

PRD-108 field memory has two interlocking failure modes that combined to make the field grid look like it never worked:

### Bug 1 — stale field_id silently survives forever

\`\_cleanup_terminal_fields\` destroys Qdrant collections for terminal missions. But \`\_process_run\` only lazy-creates a field if \`field_id\` is **missing** from \`run.config\` — it never validates that the collection exists.

Result: any mission that inherits a \`field_id\` (template / replan / duplicate) from an ancestor whose collection has been destroyed gets stuck pointing at a dead collection. Every \`platform_field_query\`, \`platform_field_inject\`, and \`_inject_task_output_into_field\` 404s for the rest of the mission.

Today's mission \`22c489bb\` shows the pattern:
\`\`\`
16:51:41  CREATE field_2e60071b-...  (some earlier mission)
16:54:21  ...working fine, query + inject 200 OK
16:54:31  Mission 22c489bb created (planning)
16:54:50  Mission 22c489bb running (inherits same field_id)
16:58:05  DELETE field_2e60071b-...  (cleanup of the terminal ancestor)
16:58:20+  All 22c489bb agent calls 404 forever
\`\`\`

### Bug 2 — the viz panel can't tell broken from idle

The \`/missions/{id}/field\` endpoint hid every failure mode behind the same empty-patterns response:

- \`get_patterns\` swallowed Qdrant 404s and returned \`[]\`
- \`measure_stability\` didn't catch 404s → endpoint returned 500
- The same \`{patterns: []}\` shape was returned for "not created", "collection destroyed", "Qdrant down", and "no activity yet"
- The frontend panel rendered "Field is empty. Waiting for agent activity..." for all four cases

Net effect: the user has been seeing the same empty-state panel since PRD-108 shipped, with no way to know whether agents weren't injecting or the field was actually broken.

## The fixes

### Auto-heal (Bug 1)
- Add \`context_exists()\` to the field adapter (Qdrant \`collection_exists\`) and surface it through the instrumentation wrapper.
- In \`_process_run\`, validate the collection exists before deciding to skip lazy-create. If it's gone, clear the stale \`field_id\` and let \`_create_mission_field\` assign a fresh one.

### Honest API + UI (Bug 2)
- \`measure_stability\` now returns zeros + \`{missing: True}\` on 404 instead of crashing the endpoint.
- The endpoint returns a \`status\` field with five distinct values: \`not_created\` | \`missing\` | \`empty\` | \`active\` | \`unavailable\`.
- The frontend renders distinct UI for each state — including a clear "Field collection missing — coordinator will recreate on next tick" panel for the auto-heal pending case.

## Recovery for affected running missions

\`\`\`sql
UPDATE orchestration_runs SET config = config - 'field_id'
WHERE id = '<mission_id>';
\`\`\`

Next coordinator tick will lazy-create a fresh collection. Prior field state is lost (already gone), but new upstream-output injections will succeed.

After this PR deploys, the auto-heal path covers the same case automatically — no SQL needed.

## Test plan
- [ ] Repro Bug 1: manually \`DELETE\` a Qdrant collection, observe next \`_process_run\` tick clears stale \`field_id\` and recreates.
- [ ] Field grid panel shows the 3D viz once a healthy field has \`>0\` patterns.
- [ ] Force-broken mission shows "Field collection missing" panel (not silently empty).
- [ ] Healthy idle mission shows "Field is empty. Waiting for agent activity..." (existing behaviour preserved).
- [ ] No regression on the \`field_id is null\` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)