### PR TITLE
fix: cover_image_url must be absolute so blog widget can resolve it

### DIFF
--- a/orchestrator/api/blog.py
+++ b/orchestrator/api/blog.py
@@ -16,6 +16,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, UploadFile, File
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
+from config import config
 from core.auth.dependencies import RequestContext
 from core.auth.hybrid import get_request_context_hybrid
 from core.database.database import get_db
@@ -234,7 +235,7 @@ async def upload_cover_image(
     image_id = await store.save_image(b64, mime_type=content_type, workspace_id=str(ctx.workspace_id))
     return {
         "image_id": image_id,
-        "cover_image_url": f"/api/generated-images/{image_id}",
+        "cover_image_url": f"{config.BACKEND_URL.rstrip('/')}/api/generated-images/{image_id}",
         "size_bytes": len(body_bytes),
         "content_type": content_type,
     }

--- a/orchestrator/modules/tools/discovery/handlers_blog.py
+++ b/orchestrator/modules/tools/discovery/handlers_blog.py
@@ -382,7 +382,7 @@ async def generate_cover_image(
         logger.error("Image store save failed: %s", e, exc_info=True)
         return {"success": False, "error": f"Image upload failed: {str(e)[:200]}"}
 
-    cover_url = f"/api/generated-images/{image_id}"
+    cover_url = f"{config.BACKEND_URL.rstrip('/')}/api/generated-images/{image_id}"
 
     try:
         updated = await svc.update_post(post.id, cover_image_url=cover_url)


### PR DESCRIPTION
Both the platform_generate_cover_image tool and the manual upload endpoint stored cover_image_url as relative `/api/generated-images/{id}`. The blog widget renders on automatos.app, so the browser resolved that to automatos.app/api/... which 404s back to the landing page HTML — broken image on every post that uses it.

Use config.BACKEND_URL (set to https://api.automatos.app in prod) to build an absolute URL pointing at the orchestrator.