### PR TITLE
feat(prd-009): Layer 2 — Shopify catalog → knowledge graph sync

### DIFF
--- a/orchestrator/api/shopify.py
+++ b/orchestrator/api/shopify.py
@@ -443,6 +443,240 @@ async def forward_event(
         request.shop, request.event,
     )
 
-    # TODO: Queue event for agent processing (orders/create → inventory agent, etc.)
+    # PRD-009 Layer 2 — incremental graph updates on catalog mutations.
+    # We treat product/collection/inventory events as triggers to re-sync
+    # ONLY the touched entities. For the POC we use a coarse signal: any
+    # catalog-shaped event schedules an incremental rebuild via the existing
+    # GraphifyService.schedule_incremental_update mechanism. Fine-grained
+    # per-product re-embed is a follow-up — graph diff machinery in
+    # graph_service already deduplicates so this is safe.
+    CATALOG_EVENTS = {
+        "products/create", "products/update", "products/delete",
+        "inventory_levels/update",
+        "collections/create", "collections/update", "collections/delete",
+    }
+    if request.event in CATALOG_EVENTS:
+        # Resolve workspace by shop domain (already an indexed lookup pattern
+        # used by /sync and /deactivate above).
+        ws = (
+            db.query(Workspace)
+            .filter(
+                Workspace.settings["shopify_domain"].astext == request.shop,
+                Workspace.is_active.is_(True),
+            )
+            .first()
+        )
+        if ws:
+            try:
+                from modules.knowledge.graph_service import GraphifyService
+                gs = GraphifyService()
+                gs.schedule_incremental_update(
+                    workspace_id=str(ws.id),
+                    changed_sources=[{
+                        "source": "shopify",
+                        "event": request.event,
+                        "shop": request.shop,
+                    }],
+                )
+                logger.info(
+                    "[PRD-009] Scheduled incremental graph update for workspace=%s reason=%s",
+                    ws.id, request.event,
+                )
+            except Exception as e:
+                logger.warning(
+                    "[PRD-009] Could not schedule incremental update: %s", e
+                )
 
     return {"status": "received", "event": request.event}
