### PR TITLE
feat(workspace): seed default folder structure for non-coder clients

### DIFF
--- a/services/workspace-worker/main.py
+++ b/services/workspace-worker/main.py
@@ -527,19 +527,20 @@ class WorkspaceWorker:
             })
 
         async def list_files_handler(request):
-            """GET /workspaces/{workspace_id}/files?path=. — directory listing."""
+            """GET /workspaces/{workspace_id}/files?path=. — directory listing.
+
+            Provisions the workspace directory tree on first read so non-coder
+            clients see the default folder structure (reports/, content/, etc.)
+            even before any mission has run.
+            """
             from pathlib import Path as P
 
             workspace_id = request.match_info["workspace_id"]
             rel_path = request.query.get("path", ".")
 
             ws_manager = WorkspaceManager(workspace_id, volume_path)
+            ws_manager.ensure_workspace_exists()
             ws_dir = P(volume_path) / workspace_id
-
-            if not ws_dir.is_dir():
-                return web.json_response(
-                    {"error": "Workspace directory not found"}, status=404
-                )
 
             try:
                 target = ws_manager.resolve_safe_path(rel_path)

--- a/services/workspace-worker/workspace_manager.py
+++ b/services/workspace-worker/workspace_manager.py
@@ -10,8 +10,12 @@ and ephemeral task execution dirs.
 Filesystem layout per workspace:
     /workspaces/{workspace_id}/
     ├── repos/          ← Cloned repos (persistent, git pull on revisit)
-    ├── tasks/          ← Ephemeral per-task execution dirs (cleaned up)
+    ├── reports/        ← Agent reports (platform_submit_report)
+    ├── content/        ← Long-form content (posts, articles, drafts)
     ├── artifacts/      ← Test reports, build outputs (persistent)
+    ├── analytics/      ← Analytics exports, KPI snapshots
+    ├── graph/          ← Knowledge graph exports
+    ├── tasks/          ← Ephemeral per-task execution dirs (cleaned up)
     ├── .ssh/           ← Deploy keys (injected from credential store)
     ├── .gitconfig      ← Per-workspace git identity
     └── .workspace_meta.json
@@ -55,11 +59,21 @@ class WorkspaceManager:
     # Directory provisioning
     # =========================================================================
 
+    DEFAULT_SUBDIRS: tuple[str, ...] = (
+        "repos",
+        "reports",
+        "content",
+        "artifacts",
+        "analytics",
+        "graph",
+        "tasks",
+    )
+
     def ensure_workspace_exists(self) -> bool:
         """Create workspace directory tree if first use. Returns True if newly created."""
         created = not self.root.exists()
 
-        for subdir in ("repos", "tasks", "artifacts"):
+        for subdir in self.DEFAULT_SUBDIRS:
             (self.root / subdir).mkdir(parents=True, exist_ok=True)
 
         meta_path = self.root / ".workspace_meta.json"


### PR DESCRIPTION
The worker only seeded repos/, tasks/, artifacts/ — and only on first task run. New clients who hadn't run a mission yet saw a truly empty workspace, which read as broken.

Changes:
- Expand DEFAULT_SUBDIRS to repos, reports, content, artifacts, analytics, graph, tasks — matching the canonical layout.
- list_files_handler now calls ensure_workspace_exists() so the structure appears on first view, before any mission runs. Idempotent.

Existing workspaces backfill missing dirs on next file-tree GET.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Workspaces are now automatically created and set up upon first access, eliminating the need for manual initialization
  * Workspace structure expanded to include additional subdirectories: reports, content, analytics, and graph

* **Bug Fixes**
  * File listing operations no longer fail when accessing uninitialized workspaces

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AutomatosAI/automatos-ai/pull/351?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->