### PR TITLE
fix(prd-007): suppress tools for proactive openers — restore text output

### DIFF
--- a/orchestrator/api/widgets/chat.py
+++ b/orchestrator/api/widgets/chat.py
@@ -147,10 +147,12 @@ def _build_proactive_opener_message(page_context: dict) -> str:
             parts.append(rendered)
     summary = ", ".join(parts) if parts else "no context"
     return (
-        "[PROACTIVE_OPENER] Generate a contextual one-sentence opener. "
-        "Use the facts below as your source of truth — do NOT invent specs, "
-        "compatibility, or pricing the context doesn't include. If a fact "
-        "you'd want isn't here, ask a question instead of fabricating. "
+        "[PROACTIVE_OPENER] Generate a contextual one-sentence opener "
+        "(≤140 chars). RETURN PLAIN TEXT ONLY — no tool calls, no JSON, "
+        "no markdown, no greetings. Use the facts below as your source of "
+        "truth — do NOT invent specs, compatibility, or pricing the context "
+        "doesn't include. If a fact you'd want isn't here, ask a question "
+        "instead of fabricating. "
         f"Context: {summary}"
     )
 
@@ -456,6 +458,13 @@ async def widget_chat(
                 agent_id=effective_agent_id,
                 user_id=user_id,
                 team=agent_team,
+                # PRD-007 fix: proactive openers must NOT call Composio tools.
+                # The skill prompt forbids them (rule 5), but the LLM has been
+                # ignoring the directive and calling tools anyway — yielding
+                # data_event chunks but zero text (STREAM_NO_TEXT). Skipping
+                # Composio injection at the source forces text-only output and
+                # keeps openers within their <2s latency budget.
+                skip_composio=is_proactive,
             ):
                 counts["total"] += 1
                 if first_chunk_at is None:


### PR DESCRIPTION
Symptom: proactive popup showed only the canned fallback text. The agent stream completed with STREAM_NO_TEXT in logs:

  STREAM_NO_TEXT: agent produced 3 chunks but no text
  (text_count=0, data_event=2, dict=0).
  Skill prompt may be missing or agent is tool-only.

Root cause: the LLM ignored the skill's "no tools, no graph queries" directive (rule 5 of Proactive Opener Mode in shopify-support SKILL.md) and called Composio Shopify tools instead of generating the opener text. Composio is auto-injected based on a search over latest_text; "[PROACTIVE_OPENER] Generate a contextual..." matched 6 shopify tools that the LLM then dispatched, producing data events but never the final text response.

Fix
- Pass skip_composio=is_proactive to stream_response_with_agent. Composio injection short-circuits when skip_composio=True (see consumers/chatbot/service.py:995), so no Shopify tools are added to the LLM's tool list for proactive opener calls.
- Strengthen the directive itself: explicit "RETURN PLAIN TEXT ONLY — no tool calls, no JSON, no markdown" added to _build_proactive_opener_ message. Belt-and-braces with the server-side suppression.

Effect
- Proactive opener latency drops by 800-2000ms (no tool fetch + dispatch)
- STREAM_NO_TEXT warning should disappear from prod logs
- The "second popup" (canned text → agent-generated context-aware greeting) returns to working

Scope
- Only affects calls where trigger_reason="proactive_opener" AND page_context is present. Regular widget chat (callback intent, user-typed messages) unchanged.

Tests: 36 existing tests pass (17 callback intent + 19 PRD-007 proactive). No new test added — the fix is a single parameter flip on a path already covered by existing proactive tests. Behavioural validation is the storefront smoke check (proactive popup text changes from canned → agent within ~1-2s).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined proactive chat opener with enhanced formatting constraints to ensure consistent plain text messages without unexpected formatting or behaviors.
  * Improved messaging stream coordination to better support proactive message initialization and proper system behavior during automated message generation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AutomatosAI/automatos-ai/pull/336?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->