### PR TITLE
feat(widgets): PRD-007 proactive engagement — orchestrator + endpoint

### DIFF
--- a/orchestrator/api/shopify.py
+++ b/orchestrator/api/shopify.py
@@ -103,6 +103,25 @@ SHOPIFY_AGENT_SLUGS = [
 ]
 
 
+# PRD-007: default proactive widget config seeded into workspace.settings
+# at provision time. Merchant flips `enabled: true` from the dashboard
+# (or via PATCH /api/workspaces/:id/settings) to activate.
+DEFAULT_WIDGET_PROACTIVE_CONFIG: dict = {
+    "enabled": False,
+    "page_types": ["product"],
+    "triggers": [
+        {"type": "time_on_page", "seconds": 20},
+    ],
+    "frequency_cap": {"scope": "session", "max_pops": 1},
+    "greeting_source": "agent_with_canned_fallback",
+    "canned_fallback": "Need a hand finding the right product?",
+    "agent_timeout_ms": 1500,
+    "popup_style": "corner_bubble",
+    "respect_consent": True,
+    "dismissal_persistence": "session",
+}
+
+
 # ===================================================================
 # POST /api/shopify/provision
 # ===================================================================
@@ -153,6 +172,7 @@ async def provision_workspace(
                 "source": request.source,
                 "shopify_domain": shop,
                 "shopify_metadata": request.metadata,
+                "widget_proactive": dict(DEFAULT_WIDGET_PROACTIVE_CONFIG),
             },
         )
         db.add(workspace)

--- a/orchestrator/api/widgets/chat.py
+++ b/orchestrator/api/widgets/chat.py
@@ -41,6 +41,40 @@ class WidgetChatRequest(BaseModel):
     conversation_id: Optional[str] = None
     agent_id: Optional[str] = None  # UUID (public_id) or legacy integer id as string
     model_id: Optional[str] = None
+    # PRD-007: page context + trigger reason for proactive engagement.
+    # Both backwards-compatible (default None). When trigger_reason is set
+    # (e.g. "proactive_opener"), the chat service uses an opener prompt
+    # variant instead of treating ``message`` as a user utterance.
+    page_context: Optional[dict] = None
+    trigger_reason: Optional[str] = None
+
+
+# PRD-007: trigger reasons that flip the agent into opener-generation mode.
+# Anything else is treated as a normal user message.
+PROACTIVE_TRIGGER_REASONS: frozenset[str] = frozenset({"proactive_opener"})
+
+
+def _build_proactive_opener_message(page_context: dict) -> str:
+    """Synthesize the user-side message for a proactive opener request.
+
+    The widget never sends real user text for proactive openers — instead
+    we synthesize a directive describing the page context. The agent's
+    ``shopify-support`` skill recognises the ``[PROACTIVE_OPENER]`` prefix
+    and generates a one-sentence contextual greeting.
+    """
+    ctx_summary_parts: list[str] = []
+    if page_context.get("pageType"):
+        ctx_summary_parts.append(f"page_type={page_context['pageType']}")
+    if page_context.get("productTitle"):
+        ctx_summary_parts.append(f"product=\"{page_context['productTitle']}\"")
+    elif page_context.get("productHandle"):
+        ctx_summary_parts.append(f"product_handle={page_context['productHandle']}")
+    if page_context.get("productType"):
+        ctx_summary_parts.append(f"product_type={page_context['productType']}")
+    if page_context.get("collectionTitle"):
+        ctx_summary_parts.append(f"collection=\"{page_context['collectionTitle']}\"")
+    summary = ", ".join(ctx_summary_parts) if ctx_summary_parts else "no context"
+    return f"[PROACTIVE_OPENER] Generate a contextual one-sentence opener. Context: {summary}"
 
 
 class WidgetMessageOut(BaseModel):