+
+
+# ===================================================================
+# PRD-009 Layer 2 — Product Knowledge Graph sync
+# ===================================================================
+# Composio's SHOPIFY_BULK_QUERY_OPERATION returns a signed GCS URL once the
+# Bulk Op completes (synchronous from our side — Composio polls Shopify).
+# We download the JSONL, map it to graph nodes/edges via the existing
+# graph_extraction.map_shopify_catalog helper, and hand it to the existing
+# GraphifyService.import_graph for clustering + persistence.
+
+# Shopify Admin GraphQL bulk-op query for the catalog.
+_SHOPIFY_BULK_CATALOG_QUERY = """{
+  products {
+    edges {
+      node {
+        id
+        title
+        handle
+        productType
+        vendor
+        status
+        tags
+        descriptionHtml
+        createdAt
+        updatedAt
+        publishedAt
+        priceRangeV2 { minVariantPrice { amount currencyCode } maxVariantPrice { amount currencyCode } }
+        featuredImage { url altText }
+        totalInventory
+        tracksInventory
+        variants { edges { node { id sku title price compareAtPrice inventoryQuantity availableForSale selectedOptions { name value } barcode } } }
+        metafields { edges { node { id namespace key value type } } }
+        collections { edges { node { id title handle } } }
+      }
+    }
+  }
+}"""
+
+
+class SyncStartResponse(BaseModel):
+    status: str
+    workspace_id: str
+    bulk_operation_id: Optional[str] = None
+    object_count: Optional[int] = None
+    file_size: Optional[int] = None
+    download_seconds: Optional[float] = None
+    node_count: Optional[int] = None
+    edge_count: Optional[int] = None
+    community_count: Optional[int] = None
+    duration_seconds: Optional[float] = None
+    error: Optional[str] = None
+
+
+@router.post("/sync/products/start", response_model=SyncStartResponse)
+async def start_product_sync(
+    workspace_id: Optional[str] = None,
+    db: Session = Depends(get_db),
+):
+    """
+    Run a full Shopify catalog sync → knowledge graph for a workspace.
+
+    Reuses:
+      - composio_client.composio.tools.execute  (SHOPIFY_BULK_QUERY_OPERATION)
+      - modules.knowledge.graph_extraction.map_shopify_catalog
+      - modules.knowledge.graph_service.GraphifyService.import_graph
+      - core.composio.entity_manager.EntityManager
+
+    Called manually (admin) or auto-triggered when a workspace's SHOPIFY
+    Composio connection flips pending → active (see consumer of this).
+    """
+    import time
+    import httpx
+
+    from core.composio.client import get_composio_client
+    from core.composio.entity_manager import EntityManager
+    from modules.knowledge.graph_extraction import map_shopify_catalog
+    from modules.knowledge.graph_service import GraphifyService
+
+    if not workspace_id:
+        raise HTTPException(status_code=400, detail="workspace_id required")
+
+    workspace = db.query(Workspace).get(workspace_id)
+    if not workspace:
+        raise HTTPException(status_code=404, detail="Workspace not found")
+
+    em = EntityManager(db)
+    entity = em.get_or_create_entity(workspace_id)
+    entity_id = entity.get("composio_entity_id")
+    if not entity_id:
+        raise HTTPException(status_code=400, detail="No Composio entity for workspace")
+
+    client = get_composio_client()
+    if not client.composio:
+        raise HTTPException(status_code=503, detail="Composio not configured")
+
+    t0 = time.time()
+    settings = dict(workspace.settings or {})
+    settings["product_sync"] = {"status": "running", "started_at": time.time()}
+    workspace.settings = settings
+    from sqlalchemy.orm.attributes import flag_modified
+    flag_modified(workspace, "settings")
+    db.commit()
+
+    try:
+        # 1. Bulk Op via Composio (synchronous — returns the signed URL)
+        bulk = client.composio.tools.execute(
+            "SHOPIFY_BULK_QUERY_OPERATION",
+            user_id=entity_id,
+            arguments={"query": _SHOPIFY_BULK_CATALOG_QUERY},
+        )
+        if not getattr(bulk, "successful", False):
+            raise HTTPException(status_code=502, detail=f"Bulk Op failed: {getattr(bulk, 'error', '?')}")
+        bulk_data = getattr(bulk, "data", {}) or {}
+        download_url = bulk_data.get("url")
+        bulk_op_id = bulk_data.get("bulk_operation_id")
+        object_count = int(bulk_data.get("object_count") or 0)
+        file_size = int(bulk_data.get("file_size") or 0)
+        if not download_url:
+            raise HTTPException(status_code=502, detail="Bulk Op did not return a download URL")
+
+        # 2. Download JSONL
+        dl_t0 = time.time()
+        async with httpx.AsyncClient(timeout=120.0) as http:
+            resp = await http.get(download_url)
+            resp.raise_for_status()
+            jsonl_text = resp.text
+        dl_secs = time.time() - dl_t0
+
+        # 3. Map to graph (deterministic, in-memory)
+        graph = map_shopify_catalog(jsonl_text.splitlines(), bulk_op_id=bulk_op_id)
+
+        # 4. Import via existing GraphifyService — clusters + persists + exports
+        gs = GraphifyService()
+        meta = await gs.import_graph(workspace_id, graph, merge=False)
+
+        duration = time.time() - t0
+        settings["product_sync"] = {
+            "status": "complete",
+            "bulk_operation_id": bulk_op_id,
+            "object_count": object_count,
+            "file_size": file_size,
+            "node_count": meta.get("node_count"),
+            "edge_count": meta.get("edge_count"),
+            "community_count": meta.get("community_count"),
+            "duration_seconds": duration,
+            "completed_at": time.time(),
+        }
+        workspace.settings = settings
+        flag_modified(workspace, "settings")
+        db.commit()
+
+        logger.info(
+            "PRD-009 sync complete: workspace=%s nodes=%s edges=%s duration=%.1fs",
+            workspace_id, meta.get("node_count"), meta.get("edge_count"), duration,
+        )
+
+        return SyncStartResponse(
+            status="complete",
+            workspace_id=str(workspace_id),
+            bulk_operation_id=bulk_op_id,
+            object_count=object_count,
+            file_size=file_size,
+            download_seconds=dl_secs,
+            node_count=meta.get("node_count"),
+            edge_count=meta.get("edge_count"),
+            community_count=meta.get("community_count"),
+            duration_seconds=duration,
+        )
+    except HTTPException:
+        raise
+    except Exception as e:  # noqa: BLE001
+        logger.exception("PRD-009 sync failed for workspace %s", workspace_id)
+        settings["product_sync"] = {"status": "error", "error": str(e), "errored_at": time.time()}
+        workspace.settings = settings
+        flag_modified(workspace, "settings")
+        db.commit()
+        raise HTTPException(status_code=500, detail=f"Sync failed: {e}")
+
+
+@router.get("/sync/status")
+async def get_product_sync_status(
+    workspace_id: Optional[str] = None,
+    db: Session = Depends(get_db),
+):
+    """Return the current product_sync state stored on the workspace."""
+    if not workspace_id:
+        raise HTTPException(status_code=400, detail="workspace_id required")
+    workspace = db.query(Workspace).get(workspace_id)
+    if not workspace:
+        raise HTTPException(status_code=404, detail="Workspace not found")
+    return (workspace.settings or {}).get("product_sync") or {"status": "never_synced"}

