### PR TITLE
fix(activity): View / View Logs actually land on the execution screen

### DIFF
--- a/frontend/components/activity/activity-page.tsx
+++ b/frontend/components/activity/activity-page.tsx
@@ -89,7 +89,8 @@ export function ActivityPage() {
   const [activeTab, setActiveTab] = useState('summary')
   const [period, setPeriod] = useState('1d')
 
-  // Deep-link: /activity?tab=board&task_id=123 or /activity?openExecution=X&recipeId=Y
+  // Deep-link: /activity?tab=board&task_id=123
+  // (Live execution deep-link is /activity/execution?id=<execId>&recipeId=<recipeId>)
   const searchParams = useSearchParams()
   const openExecution = searchParams.get('openExecution')
   const deepLinkRecipeId = searchParams.get('recipeId')
@@ -101,6 +102,9 @@ export function ActivityPage() {
     if (tabParam && TAB_DEFS.some((t) => t.value === tabParam)) {
       setActiveTab(tabParam)
     } else if (openExecution) {
+      // Legacy deep-link from old /activity?openExecution=... URLs that
+      // got redirected here. Land on the feed; ActivityFeed will open the
+      // slide-over for the matching item as a fallback.
       setActiveTab('feed')
     }
   }, [tabParam, openExecution])

--- a/orchestrator/services/activity_service.py
+++ b/orchestrator/services/activity_service.py
@@ -273,10 +273,13 @@ class ActivityService:
                 # Map trigger
                 trigger = self._map_recipe_trigger(ex.triggered_by)
 
-                # Build deep-link to ExecutionKitchen
+                # Build deep-link to ExecutionKitchen.
+                # /activity/execution renders ExecutionKitchen directly. The
+                # old /activity?openExecution=... pattern only changed the
+                # feed tab — it never opened the live run screen.
                 exec_id = getattr(ex, "execution_id", None) or str(ex.id)
                 recipe_template_id = recipe.template_id if recipe else str(ex.recipe_id)
-                source_url = f"/activity?openExecution={exec_id}&recipeId={recipe_template_id}"
+                source_url = f"/activity/execution?id={exec_id}&recipeId={recipe_template_id}"
 
                 # Aggregate tokens and duration from step_results
                 total_tokens = 0


### PR DESCRIPTION
## The bug

Both **View** (Feed) and **View Logs** (History slide-over) were routing users back to the same Command Centre page they were already on, instead of the live execution screen.

## Root cause

Backend built this deep-link for every recipe execution feed item:

\`\`\`python
source_url = f"/activity?openExecution={exec_id}&recipeId={recipe_template_id}"
\`\`\`

What actually happens when you click View:

1. \`router.push(item.source_url)\` → \`/activity?openExecution=X&recipeId=Y\`
2. \`next.config.js\` redirects \`/activity\` → \`/command-center\` (query preserved)
3. \`activity-page.tsx\` reads \`openExecution\` from query and... \`setActiveTab('feed')\`
4. User lands on the feed tab they came from. ExecutionKitchen never opens.

The execution screen they expect lives at \`/activity/execution?id=<execId>&recipeId=<recipeId>\` — that page exists and renders \`<ExecutionKitchen recipeExecutionId={...} recipeId={...} />\` correctly. Just nothing was pointing at it.

## Fix

\`\`\`python
source_url = f"/activity/execution?id={exec_id}&recipeId={recipe_template_id}"
\`\`\`

That URL is **not** caught by the \`/activity\` → \`/command-center\` redirect (the redirect rule matches \`/activity\` exactly, not \`/activity/...\`), so users land directly on the execution page.

The history slide-over's \`handleViewSource\` for recipes already constructs the same URL pattern internally, so it works after this fix lands.

Marked the \`openExecution\` branch in \`activity-page.tsx\` as a legacy fallback in case old emails / notifications still point at \`/activity?openExecution=...\`.

## Test plan
- [ ] Run a playbook → click **View** on its feed card → land on \`/activity/execution\` showing live ExecutionKitchen
- [ ] Click a row in the History tab → slide-over opens → click **View Logs** → land on the same execution screen
- [ ] Verify ExecutionKitchen polls and shows step status, logs, and cancel button
- [ ] Verify old \`/activity?openExecution=...\` URLs still work (legacy fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated inline comments documenting deep-link behavior for activity pages, including board task navigation and live execution formats.

* **Refactor**
  * Updated recipe feed item deep-link routing to use a new execution route format.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AutomatosAI/automatos-ai/pull/317)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->