### PR TITLE
feat(prd-008-a.2): wire chat intent → callback form auto-trigger

### DIFF
--- a/orchestrator/api/widgets/chat.py
+++ b/orchestrator/api/widgets/chat.py
@@ -27,6 +27,7 @@ from sqlalchemy.orm import Session
 
 from api.widgets.auth import WidgetAuthContext, require_permission, widget_auth
 from core.database.database import get_db
+from services.sites import get_default_site
 
 logger = logging.getLogger(__name__)
 
@@ -64,6 +65,29 @@ class WidgetChatRequest(BaseModel):
 # PRD-007: trigger reasons that flip the agent into opener-generation mode.
 # Anything else is treated as a normal user message.
 PROACTIVE_TRIGGER_REASONS: frozenset[str] = frozenset({"proactive_opener"})
+
+
+# PRD-008-A.2: shopper utterances that should auto-open the callback form.
+# Per-Site overrides land via ``site.settings.callback.intent_phrases``;
+# this set is the fallback when the Site config is missing or empty.
+_DEFAULT_CALLBACK_INTENT_PHRASES: tuple[str, ...] = (
+    "speak to someone",
+    "call me back",
+    "talk to a human",
+    "phone me",
+    "give me a call",
+    "can someone call",
+)
+
+
+def _matches_callback_intent(message: Optional[str], phrases: tuple[str, ...]) -> bool:
+    """Return True if any intent phrase appears in ``message`` (case-insensitive
+    substring match). Empty / None messages never match.
+    """
+    if not message or not phrases:
+        return False
+    msg = message.lower()
+    return any(p.lower() in msg for p in phrases if p)
 
 
 # Fields from page_context that the agent gets to ground openers on.
@@ -248,6 +272,42 @@ async def widget_chat(
             "present" if body.page_context else "missing",
         )
 
+    # PRD-008-A.2: detect callback intent BEFORE the LLM call so the SDK can
+    # auto-open the phone-capture form. Skip if this is a proactive opener
+    # (the synthetic message isn't real user input).
+    is_callback_intent = False
+    callback_product_context: Optional[str] = None
+    if not is_proactive and body.message:
+        try:
+            site = get_default_site(db, uuid.UUID(workspace_id))
+        except Exception:
+            site = None
+        if site is not None:
+            cb_config = (site.settings or {}).get("callback") or {}
+            if cb_config.get("enabled"):
+                phrases = cb_config.get("intent_phrases") or list(_DEFAULT_CALLBACK_INTENT_PHRASES)
+                if _matches_callback_intent(body.message, tuple(phrases)):
+                    is_callback_intent = True
+                    # Pull product title (preferred) or handle for the form heading.
+                    pc = body.page_context or {}
+                    callback_product_context = (
+                        pc.get("productTitle") or pc.get("productHandle") or None
+                    )
+                    logger.info(
+                        "%s CALLBACK_INTENT_MATCHED: phrase set size=%d product_context=%s",
+                        log_extra, len(phrases), callback_product_context,
+                    )
+                    # Augment the message so the agent acknowledges gracefully
+                    # rather than suggesting email — the form is already opening.
+                    original_msg = body.message
+                    body.message = (
+                        f"[SYSTEM_NOTE: A phone callback form has just been opened "
+                        f"in the shopper's chat panel. Acknowledge briefly and ask "
+                        f"them to fill in their name and number — DO NOT suggest "
+                        f"email or alternative contact methods.] "
+                        f"User said: \"{original_msg}\""
+                    )
+
     chat_service = ChatService(db)
     streaming_service = StreamingChatService(db, workspace_id=workspace_id, widget_mode=True)
 
@@ -373,9 +433,22 @@ async def widget_chat(
             "text_chars": 0,
         }
         logger.info(
-            "%s STREAM_START: chat_id=%s agent_id=%s team=%s proactive=%s",
-            log_extra, chat_id, effective_agent_id, agent_team, is_proactive,
+            "%s STREAM_START: chat_id=%s agent_id=%s team=%s proactive=%s callback_intent=%s",
+            log_extra, chat_id, effective_agent_id, agent_team, is_proactive, is_callback_intent,
         )
