### PR TITLE
feat(auto): platform_notify_owner — Auto's escalation channel

### DIFF
--- a/frontend/components/settings/SystemLLMSettingsTab.tsx
+++ b/frontend/components/settings/SystemLLMSettingsTab.tsx
@@ -61,6 +61,7 @@ interface OrchestratorConfig {
   communication_style: string
   proactive_level: string
   thinking_level: string
+  preferred_channel: string
   llm?: LLMConfig
   heartbeat: {
     enabled: boolean
@@ -206,6 +207,7 @@ export default function SystemLLMSettingsTab({
           communication_style: 'balanced',
           proactive_level: 'notify',
           thinking_level: 'medium',
+          preferred_channel: 'in_app',
           heartbeat: {
             enabled: false,
             interval_minutes: 30,
@@ -772,6 +774,35 @@ export default function SystemLLMSettingsTab({
                     </Select>
                     <p className="text-xs text-muted-foreground">
                       Controls what the orchestrator does when its heartbeat finds something
+                    </p>
+                  </div>
+
+                  {/* Preferred Channel — where Auto reaches the owner for approvals */}
+                  <div className="space-y-3">
+                    <Label className="flex items-center gap-1">
+                      <MessageSquare className="h-4 w-4" />
+                      Preferred Channel for Approvals
+                    </Label>
+                    <Select
+                      value={orchConfig.preferred_channel || 'in_app'}
+                      onValueChange={(v) => handleOrchChange('preferred_channel', v)}
+                    >
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="in_app">In-App Notification</SelectItem>
+                        {connectedChannels.map((ch) => (
+                          <SelectItem key={ch.key} value={ch.platform}>
+                            {ch.platform.charAt(0).toUpperCase() + ch.platform.slice(1)}
+                          </SelectItem>
+                        ))}
+                        <SelectItem value="webhook">Webhook URL</SelectItem>
+                      </SelectContent>
+                    </Select>
+                    <p className="text-xs text-muted-foreground">
+                      Where Auto sends approval requests, decision asks, and urgent escalations.
+                      A board task is always created as a backup record.
                     </p>
                   </div>
 

--- a/orchestrator/api/workspaces.py
+++ b/orchestrator/api/workspaces.py
@@ -233,6 +233,7 @@ _ORCHESTRATOR_DEFAULTS = {
     "communication_style": "balanced",
     "proactive_level": "notify",
     "thinking_level": "medium",
+    "preferred_channel": "in_app",
     "heartbeat": {
         "enabled": False,
         "interval_minutes": 30,
@@ -422,6 +423,11 @@ async def save_orchestrator_settings(
         raise HTTPException(400, f"proactive_level must be one of {_VALID_PROACTIVE_LEVELS}")
     if "thinking_level" in payload and payload["thinking_level"] not in _VALID_THINKING_LEVELS:
         raise HTTPException(400, f"thinking_level must be one of {_VALID_THINKING_LEVELS}")
+    if "preferred_channel" in payload and payload["preferred_channel"] is not None:
+        # Allow stored channel keys (e.g. "channel:<uuid>") in addition to platform names.
+        pc = payload["preferred_channel"]
+        if not isinstance(pc, str):
+            raise HTTPException(400, "preferred_channel must be a string")
 
     # Validate heartbeat
     hb = payload.get("heartbeat")
@@ -455,7 +461,7 @@ async def save_orchestrator_settings(
     existing_orch = dict(settings.get("orchestrator", {}))
 
     # Update top-level orchestrator fields
-    for key in ("personality_mode", "custom_soul", "communication_style", "proactive_level", "thinking_level"):
+    for key in ("personality_mode", "custom_soul", "communication_style", "proactive_level", "thinking_level", "preferred_channel"):
         if key in payload:
             existing_orch[key] = payload[key]
 

--- a/orchestrator/modules/tools/discovery/actions_notifications.py
+++ b/orchestrator/modules/tools/discovery/actions_notifications.py
@@ -1,0 +1,68 @@
+"""Notification ActionDefinitions — Auto's escalation channel to the owner."""
+
+from .action_registry import ActionDefinition, ActionRegistry
+
+
+def register_notifications_actions(registry: ActionRegistry) -> None:
+    """Register owner-notification actions."""
+
+    registry.register(ActionDefinition(
+        name="platform_notify_owner",
+        description=(
+            "Send the workspace owner a direct message via their preferred channel "
+            "(Telegram, Slack, webhook, or in-app) when you need a decision, approval, "
+            "or want to surface something time-sensitive that shouldn't wait for them "
+            "to check the board. Also creates a BoardTask so the request has a "
+            "persistent record. Use this for: approval requests, urgent risks, "
+            "blocking decisions, status that needs eyes within the hour. Do NOT use "
+            "this for routine completion reports — use platform_submit_report."
+        ),
+        category="notifications",
+        parameters={
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string",
+                    "description": (
+                        "Body of the message. Be specific: state the decision needed, "
+                        "the options, your recommendation, and what you'll do if no "
+                        "reply arrives. Markdown is supported on Telegram/Slack."
+                    ),
+                },
+                "subject": {
+                    "type": "string",
+                    "description": "Short headline (e.g. 'Approve $500 LinkedIn ad?'). Defaults to 'Auto needs your input'.",
+                },
+                "urgency": {
+                    "type": "string",
+                    "enum": ["low", "normal", "high", "urgent"],
+                    "description": (
+                        "low/normal = informational. high = decision needed today. "
+                        "urgent = blocking right now (rare — only use when work stops "
+                        "without a reply). Affects message prefix and BoardTask priority."
+                    ),
+                },
+                "channel": {
+                    "type": "string",
+                    "description": (
+                        "Optional explicit override (telegram | slack | webhook | in_app). "
+                        "Default: workspace.settings.orchestrator.preferred_channel."
+                    ),
+                },
+                "create_task": {
+                    "type": "boolean",
+                    "description": "Also create a BoardTask as a persistent backup record. Default: true.",
+                },
+            },
+            "required": ["message"],
+        },
+        permission_level="write",
+        requires_confirmation=False,
+        tags=["notifications", "escalation", "approval", "owner"],
+        examples=[
+            "ask Gerard whether to approve the $500 LinkedIn ad spend",
+            "tell the owner the daily-social-post agent has been failing for 3 days",
+            "escalate to Gerard — mission 22c489bb is blocked on a config decision",
+            "notify the owner that the cost spike on agent 337 needs review",
+        ],
+    ))

--- a/orchestrator/modules/tools/discovery/handlers_notifications.py
+++ b/orchestrator/modules/tools/discovery/handlers_notifications.py
@@ -1,0 +1,127 @@
+"""Owner notification handler — Auto's escalation channel."""
+
+import logging
+from typing import Any, Dict
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+
+_VALID_URGENCIES = {"low", "normal", "high", "urgent"}
+
+
+async def notify_owner(db: Session, workspace_id: UUID, params: Dict[str, Any]) -> Dict[str, Any]:
+    """Send a message to the workspace owner via their configured channel.
+
+    Resolves the channel in this order:
+      1. params.channel (explicit override)
+      2. workspace.settings.orchestrator.preferred_channel
+      3. workspace.settings.default_notification_channel
+      4. "in_app" (no external delivery)
+
+    Always also creates a BoardTask so the request has a persistent
+    record the owner can find on the board if they miss the channel
+    message.
+    """
+    message = params.get("message")
+    if not message or not isinstance(message, str):
+        return {"success": False, "error": "message is required"}
+
+    subject = params.get("subject") or "Auto needs your input"
+    urgency = (params.get("urgency") or "normal").lower()
+    if urgency not in _VALID_URGENCIES:
+        return {"success": False, "error": f"urgency must be one of {sorted(_VALID_URGENCIES)}"}
+
+    create_task = params.get("create_task", True)
+
+    # Channel resolution
+    from core.models.workspaces import Workspace
+    workspace = db.query(Workspace).get(workspace_id)
+    if not workspace:
+        return {"success": False, "error": "Workspace not found"}
+
+    settings = workspace.settings or {}
+    orchestrator_settings = settings.get("orchestrator", {})
+
+    channel = (
+        params.get("channel")
+        or orchestrator_settings.get("preferred_channel")
+        or settings.get("default_notification_channel")
+        or "in_app"
+    )
+
+    # Format the message with subject + urgency prefix so the channel-side
+    # rendering carries the same context the board task would have.
+    urgency_marker = {
+        "urgent": "🚨 URGENT",
+        "high": "⚠️ Decision needed",
+        "normal": "💬 Auto",
+        "low": "ℹ️ Auto",
+    }.get(urgency, "💬 Auto")
+
+    formatted = f"{urgency_marker} — {subject}\n\n{message}"
+
+    # Send via the channel
+    delivered = False
+    delivery_error = None
+    try:
+        from core.services.notification_service import send_workspace_notification
+        delivered = await send_workspace_notification(
+            workspace_id=str(workspace_id),
+            message=formatted,
+            channel=channel if channel not in ("orchestrator", "direct") else None,
+        )
+    except Exception as e:
+        delivery_error = str(e)
+        logger.warning("[notify_owner] send failed for ws=%s: %s", workspace_id, e, exc_info=True)
+
+    # Persistent backup: BoardTask assigned to Auto for review queue
+    board_task_id = None
+    if create_task:
+        try:
+            from core.models import Agent, BoardTask
+            from sqlalchemy import and_
+            auto = db.query(Agent).filter(
+                and_(
+                    Agent.workspace_id == workspace_id,
+                    Agent.is_system_agent.is_(True),
+                    Agent.name == "Auto",
+                )
+            ).first()
+
+            priority_map = {"urgent": "urgent", "high": "high", "normal": "medium", "low": "low"}
+            agent_id = params.get("_agent_id")
+
+            task = BoardTask(
+                workspace_id=workspace_id,
+                title=f"[Auto] {subject}",
+                description=message,
+                status="assigned" if auto else "inbox",
+                priority=priority_map.get(urgency, "medium"),
+                assigned_agent_id=auto.id if auto else None,
+                created_by_type="agent",
+                created_by_id=str(agent_id) if agent_id else None,
+                source_type="notification",
+                tags=["auto-escalation", f"urgency:{urgency}"],
+            )
+            db.add(task)
+            db.flush()
+            board_task_id = task.id
+        except Exception as e:
+            logger.warning("[notify_owner] BoardTask creation failed: %s", e, exc_info=True)
+
+    if not delivered and not board_task_id:
+        return {
+            "success": False,
+            "error": delivery_error or f"Could not deliver via {channel} and BoardTask creation failed",
+        }
+
+    return {
+        "success": True,
+        "delivered_via": channel if delivered else "board_task_only",
+        "channel_delivered": delivered,
+        "board_task_id": board_task_id,
+        "delivery_error": delivery_error,
+    }

--- a/orchestrator/modules/tools/discovery/platform_actions.py
+++ b/orchestrator/modules/tools/discovery/platform_actions.py
@@ -33,6 +33,7 @@ from .actions_governance import register_governance_actions
 from .actions_harness import register_harness_actions
 from .actions_graph import register_graph_actions
 from .actions_auto_reporting import register_auto_reporting_actions
+from .actions_notifications import register_notifications_actions
 
 
 def register_all_actions(registry: ActionRegistry) -> None:
@@ -59,6 +60,7 @@ def register_all_actions(registry: ActionRegistry) -> None:
     register_harness_actions(registry)
     register_graph_actions(registry)
     register_auto_reporting_actions(registry)
+    register_notifications_actions(registry)
 
     # Workspace tools (file I/O, grep, exec, git)
     from .workspace_actions import register_workspace_actions

--- a/orchestrator/modules/tools/discovery/platform_executor.py
+++ b/orchestrator/modules/tools/discovery/platform_executor.py
@@ -122,6 +122,7 @@ from modules.tools.discovery.handlers_auto_reporting import (
     update_auto_reporting_prefs,
     send_notification,
 )
+from modules.tools.discovery.handlers_notifications import notify_owner
 from modules.tools.discovery.handlers_assignments import (
     assign_tool_to_agent,
     assign_skill_to_agent,
@@ -323,6 +324,8 @@ class PlatformActionExecutor:
             "platform_get_agent_heartbeat": get_agent_heartbeat,
             "platform_unassign_skill_from_agent": unassign_skill_from_agent,
             "platform_unassign_tool_from_agent": unassign_tool_from_agent,
+            # Owner escalation channel
+            "platform_notify_owner": notify_owner,
             # PRD-76: Agent Reports
             "platform_submit_report": submit_report,
             "platform_get_latest_report": get_latest_report,


### PR DESCRIPTION
## What

Auto can now reach Gerard directly via his configured channel (Telegram/Slack/webhook/in-app) when something needs his eyes — approvals, decisions, blocking risks — instead of just opening tickets and hoping he checks the board.

## How

Reuses heartbeat plumbing wherever possible:

| Layer | Existing? | New |
|---|---|---|
| Channel routing (\`send_workspace_notification\`) | ✅ already used by heartbeat | — |
| \`channel_connections\` table + Telegram/Slack adapters | ✅ | — |
| Inbound (Gerard replies on Telegram → router → Auto) | ✅ \`TelegramAdapter\` → \`UniversalRouter\` | — |
| Settings UI (loading connected channels) | ✅ same dropdown source as heartbeat | New select for \`preferred_channel\` |
| Backend setting | — | \`workspace.settings.orchestrator.preferred_channel\` |
| Tool | — | \`platform_notify_owner(message, subject?, urgency?, channel?, create_task?)\` |

Inbound side is genuinely free — replies on Telegram already route to Auto via the existing \`UniversalRouter\` (Auto is a first-class \`id=0\` synthetic route). Two-way loop closes with the same outbound code.

## Tool behaviour

- Resolves channel: \`params.channel\` → \`orchestrator.preferred_channel\` → \`default_notification_channel\` → \`in_app\`
- Formats with urgency marker (🚨 URGENT / ⚠️ Decision needed / 💬 Auto / ℹ️ Auto)
- Calls \`send_workspace_notification\` (telegram/slack/webhook delivery)
- Always creates a \`BoardTask\` as a persistent backup so requests are recoverable if Gerard misses the channel message
- Returns \`{success, delivered_via, channel_delivered, board_task_id}\`

## Settings UI

New "Preferred Channel for Approvals" select in the Orchestrator tab, between Proactive Level and Voice. Populated from the same \`channel_connections\` source the heartbeat dropdown uses.

## Skill update (separate repo: automatos-skills)

\`team/auto/SKILL.md\` v2.1.0 → v2.2.0 adds:
- \`platform_notify_owner\` to the tools list
- "How to ask Gerard for approval" section with the canonical message pattern: subject + body + recommendation + what-I-do-without-input + when

## Test plan
- [ ] Set Preferred Channel = Telegram, confirm save persists in \`workspace.settings.orchestrator.preferred_channel\`
- [ ] Call \`platform_notify_owner\` from chat → message appears on Telegram + BoardTask shows up assigned to Auto
- [ ] Set Preferred Channel = In-App, confirm \`channel_delivered=true\` (in-app skip path) and BoardTask still created
- [ ] Reply on Telegram → router lands message on Auto (existing behaviour, just verify nothing regressed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)