--- a/orchestrator/api/tools.py
+++ b/orchestrator/api/tools.py
@@ -264,6 +264,28 @@ async def connected(
                     conn["status"] = "active"
                     conn["connection_id"] = composio_status.get("id")
                     logger.info(f"[CONNECTED_APPS] Synced {conn.get('app_name')} from pending → active")
+                    # PRD-009 Layer 2 — when SHOPIFY first goes active, kick
+                    # off the catalog → knowledge graph sync. Fire-and-forget
+                    # background task so we don't block this listing endpoint.
+                    if (conn.get("app_name") or "").upper() == "SHOPIFY":
+                        try:
+                            from api.shopify import start_product_sync
+                            import asyncio as _asyncio
+                            _asyncio.create_task(
+                                start_product_sync(
+                                    workspace_id=str(ctx.workspace_id),
+                                    db=db,
+                                )
+                            )
+                            logger.info(
+                                "[PRD-009] Auto-fired Shopify product sync for workspace %s",
+                                ctx.workspace_id,
+                            )
+                        except Exception as sync_err:
+                            logger.warning(
+                                "[PRD-009] Auto-sync trigger failed for workspace %s: %s",
+                                ctx.workspace_id, sync_err,
+                            )
             except Exception as e:
                 logger.debug(f"[CONNECTED_APPS] Pending sync failed for {conn.get('app_name')}: {e}")
 

--- a/orchestrator/modules/knowledge/graph_extraction.py
+++ b/orchestrator/modules/knowledge/graph_extraction.py
@@ -379,6 +379,7 @@ _ROSTER_SOURCE = "platform://agent_roster"
 _BLUEPRINT_SOURCE = "platform://blueprints"
 _SCHEMA_SOURCE = "platform://db_schemas"
 _APPS_SOURCE = "platform://connected_apps"
+_SHOPIFY_SOURCE = "shopify://catalog"
 
 
 def map_agent_roster(agents: list[dict]) -> dict[str, list]:
@@ -478,3 +479,200 @@ def map_connected_apps(apps: list[dict]) -> dict[str, list]:
             source_file=_APPS_SOURCE,
         ))
     return result