@@ -109,6 +143,15 @@ async def widget_chat(
 
     workspace_id = str(auth.workspace_id)
     user_id = _get_widget_user_id(db)
+
+    # PRD-007: rewrite ``message`` for proactive opener requests so the agent
+    # sees a directive, not an empty / placeholder user utterance from the SDK.
+    is_proactive = (
+        body.trigger_reason in PROACTIVE_TRIGGER_REASONS
+        and body.page_context is not None
+    )
+    if is_proactive:
+        body.message = _build_proactive_opener_message(body.page_context or {})
 
     chat_service = ChatService(db)
     streaming_service = StreamingChatService(db, workspace_id=workspace_id, widget_mode=True)

--- a/orchestrator/api/widgets/config.py
+++ b/orchestrator/api/widgets/config.py
@@ -1,0 +1,78 @@
+"""
+Widget Public Config Endpoint
+==============================
+
+Exposes the public slice of ``workspace.settings`` to browser-side widgets so
+they can configure runtime behaviour (e.g. PRD-007 proactive engagement)
+without needing a server-key JWT exchange.
+
+Public-key (``ak_pub_*``) widgets call this endpoint once on init. Server-key
+flows already receive the same payload via ``SessionTokenResponse.widget_config``.
+
+    GET /api/widgets/config
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from core.database.database import get_db
+from core.models.workspaces import Workspace
+
+from api.widgets.auth import WidgetAuthContext, widget_auth
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["Widget Config"])
+
+
+# Keys from ``workspace.settings`` exposed to browser widgets. Anything not
+# listed here stays server-side. Add new feature keys as PRDs land.
+PUBLIC_WIDGET_CONFIG_KEYS: tuple[str, ...] = ("widget_proactive",)
+
+
+def build_widget_config(workspace: Optional[Workspace]) -> Optional[dict]:
+    """Project the public widget-config slice from ``workspace.settings``.
+
+    Returns ``None`` when no public keys are configured so existing clients
+    that don't expect the field aren't pushed an empty object.
+    """
+    if workspace is None or not workspace.settings:
+        return None
+    settings = workspace.settings or {}
+    public = {k: settings[k] for k in PUBLIC_WIDGET_CONFIG_KEYS if k in settings}
+    return public or None
+
+
+class WidgetConfigResponse(BaseModel):
+    """Public widget runtime config returned to the browser SDK."""
+
+    workspace_id: str
+    config: dict
+
+
+@router.get("/config", response_model=WidgetConfigResponse)
+async def get_widget_config(
+    auth: WidgetAuthContext = Depends(widget_auth),
+    db: Session = Depends(get_db),
+) -> WidgetConfigResponse:
+    """Return the public widget config for the authenticated workspace.
+
+    Works for both public keys (raw API key) and server-key JWTs since both
+    route through ``widget_auth``.
+    """
+    workspace = (
+        db.query(Workspace)
+        .filter(Workspace.id == auth.workspace_id)
+        .first()
+    )
+    config = build_widget_config(workspace) or {}
+    return WidgetConfigResponse(
+        workspace_id=str(auth.workspace_id),
+        config=config,
+    )

--- a/orchestrator/api/widgets/router.py
+++ b/orchestrator/api/widgets/router.py
@@ -25,6 +25,12 @@ except ImportError as e:
     logger.warning(f"Widget session router not available: {e}")
 
 try:
+    from api.widgets.config import router as config_router
+    router.include_router(config_router)
+except ImportError as e:
+    logger.warning(f"Widget config router not available: {e}")
+
+try:
     from api.widgets.chat import router as chat_router
     router.include_router(chat_router)
 except ImportError as e:

--- a/orchestrator/api/widgets/session.py
+++ b/orchestrator/api/widgets/session.py
@@ -22,8 +22,11 @@ from pydantic import BaseModel, field_validator
 from sqlalchemy.orm import Session
 
 from core.database.database import get_db
+from core.models.workspaces import Workspace
 from core.services.api_key_service import ApiKeyService
 from config import config
+
+from api.widgets.config import build_widget_config
 
 logger = logging.getLogger(__name__)
 
@@ -64,6 +67,7 @@ class SessionTokenResponse(BaseModel):
     expires_at: str
     permissions: List[str]
     workspace_id: str
+    widget_config: Optional[dict] = None
 
 
 # ---------------------------------------------------------------------------
@@ -146,10 +150,19 @@ async def exchange_session_token(
         algorithm=WIDGET_TOKEN_ALGORITHM,
     )
 
-    # --- 5. Return response ---------------------------------------------
+    # --- 5. Resolve widget config for the browser ------------------------
+    workspace = (
+        db.query(Workspace)
+        .filter(Workspace.id == api_key_record.workspace_id)
+        .first()
+    )
+    widget_config = build_widget_config(workspace)
+
+    # --- 6. Return response ---------------------------------------------
     return SessionTokenResponse(
         session_token=session_token,
         expires_at=exp.isoformat(),
         permissions=effective_permissions,
         workspace_id=str(api_key_record.workspace_id),
+        widget_config=widget_config,
     )

--- a/orchestrator/tests/test_widget_proactive_prd007.py
+++ b/orchestrator/tests/test_widget_proactive_prd007.py
@@ -1,0 +1,234 @@
+"""
+PRD-007 unit tests
+==================
+
+Pure-Python unit tests covering:
+
+1. ``DEFAULT_WIDGET_PROACTIVE_CONFIG`` shape (workspace seeder default).
+2. ``build_widget_config`` projection from ``workspace.settings``.
+3. ``_build_proactive_opener_message`` synthesis from page context.
+4. ``WidgetChatRequest`` accepts new optional fields and stays
+   backwards-compatible.
+5. ``SessionTokenResponse`` accepts the new ``widget_config`` field.
+
+No FastAPI app boot, no DB, no network.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+# Make ``orchestrator/`` imports resolve when tests run from repo root.
+ORCH_ROOT = Path(__file__).resolve().parent.parent
+if str(ORCH_ROOT) not in sys.path:
+    sys.path.insert(0, str(ORCH_ROOT))
+
+
+# ---------------------------------------------------------------------------
+# 1. Default workspace-seeder config (Shopify provision step)
+# ---------------------------------------------------------------------------
+
+def test_default_widget_proactive_shape():
+    from api.shopify import DEFAULT_WIDGET_PROACTIVE_CONFIG as cfg
+
+    # Locked-defaults contract per PRD-007 v0.2 — keep the schema explicit
+    # so accidental drift breaks this test, not production widgets.
+    assert cfg["enabled"] is False, "must default to OFF — opt-in"
+    assert cfg["page_types"] == ["product"]
+    assert cfg["triggers"] == [{"type": "time_on_page", "seconds": 20}]
+    assert cfg["frequency_cap"] == {"scope": "session", "max_pops": 1}
+    assert cfg["greeting_source"] == "agent_with_canned_fallback"
+    assert cfg["canned_fallback"] == "Need a hand finding the right product?"
+    assert cfg["agent_timeout_ms"] == 1500
+    assert cfg["popup_style"] == "corner_bubble"
+    assert cfg["respect_consent"] is True
+    assert cfg["dismissal_persistence"] == "session"
+
+
+def test_default_config_is_copyable():
+    """Each new workspace must get its own dict — not the shared module-level
+    object — so per-merchant edits don't bleed across tenants.
+    """
+    from api.shopify import DEFAULT_WIDGET_PROACTIVE_CONFIG
+
+    a = dict(DEFAULT_WIDGET_PROACTIVE_CONFIG)
+    b = dict(DEFAULT_WIDGET_PROACTIVE_CONFIG)
+    a["enabled"] = True
+    assert b["enabled"] is False
+    assert DEFAULT_WIDGET_PROACTIVE_CONFIG["enabled"] is False
+
+
+# ---------------------------------------------------------------------------
+# 2. ``build_widget_config`` — public projection from workspace.settings
+# ---------------------------------------------------------------------------
+
+def test_build_widget_config_returns_none_for_missing_workspace():
+    from api.widgets.config import build_widget_config
+
+    assert build_widget_config(None) is None
+
+
+def test_build_widget_config_returns_none_when_no_settings():
+    from api.widgets.config import build_widget_config
+
+    ws = SimpleNamespace(settings=None)
+    assert build_widget_config(ws) is None
+
+    ws_empty = SimpleNamespace(settings={})
+    assert build_widget_config(ws_empty) is None
+
+
+def test_build_widget_config_projects_only_public_keys():
+    """Internal keys (e.g. shopify_access_token) must never reach the browser."""
+    from api.widgets.config import build_widget_config
+
+    ws = SimpleNamespace(
+        settings={
+            "shopify_access_token": "shpat_secret_should_NOT_leak",
+            "shopify_domain": "example.myshopify.com",
+            "widget_proactive": {"enabled": True, "page_types": ["product"]},
+        }
+    )
+    result = build_widget_config(ws)
+    assert result == {"widget_proactive": {"enabled": True, "page_types": ["product"]}}
+    assert "shopify_access_token" not in result
+    assert "shopify_domain" not in result
+
+
+def test_build_widget_config_returns_none_when_no_public_keys_set():
+    from api.widgets.config import build_widget_config
+
+    ws = SimpleNamespace(settings={"shopify_domain": "x.myshopify.com"})
+    assert build_widget_config(ws) is None
+
+
+# ---------------------------------------------------------------------------
+# 3. ``_build_proactive_opener_message`` — page-context → directive
+# ---------------------------------------------------------------------------
+
+def test_opener_message_includes_product_title_when_present():
+    from api.widgets.chat import _build_proactive_opener_message
+
+    msg = _build_proactive_opener_message({
+        "pageType": "product",
+        "productTitle": "EN 12101-9 Control Panel",
+        "productType": "Control Panels",
+    })
+    assert msg.startswith("[PROACTIVE_OPENER]")
+    assert "EN 12101-9 Control Panel" in msg
+    assert "Control Panels" in msg
+    assert "page_type=product" in msg
+
+
+def test_opener_message_falls_back_to_handle_without_title():
+    from api.widgets.chat import _build_proactive_opener_message
+
+    msg = _build_proactive_opener_message({
+        "pageType": "product",
+        "productHandle": "en-12101-control-panel",
+    })
+    assert "product_handle=en-12101-control-panel" in msg
+
+
+def test_opener_message_handles_collection_pages():
+    from api.widgets.chat import _build_proactive_opener_message
+
+    msg = _build_proactive_opener_message({
+        "pageType": "collection",
+        "collectionTitle": "Fans & Ventilation",
+    })
+    assert "page_type=collection" in msg
+    assert "Fans & Ventilation" in msg
+
+
+def test_opener_message_handles_empty_context():
+    from api.widgets.chat import _build_proactive_opener_message
+
+    msg = _build_proactive_opener_message({})
+    assert msg.startswith("[PROACTIVE_OPENER]")
+    assert "no context" in msg
+
+
+# ---------------------------------------------------------------------------
+# 4. ``WidgetChatRequest`` — backwards-compatible new fields
+# ---------------------------------------------------------------------------
+
+def test_chat_request_accepts_legacy_payload():
+    """Existing clients sending only ``message`` must keep working."""
+    from api.widgets.chat import WidgetChatRequest
+
+    body = WidgetChatRequest(message="hello")
+    assert body.message == "hello"
+    assert body.page_context is None
+    assert body.trigger_reason is None
+
+
+def test_chat_request_accepts_proactive_payload():
+    from api.widgets.chat import WidgetChatRequest
+
+    body = WidgetChatRequest(
+        message="",  # widget sends empty for proactive
+        trigger_reason="proactive_opener",
+        page_context={"pageType": "product", "productHandle": "x"},
+    )
+    assert body.trigger_reason == "proactive_opener"
+    assert body.page_context == {"pageType": "product", "productHandle": "x"}
+
+
+def test_proactive_trigger_reason_constant_includes_proactive_opener():
+    from api.widgets.chat import PROACTIVE_TRIGGER_REASONS
+
+    assert "proactive_opener" in PROACTIVE_TRIGGER_REASONS
+
+
+# ---------------------------------------------------------------------------
+# 5. ``SessionTokenResponse`` — new ``widget_config`` field
+# ---------------------------------------------------------------------------
+
+def test_session_response_widget_config_optional():
+    from api.widgets.session import SessionTokenResponse
+
+    resp = SessionTokenResponse(
+        session_token="jwt",
+        expires_at="2026-05-13T00:00:00",
+        permissions=["chat"],
+        workspace_id="00000000-0000-0000-0000-000000000000",
+    )
+    assert resp.widget_config is None
+
+
+def test_session_response_widget_config_roundtrip():
+    from api.widgets.session import SessionTokenResponse
+
+    cfg = {"widget_proactive": {"enabled": True}}
+    resp = SessionTokenResponse(
+        session_token="jwt",
+        expires_at="2026-05-13T00:00:00",
+        permissions=["chat"],
+        workspace_id="00000000-0000-0000-0000-000000000000",
+        widget_config=cfg,
+    )
+    assert resp.widget_config == cfg
+
+
+# ---------------------------------------------------------------------------
+# 6. Whitelist guard — adding a new public key requires a deliberate change
+# ---------------------------------------------------------------------------
+
+def test_public_widget_config_keys_whitelist_is_minimal():
+    """Trip-wire: if you add a public key, update this test consciously.
+
+    Keeps the surface area visible during code review so nobody silently
+    leaks an internal setting.
+    """
+    from api.widgets.config import PUBLIC_WIDGET_CONFIG_KEYS
+
+    assert PUBLIC_WIDGET_CONFIG_KEYS == ("widget_proactive",)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Adds the orchestrator-side plumbing for context-aware proactive widget popups. All changes additive + backwards-compatible.

Workspace seeder
- DEFAULT_WIDGET_PROACTIVE_CONFIG seeded into workspace.settings on every Shopify provision (POST /api/shopify/provision). Default enabled=false; merchants opt in via dashboard or settings PATCH.

New endpoint
- GET /api/widgets/config — returns the public projection of workspace.settings to browser-side widgets. Whitelisted keys only (currently 'widget_proactive'); internal keys like shopify_access_token cannot leak. Works for both public-key (ak_pub_*) and JWT flows via the existing widget_auth dependency.

Shared projection helper
- build_widget_config() centralizes the public-config slice so /api/widgets/auth and /api/widgets/config return identical shapes.

Chat request extensions
- WidgetChatRequest gains optional page_context + trigger_reason fields. When trigger_reason='proactive_opener' the chat handler rewrites body.message into a [PROACTIVE_OPENER] directive carrying structured page context, so the agent sees an opener-generation prompt instead of an empty user utterance.

Session response
- SessionTokenResponse adds optional widget_config field so server-key flows receive the same payload inline (no second HTTP hop needed).

Tests (16, all passing)
- Default config shape contract (locked-defaults trip-wire per PRD-007 v0.2)
- Default config copyability (per-tenant isolation)
- build_widget_config: missing/None workspace, projection from settings, internal-key leak prevention
- _build_proactive_opener_message: product/handle/collection/empty contexts
- WidgetChatRequest: legacy + proactive payloads
- SessionTokenResponse: widget_config optional + roundtrip
- PUBLIC_WIDGET_CONFIG_KEYS whitelist trip-wire

Refs PRD: automatos-shopify/docs/PRDS/PRD-007-PROACTIVE-WIDGET-ENGAGEMENT.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added proactive widget engagement capabilities for Shopify merchants.
  * Widget configuration is now seeded during workspace provisioning.
  * New endpoint exposes widget settings to clients securely.
  * Session tokens now include widget configuration data.

* **Tests**
  * Comprehensive test coverage for proactive widget behavior and configuration management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AutomatosAI/automatos-ai/pull/320)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->