### PR TITLE
feat(widgets/chat): PRD-009 Layer 1 — enriched grounding for proactiv…

### DIFF
--- a/orchestrator/api/widgets/chat.py
+++ b/orchestrator/api/widgets/chat.py
@@ -66,27 +66,69 @@ class WidgetChatRequest(BaseModel):
 PROACTIVE_TRIGGER_REASONS: frozenset[str] = frozenset({"proactive_opener"})
 
 
+# Fields from page_context that the agent gets to ground openers on.
+# Order matters — first match per group wins. Numeric/boolean fields are
+# coerced to strings only when present + non-default.
+_OPENER_CONTEXT_FIELDS: tuple[tuple[str, str], ...] = (
+    ("pageType",          "page_type"),
+    ("template",          "template"),
+    # Product
+    ("productTitle",      "product"),
+    ("productType",       "product_type"),
+    ("productVendor",     "vendor"),
+    ("productPrice",      "price"),
+    ("productAvailable",  "in_stock"),
+    ("productHandle",     "product_handle"),
+    # Collection (when on a collection page)
+    ("collectionTitle",   "collection"),
+    ("collectionHandle",  "collection_handle"),
+    # Shop / locale
+    ("shopDomain",        "shop"),
+    ("shopCurrency",      "currency"),
+    ("shopLocale",        "locale"),
+    # Customer / cart
+    ("customerId",        "logged_in_customer_id"),
+    ("customerTags",      "customer_tags"),
+    ("cartItemCount",     "cart_item_count"),
+    ("cartTotalPrice",    "cart_total"),
+)
+
+
+def _format_opener_context_value(key: str, value) -> Optional[str]:
+    """Render a single page-context value into the directive. Returns None
+    if the value is empty/zero/false and shouldn't be sent to the agent."""
+    if value is None or value == "" or value == 0 or value is False:
+        return None
+    if isinstance(value, str):
+        return f'{key}="{value}"' if " " in value or '"' in value else f"{key}={value}"
+    return f"{key}={value}"
+
+
 def _build_proactive_opener_message(page_context: dict) -> str:
     """Synthesize the user-side message for a proactive opener request.
 
     The widget never sends real user text for proactive openers — instead
-    we synthesize a directive describing the page context. The agent's
-    ``shopify-support`` skill recognises the ``[PROACTIVE_OPENER]`` prefix
-    and generates a one-sentence contextual greeting.
+    we synthesize a directive carrying the FULL page context the agent
+    needs to ground a contextual one-line opener.
+
+    PRD-007 v0.4: previously only pageType + productTitle/Type leaked into
+    the directive; agents had to make up everything else (price, vendor,
+    availability). Now every populated page_context field is forwarded so
+    the agent can lean on real facts before reaching for a tool call.
     """
-    ctx_summary_parts: list[str] = []
-    if page_context.get("pageType"):
-        ctx_summary_parts.append(f"page_type={page_context['pageType']}")
-    if page_context.get("productTitle"):
-        ctx_summary_parts.append(f"product=\"{page_context['productTitle']}\"")
-    elif page_context.get("productHandle"):
-        ctx_summary_parts.append(f"product_handle={page_context['productHandle']}")
-    if page_context.get("productType"):
-        ctx_summary_parts.append(f"product_type={page_context['productType']}")
-    if page_context.get("collectionTitle"):
-        ctx_summary_parts.append(f"collection=\"{page_context['collectionTitle']}\"")
-    summary = ", ".join(ctx_summary_parts) if ctx_summary_parts else "no context"
-    return f"[PROACTIVE_OPENER] Generate a contextual one-sentence opener. Context: {summary}"
+    parts: list[str] = []
+    for src_key, label in _OPENER_CONTEXT_FIELDS:
+        rendered = _format_opener_context_value(label, page_context.get(src_key))
+        if rendered is not None:
+            parts.append(rendered)
+    summary = ", ".join(parts) if parts else "no context"
+    return (
+        "[PROACTIVE_OPENER] Generate a contextual one-sentence opener. "
+        "Use the facts below as your source of truth — do NOT invent specs, "
+        "compatibility, or pricing the context doesn't include. If a fact "
+        "you'd want isn't here, ask a question instead of fabricating. "
+        f"Context: {summary}"
+    )
 
 
 class WidgetMessageOut(BaseModel):

