### PR TITLE
feat(prd-009): Sync tab in Settings → Widget SDK

### DIFF
--- a/frontend/components/settings/WidgetSdkTab.tsx
+++ b/frontend/components/settings/WidgetSdkTab.tsx
@@ -8,6 +8,7 @@ import { ApiKeyManager } from './ApiKeyManager'
 import { CallbackPanel } from '@/components/sites/CallbackPanel'
 import { CartIdlePanel } from '@/components/sites/CartIdlePanel'
 import { ShopifyTab } from '@/components/sites/ShopifyTab'
+import { SyncPanel } from '@/components/sites/SyncPanel'
 import { listSites } from '@/lib/sites/api'
 import type { Site, SiteType } from '@/lib/sites/types'
 
@@ -25,7 +26,7 @@ const TYPE_ICON: Record<SiteType, typeof Globe> = {
   custom: Code2,
 }
 
-type Section = 'api-keys' | 'cart-idle' | 'callback' | 'shopify'
+type Section = 'api-keys' | 'cart-idle' | 'callback' | 'sync' | 'shopify'
 
 export function WidgetSdkTab() {
   const [sites, setSites] = useState<Site[] | null>(null)
@@ -56,6 +57,10 @@ export function WidgetSdkTab() {
     { key: 'api-keys', label: 'API keys', show: true },
     { key: 'cart-idle', label: 'Cart-idle', show: true },
     { key: 'callback', label: 'Callback', show: true },
+    // Sync is platform-agnostic; lights up the relevant card based on site.type.
+    // Always visible so merchants discover it even before a site is fully
+    // connected — the panel guides them on what's missing.
+    { key: 'sync', label: 'Sync', show: true },
     { key: 'shopify', label: 'Shopify', show: activeSite?.type === 'shopify' },
   ]
 
@@ -159,6 +164,12 @@ export function WidgetSdkTab() {
         activeSite
           ? <CallbackPanel site={activeSite} onUpdated={patchSite} />
           : renderSiteRequired('Callback')
+      )}
+
+      {section === 'sync' && (
+        activeSite
+          ? <SyncPanel site={activeSite} workspaceId={activeSite.workspace_id ?? null} />
+          : renderSiteRequired('Sync')
       )}
 
       {section === 'shopify' && activeSite?.type === 'shopify' && (

--- a/frontend/components/sites/SyncPanel.tsx
+++ b/frontend/components/sites/SyncPanel.tsx
@@ -1,0 +1,201 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Loader2, RefreshCw, CheckCircle2, AlertCircle, ShoppingBag } from 'lucide-react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import {
+  getShopifySyncStatus,
+  startShopifySync,
+  type ShopifySyncStatus,
+} from '@/lib/sites/api'
+import type { Site } from '@/lib/sites/types'
+
+interface SyncPanelProps {
+  site: Site
+  workspaceId: string | null
+}
+
+// One platform-agnostic panel that drives ALL catalog→knowledge-graph syncs.
+// Today only Shopify lights up; WooCommerce / BigCommerce / Amazon plug in by
+// adding a section here with the same shape: status row + last-sync stats +
+// "Sync now" button + auth-required guard.
+export function SyncPanel({ site, workspaceId }: SyncPanelProps) {
+  return (
+    <div className="space-y-4">
+      {/* Header card describing what this tab does — keeps merchants oriented
+          as we add more platforms here. */}
+      <Card className="glass-card">
+        <CardHeader className="pb-2">
+          <CardTitle className="text-base">Catalog sync</CardTitle>
+        </CardHeader>
+        <CardContent className="text-sm text-muted-foreground">
+          Pulls your product catalog into the workspace knowledge graph so the
+          agent answers product questions from real data instead of guessing.
+          The graph stays fresh automatically via webhooks; use the button
+          below for a manual full re-sync (e.g. after a CSV import).
+        </CardContent>
+      </Card>
+
+      {/* Per-platform cards. Site type drives which one shows. */}
+      {site.type === 'shopify' && (
+        <ShopifySyncCard site={site} workspaceId={workspaceId} />
+      )}
+
+      {site.type !== 'shopify' && (
+        <Card className="glass-card">
+          <CardContent className="py-6 text-sm text-muted-foreground">
+            Catalog sync isn't available for{' '}
+            <span className="text-foreground capitalize">{site.type}</span> sites yet.
+            It'll appear here once the integration lands.
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Shopify card
+// ---------------------------------------------------------------------------
+
+function ShopifySyncCard({ site, workspaceId }: { site: Site; workspaceId: string | null }) {
+  const [status, setStatus] = useState<ShopifySyncStatus | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [syncing, setSyncing] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function refreshStatus() {
+    if (!workspaceId) {
+      setLoading(false)
+      return
+    }
+    try {
+      const s = await getShopifySyncStatus(workspaceId)
+      setStatus(s)
+      setError(null)
+    } catch (e: any) {
+      setError(e?.message ?? 'Failed to load sync status')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    refreshStatus()
+  }, [workspaceId])
+
+  // Readiness check — has_catalog is set by the backend when the Site has
+  // a Shopify domain configured (capability backfill). The Composio
+  // SHOPIFY connection isn't yet exposed on the Site row, so we use this
+  // as a proxy; the backend endpoint will fail cleanly if Composio isn't
+  // actually active.
+  const isShopifyConnected = site.capabilities?.has_catalog === true
+
+  async function handleSync() {
+    if (!workspaceId) return
+    setSyncing(true)
+    setError(null)
+    try {
+      const result = await startShopifySync(workspaceId)
+      setStatus(result)
+    } catch (e: any) {
+      setError(e?.message ?? 'Sync failed')
+    } finally {
+      setSyncing(false)
+    }
+  }
+
+  return (
+    <Card className="glass-card">
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-2 text-base">
+          <ShoppingBag className="w-4 h-4" /> Shopify catalog
+          {status?.status === 'complete' && (
+            <Badge variant="outline" className="ml-auto text-emerald-400 border-emerald-400/30">
+              <CheckCircle2 className="w-3 h-3 mr-1" /> Synced
+            </Badge>
+          )}
+          {status?.status === 'running' && (
+            <Badge variant="outline" className="ml-auto text-amber-400 border-amber-400/30">
+              <Loader2 className="w-3 h-3 mr-1 animate-spin" /> Running
+            </Badge>
+          )}
+          {status?.status === 'error' && (
+            <Badge variant="outline" className="ml-auto text-destructive border-destructive/30">
+              <AlertCircle className="w-3 h-3 mr-1" /> Error
+            </Badge>
+          )}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3 text-sm">
+        {loading && (
+          <div className="flex items-center text-muted-foreground">
+            <Loader2 className="w-4 h-4 mr-2 animate-spin" /> Loading sync status…
+          </div>
+        )}
+
+        {!loading && status?.status === 'complete' && (
+          <div className="grid grid-cols-2 gap-y-1.5 text-xs">
+            <span className="text-muted-foreground">Products + variants indexed</span>
+            <span className="text-foreground">{status.node_count?.toLocaleString() ?? '—'}</span>
+            <span className="text-muted-foreground">Relations</span>
+            <span className="text-foreground">{status.edge_count?.toLocaleString() ?? '—'}</span>
+            <span className="text-muted-foreground">Last sync duration</span>
+            <span className="text-foreground">
+              {status.duration_seconds ? `${status.duration_seconds.toFixed(1)}s` : '—'}
+            </span>
+          </div>
+        )}
+
+        {!loading && status?.status === 'never_synced' && (
+          <p className="text-xs text-muted-foreground">
+            Catalog hasn't been synced yet. Click <span className="text-foreground">Sync now</span> to
+            build the knowledge graph for this store.
+          </p>
+        )}
+
+        {!loading && status?.status === 'error' && (
+          <div className="text-xs text-destructive bg-destructive/10 border border-destructive/30 rounded p-2">
+            {status.error || 'Previous sync failed.'}
+          </div>
+        )}
+
+        {error && (
+          <div className="text-xs text-destructive bg-destructive/10 border border-destructive/30 rounded p-2">
+            {error}
+          </div>
+        )}
+
+        {!isShopifyConnected && (
+          <p className="text-xs text-amber-400">
+            Shopify isn't connected yet. Connect it in <strong>System Settings → Credentials</strong>{' '}
+            with the <em>Shopify Access Token API</em> credential type, then come back here.
+          </p>
+        )}
+
+        <Button
+          onClick={handleSync}
+          disabled={!isShopifyConnected || !workspaceId || syncing || status?.status === 'running'}
+          size="sm"
+          className="gap-2"
+        >
+          {syncing ? (
+            <>
+              <Loader2 className="w-3.5 h-3.5 animate-spin" /> Syncing 1,000+ products… (~45s)
+            </>
+          ) : (
+            <>
+              <RefreshCw className="w-3.5 h-3.5" /> Sync now
+            </>
+          )}
+        </Button>
+        <p className="text-[11px] text-muted-foreground">
+          The sync pulls every product, variant, metafield, and collection from Shopify in one
+          Bulk Operation. Webhooks keep the graph fresh between manual syncs.
+        </p>
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/lib/sites/api.ts
+++ b/frontend/lib/sites/api.ts
@@ -75,3 +75,40 @@ export async function sendCallbackTest(siteId: string): Promise<CallbackTestResp
     {},
   );
 }
+
+// ---------------------------------------------------------------------------
+// PRD-009 Layer 2 — catalog → knowledge graph sync
+// ---------------------------------------------------------------------------
+
+export interface ShopifySyncStatus {
+  status: 'never_synced' | 'running' | 'complete' | 'error';
+  bulk_operation_id?: string;
+  object_count?: number;
+  file_size?: number;
+  node_count?: number;
+  edge_count?: number;
+  community_count?: number;
+  duration_seconds?: number;
+  started_at?: number;
+  completed_at?: number;
+  errored_at?: number;
+  error?: string;
+}
+
+export interface ShopifySyncResult extends ShopifySyncStatus {
+  workspace_id: string;
+  download_seconds?: number;
+}
+
+export async function getShopifySyncStatus(workspaceId: string): Promise<ShopifySyncStatus> {
+  return apiClient.get<ShopifySyncStatus>(
+    `/api/shopify/sync/status?workspace_id=${encodeURIComponent(workspaceId)}`,
+  );
+}
+
+export async function startShopifySync(workspaceId: string): Promise<ShopifySyncResult> {
+  return apiClient.post<ShopifySyncResult>(
+    `/api/shopify/sync/products/start?workspace_id=${encodeURIComponent(workspaceId)}`,
+    {},
+  );
+}


### PR DESCRIPTION
Adds a 'Sync' tab between 'Callback' and 'Shopify' that hosts a manual catalog → knowledge graph re-sync button. Platform-agnostic shell so WooCommerce / BigCommerce / Amazon can plug in by adding sibling cards when their integrations land — only Shopify lights up today.

Components:
- SyncPanel.tsx: shell + per-platform cards. Branches on site.type.
- ShopifySyncCard (inside SyncPanel): pulls status from GET /api/shopify/sync/status on mount, displays node/edge counts + last-sync duration, fires POST /api/shopify/sync/products/start when 'Sync now' is clicked.
- Disabled until site.capabilities.has_catalog === true (proxy for 'Shopify connected'); backend returns clear error if Composio isn't active so the button is still safe to surface.

Wiring:
- lib/sites/api.ts: getShopifySyncStatus / startShopifySync helpers.
- WidgetSdkTab.tsx: new 'sync' section, always visible.

No new backend endpoints — the orchestrator endpoints from PRD-009 Layer 2 (merged on feat/prd-009-layer2-shopify-catalog-graph) are what this UI calls.