### PR TITLE
fix(cors): strip upstream CORS headers to prevent duplicates

### DIFF
--- a/orchestrator/api/widgets/cors.py
+++ b/orchestrator/api/widgets/cors.py
@@ -97,12 +97,26 @@ class WidgetCORSMiddleware:
             await send({"type": "http.response.body", "body": b""})
             return
 
-        # For actual requests, inject CORS headers only for allowed origins
+        # For actual requests, inject CORS headers only for allowed origins.
+        # Strip any CORS headers an upstream middleware (e.g. FastAPI's
+        # CORSMiddleware) already added — duplicate Access-Control-Allow-*
+        # headers cause Chrome to reject the response with "Failed to fetch".
         allowed = _origin_allowed(origin) if origin else False
+
+        _CORS_HEADERS_TO_OVERRIDE = (
+            b"access-control-allow-origin",
+            b"access-control-allow-credentials",
+            b"vary",
+        )
 
         async def send_with_cors(message: dict) -> None:
             if message["type"] == "http.response.start":
-                headers = list(message.get("headers", []))
+                upstream = list(message.get("headers", []))
+                # Drop any CORS headers from upstream so we own them exclusively.
+                headers = [
+                    (k, v) for (k, v) in upstream
+                    if k.lower() not in _CORS_HEADERS_TO_OVERRIDE
+                ]
                 headers.append((b"vary", b"Origin"))
                 if origin and allowed:
                     headers.append((b"access-control-allow-origin", origin.encode("latin-1")))


### PR DESCRIPTION
The response on /api/sites carried two
'access-control-allow-credentials: true' headers — one from FastAPI's CORSMiddleware, one from WidgetCORSMiddleware. Chrome silently rejects duplicate Access-Control-Allow-* headers, surfacing as 'Failed to fetch' in the browser even though every server-side log shows a clean 200/401.

The reason this didn't bite earlier: only storefronts called /api/widgets/* — they don't preflight against app.automatos.app, so the duplicate headers were never evaluated. The dashboard browser is the first cross-origin caller of these middleware-covered paths.

Fix: WidgetCORSMiddleware now strips every CORS header from the upstream response before appending its own. We own them exclusively for covered paths.