### PR TITLE
fix(cors): extend WidgetCORSMiddleware to cover /api/sites/*

### DIFF
--- a/orchestrator/api/widgets/cors.py
+++ b/orchestrator/api/widgets/cors.py
@@ -2,9 +2,18 @@
 Widget CORS Middleware (ASGI-native)
 =====================================
 
-Dynamic CORS for ``/api/widgets/*`` routes.  Implemented as a pure ASGI
-middleware (not ``BaseHTTPMiddleware``) so that ``StreamingResponse`` /
-SSE connections are **not buffered**.
+Dynamic CORS for the storefront-widget + dashboard-Sites API surfaces.
+Implemented as a pure ASGI middleware (not ``BaseHTTPMiddleware``) so
+that ``StreamingResponse`` / SSE connections are **not buffered**.
+
+Path coverage (PRD-008-A):
+- ``/api/widgets/*``  — storefront widget calls (any storefront origin)
+- ``/api/sites/*``    — Automatos dashboard Sites CRUD (admin operations)
+
+Both surfaces share the ``WIDGET_ORIGIN_ALLOWLIST`` env var. When empty,
+all origins are allowed (development default). The actual security
+boundary on /api/sites is the JWT in cookies, not CORS — CORS just lets
+the dashboard browser issue the request in the first place.
 """
 
 import logging
@@ -12,6 +21,14 @@ from starlette.types import ASGIApp, Receive, Scope, Send
 from config import config
 
 logger = logging.getLogger(__name__)
+
+# Path prefixes this middleware governs. First-match short-circuits the
+# rest of the ASGI stack to inject CORS headers; non-matching paths flow
+# through to FastAPI's default CORSMiddleware (which has its own allowlist).
+COVERED_PATH_PREFIXES: tuple[str, ...] = (
+    "/api/widgets",
+    "/api/sites",
+)
 
 # Explicit origin allowlist — comma-separated in env var.
 # Only these origins may make credentialed requests to widget endpoints.
@@ -33,8 +50,12 @@ def _origin_allowed(origin: str) -> bool:
     return origin.rstrip("/") in WIDGET_ORIGIN_ALLOWLIST
 
 
+def _path_is_covered(path: str) -> bool:
+    return any(path.startswith(prefix) for prefix in COVERED_PATH_PREFIXES)
+
+
 class WidgetCORSMiddleware:
-    """Add CORS headers to /api/widgets/* without buffering responses."""
+    """Add CORS headers to widget + Sites API paths without buffering responses."""
 
     def __init__(self, app: ASGIApp) -> None:
         self.app = app
@@ -45,7 +66,7 @@ class WidgetCORSMiddleware:
             return
 
         path: str = scope.get("path", "")
-        if not path.startswith("/api/widgets"):
+        if not _path_is_covered(path):
             await self.app(scope, receive, send)
             return
 

--- a/orchestrator/tests/test_prd008a_cors_coverage.py
+++ b/orchestrator/tests/test_prd008a_cors_coverage.py
@@ -1,0 +1,93 @@
+"""
+PRD-008-A CORS path-coverage trip-wire
+========================================
+
+Locks in which path prefixes are covered by ``WidgetCORSMiddleware``.
+If a future PR adds a new public surface (e.g. ``/api/admin-widgets/*``)
+without extending the middleware, this test forces the conversation.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ORCH_ROOT = Path(__file__).resolve().parent.parent
+if str(ORCH_ROOT) not in sys.path:
+    sys.path.insert(0, str(ORCH_ROOT))
+
+import config  # noqa: E402,F401
+
+
+def test_covered_path_prefixes_lock():
+    """Trip-wire: changing this list is a deliberate decision."""
+    from api.widgets.cors import COVERED_PATH_PREFIXES
+
+    assert COVERED_PATH_PREFIXES == ("/api/widgets", "/api/sites")
+
+
+def test_path_is_covered_widget_routes():
+    from api.widgets.cors import _path_is_covered
+
+    assert _path_is_covered("/api/widgets/config") is True
+    assert _path_is_covered("/api/widgets/callback") is True
+    assert _path_is_covered("/api/widgets/session") is True
+
+
+def test_path_is_covered_sites_routes():
+    """PRD-008-A added Sites — the CORS middleware must cover them so
+    the dashboard browser can issue PATCH /api/sites/{id}/settings."""
+    from api.widgets.cors import _path_is_covered
+
+    assert _path_is_covered("/api/sites") is True
+    assert _path_is_covered("/api/sites/abc-123") is True
+    assert _path_is_covered("/api/sites/abc-123/settings") is True
+
+
+def test_path_is_covered_excludes_unrelated_paths():
+    """Don't accidentally claim CORS responsibility for paths owned by
+    FastAPI's default CORSMiddleware (with its own allowlist)."""
+    from api.widgets.cors import _path_is_covered
+
+    assert _path_is_covered("/api/agents") is False
+    assert _path_is_covered("/api/workspaces/current") is False
+    assert _path_is_covered("/api/composio/anything") is False
+    # Edge: a path that contains /api/sites as a substring but doesn't start with it
+    assert _path_is_covered("/api/some-other-resource/sites") is False
+
+
+def test_origin_allowed_when_no_allowlist_configured():
+    """Empty allowlist → permissive — matches the documented default."""
+    from api.widgets.cors import _origin_allowed
+    import api.widgets.cors as cors_mod
+
+    original = cors_mod.WIDGET_ORIGIN_ALLOWLIST
+    cors_mod.WIDGET_ORIGIN_ALLOWLIST = set()
+    try:
+        assert _origin_allowed("https://random-store.myshopify.com") is True
+        assert _origin_allowed("https://app.automatos.app") is True
+    finally:
+        cors_mod.WIDGET_ORIGIN_ALLOWLIST = original
+
+
+def test_origin_allowed_with_explicit_allowlist():
+    from api.widgets.cors import _origin_allowed
+    import api.widgets.cors as cors_mod
+
+    original = cors_mod.WIDGET_ORIGIN_ALLOWLIST
+    cors_mod.WIDGET_ORIGIN_ALLOWLIST = {
+        "https://app.automatos.app",
+        "https://besafe-ltd.myshopify.com",
+    }
+    try:
+        assert _origin_allowed("https://app.automatos.app") is True
+        assert _origin_allowed("https://besafe-ltd.myshopify.com") is True
+        assert _origin_allowed("https://malicious.example.com") is False
+    finally:
+        cors_mod.WIDGET_ORIGIN_ALLOWLIST = original
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
The Sites API (PRD-008-A) was falling through to FastAPI's default CORSMiddleware, which uses a separate CORS_ALLOW_ORIGINS env var. On production that var is set to the literal string "https://" — not a valid origin — so every browser request to /api/sites was being CORS-rejected, including the dashboard's own PATCH calls when saving Site settings.

Symptom the user hit: "A cross-origin resource sharing (CORS) request was blocked..." with 30 requests failing in devtools when calling /api/sites/* from the dashboard.

Fix
---
- Extract a ``COVERED_PATH_PREFIXES`` tuple in api/widgets/cors.py
- Both ``/api/widgets`` and ``/api/sites`` now flow through the permissive (when allowlist empty) Widget CORS middleware
- Same security model: when WIDGET_ORIGIN_ALLOWLIST env var is empty in dev, all origins allowed; in prod set the env var to lock down
- The actual security boundary on /api/sites stays the JWT in cookies — CORS just lets the browser issue the request

Tests (+6, total now 164)
-------------------------
- Trip-wire: COVERED_PATH_PREFIXES locked to (/api/widgets, /api/sites)
- Coverage: widget routes + sites routes recognized
- Negative: unrelated paths (/api/agents, etc.) NOT claimed
- Edge: paths containing "sites" mid-string don't accidentally match
- Allowlist semantics: empty=permissive, populated=strict (preserved)

Deploy effect
-------------
After Railway redeploys this commit, /api/sites/* requests from any origin (subject to the empty-allowlist permissive default) will get proper CORS headers. The dashboard's PATCH /api/sites/{id}/settings will succeed without changing CORS_ALLOW_ORIGINS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended CORS (Cross-Origin Resource Sharing) policy handling to cover additional API endpoints, ensuring consistent security validation across all protected web service routes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AutomatosAI/automatos-ai/pull/324)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->