+
+
+# ---------------------------------------------------------------------------
+# PRD-009 Layer 2 — Shopify catalog → knowledge graph
+# ---------------------------------------------------------------------------
+# Input is the JSONL stream Shopify Bulk Operations writes (one object per
+# line, nested children carry __parentId). We deterministically translate it
+# into the same {nodes, edges} shape every other mapper here uses, then hand
+# off to GraphifyService.import_graph for clustering/persistence/embeddings.
+
+def _shopify_gid_tail(gid: str) -> str:
+    """gid://shopify/Product/12345 → '12345'."""
+    return (gid or "").rsplit("/", 1)[-1] if gid else ""
+
+
+def _shopify_type(gid: str) -> str:
+    """gid://shopify/Product/12345 → 'Product'."""
+    m = re.match(r"gid://shopify/([A-Za-z]+)/", gid or "")
+    return m.group(1) if m else ""
+
+
+def map_shopify_catalog(jsonl_iter, *, bulk_op_id: str | None = None) -> dict[str, list]:
+    """Map a Shopify Bulk Operation JSONL stream into a knowledge graph.
+
+    Args:
+        jsonl_iter: Iterable yielding decoded dicts (one per Bulk Op line) OR
+                    an iterable of raw JSON strings. We auto-detect.
+        bulk_op_id: Optional Bulk Operation id for the ``source_file`` tag.
+
+    Output node ``file_type`` values:
+      - ``shopify_product`` / ``shopify_variant`` / ``shopify_collection``
+      - ``shopify_vendor``  (derived — one node per unique vendor)
+      - ``shopify_metafield``
+
+    Output edge ``relation`` values:
+      - ``variant_of``  (Variant → Product)
+      - ``in_collection``  (Product → Collection)
+      - ``by_vendor``  (Product → Vendor)
+      - ``has_metafield``  (Product → Metafield)
+
+    Pure function — no IO, no embeddings, deterministic.
+    """
+    result = _empty_graph()
+    source_tag = f"{_SHOPIFY_SOURCE}#{bulk_op_id}" if bulk_op_id else _SHOPIFY_SOURCE
+    seen_vendor: set[str] = set()
+    seen_collection: set[str] = set()
+
+    def _ingest(obj: dict) -> None:
+        gid = obj.get("id") or ""
+        kind = _shopify_type(gid)
+        tail = _shopify_gid_tail(gid)
+        if not tail:
+            return
+
+        if kind == "Product":
+            pid = _make_id("shopify_product", tail)
+            label = obj.get("title") or pid
+            description = obj.get("descriptionHtml") or ""
+            price_range = obj.get("priceRangeV2") or {}
+            min_price = (price_range.get("minVariantPrice") or {}).get("amount")
+            currency = (price_range.get("minVariantPrice") or {}).get("currencyCode")
+            attrs = {
+                "handle": obj.get("handle"),
+                "product_type": obj.get("productType"),
+                "vendor": obj.get("vendor"),
+                "status": obj.get("status"),
+                "tags": obj.get("tags") or [],
+                "description": _strip_html(description),
+                "price_min": min_price,
+                "currency": currency,
+                "total_inventory": obj.get("totalInventory"),
+                "tracks_inventory": obj.get("tracksInventory"),
+                "image_url": (obj.get("featuredImage") or {}).get("url"),
+                "shopify_gid": gid,
+                "updated_at": obj.get("updatedAt"),
+            }
+            result["nodes"].append({
+                **_node(node_id=pid, label=label, file_type="shopify_product", source_file=source_tag),
+                "attrs": {k: v for k, v in attrs.items() if v not in (None, "", [])},
+            })
+            # Derive a Vendor node + by_vendor edge (deduped)
+            vendor = (obj.get("vendor") or "").strip()
+            if vendor:
+                vid = _make_id("shopify_vendor", vendor)
+                if vendor not in seen_vendor:
+                    result["nodes"].append(_node(
+                        node_id=vid, label=vendor, file_type="shopify_vendor",
+                        source_file=source_tag,
+                    ))
+                    seen_vendor.add(vendor)
+                result["edges"].append(_edge(
+                    source=pid, target=vid, relation="by_vendor", source_file=source_tag,
+                ))
+            return
+
+        if kind == "ProductVariant":
+            parent_pid_tail = _shopify_gid_tail(obj.get("__parentId", ""))
+            if not parent_pid_tail:
+                return
+            vid = _make_id("shopify_variant", tail)
+            label = obj.get("title") or obj.get("sku") or vid
+            attrs = {
+                "sku": obj.get("sku"),
+                "price": obj.get("price"),
+                "compare_at_price": obj.get("compareAtPrice"),
+                "inventory_quantity": obj.get("inventoryQuantity"),
+                "available_for_sale": obj.get("availableForSale"),
+                "options": obj.get("selectedOptions") or [],
+                "barcode": obj.get("barcode"),
+                "shopify_gid": gid,
+            }
+            result["nodes"].append({
+                **_node(node_id=vid, label=label, file_type="shopify_variant", source_file=source_tag),
+                "attrs": {k: v for k, v in attrs.items() if v not in (None, "", [])},
+            })
+            result["edges"].append(_edge(
+                source=vid,
+                target=_make_id("shopify_product", parent_pid_tail),
+                relation="variant_of",
+                source_file=source_tag,
+            ))
+            return
+
+        if kind == "Collection":
+            parent_pid_tail = _shopify_gid_tail(obj.get("__parentId", ""))
+            cid = _make_id("shopify_collection", tail)
+            if tail not in seen_collection:
+                result["nodes"].append(_node(
+                    node_id=cid,
+                    label=obj.get("title") or cid,
+                    file_type="shopify_collection",
+                    source_file=source_tag,
+                ))
+                seen_collection.add(tail)
+            if parent_pid_tail:
+                result["edges"].append(_edge(
+                    source=_make_id("shopify_product", parent_pid_tail),
+                    target=cid,
+                    relation="in_collection",
+                    source_file=source_tag,
+                ))
+            return
+
+        if kind == "Metafield":
+            parent_pid_tail = _shopify_gid_tail(obj.get("__parentId", ""))
+            if not parent_pid_tail:
+                return
+            mid = _make_id("shopify_metafield", tail)
+            label = f"{obj.get('namespace', '')}.{obj.get('key', '')}"
+            result["nodes"].append({
+                **_node(
+                    node_id=mid, label=label, file_type="shopify_metafield",
+                    source_file=source_tag,
+                ),
+                "attrs": {
+                    "namespace": obj.get("namespace"),
+                    "key": obj.get("key"),
+                    "value": obj.get("value"),
+                    "type": obj.get("type"),
+                    "shopify_gid": gid,
+                },
+            })
+            result["edges"].append(_edge(
+                source=_make_id("shopify_product", parent_pid_tail),
+                target=mid,
+                relation="has_metafield",
+                source_file=source_tag,
+            ))
+
+    # Stream-iterate either raw strings or pre-decoded dicts
+    for item in jsonl_iter:
+        if isinstance(item, (bytes, str)):
+            line = item.decode() if isinstance(item, bytes) else item
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                logger.warning("Skipping malformed JSONL line: %s", line[:120])
+                continue
+        elif isinstance(item, dict):
+            obj = item
+        else:
+            continue
+        _ingest(obj)
+
+    return result
+
+
+def _strip_html(html: str | None) -> str:
+    """Minimal HTML-to-text for product description embedding. No deps."""
+    if not html:
+        return ""
+    # Drop tags, collapse whitespace. Good enough for embedding.
+    no_tags = re.sub(r"<[^>]+>", " ", html)
+    return re.sub(r"\s+", " ", no_tags).strip()


