### PR TITLE
feat(business-graph): swap d3-SVG renderer for react-force-graph-2d

### DIFF
--- a/frontend/components/knowledge/BusinessGraphPanel.tsx
+++ b/frontend/components/knowledge/BusinessGraphPanel.tsx
@@ -203,7 +203,10 @@ export function BusinessGraphPanel() {
     retry: false,
   })
 
-  const vizSafe = !!meta && (meta.node_count ?? 0) <= 5000
+  // The Canvas-based ForceGraph2D renderer handles tens of thousands of nodes
+  // smoothly (Obsidian-tier perf). Cap raised from 5,000 (old SVG/d3 limit)
+  // to 100,000. The hard ceiling is browser memory, not the renderer.
+  const vizSafe = !!meta && (meta.node_count ?? 0) <= 100000
 
   const {
     data: graphData,

--- a/frontend/components/knowledge/BusinessGraphVisualization.tsx
+++ b/frontend/components/knowledge/BusinessGraphVisualization.tsx
@@ -2,15 +2,30 @@
 
 /**
  * Business Graph Visualization Component
- * D3 force-directed graph for business entity relationships
- * Features: community coloring, god-node scaling, confidence-based edge styling
+ * Canvas/WebGL force-directed graph for the workspace knowledge graph.
+ *
+ * Renderer: react-force-graph-2d (same d3-force physics under the hood,
+ * Canvas-based rendering — handles 25k+ nodes smoothly where SVG d3 chokes
+ * around 5k). Matches Obsidian's approach for large knowledge graphs.
+ *
+ * Features kept from the previous SVG implementation:
+ *  - Community-based coloring
+ *  - Node size proportional to degree ("god-node scaling")
+ *  - Click-to-select with selected-community highlighting
+ *  - Confidence-score edge filtering
  */
 
-import React, { useEffect, useRef, useCallback, useMemo } from "react";
-import * as d3 from "d3";
+import React, { useCallback, useMemo, useRef, useEffect, useState } from "react";
+import dynamic from "next/dynamic";
+
+// SSR-disabled dynamic import — react-force-graph needs window/canvas.
+const ForceGraph2D = dynamic(
+  () => import("react-force-graph-2d").then((m) => m.default),
+  { ssr: false },
+) as any;
 
 // ---------------------------------------------------------------------------
-// Types
+// Types — same shape the existing BusinessGraphPanel feeds in.
 // ---------------------------------------------------------------------------
 
 interface GraphNode {
@@ -39,46 +54,19 @@ interface BusinessGraphVisualizationProps {
   minConfidence?: number;
 }
 
-// D3 simulation node (extends GraphNode with x/y/fx/fy)
-interface SimNode extends d3.SimulationNodeDatum {
-  id: string;
-  label: string;
-  file_type: string;
-  community?: number;
-  source_file?: string;
+// Runtime-augmented node — degree added per render for sizing.
+interface VizNode extends GraphNode {
   degree: number;
 }
 
-interface SimLink extends d3.SimulationLinkDatum<SimNode> {
-  relation: string;
-  confidence: string;
-  confidence_score: number;
-}
-
 // ---------------------------------------------------------------------------
-// Constants
+// Visual constants
 // ---------------------------------------------------------------------------
 
-const ORANGE_ACCENT = "#FF6B35";
-const BG_COLOR = "#0f1117";
-const NODE_STROKE = "#ffffff";
-const LABEL_COLOR = "#e5e7eb";
-const DIMMED_OPACITY = 0.15;
-
-// Warm palette for community coloring (up to 12 distinct communities)
 const COMMUNITY_COLORS = [
-  "#e6194b", // red
-  "#f58231", // orange
-  "#ffe119", // yellow
-  "#3cb44b", // green
-  "#42d4f4", // cyan
-  "#4363d8", // blue
-  "#911eb4", // purple
-  "#f032e6", // magenta
-  "#fabebe", // pink
-  "#9a6324", // brown
-  "#800000", // maroon
-  "#aaffc3", // mint
+  "#e6194b", "#f58231", "#ffe119", "#3cb44b", "#42d4f4", "#4363d8",
+  "#911eb4", "#f032e6", "#fabebe", "#9a6324", "#800000", "#aaffc3",
+  "#469990", "#bfef45", "#fffac8", "#dcbeff", "#9A6324", "#fffac8",
 ];
 
 const communityColor = (community: number | undefined): string => {
@@ -86,19 +74,7 @@ const communityColor = (community: number | undefined): string => {
   return COMMUNITY_COLORS[community % COMMUNITY_COLORS.length];
 };
 
-/** Map confidence label to SVG stroke-dasharray */
-const confidenceDash = (confidence: string): string => {
-  switch (confidence.toUpperCase()) {
-    case "EXTRACTED":
-      return "none"; // solid
-    case "INFERRED":
-      return "6,4"; // dashed
-    case "AMBIGUOUS":
-      return "2,3"; // dotted
-    default:
-      return "none";
-  }
-};
+const DIMMED_OPACITY = 0.18;
 
 // ---------------------------------------------------------------------------
 // Component
@@ -110,353 +86,164 @@ const BusinessGraphVisualization: React.FC<BusinessGraphVisualizationProps> = ({
   selectedCommunity = null,
   minConfidence = 0,
 }) => {
-  const svgRef = useRef<SVGSVGElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
-  const simulationRef = useRef<d3.Simulation<SimNode, SimLink> | null>(null);
+  const fgRef = useRef<any>(null);
+  const [size, setSize] = useState<{ w: number; h: number }>({ w: 800, h: 600 });
 
-  // ---- Derived data (filtered, with degree counts) -----------------------
+  // ── Filter links + compute degree per node ──────────────────────────────
 
-  const { nodes, links } = useMemo(() => {
-    // Filter links by minConfidence
-    const filteredLinks: SimLink[] = graphData.links
-      .filter((l) => l.confidence_score >= minConfidence)
-      .map((l) => ({
-        source: l.source,
-        target: l.target,
-        relation: l.relation,
-        confidence: l.confidence,
-        confidence_score: l.confidence_score,
-      }));
-
-    // Compute degree per node from filtered links
-    const degreeMap = new Map<string, number>();
+  const data = useMemo(() => {
+    const filteredLinks = graphData.links.filter(
+      (l) => l.confidence_score >= minConfidence,
+    );
+    const degree = new Map<string, number>();
     for (const l of filteredLinks) {
-      const src = typeof l.source === "string" ? l.source : (l.source as SimNode).id;
-      const tgt = typeof l.target === "string" ? l.target : (l.target as SimNode).id;
-      degreeMap.set(src, (degreeMap.get(src) ?? 0) + 1);
-      degreeMap.set(tgt, (degreeMap.get(tgt) ?? 0) + 1);
+      const s = typeof l.source === "string" ? l.source : (l.source as any).id;
+      const t = typeof l.target === "string" ? l.target : (l.target as any).id;
+      degree.set(s, (degree.get(s) ?? 0) + 1);
+      degree.set(t, (degree.get(t) ?? 0) + 1);
     }
-
-    const simNodes: SimNode[] = graphData.nodes.map((n) => ({
+    const nodes: VizNode[] = graphData.nodes.map((n) => ({
       ...n,
-      degree: degreeMap.get(n.id) ?? 0,
+      degree: degree.get(n.id) ?? 0,
     }));
-
-    return { nodes: simNodes, links: filteredLinks };
+    return { nodes, links: filteredLinks };
   }, [graphData, minConfidence]);
 
-  // ---- Node radius (god-node scaling) ------------------------------------
-
-  const nodeRadius = useCallback(
-    (d: SimNode): number => {
-      const maxDegree = Math.max(1, ...nodes.map((n) => n.degree));
-      const normalized = d.degree / maxDegree;
-      return 6 + normalized * 20; // 6px min, 26px max
-    },
-    [nodes],
+  // For node sizing — relative to the max-degree node in the current view.
+  const maxDegree = useMemo(
+    () => Math.max(1, ...data.nodes.map((n) => n.degree)),
+    [data.nodes],
   );
 
-  // ---- Render D3 graph ---------------------------------------------------
+  // ── Resize observer keeps the canvas filling its container ─────────────
 
   useEffect(() => {
-    if (!svgRef.current || nodes.length === 0) return;
+    if (!containerRef.current) return;
+    const el = containerRef.current;
+    const update = () => setSize({ w: el.clientWidth, h: el.clientHeight || 500 });
+    update();
+    const ro = new ResizeObserver(update);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
 
-    const svg = d3.select(svgRef.current);
-    svg.selectAll("*").remove();
+  // ── Node visual: filled circle, color by community, size by degree.
+  // For dense graphs (25k+) drawing per-node labels is too noisy — only
+  // show labels for high-degree nodes ("god nodes") and when zoomed in.
 
-    const width = svgRef.current.clientWidth || 800;
-    const height = svgRef.current.clientHeight || 600;
+  const nodeCanvasObject = useCallback(
+    (node: any, ctx: CanvasRenderingContext2D, globalScale: number) => {
+      const baseR = 2 + 6 * (node.degree / maxDegree);  // 2–8px radius
+      const dim = selectedCommunity != null && node.community !== selectedCommunity;
+      ctx.globalAlpha = dim ? DIMMED_OPACITY : 0.95;
 
-    // Background
-    svg
-      .append("rect")
-      .attr("width", width)
-      .attr("height", height)
-      .attr("fill", BG_COLOR);
+      ctx.beginPath();
+      ctx.arc(node.x, node.y, baseR, 0, 2 * Math.PI);
+      ctx.fillStyle = communityColor(node.community);
+      ctx.fill();
+      ctx.lineWidth = 0.5 / globalScale;
+      ctx.strokeStyle = "rgba(255,255,255,0.4)";
+      ctx.stroke();
 
-    // Zoom container
-    const g = svg.append("g");
-
-    const zoomBehavior = d3
-      .zoom<SVGSVGElement, unknown>()
-      .scaleExtent([0.1, 6])
-      .on("zoom", (event) => {
-        g.attr("transform", event.transform);
-      });
-
-    svg.call(zoomBehavior);
-
-    // ---- Simulation -------------------------------------------------------
-
-    const simulation = d3
-      .forceSimulation<SimNode>(nodes)
-      .force(
-        "link",
-        d3
-          .forceLink<SimNode, SimLink>(links)
-          .id((d) => d.id)
-          .distance(100),
-      )
-      .force("charge", d3.forceManyBody().strength(-250))
-      .force("center", d3.forceCenter(width / 2, height / 2))
-      .force(
-        "collision",
-        d3.forceCollide<SimNode>().radius((d) => nodeRadius(d) + 4),
-      );
-
-    simulationRef.current = simulation;
-
-    // ---- Links ------------------------------------------------------------
-
-    const linkGroup = g.append("g").attr("class", "links");
-
-    const linkSelection = linkGroup
-      .selectAll<SVGLineElement, SimLink>("line")
-      .data(links)
-      .enter()
-      .append("line")
-      .attr("stroke", "#8b8b8b")
-      .attr("stroke-width", (d) => 1 + d.confidence_score * 2)
-      .attr("stroke-opacity", 0.6)
-      .attr("stroke-dasharray", (d) => confidenceDash(d.confidence));
-
-    // Link labels (relation)
-    const linkLabelGroup = g.append("g").attr("class", "link-labels");
-
-    const linkLabels = linkLabelGroup
-      .selectAll<SVGTextElement, SimLink>("text")
-      .data(links)
-      .enter()
-      .append("text")
-      .attr("font-size", 9)
-      .attr("fill", "#9ca3af")
-      .attr("text-anchor", "middle")
-      .attr("pointer-events", "none")
-      .text((d) => d.relation);
-
-    // ---- Nodes ------------------------------------------------------------
-
-    const nodeGroup = g.append("g").attr("class", "nodes");
-
-    const nodeSelection = nodeGroup
-      .selectAll<SVGCircleElement, SimNode>("circle")
-      .data(nodes)
-      .enter()
-      .append("circle")
-      .attr("r", (d) => nodeRadius(d))
-      .attr("fill", (d) => communityColor(d.community))
-      .attr("fill-opacity", (d) => {
-        if (selectedCommunity != null && d.community !== selectedCommunity) {
-          return DIMMED_OPACITY;
-        }
-        return 0.85;
-      })
-      .attr("stroke", NODE_STROKE)
-      .attr("stroke-width", 1.5)
-      .style("cursor", "pointer")
-      .call(
-        d3
-          .drag<SVGCircleElement, SimNode>()
-          .on("start", (event, d) => {
-            if (!event.active) simulation.alphaTarget(0.3).restart();
-            d.fx = d.x;
-            d.fy = d.y;
-          })
-          .on("drag", (event, d) => {
-            d.fx = event.x;
-            d.fy = event.y;
-          })
-          .on("end", (event, d) => {
-            if (!event.active) simulation.alphaTarget(0);
-            d.fx = null;
-            d.fy = null;
-          }),
-      );
-
-    // Hover effects
-    nodeSelection
-      .on("mouseenter", function (_event, d) {
-        d3.select(this)
-          .attr("stroke", ORANGE_ACCENT)
-          .attr("stroke-width", 3);
-      })
-      .on("mouseleave", function (_event, _d) {
-        d3.select(this)
-          .attr("stroke", NODE_STROKE)
-          .attr("stroke-width", 1.5);
-      });
-
-    // Click handler
-    nodeSelection.on("click", (_event, d) => {
-      // Highlight selected node
-      nodeSelection
-        .attr("stroke", NODE_STROKE)
-        .attr("stroke-width", 1.5);
-      d3.select(_event.currentTarget as SVGCircleElement)
-        .attr("stroke", ORANGE_ACCENT)
-        .attr("stroke-width", 3);
-
-      if (onNodeSelect) {
-        onNodeSelect({
-          id: d.id,
-          label: d.label,
-          file_type: d.file_type,
-          community: d.community,
-          source_file: d.source_file,
-        });
+      // Only label when zoomed enough AND node is significant — avoids
+      // unreadable text-spaghetti at low zoom on big graphs.
+      const showLabel = globalScale > 1.5 || node.degree > maxDegree * 0.6;
+      if (showLabel && node.label) {
+        const fontSize = Math.max(8, 12 / globalScale);
+        ctx.font = `${fontSize}px Inter, ui-sans-serif`;
+        ctx.fillStyle = "#e5e7eb";
+        ctx.textBaseline = "middle";
+        ctx.fillText(node.label, node.x + baseR + 2, node.y);
       }
-    });
+      ctx.globalAlpha = 1;
+    },
+    [maxDegree, selectedCommunity],
+  );
 
-    // Tooltips
-    nodeSelection
-      .append("title")
-      .text(
-        (d) =>
-          `${d.label}\nType: ${d.file_type}\nCommunity: ${d.community ?? "none"}\nConnections: ${d.degree}`,
-      );
+  // Click hit-area: extend slightly past the visible radius so it's easy
+  // to click small nodes on a dense graph.
+  const nodePointerAreaPaint = useCallback(
+    (node: any, color: string, ctx: CanvasRenderingContext2D) => {
+      const baseR = 2 + 6 * (node.degree / maxDegree);
+      ctx.fillStyle = color;
+      ctx.beginPath();
+      ctx.arc(node.x, node.y, baseR + 3, 0, 2 * Math.PI);
+      ctx.fill();
+    },
+    [maxDegree],
+  );
 
-    // ---- Node labels ------------------------------------------------------
+  const linkColor = useCallback(
+    (l: any) => {
+      // Dim links that don't touch the selected community.
+      if (selectedCommunity != null) {
+        const s = typeof l.source === "object" ? l.source : null;
+        const t = typeof l.target === "object" ? l.target : null;
+        const touches = s?.community === selectedCommunity || t?.community === selectedCommunity;
+        return touches ? "rgba(180,180,200,0.45)" : `rgba(180,180,200,${DIMMED_OPACITY})`;
+      }
+      return "rgba(180,180,200,0.30)";
+    },
+    [selectedCommunity],
+  );
 
-    const nodeLabelGroup = g.append("g").attr("class", "node-labels");
+  const handleNodeClick = useCallback(
+    (node: any) => {
+      if (!onNodeSelect) return;
+      const { degree, ...plain } = node;
+      onNodeSelect(plain as GraphNode);
+    },
+    [onNodeSelect],
+  );
 
-    const nodeLabels = nodeLabelGroup
-      .selectAll<SVGTextElement, SimNode>("text")
-      .data(nodes)
-      .enter()
-      .append("text")
-      .attr("font-size", 11)
-      .attr("fill", (d) => {
-        if (selectedCommunity != null && d.community !== selectedCommunity) {
-          return `rgba(229,231,235,${DIMMED_OPACITY})`;
-        }
-        return LABEL_COLOR;
-      })
-      .attr("text-anchor", "middle")
-      .attr("dy", (d) => nodeRadius(d) + 14)
-      .attr("pointer-events", "none")
-      .text((d) => {
-        // Truncate long labels
-        return d.label.length > 20 ? d.label.slice(0, 18) + "\u2026" : d.label;
-      });
+  // ── Zoom to fit on first load / when data changes substantially ────────
 
-    // ---- Tick -------------------------------------------------------------
+  useEffect(() => {
+    if (!fgRef.current || data.nodes.length === 0) return;
+    // Let the simulation settle a bit before zooming.
+    const timer = setTimeout(() => {
+      try {
+        fgRef.current.zoomToFit(400, 40);
+      } catch {
+        /* ignore — graph not mounted */
+      }
+    }, 600);
+    return () => clearTimeout(timer);
+  }, [data.nodes.length]);
 
-    simulation.on("tick", () => {
-      linkSelection
-        .attr("x1", (d) => (d.source as SimNode).x ?? 0)
-        .attr("y1", (d) => (d.source as SimNode).y ?? 0)
-        .attr("x2", (d) => (d.target as SimNode).x ?? 0)
-        .attr("y2", (d) => (d.target as SimNode).y ?? 0);
-
-      linkLabels
-        .attr(
-          "x",
-          (d) =>
-            (((d.source as SimNode).x ?? 0) + ((d.target as SimNode).x ?? 0)) /
-            2,
-        )
-        .attr(
-          "y",
-          (d) =>
-            (((d.source as SimNode).y ?? 0) + ((d.target as SimNode).y ?? 0)) /
-            2,
-        );
-
-      nodeSelection
-        .attr("cx", (d) => d.x ?? 0)
-        .attr("cy", (d) => d.y ?? 0);
-
-      nodeLabels
-        .attr("x", (d) => d.x ?? 0)
-        .attr("y", (d) => d.y ?? 0);
-    });
-
-    // ---- Cleanup ----------------------------------------------------------
-
-    return () => {
-      simulation.stop();
-      simulationRef.current = null;
-    };
-  }, [nodes, links, selectedCommunity, nodeRadius, onNodeSelect]);
-
-  // ---- Render -------------------------------------------------------------
+  // ── Render ─────────────────────────────────────────────────────────────
 
   return (
-    <div ref={containerRef} className="relative w-full h-full min-h-[400px]">
-      <svg
-        ref={svgRef}
-        className="w-full h-full"
-        style={{ backgroundColor: BG_COLOR }}
-      />
-
-      {/* Legend overlay — bottom-left */}
-      {nodes.length > 0 && (
-        <div
-          className="absolute bottom-3 left-3 px-3 py-2 rounded-lg text-xs"
-          style={{
-            background: "rgba(15, 17, 23, 0.8)",
-            backdropFilter: "blur(8px)",
-            border: "1px solid rgba(255,255,255,0.1)",
-          }}
-        >
-          <div className="flex items-center gap-4 flex-wrap">
-            <span className="text-muted-foreground font-medium">Edges:</span>
-            <span className="text-foreground/90 flex items-center gap-1">
-              <svg width="24" height="8">
-                <line
-                  x1="0"
-                  y1="4"
-                  x2="24"
-                  y2="4"
-                  stroke="#9ca3af"
-                  strokeWidth="2"
-                />
-              </svg>
-              Extracted
-            </span>
-            <span className="text-foreground/90 flex items-center gap-1">
-              <svg width="24" height="8">
-                <line
-                  x1="0"
-                  y1="4"
-                  x2="24"
-                  y2="4"
-                  stroke="#9ca3af"
-                  strokeWidth="2"
-                  strokeDasharray="6,4"
-                />
-              </svg>
-              Inferred
-            </span>
-            <span className="text-foreground/90 flex items-center gap-1">
-              <svg width="24" height="8">
-                <line
-                  x1="0"
-                  y1="4"
-                  x2="24"
-                  y2="4"
-                  stroke="#9ca3af"
-                  strokeWidth="2"
-                  strokeDasharray="2,3"
-                />
-              </svg>
-              Ambiguous
-            </span>
-          </div>
+    <div ref={containerRef} className="w-full h-full min-h-[500px]">
+      {data.nodes.length === 0 ? (
+        <div className="flex items-center justify-center h-full text-sm text-muted-foreground">
+          No nodes match the current filters.
         </div>
-      )}
-
-      {/* Empty state */}
-      {nodes.length === 0 && (
-        <div className="absolute inset-0 flex items-center justify-center">
-          <p className="text-muted-foreground text-sm">
-            No graph data available
-          </p>
-        </div>
+      ) : (
+        <ForceGraph2D
+          ref={fgRef}
+          graphData={data}
+          width={size.w}
+          height={size.h}
+          backgroundColor="#0f1117"
+          nodeRelSize={4}
+          nodeCanvasObject={nodeCanvasObject}
+          nodePointerAreaPaint={nodePointerAreaPaint}
+          linkColor={linkColor}
+          linkWidth={0.5}
+          // Force config tuned for large graphs — quicker cooldown so we
+          // don't burn CPU rebalancing 25k nodes forever.
+          cooldownTicks={120}
+          d3AlphaDecay={0.03}
+          d3VelocityDecay={0.35}
+          warmupTicks={20}
+          enableNodeDrag={false}
+          onNodeClick={handleNodeClick}
+        />
       )}
     </div>
   );
 };
 
-export { BusinessGraphVisualization };
 export default BusinessGraphVisualization;

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -73,6 +73,7 @@
         "react-day-picker": "8.8.2",
         "react-dom": "18.2.0",
         "react-dropzone": "14.2.3",
+        "react-force-graph-2d": "^1.29.1",
         "react-grid-layout": "^2.2.2",
         "react-hook-form": "7.47.0",
         "react-hot-toast": "2.4.1",
@@ -6078,6 +6079,14 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/accessor-fn": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/accessor-fn/-/accessor-fn-1.5.3.tgz",
+      "integrity": "sha512-rkAofCwe/FvYFUlMB0v0gWmhqtfAtV1IUkdPbfhTUyYniu5LrC0A0UJkTH0Jv3S8SvwkmfuAlY+mQIJATdocMA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -6599,6 +6608,15 @@
         }
       ]
     },
+    "node_modules/bezier-js": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/bezier-js/-/bezier-js-6.1.4.tgz",
+      "integrity": "sha512-PA0FW9ZpcHbojUCMu28z9Vg/fNkwTj5YhusSAjHHDfHDGLxJ6YUKrAN2vk1fP2MMOxVw4Oko16FMlRGVBGqLKg==",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/Pomax/bezierjs/blob/master/FUNDING.md"
+      }
+    },
     "node_modules/bidi-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
@@ -6819,6 +6837,17 @@
           "url": "https://github.com/sponsors/ai"
         }
       ]
+    },
+    "node_modules/canvas-color-tracker": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/canvas-color-tracker/-/canvas-color-tracker-1.3.2.tgz",
+      "integrity": "sha512-ryQkDX26yJ3CXzb3hxUVNlg1NKE4REc5crLBq661Nxzr8TNd236SaEf2ffYLXyI5tSABSeguHLqcVq4vf9L3Zg==",
+      "dependencies": {
+        "tinycolor2": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/ccount": {
       "version": "2.0.1",
@@ -7462,6 +7491,17 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-axis": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
@@ -7469,6 +7509,11 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/d3-binarytree": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/d3-binarytree/-/d3-binarytree-1.0.2.tgz",
+      "integrity": "sha512-cElUNH+sHu95L04m92pG73t2MEJXKu+GeKUN1TJkFsu93E5W8E9Sc3kHEGJKgenGvj19m6upSn2EunvMgMD2Yw=="
     },
     "node_modules/d3-brush": {
       "version": "3.0.0",
@@ -7511,17 +7556,6 @@
       "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
       "dependencies": {
         "d3-array": "^3.2.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-contour/node_modules/d3-array": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
-      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
-      "dependencies": {
-        "internmap": "1 - 2"
       },
       "engines": {
         "node": ">=12"
@@ -7607,6 +7641,21 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-force-3d": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/d3-force-3d/-/d3-force-3d-3.0.6.tgz",
+      "integrity": "sha512-4tsKHUPLOVkyfEffZo1v6sFHvGFwAIIjt/W8IThbp08DYAsXZck+2pSHEG5W1+gQgEvFLdZkYvmJAbRM2EzMnA==",
+      "dependencies": {
+        "d3-binarytree": "1",
+        "d3-dispatch": "1 - 3",
+        "d3-octree": "1",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-format": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
@@ -7625,6 +7674,11 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-octree": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-octree/-/d3-octree-1.1.0.tgz",
+      "integrity": "sha512-F8gPlqpP+HwRPMO/8uOu5wjH110+6q4cgJvgJT6vlpy3BEaDIKlTZrgHKZSp/i1InRpVfh4puY/kvL6MxK930A=="
+    },
     "node_modules/d3-path": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
@@ -7635,6 +7689,14 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
       "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
       "engines": {
         "node": ">=12"
       }
@@ -7669,17 +7731,6 @@
       "dependencies": {
         "d3-color": "1 - 3",
         "d3-interpolate": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-scale/node_modules/d3-array": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
-      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
-      "dependencies": {
-        "internmap": "1 - 2"
       },
       "engines": {
         "node": ">=12"
@@ -7758,17 +7809,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/d3/node_modules/d3-array": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
-      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
-      "dependencies": {
-        "internmap": "1 - 2"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/d3/node_modules/d3-dispatch": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
@@ -7821,14 +7861,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
       "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3/node_modules/d3-quadtree": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
-      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
       "engines": {
         "node": ">=12"
       }
@@ -9220,6 +9252,19 @@
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true
     },
+    "node_modules/float-tooltip": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/float-tooltip/-/float-tooltip-1.7.5.tgz",
+      "integrity": "sha512-/kXzuDnnBqyyWyhDMH7+PfP8J/oXiAavGzcRxASOMRHFuReDtofizLLJsf7nnDLAfEaMW4pVWaXrAjtnglpEkg==",
+      "dependencies": {
+        "d3-selection": "2 - 3",
+        "kapsule": "^1.16",
+        "preact": "10"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -9234,6 +9279,31 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/force-graph": {
+      "version": "1.51.4",
+      "resolved": "https://registry.npmjs.org/force-graph/-/force-graph-1.51.4.tgz",
+      "integrity": "sha512-TdJ2KbkoiDQ7NIRx8IPGD0mAXXpLhamS7c+b7W98b0MHG7lphnda1VOQX/98UDTsttIAdH4TcP0l0MauSnLK8w==",
+      "dependencies": {
+        "@tweenjs/tween.js": "18 - 25",
+        "accessor-fn": "1",
+        "bezier-js": "3 - 6",
+        "canvas-color-tracker": "^1.3",
+        "d3-array": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-force-3d": "2 - 3",
+        "d3-scale": "1 - 4",
+        "d3-scale-chromatic": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-zoom": "2 - 3",
+        "float-tooltip": "^1.7",
+        "index-array-by": "1",
+        "kapsule": "^1.16",
+        "lodash-es": "4"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/foreground-child": {
@@ -9884,6 +9954,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/index-array-by": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/index-array-by/-/index-array-by-1.4.2.tgz",
+      "integrity": "sha512-SP23P27OUKzXWEC/TOyWlwLviofQkCSCKONnc62eItjp69yCZZPqDQtr3Pw5gJDnPeUMqExmKydNZaJO0FU9pw==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -10481,6 +10559,14 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
+    "node_modules/jerrypick": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/jerrypick/-/jerrypick-1.1.2.tgz",
+      "integrity": "sha512-YKnxXEekXKzhpf7CLYA0A+oDP8V0OhICNCr5lv96FvSsDEmrb0GKM776JgQvHTMjr7DTTPEVv/1Ciaw0uEWzBA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/jiti": {
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
@@ -10637,6 +10723,17 @@
         "setimmediate": "^1.0.5"
       }
     },
+    "node_modules/kapsule": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/kapsule/-/kapsule-1.16.3.tgz",
+      "integrity": "sha512-4+5mNNf4vZDSwPhKprKwz3330iisPrb08JyMgbsdFrimBCKNHecua/WBwvVg3n7vwx0C1ARjfhwIpbrbd9n5wg==",
+      "dependencies": {
+        "lodash-es": "4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -10740,6 +10837,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -12650,6 +12752,15 @@
       "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
       "integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ=="
     },
+    "node_modules/preact": {
+      "version": "10.29.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.2.tgz",
+      "integrity": "sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -13094,6 +13205,22 @@
         "react": ">= 16.8 || 18.0.0"
       }
     },
+    "node_modules/react-force-graph-2d": {
+      "version": "1.29.1",
+      "resolved": "https://registry.npmjs.org/react-force-graph-2d/-/react-force-graph-2d-1.29.1.tgz",
+      "integrity": "sha512-1Rl/1Z3xy2iTHKj6a0jRXGyiI86xUti81K+jBQZ+Oe46csaMikp47L5AjrzA9hY9fNGD63X8ffrqnvaORukCuQ==",
+      "dependencies": {
+        "force-graph": "^1.51",
+        "prop-types": "15",
+        "react-kapsule": "^2.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-grid-layout": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/react-grid-layout/-/react-grid-layout-2.2.2.tgz",
@@ -13168,6 +13295,20 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+    },
+    "node_modules/react-kapsule": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/react-kapsule/-/react-kapsule-2.5.7.tgz",
+      "integrity": "sha512-kifAF4ZPD77qZKc4CKLmozq6GY1sBzPEJTIJb0wWFK6HsePJatK3jXplZn2eeAt3x67CDozgi7/rO8fNQ/AL7A==",
+      "dependencies": {
+        "jerrypick": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      }
     },
     "node_modules/react-lifecycles-compat": {
       "version": "3.0.4",
@@ -14876,6 +15017,11 @@
       "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
       "dev": true
     },
+    "node_modules/tinycolor2": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
+      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw=="
+    },
     "node_modules/tinyexec": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
@@ -15595,17 +15741,6 @@
         "d3-shape": "^3.1.0",
         "d3-time": "^3.0.0",
         "d3-timer": "^3.0.1"
-      }
-    },
-    "node_modules/victory-vendor/node_modules/d3-array": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
-      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
-      "dependencies": {
-        "internmap": "1 - 2"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/victory-vendor/node_modules/d3-path": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -113,6 +113,7 @@
     "react-day-picker": "8.8.2",
     "react-dom": "18.2.0",
     "react-dropzone": "14.2.3",
+    "react-force-graph-2d": "^1.29.1",
     "react-grid-layout": "^2.2.2",
     "react-hook-form": "7.47.0",
     "react-hot-toast": "2.4.1",


### PR DESCRIPTION
The d3-force/SVG implementation locks the browser tab past ~5,000 nodes, which is why BusinessGraphPanel currently hides the visualization for the InbuildUK catalog graph (24,505 nodes) behind a 'visualization disabled' info card.

Swap in react-force-graph-2d — same d3-force physics under the hood, but Canvas-rendered, so it handles tens of thousands of nodes smoothly (Obsidian-tier perf for big knowledge graphs).

Changes:
- frontend/components/knowledge/BusinessGraphVisualization.tsx Rewritten end-to-end (~210 lines vs 462). Same props/feature surface: community coloring, degree-based node sizing, click-to-select, selected-community dimming, confidence-score edge filter. Labels are zoom-gated so 25k+ doesn't become unreadable text spaghetti.
- frontend/components/knowledge/BusinessGraphPanel.tsx Raised the vizSafe threshold from 5,000 to 100,000 — the new renderer comfortably handles InbuildUK's 24,505 nodes; hard ceiling is browser memory, not the renderer.
- frontend/package.json: add react-force-graph-2d (^1.27.0).

No backend changes — same graph.json shape feeds straight in.