--- a/orchestrator/tests/test_widget_proactive_prd007.py
+++ b/orchestrator/tests/test_widget_proactive_prd007.py
@@ -145,6 +145,64 @@ def test_opener_message_handles_collection_pages():
     assert "Fans & Ventilation" in msg
 
 
+def test_opener_message_includes_full_grounding_context():
+    """PRD-007 v0.4: rich page context grounds the agent so it stops
+    inventing facts. Every populated field should reach the directive."""
+    from api.widgets.chat import _build_proactive_opener_message
+
+    msg = _build_proactive_opener_message({
+        "pageType": "product",
+        "productTitle": "Actulux SVM 4 amp Micro 24V Basic",
+        "productType": "Smoke Control",
+        "productVendor": "Actulux",
+        "productPrice": "362.18",
+        "productAvailable": True,
+        "productHandle": "actulux-svm-basic",
+        "shopDomain": "inbuilduk.com",
+        "shopCurrency": "GBP",
+        "cartItemCount": 0,
+    })
+    # All the rich facts the agent would otherwise invent
+    assert "Actulux SVM 4 amp Micro 24V Basic" in msg
+    assert "Smoke Control" in msg
+    assert "Actulux" in msg
+    assert "362.18" in msg
+    assert "in_stock=True" in msg
+    assert "GBP" in msg
+    # Anti-fabrication directive
+    assert "do NOT invent" in msg
+
+
+def test_opener_message_skips_empty_zero_false_fields():
+    """Don't pollute the directive with empty / zero / false signals."""
+    from api.widgets.chat import _build_proactive_opener_message
+
+    msg = _build_proactive_opener_message({
+        "pageType": "product",
+        "productTitle": "Widget",
+        "productAvailable": False,        # should NOT appear
+        "cartItemCount": 0,                # should NOT appear
+        "productVendor": "",               # should NOT appear
+        "customerId": None,                # should NOT appear
+    })
+    assert "in_stock" not in msg
+    assert "cart_item_count" not in msg
+    assert "vendor" not in msg
+    assert "logged_in_customer_id" not in msg
+
+
+def test_opener_message_quotes_values_with_spaces():
+    """Multi-word values (like product titles) need quoting so the agent
+    parses them as single tokens."""
+    from api.widgets.chat import _build_proactive_opener_message
+
+    msg = _build_proactive_opener_message({
+        "pageType": "product",
+        "productTitle": "EN 12101-9 Control Panel",
+    })
+    assert 'product="EN 12101-9 Control Panel"' in msg
+
+
 def test_opener_message_handles_empty_context():
     from api.widgets.chat import _build_proactive_opener_message
 


### PR DESCRIPTION
…e openers

Previously the proactive opener directive only forwarded pageType + productTitle/Type/Handle to the agent — leaving it to invent price, vendor, availability, currency, etc. or to round-trip a Composio call on every popup. Both modes produced fabricated facts ("agents made his response up").

This change forwards the full populated page_context to the agent in the synthesized [PROACTIVE_OPENER] directive and adds an explicit anti-fabrication clause: use the facts as source of truth; if a fact isn't here, ASK rather than make one up.

Empty / zero / false fields are skipped so the directive stays tight (no "in_stock=False" pollution on out-of-stock products that wasn't the point of the popup). String values with spaces are quoted so the agent reads them as single tokens.

Layer 1 of the PRD-009 product knowledge grounding plan. Layers 2–3 (catalog sync via Composio bulk → pgvector embeddings; live actions via Composio per-query) are still scoped, not built.

Tests
-----
+3 unit tests in test_widget_proactive_prd007.py:
- test_opener_message_includes_full_grounding_context
- test_opener_message_skips_empty_zero_false_fields
- test_opener_message_quotes_values_with_spaces

19/19 pass locally.