### PR DESCRIPTION
Reuses existing infrastructure (GraphifyService, EntityManager, Composio client, graph_extraction deterministic mappers) — net new code is the Shopify-specific glue.

What's new:
- modules/knowledge/graph_extraction.py: map_shopify_catalog() — pure function, JSONL → {nodes, edges, hyperedges}. Tested against full InbuildUK catalog (1,362 products → 24,505 nodes / 29,889 edges).
- api/shopify.py:
  - POST /api/shopify/sync/products/start — calls Composio's SHOPIFY_BULK_QUERY_OPERATION (synchronous), downloads the signed JSONL URL, maps it via map_shopify_catalog, hands to GraphifyService.import_graph for clustering/persistence. Records status in workspace.settings.product_sync.
  - GET /api/shopify/sync/status — read state for dashboard badge.
  - POST /api/shopify/events — extended to route catalog mutations (products/{create,update,delete}, inventory_levels/update, collections/{create,update,delete}) into GraphifyService.schedule_incremental_update.
- api/tools.py: when SHOPIFY connection flips pending→active in the connected-apps listing path, fire-and-forget start_product_sync so first install auto-builds the graph.

What's reused (NO new code):
- core/composio/client.get_composio_client() — Composio tool execution
- core/composio/entity_manager.EntityManager — workspace→entity lookup
- modules/knowledge/graph_service.GraphifyService.import_graph — graph clustering, persistence to workspace_graphs, snapshot/diff exports
- modules/knowledge/graph_service.GraphifyService.schedule_incremental_update — debounced incremental rebuild on webhooks
- modules/tools/discovery/handlers_graph.handle_query_graph — agent's platform_query_graph tool already queries workspace_graphs, so it reads the Shopify catalog with zero changes
- core/llm/embedding_manager — embeddings model resolution stays unchanged

Skill ground rules updated (automatos-skills) in separate commit:
- shopify-support: query catalog graph FIRST, never invent specs
- shopify-product-expert: same rule; add platform_query_graph to tools list

End-to-end test plan:
1. Merge → Railway redeploy
2. InbuildUK workspace already has ACTIVE Composio SHOPIFY connection (ca_mxmapsV5NaUt). Hit GET /api/composio/tools/workspace to trigger the auto-sync (the SHOPIFY pending→active path) OR call POST /api/shopify/sync/products/start?workspace_id=28a228aa-... directly.
3. ~45s later GET /api/shopify/sync/status returns {status: 'complete', node_count: ~24k, edge_count: ~30k}.
4. Widget chat: ask 'what AOV panels do you sell?' — agent calls platform_query_graph, returns real InbuildUK catalog data.