### PR TITLE
fix(recipe): retry empty-choices LLM responses so final tool calls don't get dropped

### DIFF
--- a/frontend/components/activity/activity-page.tsx
+++ b/frontend/components/activity/activity-page.tsx
@@ -89,7 +89,8 @@ export function ActivityPage() {
   const [activeTab, setActiveTab] = useState('summary')
   const [period, setPeriod] = useState('1d')
 
-  // Deep-link: /activity?tab=board&task_id=123 or /activity?openExecution=X&recipeId=Y
+  // Deep-link: /activity?tab=board&task_id=123
+  // (Live execution deep-link is /activity/execution?id=<execId>&recipeId=<recipeId>)
   const searchParams = useSearchParams()
   const openExecution = searchParams.get('openExecution')
   const deepLinkRecipeId = searchParams.get('recipeId')
@@ -101,6 +102,9 @@ export function ActivityPage() {
     if (tabParam && TAB_DEFS.some((t) => t.value === tabParam)) {
       setActiveTab(tabParam)
     } else if (openExecution) {
+      // Legacy deep-link from old /activity?openExecution=... URLs that
+      // got redirected here. Land on the feed; ActivityFeed will open the
+      // slide-over for the matching item as a fallback.
       setActiveTab('feed')
     }
   }, [tabParam, openExecution])

--- a/orchestrator/api/recipe_executor.py
+++ b/orchestrator/api/recipe_executor.py
@@ -472,6 +472,25 @@ async def _execute_step(
 
         response = await llm.generate_response(messages=messages, tools=tools)
 
+        # Detect empty-choices responses (OpenRouter intermittency): the call
+        # returns successfully but with no content AND no tool_calls. Without
+        # retry, the tool loop below would treat empty as "LLM done" and the
+        # step would finish without ever emitting its final tool call (e.g.
+        # platform_submit_report). Retry up to the configured budget before
+        # giving up.
+        if response and not response.tool_calls and not (response.content or "").strip():
+            from config import config as _app_config
+            empty_retry_budget = _app_config.RECIPE_EMPTY_COMPLETION_RETRY_BUDGET
+            for retry_idx in range(empty_retry_budget):
+                logger.warning(
+                    "[recipe_direct] Empty completion at step %d iter %d (retry %d/%d) "
+                    "— content+tool_calls both empty, retrying",
+                    step_order, iteration, retry_idx + 1, empty_retry_budget,
+                )
+                response = await llm.generate_response(messages=messages, tools=tools)
+                if response and (response.tool_calls or (response.content or "").strip()):
+                    break  # got a real response
+
         if not response or not response.tool_calls:
             break  # LLM done, has final text
 

--- a/orchestrator/config.py
+++ b/orchestrator/config.py
@@ -263,6 +263,14 @@ class Config:
         return self._required_int_setting("recipe", "default_max_iterations")
 
     @property
+    def RECIPE_EMPTY_COMPLETION_RETRY_BUDGET(self) -> int:
+        """Retries for empty LLM completions (no content + no tool_calls).
+        OpenRouter intermittently returns 'empty-choices' responses with
+        zero tokens — without retry, the tool loop treats empty as 'done'
+        and the step finishes without emitting its final tool call."""
+        return self._required_int_setting("recipe", "empty_completion_retry_budget")
+
+    @property
     def AGENT_HEARTBEAT_MAX_TOOL_ITERATIONS(self) -> int:
         """Max tool-call turns per heartbeat tick."""
         return self._required_int_setting("agent_heartbeat", "max_tool_iterations")

--- a/orchestrator/core/seeds/seed_system_settings.py
+++ b/orchestrator/core/seeds/seed_system_settings.py
@@ -624,6 +624,21 @@ def seed_system_settings(db: Session):
             "is_required": True,
             "validation_rules": {"min": 5, "max": 100},
         },
