### PR TITLE
fix(cors): add PATCH to WidgetCORSMiddleware's preflight allow-methods

### DIFF
--- a/orchestrator/api/widgets/cors.py
+++ b/orchestrator/api/widgets/cors.py
@@ -88,8 +88,12 @@ class WidgetCORSMiddleware:
 
             response_headers = [
                 (b"access-control-allow-origin", origin.encode("latin-1")),
-                (b"access-control-allow-methods", b"GET, POST, PUT, DELETE, OPTIONS"),
-                (b"access-control-allow-headers", b"Authorization, Content-Type, X-Workspace-ID"),
+                # PRD-008-A.4: include PATCH — the dashboard CallbackPanel
+                # uses PATCH /api/sites/{id}/settings to save destinations.
+                # Without it the browser silently drops the actual request
+                # after a successful preflight and surfaces "Failed to fetch".
+                (b"access-control-allow-methods", b"GET, POST, PUT, PATCH, DELETE, OPTIONS"),
+                (b"access-control-allow-headers", b"Authorization, Content-Type, X-API-Key, X-Workspace-ID, X-Request-ID"),
                 (b"access-control-max-age", b"86400"),
                 (b"access-control-allow-credentials", b"true"),
             ]


### PR DESCRIPTION
The dashboard's CallbackPanel saves callback settings via ``PATCH /api/sites/{id}/settings``. WidgetCORSMiddleware covers ``/api/sites/*`` and was hardcoding the preflight allow-methods to ``GET, POST, PUT, DELETE, OPTIONS`` — without PATCH. Browsers accepted the 200 preflight, then silently refused to send the PATCH because its method wasn't whitelisted, surfacing as "Failed to fetch" in the toast with zero corresponding server log line (we saw repeated ``OPTIONS /api/sites/.../settings 200 OK`` with no PATCH following).

Also extends allow-headers to include X-API-Key + X-Request-ID — both are sent by the dashboard's api-client and would have hit the same silent-block path if exercised on a /api/sites route.

Two-character fix for a demo-stopper.