### PR TITLE
fix(mem0,qdrant,llm): stabilize memory + pilot key fallback

### DIFF
--- a/orchestrator/config.py
+++ b/orchestrator/config.py
@@ -562,8 +562,11 @@ class Config:
     RECIPE_LOG_S3_BUCKET: str = os.getenv("RECIPE_LOG_S3_BUCKET", "automatos-ai")
     MEM0_API_URL: str = os.getenv("MEM0_API_URL", "http://automatos-mem0-server.railway.internal")
     MEM0_API_KEY: str = os.getenv("MEM0_API_KEY")
-    # PRD-137 Fix #6: timeout was 15s — too long for chat critical path.
+    # Read path (search/get_all) blocks TTFT — keep short.
     MEM0_TIMEOUT_SECONDS: float = float(os.getenv("MEM0_TIMEOUT_SECONDS", "3.0"))
+    # Write path runs post-LLM; mem0 does sync inference+embedding server-side
+    # (observed 2-7s). 3s causes constant timeouts → CB trips → 5min blackouts.
+    MEM0_WRITE_TIMEOUT_SECONDS: float = float(os.getenv("MEM0_WRITE_TIMEOUT_SECONDS", "15.0"))
     # Open circuit after this many consecutive failures.
     MEM0_CIRCUIT_THRESHOLD: int = int(os.getenv("MEM0_CIRCUIT_THRESHOLD", "3"))
     # Stay open for this many seconds before allowing a probe.

--- a/orchestrator/main.py
+++ b/orchestrator/main.py
@@ -805,6 +805,18 @@ app = FastAPI(
     }
 )
 
+# Pilot fallback health log — platform OpenRouter key kicks in when a user has no BYOK.
+# If this is missing, new users without a key cannot run agents/chat.
+_platform_or_key = bool((config.OPENROUTER_API_KEY or "").strip())
+if _platform_or_key:
+    logger.info("Platform OpenRouter fallback ACTIVE (OPENROUTER_API_KEY configured)")
+else:
+    logger.error(
+        "Platform OpenRouter fallback MISSING — OPENROUTER_API_KEY env var not set. "
+        "New users without their own BYOK key will fail at first LLM call. "
+        "Set OPENROUTER_API_KEY on the API service to unblock pilot users."
+    )
+
 # CORS middleware - use centralized config
 # Parse and clean CORS origins (handle comma-separated list with whitespace)
 cors_origins = [origin.strip() for origin in config.CORS_ALLOW_ORIGINS.split(",") if origin.strip()]

--- a/orchestrator/modules/agents/factory/agent_factory.py
+++ b/orchestrator/modules/agents/factory/agent_factory.py
@@ -502,7 +502,11 @@ class AgentFactory:
         provider = provider_map[effective_provider]
         resolved = await self._resolve_api_key(effective_provider, agent_name, workspace_id=workspace_id)
         if not resolved:
