### PR TITLE
fix(recipe): backoff + model fallback for sustained empty-completion …

### DIFF
--- a/orchestrator/api/recipe_executor.py
+++ b/orchestrator/api/recipe_executor.py
@@ -476,20 +476,50 @@ async def _execute_step(
         # returns successfully but with no content AND no tool_calls. Without
         # retry, the tool loop below would treat empty as "LLM done" and the
         # step would finish without ever emitting its final tool call (e.g.
-        # platform_submit_report). Retry up to the configured budget before
-        # giving up.
+        # platform_submit_report). Retry with backoff, then swap to a fallback
+        # model if the agent's primary model is in a sustained empty-choices
+        # window (e.g. Gemini 2.5 Pro degradation).
         if response and not response.tool_calls and not (response.content or "").strip():
             from config import config as _app_config
             empty_retry_budget = _app_config.RECIPE_EMPTY_COMPLETION_RETRY_BUDGET
             for retry_idx in range(empty_retry_budget):
+                backoff_s = min(0.5 * (2 ** retry_idx), 4.0)
                 logger.warning(
-                    "[recipe_direct] Empty completion at step %d iter %d (retry %d/%d) "
+                    "[recipe_direct] Empty completion at step %d iter %d (retry %d/%d, backoff=%.1fs) "
                     "— content+tool_calls both empty, retrying",
-                    step_order, iteration, retry_idx + 1, empty_retry_budget,
+                    step_order, iteration, retry_idx + 1, empty_retry_budget, backoff_s,
                 )
+                await asyncio.sleep(backoff_s)
                 response = await llm.generate_response(messages=messages, tools=tools)
                 if response and (response.tool_calls or (response.content or "").strip()):
                     break  # got a real response
+
+            # If still empty after same-model retries, swap to fallback model
+            # for one final attempt. This survives sustained per-model provider
+            # degradation that affects the primary model only.
+            if response and not response.tool_calls and not (response.content or "").strip():
+                fallback_model = _app_config.RECIPE_EMPTY_COMPLETION_FALLBACK_MODEL
+                if fallback_model:
+                    logger.warning(
+                        "[recipe_direct] Empty completion persists at step %d iter %d after %d retries "
+                        "— swapping to fallback model %s",
+                        step_order, iteration, empty_retry_budget, fallback_model,
+                    )
+                    try:
+                        from core.llm.manager import create_llm_manager
+                        fallback_llm = create_llm_manager(
+                            service_name="orchestrator",
+                            model=fallback_model,
+                            request_type="recipe_fallback",
+                        )
+                        if recipe_execution_id and hasattr(fallback_llm, "_tracking_ctx"):
+                            fallback_llm._tracking_ctx["execution_id"] = recipe_execution_id
+                        response = await fallback_llm.generate_response(messages=messages, tools=tools)
+                    except Exception as fallback_exc:
+                        logger.error(
+                            "[recipe_direct] Fallback model %s also failed at step %d iter %d: %s",
+                            fallback_model, step_order, iteration, fallback_exc,
+                        )
 
         if not response or not response.tool_calls:
             break  # LLM done, has final text

--- a/orchestrator/config.py
+++ b/orchestrator/config.py
@@ -271,6 +271,14 @@ class Config:
         return self._required_int_setting("recipe", "empty_completion_retry_budget")
 
     @property
+    def RECIPE_EMPTY_COMPLETION_FALLBACK_MODEL(self) -> str:
+        """Fallback model used when same-model retries still return empty.
+        Empty string disables fallback. Stored as system_settings.recipe.empty_completion_fallback_model."""
+        from core.llm.manager import get_system_setting
+        val = get_system_setting("recipe", "empty_completion_fallback_model", "")
+        return str(val).strip() if val is not None else ""
+
+    @property
     def AGENT_HEARTBEAT_MAX_TOOL_ITERATIONS(self) -> int:
         """Max tool-call turns per heartbeat tick."""
         return self._required_int_setting("agent_heartbeat", "max_tool_iterations")

--- a/orchestrator/core/seeds/seed_system_settings.py
+++ b/orchestrator/core/seeds/seed_system_settings.py
@@ -627,17 +627,34 @@ def seed_system_settings(db: Session):
         {
             "category": SettingCategory.RECIPE.value,
             "key": "empty_completion_retry_budget",
-            "default_value": "2",
+            "default_value": "4",
             "value_type": "number",
             "description": (
                 "How many times to retry an LLM call that returns an empty "
                 "completion (no content AND no tool_calls — typically an "
                 "OpenRouter empty-choices event). Without this, the recipe "
                 "tool loop treats empty as 'LLM done' and the step finishes "
-                "without ever calling its final tool (e.g. platform_submit_report)."
+                "without ever calling its final tool (e.g. platform_submit_report). "
+                "Retries use exponential backoff (0.5s, 1s, 2s, 4s)."
             ),
             "is_required": True,
-            "validation_rules": {"min": 0, "max": 5},
+            "validation_rules": {"min": 0, "max": 8},
+        },
+        {
+            "category": SettingCategory.RECIPE.value,
+            "key": "empty_completion_fallback_model",
+            "default_value": "anthropic/claude-sonnet-4.6",
+            "value_type": "string",
+            "description": (
+                "If all empty_completion_retry_budget retries against the "
+                "agent's primary model still return empty, do one final attempt "
+                "with this fallback model. Lets a step survive sustained "
+                "provider degradation on a specific model (e.g. Gemini 2.5 Pro "
+                "empty-choices windows) so the step still emits its final "
+                "tool call. Set to empty string to disable model fallback."
+            ),
+            "is_required": False,
+            "validation_rules": {},
         },
     ])
 


### PR DESCRIPTION
…windows

Yesterday's fix (PR #318) added 2 retries for OpenRouter empty-choices responses. It rescued steps 2 and 4 of the daily-social-analytics run (exec-633cf3146227) but step 6 hit 3 consecutive empties on Gemini 2.5 Pro and the budget exhausted — fell through, no submit_report, fallback stats summary only. Same model + same playbook + 24h later = different provider behavior.

Three changes:

1. Bump retry budget default 2 → 4. Give the loop more chances to ride out a brief degradation window before giving up.

2. Exponential backoff between retries (0.5s, 1s, 2s, 4s). Provider gets room to recover instead of being hammered with identical requests.

3. Model fallback on retry exhaustion. New setting recipe.empty_completion_fallback_model (default anthropic/claude-sonnet-4.6). When all same-model retries still return empty, build a one-shot LLMManager with the fallback model and try once more. Survives sustained per-model degradation — different provider routing through OpenRouter usually clears the issue. Set to empty string to disable.

Net effect on step 6's failure mode: 1 success path (retry rescue) + 1 escape hatch (model fallback) before we resort to the existing break.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of empty LLM responses with exponential backoff retry mechanism.
  * Added optional fallback model support for recipe execution when standard retries are exhausted.

* **Configuration**
  * New setting available to specify a fallback model for empty response scenarios.
  * Increased default retry budget for handling empty responses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AutomatosAI/automatos-ai/pull/319)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->