+        {
+            "category": SettingCategory.RECIPE.value,
+            "key": "empty_completion_retry_budget",
+            "default_value": "2",
+            "value_type": "number",
+            "description": (
+                "How many times to retry an LLM call that returns an empty "
+                "completion (no content AND no tool_calls — typically an "
+                "OpenRouter empty-choices event). Without this, the recipe "
+                "tool loop treats empty as 'LLM done' and the step finishes "
+                "without ever calling its final tool (e.g. platform_submit_report)."
+            ),
+            "is_required": True,
+            "validation_rules": {"min": 0, "max": 5},
+        },
     ])
 
     # =========================================================================

--- a/orchestrator/services/activity_service.py
+++ b/orchestrator/services/activity_service.py
@@ -273,10 +273,13 @@ class ActivityService:
                 # Map trigger
                 trigger = self._map_recipe_trigger(ex.triggered_by)
 
-                # Build deep-link to ExecutionKitchen
+                # Build deep-link to ExecutionKitchen.
+                # /activity/execution renders ExecutionKitchen directly. The
+                # old /activity?openExecution=... pattern only changed the
+                # feed tab — it never opened the live run screen.
                 exec_id = getattr(ex, "execution_id", None) or str(ex.id)
                 recipe_template_id = recipe.template_id if recipe else str(ex.recipe_id)
-                source_url = f"/activity?openExecution={exec_id}&recipeId={recipe_template_id}"
+                source_url = f"/activity/execution?id={exec_id}&recipeId={recipe_template_id}"
 
                 # Aggregate tokens and duration from step_results
                 total_tokens = 0


### PR DESCRIPTION
## What today's daily-social-analytics-report actually did

\`\`\`
08:00:00  Cron fires, exec=cron-56211c50c52b, recipe=283
08:00 → 08:04  Steps 1–5 run normally (agent 189, 446)
08:04:44  Step 6 LLM call 1: input=22923, output=776  (gather/think — normal)
08:05:01  Step 6 LLM call 2: input=0, output=0, latency=17s, status=success  ⚠️ EMPTY
08:05:01  Step 6 marked complete
08:05:01  Recipe wraps successfully — fallback writes stats-only report
\`\`\`

That second call is an **OpenRouter empty-choices event**: provider returned a "successful" response with no content and no tool_calls. The agent was about to emit \`platform_submit_report\` with the actual analytics. Never got the chance. Step 6 finished, recipe completed "successfully", \`_auto_create_playbook_report\` wrote a stats-only summary instead of the real analytics report.

## Why the tool loop fell for it

\`recipe_executor.py:475\`:
\`\`\`python
if not response or not response.tool_calls:
    break  # LLM done, has final text
\`\`\`

Empty completion has no \`tool_calls\` — break. But it also has no \`content\`. That's not "done", that's **provider intermittency**. Yesterday's manual run worked because OpenRouter returned a normal response that turn. The bug is unprovoked and will hit again.

## Fix

Detect "content empty AND tool_calls empty" before the existing break, retry the call up to \`recipe.empty_completion_retry_budget\` (default 2) using the same messages. If the retry produces real output, the loop continues normally. If it stays empty, fall through to the existing "LLM done" break — the worst case is identical to today.

\`\`\`python
if response and not response.tool_calls and not (response.content or "").strip():
    for retry_idx in range(empty_retry_budget):
        logger.warning("Empty completion at step N iter M (retry K/B) — retrying")
        response = await llm.generate_response(messages=messages, tools=tools)
        if response and (response.tool_calls or (response.content or "").strip()):
            break  # got a real response
\`\`\`

## What this doesn't fix

- The fallback \`_auto_create_playbook_report\` will still create a stats-only summary if all retries fail. Separate ticket: differentiate "step's submit_report fired" vs "fallback only" in the activity feed so a missing real report is visible.
- The same empty-choices issue can hit chatbot, heartbeat, and coordinator tool loops. They have their own loops that probably need the same treatment. Filed as follow-up.

## Test plan
- [ ] Re-run \`daily-social-analytics-report\` manually → step 6 emits \`platform_submit_report\` → real analytics report appears in feed
- [ ] Force an empty response (mock LLM client) → log shows retry → after retries, real response → step continues
- [ ] If all retries return empty → step finishes cleanly (no infinite loop), fallback report still fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)