### PR TITLE
fix(business-graph): named-vs-default import mismatch (client crash)

### DIFF
--- a/frontend/components/knowledge/BusinessGraphPanel.tsx
+++ b/frontend/components/knowledge/BusinessGraphPanel.tsx
@@ -8,7 +8,8 @@ import { Input } from '@/components/ui/input'
 import { Slider } from '@/components/ui/slider'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
-import { BusinessGraphVisualization } from './BusinessGraphVisualization'
+import BusinessGraphVisualization from './BusinessGraphVisualization'
+import { GraphErrorBoundary } from './GraphErrorBoundary'
 import {
   Network, Loader2, Search, X, ChevronRight,
   FileText, Clock, Layers, Upload, RefreshCw, Plus,
@@ -205,8 +206,10 @@ export function BusinessGraphPanel() {
 
   // The Canvas-based ForceGraph2D renderer handles tens of thousands of nodes
   // smoothly (Obsidian-tier perf). Cap raised from 5,000 (old SVG/d3 limit)
-  // to 100,000. The hard ceiling is browser memory, not the renderer.
-  const vizSafe = !!meta && (meta.node_count ?? 0) <= 100000
+  // to 50,000 — high enough for InbuildUK (~24k) but low enough that the
+  // graph.json fetch + parse stays safely under ~30MB. Higher catalogs
+  // (~100k+) should switch to the cluster-first drill-in pattern instead.
+  const vizSafe = !!meta && (meta.node_count ?? 0) <= 50000
 
   const {
     data: graphData,
@@ -499,14 +502,18 @@ export function BusinessGraphPanel() {
           ))}
         </div>
 
-        {/* Graph Visualization */}
+        {/* Graph Visualization — wrapped in a localised error boundary so a
+            renderer-level exception (bad node, missing peer dep at runtime)
+            doesn't take down the whole dashboard. */}
         <div className="flex-1 glass-card bg-white/5 backdrop-blur-sm border border-white/10 rounded-lg overflow-hidden min-h-[400px]">
-          <BusinessGraphVisualization
-            graphData={(filteredData ?? { nodes: [], links: [] }) as any}
-            onNodeSelect={handleNodeSelect}
-            selectedCommunity={selectedCommunity}
-            minConfidence={confidenceMin}
-          />
+          <GraphErrorBoundary>
+            <BusinessGraphVisualization
+              graphData={(filteredData ?? { nodes: [], links: [] }) as any}
+              onNodeSelect={handleNodeSelect}
+              selectedCommunity={selectedCommunity}
+              minConfidence={confidenceMin}
+            />
+          </GraphErrorBoundary>
         </div>
       </div>}
 

--- a/frontend/components/knowledge/BusinessGraphVisualization.tsx
+++ b/frontend/components/knowledge/BusinessGraphVisualization.tsx
@@ -18,11 +18,17 @@
 import React, { useCallback, useMemo, useRef, useEffect, useState } from "react";
 import dynamic from "next/dynamic";
 
-// SSR-disabled dynamic import — react-force-graph needs window/canvas.
-const ForceGraph2D = dynamic(
-  () => import("react-force-graph-2d").then((m) => m.default),
-  { ssr: false },
-) as any;
+// SSR-disabled dynamic import — react-force-graph needs window/canvas. Next 15
+// can mis-resolve the default export for ESM-only packages when you go via
+// .then(m => m.default), so let Next handle the resolution itself.
+const ForceGraph2D = dynamic(() => import("react-force-graph-2d"), {
+  ssr: false,
+  loading: () => (
+    <div className="flex items-center justify-center h-full text-sm text-muted-foreground">
+      Loading graph renderer…
+    </div>
+  ),
+}) as any;
 
 // ---------------------------------------------------------------------------
 // Types — same shape the existing BusinessGraphPanel feeds in.

--- a/frontend/components/knowledge/GraphErrorBoundary.tsx
+++ b/frontend/components/knowledge/GraphErrorBoundary.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import React from "react";
+import { AlertTriangle } from "lucide-react";
+
+interface State {
+  hasError: boolean;
+  message: string | null;
+}
+
+interface Props {
+  children: React.ReactNode;
+}
+
+/**
+ * Localised error boundary for the business graph view. Without this, any
+ * exception thrown by the WebGL renderer (e.g. a malformed node, a missing
+ * peer dep at runtime) bubbles all the way to Next's root boundary and
+ * shows "Application error: a client-side exception has occurred", which
+ * is opaque and ugly. Catching it here lets the rest of the dashboard
+ * stay usable while we surface a real message.
+ */
+export class GraphErrorBoundary extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false, message: null };
+  }
+
+  static getDerivedStateFromError(error: unknown): State {
+    return {
+      hasError: true,
+      message: error instanceof Error ? error.message : "Unknown render error",
+    };
+  }
+
+  componentDidCatch(error: unknown, info: unknown) {
+    // eslint-disable-next-line no-console
+    console.error("[BusinessGraph] render error:", error, info);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="flex h-full min-h-[400px] flex-col items-center justify-center gap-2 text-center p-6">
+          <AlertTriangle className="w-6 h-6 text-amber-400" />
+          <div className="text-sm text-foreground">
+            Couldn't render the graph view.
+          </div>
+          <div className="text-xs text-muted-foreground max-w-md">
+            {this.state.message ?? "An exception was thrown by the renderer."}
+            {" "}The agent can still query this graph via tools — only the
+            browser visualisation is affected.
+          </div>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}


### PR DESCRIPTION
The previous SVG component was exported as named (`export const Business...`); the WebGL rewrite changed it to default (`export default ...`). The panel still imported it via the named syntax — at runtime React got `undefined` when trying to render <BusinessGraphVisualization/>, which threw the opaque 'Application error: a client-side exception' shown by Next 15's root error boundary.

Fixes:
- Panel: switch to `import BusinessGraphVisualization from ...` (default import to match new export style).
- New GraphErrorBoundary component wraps the visualization so future renderer-level exceptions surface a real message in the graph card instead of taking down the whole dashboard.
- dynamic() call simplified — drop the .then(m => m.default), let Next handle the resolution (more robust with ESM-only packages on Next 15).
- vizSafe threshold tightened to 50k (was 100k) — 24k still fits InbuildUK but stays comfortably under the ~30MB graph.json size where browser fetch+parse starts to struggle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added loading indicator while the business graph visualization initializes.

* **Bug Fixes**
  * Improved error handling for graph rendering to prevent dashboard crashes; errors are now contained with a user-friendly fallback message.
  * Optimized graph node limits for enhanced stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AutomatosAI/automatos-ai/pull/360?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->