### PR TITLE
feat(prd-008-a.4): "Send test" button + endpoint for callback destina…

### DIFF
--- a/frontend/components/sites/CallbackPanel.tsx
+++ b/frontend/components/sites/CallbackPanel.tsx
@@ -5,7 +5,11 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Switch } from '@/components/ui/switch'
 import { Button } from '@/components/ui/button'
 import { ChannelDestinationPicker } from './destinations/ChannelDestinationPicker'
-import { updateSiteSettings } from '@/lib/sites/api'
+import {
+  sendCallbackTest,
+  updateSiteSettings,
+  type CallbackTestResponse,
+} from '@/lib/sites/api'
 import type { Site, CallbackSettings, CallbackDestination } from '@/lib/sites/types'
 
 const DEFAULTS: CallbackSettings = {
@@ -32,10 +36,19 @@ export function CallbackPanel({
   const [draft, setDraft] = useState<CallbackSettings>(initial)
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [testing, setTesting] = useState(false)
+  const [testResult, setTestResult] = useState<CallbackTestResponse | null>(null)
+  const [testError, setTestError] = useState<string | null>(null)
 
   const dirty = JSON.stringify(draft) !== JSON.stringify(initial)
   const targetsValid = draft.destinations.every((d) => d.target.trim().length > 0)
   const canSave = dirty && !saving && targetsValid
+  // Test runs against what's saved on the server, not the unsaved draft.
+  const canTest =
+    !testing &&
+    !dirty &&
+    initial.destinations.length > 0 &&
+    initial.destinations.every((d) => d.target.trim().length > 0)
 
   async function save() {
     setSaving(true)
@@ -47,6 +60,20 @@ export function CallbackPanel({
       setError(e instanceof Error ? e.message : 'Save failed')
     } finally {
       setSaving(false)
+    }
+  }
+
+  async function runTest() {
+    setTesting(true)
+    setTestResult(null)
+    setTestError(null)
+    try {
+      const resp = await sendCallbackTest(site.id)
+      setTestResult(resp)
+    } catch (e: unknown) {
+      setTestError(e instanceof Error ? e.message : 'Test failed')
+    } finally {
+      setTesting(false)
     }
   }
 
@@ -80,18 +107,67 @@ export function CallbackPanel({
 
         {error && <p className="text-xs text-destructive">{error}</p>}
 
-        <div className="flex justify-end gap-2 pt-2">
+        <div className="flex flex-wrap items-center justify-between gap-2 pt-2">
           <Button
-            variant="outline"
-            disabled={!dirty || saving}
-            onClick={() => setDraft(initial)}
+            variant="ghost"
+            size="sm"
+            disabled={!canTest}
+            onClick={runTest}
+            title={
+              dirty
+                ? 'Save your changes first, then send a test.'
+                : initial.destinations.length === 0
+                ? 'Add at least one destination before testing.'
+                : 'Fires a dummy callback through every configured destination.'
+            }
           >
-            Reset
+            {testing ? 'Sending test…' : 'Send test'}
           </Button>
-          <Button disabled={!canSave} onClick={save}>
-            {saving ? 'Saving…' : 'Save'}
-          </Button>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              disabled={!dirty || saving}
+              onClick={() => setDraft(initial)}
+            >
+              Reset
+            </Button>
+            <Button disabled={!canSave} onClick={save}>
+              {saving ? 'Saving…' : 'Save'}
+            </Button>
+          </div>
         </div>
+
+        {testError && (
+          <p className="text-xs text-destructive">{testError}</p>
+        )}
+
+        {testResult && (
+          <div className="space-y-1 rounded-md border border-border/40 bg-muted/30 p-3 text-xs">
+            <p className="text-foreground font-medium">
+              Test dispatched — request id {testResult.request_id}
+            </p>
+            {testResult.results.length === 0 ? (
+              <p className="text-muted-foreground">
+                No destinations were attempted.
+              </p>
+            ) : (
+              <ul className="space-y-0.5">
+                {testResult.results.map((r, i) => (
+                  <li
+                    key={i}
+                    className={r.success ? 'text-emerald-500' : 'text-destructive'}
+                  >
+                    {r.success ? '✓' : '✗'}{' '}
+                    {r.platform ?? r.destination_type}
+                    {r.target ? ` → ${r.target}` : ''}
+                    {' '}({r.latency_ms}ms)
+                    {r.error ? ` — ${r.error}` : ''}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        )}
       </CardContent>
     </Card>
   )

--- a/frontend/lib/sites/api.ts
+++ b/frontend/lib/sites/api.ts
@@ -43,3 +43,35 @@ export async function updateSiteSettings(
     settings: settingsPatch,
   });
 }
+
+/**
+ * Result for a single destination from `sendCallbackTest`.
+ * Mirrors the orchestrator's `CallbackTestDestinationResult` schema.
+ */
+export interface CallbackTestDestinationResult {
+  destination_type: string;
+  success: boolean;
+  latency_ms: number;
+  error?: string | null;
+  platform?: string | null;
+  target?: string | null;
+}
+
+export interface CallbackTestResponse {
+  request_id: string;
+  destinations_attempted: number;
+  results: CallbackTestDestinationResult[];
+}
+
+/**
+ * Fire a synthetic callback through the site's configured destinations.
+ * Used by the dashboard's "Send test" button so merchants can prove their
+ * Telegram / Slack / WhatsApp wiring works without needing a real shopper
+ * submission.
+ */
+export async function sendCallbackTest(siteId: string): Promise<CallbackTestResponse> {
+  return apiClient.post<CallbackTestResponse>(
+    `/api/sites/${siteId}/callback/test`,
+    {},
+  );
+}

--- a/orchestrator/api/sites.py
+++ b/orchestrator/api/sites.py
@@ -35,7 +35,9 @@ from core.auth.hybrid import get_request_context_hybrid
 from core.database.database import get_db
 from core.models.channels import ChannelConnection
 from core.models.sites import SITE_TYPES
-from services.destinations.base import DESTINATION_TYPES
+from services.callback import new_request_id
+from services.destinations.base import CallbackPayload, DESTINATION_TYPES
+from services.destinations.dispatcher import dispatch_callback_for_site
 
 from services.sites import (
     USER_SETTABLE_STATUSES,
@@ -230,3 +232,101 @@ async def patch_site_settings_route(
     if site is None:
         raise HTTPException(status_code=404, detail="Site not found")
     return public_site_dict(site)
+
+
+# ---------------------------------------------------------------------------
+# POST /api/sites/{site_id}/callback/test
+#
+# Fires a synthetic callback through every configured destination and waits
+# for the dispatcher to report per-destination success/failure. Used by the
+# dashboard's CallbackPanel "Send test" button so a merchant can prove their
+# Telegram / Slack / WhatsApp wiring works without needing a real shopper
+# submission.
+#
+# Phone is a fixed obvious placeholder so anyone receiving the message in
+# the destination channel can tell it's a test — never a real lead.
+# ---------------------------------------------------------------------------
+
+class CallbackTestDestinationResult(BaseModel):
+    destination_type: str
+    success: bool
+    latency_ms: int
+    error: Optional[str] = None
+    platform: Optional[str] = None
+    target: Optional[str] = None
+
+
+class CallbackTestResponse(BaseModel):
+    request_id: str
+    destinations_attempted: int
+    results: list[CallbackTestDestinationResult]
+
+
+_CALLBACK_TEST_PHONE = "+10000000000"  # Reserved test-only number, never dialed.
+_CALLBACK_TEST_NAME = "Dashboard test"
+_CALLBACK_TEST_TOPIC = "Test callback from the dashboard — no action required."
+
+
+@router.post("/{site_id}/callback/test", response_model=CallbackTestResponse)
+async def send_callback_test_route(
+    site_id: UUID,
+    ctx: RequestContext = Depends(get_request_context_hybrid),
+    db: Session = Depends(get_db),
+) -> CallbackTestResponse:
+    site = get_site(db, ctx.workspace_id, site_id)
+    if site is None:
+        raise HTTPException(status_code=404, detail="Site not found")
+
+    callback_settings = (site.settings or {}).get("callback") or {}
+    destinations = callback_settings.get("destinations") or []
+    if not destinations:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "No destinations configured. Add one under "
+                "Settings → Widgets SDK → Callback before testing."
+            ),
+        )
+
+    request_id = new_request_id()
+    payload = CallbackPayload(
+        request_id=request_id,
+        name=_CALLBACK_TEST_NAME,
+        phone=_CALLBACK_TEST_PHONE,
+        product_context=_CALLBACK_TEST_TOPIC,
+        urgency=None,
+        preferred_time=None,
+        site_display_name=site.display_name,
+        site_external_id=site.external_id,
+    )
+
+    results = await dispatch_callback_for_site(
+        site_id=site.id,
+        workspace_id=site.workspace_id,
+        session_id=f"dashboard-test-{request_id}",
+        request_id=request_id,
+        payload=payload,
+        destinations=destinations,
+    )
+
+    logger.info(
+        "callback test %s dispatched for site=%s (%d destination(s), %d success)",
+        request_id, site.id, len(destinations),
+        sum(1 for r in results if r.success),
+    )
+
+    return CallbackTestResponse(
+        request_id=request_id,
+        destinations_attempted=len(destinations),
+        results=[
+            CallbackTestDestinationResult(
+                destination_type=r.destination_type,
+                success=r.success,
+                latency_ms=r.latency_ms,
+                error=r.error,
+                platform=(r.extra or {}).get("platform") if isinstance(r.extra, dict) else None,
+                target=(r.extra or {}).get("target") if isinstance(r.extra, dict) else None,
+            )
+            for r in results
+        ],
+    )

--- a/orchestrator/tests/test_prd008a_callback_test_endpoint.py
+++ b/orchestrator/tests/test_prd008a_callback_test_endpoint.py
@@ -1,0 +1,161 @@
+"""PRD-008-A — POST /api/sites/{id}/callback/test endpoint.
+
+The "Send test" button in the dashboard's CallbackPanel hits this route
+to fire a synthetic callback through every configured destination so a
+merchant can prove their Telegram/Slack/WhatsApp wiring works without
+needing a real shopper submission.
+
+These tests cover the contract:
+- 404 when the Site doesn't belong to the requesting workspace
+- 400 when no destinations are configured
+- 200 + per-destination results on the happy path (dispatcher mocked)
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+ORCH_ROOT = Path(__file__).resolve().parent.parent
+if str(ORCH_ROOT) not in sys.path:
+    sys.path.insert(0, str(ORCH_ROOT))
+
+import config  # noqa: E402,F401
+
+
+def _make_site(*, workspace_id=None, destinations=None):
+    return SimpleNamespace(
+        id=uuid4(),
+        workspace_id=workspace_id or uuid4(),
+        type="shopify",
+        external_id="test.myshopify.com",
+        display_name="Test Store",
+        status="active",
+        settings={"callback": {"enabled": True, "destinations": destinations or []}},
+        capabilities={},
+        secrets=None,
+        created_at=datetime(2026, 5, 14, 12, 0, 0, tzinfo=timezone.utc),
+        updated_at=datetime(2026, 5, 14, 12, 0, 0, tzinfo=timezone.utc),
+    )
+
+
+def _make_client(*, site, dispatch_results=None, monkeypatch=None):
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from api.sites import router as sites_router
+    from core.auth.dependencies import RequestContext, UserContext
+    from core.auth.hybrid import get_request_context_hybrid
+    from core.database.database import get_db
+    from services.destinations.base import DispatchResult
+
+    app = FastAPI()
+    app.include_router(sites_router)
+
+    fake_db = MagicMock()
+    workspace_id = site.workspace_id if site else uuid4()
+
+    def _override_ctx():
+        return RequestContext(
+            workspace_id=workspace_id,
+            user=UserContext(id="test-user", email="test@example.com", role="owner"),
+            auth_type="clerk",
+        )
+
+    def _override_db():
+        yield fake_db
+
+    app.dependency_overrides[get_request_context_hybrid] = _override_ctx
+    app.dependency_overrides[get_db] = _override_db
+
+    import api.sites as sites_mod
+
+    monkeypatch.setattr(sites_mod, "get_site", lambda db, ws, sid: site if site and ws == workspace_id else None)
+
+    async def _fake_dispatch(*, site_id, workspace_id, session_id, request_id, payload, destinations):
+        return dispatch_results or []
+
+    monkeypatch.setattr(sites_mod, "dispatch_callback_for_site", _fake_dispatch)
+
+    return TestClient(app), DispatchResult
+
+
+class TestCallbackTestEndpoint:
+    def test_404_when_site_not_in_workspace(self, monkeypatch):
+        client, _ = _make_client(site=None, monkeypatch=monkeypatch)
+        resp = client.post(f"/api/sites/{uuid4()}/callback/test")
+        assert resp.status_code == 404
+
+    def test_400_when_no_destinations(self, monkeypatch):
+        site = _make_site(destinations=[])
+        client, _ = _make_client(site=site, monkeypatch=monkeypatch)
+        resp = client.post(f"/api/sites/{site.id}/callback/test")
+        assert resp.status_code == 400
+        assert "destinations" in resp.json()["detail"].lower()
+
+    def test_200_returns_per_destination_results(self, monkeypatch):
+        site = _make_site(
+            destinations=[
+                {
+                    "type": "channel_connection",
+                    "connection_id": str(uuid4()),
+                    "target": "C123ABC",
+                    "platform": "slack",
+                }
+            ],
+        )
+        from services.destinations.base import DispatchResult
+
+        results = [
+            DispatchResult(
+                success=True,
+                destination_type="channel_connection",
+                latency_ms=142,
+                extra={"platform": "slack", "target": "C123ABC"},
+            )
+        ]
+        client, _ = _make_client(site=site, dispatch_results=results, monkeypatch=monkeypatch)
+        resp = client.post(f"/api/sites/{site.id}/callback/test")
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["destinations_attempted"] == 1
+        assert body["results"][0]["success"] is True
+        assert body["results"][0]["platform"] == "slack"
+        assert body["results"][0]["target"] == "C123ABC"
+        assert body["results"][0]["latency_ms"] == 142
+        assert body["request_id"].startswith("cb_")
+
+    def test_failure_result_surfaces_error(self, monkeypatch):
+        site = _make_site(
+            destinations=[
+                {
+                    "type": "channel_connection",
+                    "connection_id": str(uuid4()),
+                    "target": "bad",
+                    "platform": "telegram",
+                }
+            ],
+        )
+        from services.destinations.base import DispatchResult
+
+        results = [
+            DispatchResult(
+                success=False,
+                destination_type="channel_connection",
+                latency_ms=7,
+                error="channel adapter not loaded",
+                retryable=True,
+            )
+        ]
+        client, _ = _make_client(site=site, dispatch_results=results, monkeypatch=monkeypatch)
+        resp = client.post(f"/api/sites/{site.id}/callback/test")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["results"][0]["success"] is False
+        assert body["results"][0]["error"] == "channel adapter not loaded"


### PR DESCRIPTION
…tions

Adds a one-click way for merchants to verify their Telegram / Slack / WhatsApp destination is wired correctly, without having to submit a real shopper callback and stare at logs.

Backend
-------
POST /api/sites/{site_id}/callback/test
- Loads the Site (workspace-scoped via hybrid auth).
- Rejects 404 if the Site isn't in the caller's workspace.
- Rejects 400 if `site.settings.callback.destinations` is empty (the failure mode the user just hit in prod — submission accepted, lead silently lost).
- Builds a synthetic CallbackPayload with an obvious test phone number (+10000000000) and a test name/topic so anyone receiving the message in the destination channel can tell it's not a real lead.
- Awaits dispatch_callback_for_site (rather than the fire-and-forget enqueue path) so the response can return per-destination success / failure / latency / error string.

Frontend (CallbackPanel)
------------------------
- New "Send test" button on the left side of the panel footer.
- Disabled when there are unsaved changes (test runs against what's saved on the server, never the unsaved draft — avoids the confusing case where the test passes but the saved config is different) or when no destinations are configured.
- Result rendered inline below the buttons: green ✓ per successful destination with platform + target + latency, red ✗ with the dispatcher's error message on failure. Lets a merchant see exactly which adapter is broken (e.g. "channel adapter not loaded") without hunting through Railway logs.

Tests
-----
tests/test_prd008a_callback_test_endpoint.py — 404 / 400 / happy-path / failure-path coverage with the dispatcher monkey-patched. Doesn't go near the real ChannelManager (that's already covered by the existing PRD-008-A.1 destination tests).

Replaces the deleted scripts/enable-callback-1lf.sh and the diagnostic scripts/show-callback-1lf.sh — those were the saboteurs that overwrote saved destinations with [] every time they ran. The dashboard is the single source of truth from here on.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added callback test functionality to validate webhook configurations before saving
  * Users can send test callbacks directly from the dashboard to verify delivery to all configured destinations
  * Comprehensive test results display request ID, per-destination success/failure status, response latency, platform details, and error messages

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AutomatosAI/automatos-ai/pull/338?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->