-            raise ValueError(f"API key not found for provider: {effective_provider}")
+            raise ValueError(
+                f"No API key available for {effective_provider}. "
+                f"Add one in Settings → API Keys, or set platform fallback "
+                f"({effective_provider.upper()}_API_KEY env var on the API service)."
+            )
 
         llm_config = LLMConfig(
             provider=provider,

--- a/orchestrator/modules/context/adapters/vector_field.py
+++ b/orchestrator/modules/context/adapters/vector_field.py
@@ -27,6 +27,7 @@ from qdrant_client.models import (
     Distance,
     FieldCondition,
     Filter,
+    HnswConfigDiff,
     MatchValue,
     PayloadSchemaType,
     PointStruct,
@@ -78,7 +79,10 @@ class VectorFieldSharedContext(SharedContextPort):
             vectors_config=VectorParams(
                 size=self._dimension,
                 distance=Distance.COSINE,
+                on_disk=True,
             ),
+            hnsw_config=HnswConfigDiff(on_disk=True),
+            on_disk_payload=True,
         )
 
         # Payload indexes for filtered queries — wait=True to avoid race

--- a/orchestrator/modules/memory/integrations/mem0_client.py
+++ b/orchestrator/modules/memory/integrations/mem0_client.py
@@ -84,6 +84,7 @@ class Mem0Client:
         self.api_url = (api_url or config.MEM0_API_URL or "").strip()
         self.api_key = api_key or config.MEM0_API_KEY
         self.timeout = float(getattr(config, "MEM0_TIMEOUT_SECONDS", 3.0))
+        self.write_timeout = float(getattr(config, "MEM0_WRITE_TIMEOUT_SECONDS", 15.0))
 
         if not self.api_url:
             logger.info(
@@ -131,7 +132,14 @@ class Mem0Client:
                     _breaker.record_success()
                     return resp
 
-                if resp.status_code in (400, 401, 403, 404):
+                if resp.status_code == 404:
+                    logger.debug(
+                        "[Mem0] 404 on %s %s — treating as empty result",
+                        method.upper(), url,
+                    )
+                    return resp
+
+                if resp.status_code in (400, 401, 403):
                     logger.warning(
                         "[Mem0] Client/config error %d on %s %s — not retrying",
                         resp.status_code, method.upper(), url,
@@ -206,7 +214,7 @@ class Mem0Client:
 
         logger.debug("[Mem0] Adding memory for user_id=%s (text_len=%d)", user_id, len(text))
 
-        resp = self._request("POST", url, json=payload)
+        resp = self._request("POST", url, json=payload, timeout=self.write_timeout)
         if resp is None:
             return {"success": False, "error": "Mem0 unavailable (circuit breaker or timeout)"}
 
@@ -258,6 +266,10 @@ class Mem0Client:
 
         resp = self._request("GET", url, params=params)
         if resp is None:
+            return []
+
+        if resp.status_code == 404:
+            logger.debug("[Mem0] Search: no memories yet for user_id=%s", user_id)
             return []
 
         if resp.status_code >= 400:

--- a/orchestrator/scripts/nuke_orphan_field_collections.py
+++ b/orchestrator/scripts/nuke_orphan_field_collections.py
@@ -1,0 +1,105 @@
+"""One-shot orphan field collection sweep.
+
+Lists every Qdrant ``field_*`` collection, cross-references against
+``orchestration_runs.config->>'field_id'``, and deletes any collection that
+no live mission run still references.
+
+Run via Railway shell on automatos-ai-api:
+
+    python scripts/nuke_orphan_field_collections.py
+    python scripts/nuke_orphan_field_collections.py --dry-run
+
+Each field is its own Qdrant collection. Qdrant loads every collection's HNSW
+into memory on startup, so a backlog of orphans crashes the pod with OOM.
+The coordinator's tick drains 20 per loop, this script clears the whole
+backlog in one pass.
+"""
+import argparse
+import asyncio
+import logging
+import sys
+
+from sqlalchemy import text
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+)
+logger = logging.getLogger("nuke-orphan-fields")
+
+
+async def main(dry_run: bool) -> int:
+    from config import config  # noqa: F401  — ensures env validation
+    from core.database.database import SessionLocal
+    from qdrant_client import AsyncQdrantClient
+
+    qdrant_url = getattr(config, "QDRANT_URL", None) or "http://localhost:6333"
+    qdrant_api_key = getattr(config, "QDRANT_API_KEY", None) or None
+
+    client = AsyncQdrantClient(url=qdrant_url, api_key=qdrant_api_key)
+
+    try:
+        collections_resp = await client.get_collections()
+    except Exception as exc:
+        logger.error("Failed to list Qdrant collections: %s", exc)
+        return 2
+
+    field_collections = sorted(
+        c.name for c in collections_resp.collections if c.name.startswith("field_")
+    )
+    logger.info("Found %d field_* collections in Qdrant", len(field_collections))
+
+    if not field_collections:
+        return 0
+
+    db = SessionLocal()
+    try:
+        referenced_ids = {
+            row[0] for row in db.execute(
+                text(
+                    "SELECT config->>'field_id' FROM orchestration_runs "
+                    "WHERE config->>'field_id' IS NOT NULL"
+                )
+            ).fetchall()
+            if row[0]
+        }
+    finally:
+        db.close()
+
+    logger.info("Found %d referenced field_ids in orchestration_runs", len(referenced_ids))
+
+    orphans = [
+        name for name in field_collections
+        if name[len("field_"):] not in referenced_ids
+    ]
+    logger.info("Orphan count: %d (will %s)", len(orphans), "DRY-RUN list" if dry_run else "delete")
+
+    if dry_run:
+        for name in orphans:
+            print(name)
+        return 0
+
+    deleted = 0
+    failures = 0
+    for name in orphans:
+        try:
+            await client.delete_collection(name)
+            deleted += 1
+            if deleted % 25 == 0:
+                logger.info("Progress: %d / %d", deleted, len(orphans))
+        except Exception as exc:
+            failures += 1
+            logger.warning("Failed to delete %s: %s", name, exc)
+
+    logger.info("Done — deleted=%d failures=%d", deleted, failures)
+    return 0 if failures == 0 else 1
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="List orphans without deleting",
+    )
+    args = parser.parse_args()
+    sys.exit(asyncio.run(main(dry_run=args.dry_run)))

--- a/orchestrator/services/coordinator_service.py
+++ b/orchestrator/services/coordinator_service.py
@@ -23,7 +23,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional, Tuple
 from uuid import UUID
 
-from sqlalchemy import and_
+from sqlalchemy import and_, text
 from sqlalchemy.orm import Session
 
 from config import COMPLEXITY_TOKEN_BUDGET, Config, config
@@ -742,14 +742,19 @@ class CoordinatorService:
             return None
 
     async def _cleanup_terminal_fields(self, db: Session) -> None:
-        """Destroy fields for missions that have ended."""
+        """Destroy fields for missions that have ended.
+
+        Each field is its own Qdrant collection — Qdrant loads all collections
+        into memory on startup, so a backlog OOM-crashes Qdrant. Throttle
+        is intentionally generous to drain the backlog quickly.
+        """
         terminal_with_fields = (
             db.query(OrchestrationRun)
             .filter(
                 OrchestrationRun.state.in_([s.value for s in TERMINAL_RUN_STATES]),
                 OrchestrationRun.config["field_id"].astext.isnot(None),
             )
-            .limit(5)  # Throttle — max 5 cleanups per tick
+            .limit(50)
             .all()
         )
         for run in terminal_with_fields:
@@ -762,6 +767,63 @@ class CoordinatorService:
             updated_config.pop("field_id", None)
             run.config = updated_config
             db.flush()
+
+    async def _cleanup_orphan_field_collections(self, db: Session, limit: int = 20) -> None:
+        """Delete Qdrant ``field_*`` collections that no OrchestrationRun references.
+
+        Each mission field is its own Qdrant collection. Abandoned ones survive
+        when a run row is purged or its field_id is cleared without deleting
+        the collection. Qdrant loads every collection's HNSW into memory on
+        startup, so orphans bloat the baseline until pod OOMs.
+        """
+        field = self._get_field()
+        if not field:
+            return
+
+        client = getattr(field, "_client", None)
+        if client is None:
+            return
+
+        try:
+            collections_resp = await client.get_collections()
+        except Exception:
+            logger.debug("[Coordinator] Qdrant get_collections failed", exc_info=True)
+            return
+
+        field_collections = [
+            c.name for c in collections_resp.collections
+            if c.name.startswith("field_")
+        ]
+        if not field_collections:
+            return
+
+        # All field_ids still tied to a mission run (any state — only orphans go)
+        referenced_ids = {
+            row[0] for row in db.execute(
+                text(
+                    "SELECT config->>'field_id' FROM orchestration_runs "
+                    "WHERE config->>'field_id' IS NOT NULL"
+                )
+            ).fetchall()
+            if row[0]
+        }
+
+        deleted = 0
+        for name in field_collections:
+            if deleted >= limit:
+                break
+            field_id = name[len("field_"):]
+            if field_id in referenced_ids:
+                continue
+            try:
+                await client.delete_collection(name)
+                deleted += 1
+                logger.info("[Coordinator] Deleted orphan field collection %s", name)
+            except Exception:
+                logger.warning("[Coordinator] Failed to delete orphan %s", name, exc_info=True)
+
+        if deleted:
+            logger.info("[Coordinator] Orphan cleanup: removed %d field collections", deleted)
 
     async def _save_pending_output_documents(self, db: Session) -> None:
         """Save output documents for completed missions that don't have one yet."""
@@ -878,6 +940,14 @@ class CoordinatorService:
                 # --- PRD-108: Clean up fields for terminal runs ---
                 await self._cleanup_terminal_fields(db)
                 db.commit()  # Persist field_id removal to stop destroy loop
+
+                # --- PRD-108: Drop orphan Qdrant collections (no mission row) ---
+                # Each field is its own collection; abandoned collections
+                # accumulate and crash Qdrant on startup (OOM). Throttled.
+                try:
+                    await self._cleanup_orphan_field_collections(db, limit=20)
+                except Exception:
+                    logger.warning("[Coordinator] Orphan field cleanup failed", exc_info=True)
 
                 # --- Save output docs for completed missions ---
                 await self._save_pending_output_documents(db)


### PR DESCRIPTION
mem0:
- split timeout into MEM0_TIMEOUT_SECONDS (3s reads) and MEM0_WRITE_TIMEOUT_SECONDS (15s writes) — writes do sync inference server-side (2-7s), the old 3s tripped the circuit breaker into 5-min blackouts every few minutes
- downgrade 404 on get_all/search to debug — expected for fresh agents with no memories yet, was flooding logs

llm pilot fallback:
- startup log surfaces whether OPENROUTER_API_KEY is set so the next pilot signup failure tells us at a glance
- error message names the exact env var to fix instead of the cryptic "API key not found for provider: openrouter"

qdrant field memory (OOM crash loop):
- new field collections use on_disk vectors/HNSW/payload so future collections don't add RAM baseline
- raise terminal-field cleanup throttle 5 -> 50 per tick
- add orphan-field cleanup: deletes field_* collections in Qdrant with no matching orchestration_runs.config.field_id
- one-shot script scripts/nuke_orphan_field_collections.py for clearing the backlog in a single pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic detection and cleanup of orphan vector collections no longer referenced by active operations.

* **Improvements**
  * Enhanced error messaging when API credentials are unavailable, with clear guidance on configuration.
  * System now reports OpenRouter fallback status during startup.
  * Optimized vector storage persistence and request timeout handling for improved reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AutomatosAI/automatos-ai/pull/321)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->