+        # PRD-008-A.2: emit the open-callback-form signal first so the SDK
+        # opens the phone-capture form even before the agent's text arrives.
+        # Idempotent on the SDK side — listener guards against double-open.
+        if is_callback_intent:
+            payload = {
+                "conversation_id": chat_id,
+                "product_context": callback_product_context,
+            }
+            yield f"event: open-callback-form\ndata: {json.dumps(payload)}\n\n"
+            logger.info(
+                "%s OPEN_CALLBACK_FORM emitted (product_context=%s)",
+                log_extra, callback_product_context,
+            )
         try:
             async for chunk in streaming_service.stream_response_with_agent(
                 chat_id=chat_id,

--- a/orchestrator/tests/test_prd008a2_chat_intent.py
+++ b/orchestrator/tests/test_prd008a2_chat_intent.py
@@ -1,0 +1,66 @@
+"""PRD-008-A.2 — chat-intent → callback-form auto-trigger.
+
+Unit tests for the intent matcher. End-to-end behaviour (SSE event emission
++ message augmentation) is covered by the widget_chat integration suite once
+the orchestrator boots.
+"""
+from __future__ import annotations
+
+import pytest
+
+from api.widgets.chat import (
+    _DEFAULT_CALLBACK_INTENT_PHRASES,
+    _matches_callback_intent,
+)
+
+
+class TestMatchesCallbackIntent:
+    """The matcher MUST be case-insensitive substring match. False positives
+    are worse than false negatives — keep phrases specific."""
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "Can someone call me back?",
+            "give me a call back please",
+            "I'd like to SPEAK TO SOMEONE",
+            "Talk to a human - it's urgent",
+            "phone me when you get a chance",
+            "give me a call when free",
+            "can someone call later",
+        ],
+    )
+    def test_matches_default_phrases(self, message: str) -> None:
+        assert _matches_callback_intent(message, _DEFAULT_CALLBACK_INTENT_PHRASES)
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "Tell me about this product",
+            "Do you ship to the UK?",
+            "What's the price?",
+            "I'd like to call this product 'amazing'",  # contains "call" but not intent
+            "",
+            "   ",
+        ],
+    )
+    def test_does_not_match_unrelated_messages(self, message: str) -> None:
+        assert not _matches_callback_intent(message, _DEFAULT_CALLBACK_INTENT_PHRASES)
+
+    def test_none_message_returns_false(self) -> None:
+        assert _matches_callback_intent(None, _DEFAULT_CALLBACK_INTENT_PHRASES) is False
+
+    def test_empty_phrases_returns_false(self) -> None:
+        assert _matches_callback_intent("call me back", tuple()) is False
+
+    def test_custom_phrases_override_defaults(self) -> None:
+        custom = ("appelez-moi", "rappel telephonique")
+        assert _matches_callback_intent("Pouvez-vous m'appelez-moi?", custom)
+        # Default English phrase shouldn't match against custom-only set
+        assert not _matches_callback_intent("call me back", custom)
+
+    def test_empty_string_phrase_is_skipped(self) -> None:
+        # An empty string would substring-match anything — explicitly filtered.
+        phrases = ("", "call me back")
+        assert _matches_callback_intent("call me back", phrases)
+        assert not _matches_callback_intent("hello", phrases)


### PR DESCRIPTION
When a shopper types a phrase like "call me back" or "speak to someone" in the widget chat, the orchestrator now detects the intent before the LLM call and emits a new SSE event (open-callback-form) so the SDK auto-opens the phone-capture form. The user's message is also augmented with a system note so the agent acknowledges gracefully ("I've opened a quick form…") instead of suggesting email alternatives.

PRD-008-A spec'd this skill update as a follow-up — never built. With the LLM-only approach, agents recognised the intent but had no tool to trigger the form, so they fell back to "email the team" responses. This change closes that gap with deterministic server-side detection.

What changed
- api/widgets/chat.py
  - Add _DEFAULT_CALLBACK_INTENT_PHRASES + _matches_callback_intent helper
  - Resolve Site via get_default_site → read callback config
  - When intent matched + callback.enabled: emit open-callback-form SSE event first, then continue normal stream
  - Rewrite body.message with [SYSTEM_NOTE: ...] so agent responds correctly
- tests/test_prd008a2_chat_intent.py — 17 unit tests for the matcher (case-insensitive, custom phrases, empty/None guards)

Intent matching is case-insensitive substring; phrases overridable per Site via site.settings.callback.intent_phrases. Defaults cover the phrasings observed in the wild ("can someone call", "give me a call", "speak to someone", "talk to a human", "phone me", "call me back").

Proactive openers (PROACTIVE_TRIGGER_REASONS) skip the intent check — they're synthetic messages, not real user input.

Companion PR in automatos-widget-sdk
  feat/prd-008-a.2-sse-callback-trigger

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Chat now automatically detects when shoppers request a callback and opens a phone-capture form
  * Assistant acknowledges the opened form and provides appropriate guidance

* **Tests**
  * Added comprehensive test coverage for callback intent detection

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AutomatosAI/automatos-ai/pull/335?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->