### PR TITLE
feat: add 'blog' to VALID_PERMISSIONS for widget keys

### DIFF
--- a/orchestrator/api/api_keys.py
+++ b/orchestrator/api/api_keys.py
@@ -25,6 +25,7 @@ router = APIRouter(prefix="/api/api-keys", tags=["API Keys"])
 
 VALID_PERMISSIONS = [
     "chat",
+    "blog",
     "documents:read",
     "documents:write",
     "data:query",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added 'blog' permission scope to API key permissions, enabling this new option for SDK API key creation and validation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AutomatosAI/automatos-ai/pull/315)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->