### PR TITLE
fix(prd-009): persist 'error' status on HTTPException + detect stuck …

### DIFF
--- a/frontend/components/sites/SyncPanel.tsx
+++ b/frontend/components/sites/SyncPanel.tsx
@@ -86,6 +86,15 @@ function ShopifySyncCard({ site, workspaceId }: { site: Site; workspaceId: strin
   // below. Better to let merchants click and see truth than block them on a
   // stale site-level flag.
 
+  // Detect a "running" status that's actually stuck (started_at older than
+  // 5 minutes). The bulk-op should complete in ~45s; anything beyond 5 min
+  // means the previous request crashed without writing a terminal status.
+  // We let the merchant retry by treating the row as effectively idle.
+  const isStuckRunning =
+    status?.status === 'running' &&
+    !!status.started_at &&
+    Date.now() / 1000 - status.started_at > 300
+
   async function handleSync() {
     if (!workspaceId) return
     setSyncing(true)
@@ -162,9 +171,15 @@ function ShopifySyncCard({ site, workspaceId }: { site: Site; workspaceId: strin
         )}
 
 
+        {isStuckRunning && (
+          <div className="text-xs text-amber-400 bg-amber-400/10 border border-amber-400/30 rounded p-2">
+            Previous sync didn't finish cleanly. You can re-run it now.
+          </div>
+        )}
+
         <Button
           onClick={handleSync}
-          disabled={!workspaceId || syncing || status?.status === 'running'}
+          disabled={!workspaceId || syncing || (status?.status === 'running' && !isStuckRunning)}
           size="sm"
           className="gap-2"
         >

--- a/orchestrator/api/shopify.py
+++ b/orchestrator/api/shopify.py
@@ -672,7 +672,18 @@ async def start_product_sync(
             community_count=meta.get("community_count"),
             duration_seconds=duration,
         )
-    except HTTPException:
+    except HTTPException as he:
+        # Persist the failure so the UI doesn't stay stuck on "running" — the
+        # previous version's `except HTTPException: raise` skipped this and
+        # left workspaces wedged in running-forever state.
+        settings["product_sync"] = {
+            "status": "error",
+            "error": str(he.detail) if isinstance(he.detail, str) else f"HTTP {he.status_code}",
+            "errored_at": time.time(),
+        }
+        workspace.settings = settings
+        flag_modified(workspace, "settings")
+        db.commit()
         raise
     except Exception as e:  # noqa: BLE001
         logger.exception("PRD-009 sync failed for workspace %s", workspace_id)


### PR DESCRIPTION
…running

Backend:
- The previous attempt's 502 (toolkit-version-not-specified) re-raised via 'except HTTPException: raise' which skipped writing product_sync.status. Workspaces got wedged on 'running' forever. Now we write the error row before re-raising HTTPExceptions too.

Frontend:
- Detect status='running' with started_at older than 5 minutes → treat as stuck, show 'previous sync didn't finish cleanly' banner, re-enable the Sync now button. Real syncs complete in ~45s, so 5 min is comfortably past the worst-case.