### PR TITLE
feat(business-graph): WOW pass — types, colors, drill-in, fullscreen

### DIFF
--- a/frontend/components/knowledge/BusinessGraphPanel.tsx
+++ b/frontend/components/knowledge/BusinessGraphPanel.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useRef, useMemo, useCallback } from 'react'
+import { useState, useRef, useMemo, useCallback, useEffect } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { apiClient } from '@/lib/api-client'
 import { useWorkspace } from '@/hooks/use-workspace'
@@ -8,11 +8,15 @@ import { Input } from '@/components/ui/input'
 import { Slider } from '@/components/ui/slider'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
-import BusinessGraphVisualization from './BusinessGraphVisualization'
+import BusinessGraphVisualization, {
+  type BusinessGraphHandle,
+  type ColorMode,
+} from './BusinessGraphVisualization'
 import { GraphErrorBoundary } from './GraphErrorBoundary'
 import {
   Network, Loader2, Search, X, ChevronRight,
   FileText, Clock, Layers, Upload, RefreshCw, Plus,
+  Maximize2, Minimize2, Palette,
 } from 'lucide-react'
 import { formatDistanceToNow } from 'date-fns'
 
@@ -71,6 +75,13 @@ export function BusinessGraphPanel() {
   const [importError, setImportError] = useState<string | null>(null)
   const [building, setBuilding] = useState(false)
   const [dragActive, setDragActive] = useState(false)
+
+  // PRD-009 Phase-2 polish state
+  const [visibleTypes, setVisibleTypes] = useState<Set<string>>(new Set())  // empty = all
+  const [colorMode, setColorMode] = useState<ColorMode>('community')
+  const [isFullscreen, setIsFullscreen] = useState(false)
+  const vizRef = useRef<BusinessGraphHandle>(null)
+  const graphContainerRef = useRef<HTMLDivElement>(null)
 
   // ── File handling (matches document-management.tsx pattern) ──
 
@@ -241,6 +252,83 @@ export function BusinessGraphPanel() {
       .sort((a, b) => b[1] - a[1])
       .map(([id, count]) => ({ id, count }))
   }, [graphData])
+
+  // Per-type counts for the filter chips. We pre-compute once so the chip
+  // row stays static even while the user toggles things off.
+  const typeCounts = useMemo(() => {
+    if (!graphData?.nodes) return new Map<string, number>()
+    const m = new Map<string, number>()
+    for (const n of graphData.nodes) {
+      const t = n.file_type ?? 'unknown'
+      m.set(t, (m.get(t) ?? 0) + 1)
+    }
+    return m
+  }, [graphData])
+
+  // Pretty label for each node type — sortable for chip ordering.
+  const TYPE_DISPLAY: Record<string, { label: string; color: string; order: number }> = {
+    shopify_product:    { label: 'Products',    color: '#ff7849', order: 1 },
+    shopify_variant:    { label: 'Variants',    color: '#fdba74', order: 2 },
+    shopify_vendor:     { label: 'Vendors',     color: '#a78bfa', order: 3 },
+    shopify_collection: { label: 'Collections', color: '#34d399', order: 4 },
+    shopify_metafield:  { label: 'Metafields',  color: '#60a5fa', order: 5 },
+  }
+
+  const typeChips = useMemo(() => {
+    return Array.from(typeCounts.entries())
+      .map(([t, n]) => ({
+        type: t,
+        count: n,
+        label: TYPE_DISPLAY[t]?.label ?? t.replace(/_/g, ' '),
+        color: TYPE_DISPLAY[t]?.color ?? '#94a3b8',
+        order: TYPE_DISPLAY[t]?.order ?? 99,
+      }))
+      .sort((a, b) => a.order - b.order || b.count - a.count)
+  }, [typeCounts])
+
+  const toggleType = useCallback((t: string) => {
+    setVisibleTypes((prev) => {
+      const next = new Set(prev)
+      // Empty set = "show all". First click on any chip switches into
+      // explicit mode with ONLY the others removed.
+      if (next.size === 0) {
+        for (const ct of typeChips) {
+          if (ct.type !== t) next.add(ct.type)
+        }
+      } else if (next.has(t)) {
+        next.delete(t)
+      } else {
+        next.add(t)
+      }
+      // If user re-enables everything, fall back to "show all" sentinel.
+      if (next.size === typeChips.length) next.clear()
+      return next
+    })
+  }, [typeChips])
+
+  const isTypeVisible = useCallback(
+    (t: string) => visibleTypes.size === 0 || visibleTypes.has(t),
+    [visibleTypes],
+  )
+
+  // Native HTML5 fullscreen on the graph container.
+  const handleFullscreen = useCallback(() => {
+    const el = graphContainerRef.current
+    if (!el) return
+    if (!document.fullscreenElement) {
+      el.requestFullscreen?.().then(() => setIsFullscreen(true)).catch(() => {})
+    } else {
+      document.exitFullscreen?.().then(() => setIsFullscreen(false)).catch(() => {})
+    }
+  }, [])
+
+  // Keep isFullscreen in sync if the user ESC-exits without clicking the
+  // toggle — otherwise the icon shows the wrong state.
+  useEffect(() => {
+    const onChange = () => setIsFullscreen(!!document.fullscreenElement)
+    document.addEventListener('fullscreenchange', onChange)
+    return () => document.removeEventListener('fullscreenchange', onChange)
+  }, [])
 
   const filteredData = useMemo((): GraphData | null => {
     if (!graphData) return null
@@ -502,16 +590,87 @@ export function BusinessGraphPanel() {
           ))}
         </div>
 
-        {/* Graph Visualization — wrapped in a localised error boundary so a
-            renderer-level exception (bad node, missing peer dep at runtime)
-            doesn't take down the whole dashboard. */}
-        <div className="flex-1 glass-card bg-white/5 backdrop-blur-sm border border-white/10 rounded-lg overflow-hidden min-h-[400px]">
+        {/* Graph Visualization + controls — wrapped in a localised error
+            boundary so a renderer-level exception doesn't take down the
+            whole dashboard. Container is the fullscreen target. */}
+        <div
+          ref={graphContainerRef}
+          className="flex-1 glass-card bg-white/5 backdrop-blur-sm border border-white/10 rounded-lg overflow-hidden min-h-[400px] relative"
+        >
+          {/* Top-right controls — color-mode toggle + fullscreen */}
+          <div className="absolute top-3 right-3 z-10 flex items-center gap-2">
+            <div className="flex items-center bg-black/50 backdrop-blur-sm rounded-md border border-white/10 overflow-hidden">
+              <button
+                onClick={() => setColorMode('community')}
+                className={`px-2.5 py-1 text-xs flex items-center gap-1 transition ${
+                  colorMode === 'community'
+                    ? 'bg-white/15 text-foreground'
+                    : 'text-muted-foreground hover:text-foreground hover:bg-white/5'
+                }`}
+                title="Color by cluster"
+              >
+                <Layers className="w-3 h-3" /> Cluster
+              </button>
+              <button
+                onClick={() => setColorMode('type')}
+                className={`px-2.5 py-1 text-xs flex items-center gap-1 transition border-l border-white/10 ${
+                  colorMode === 'type'
+                    ? 'bg-white/15 text-foreground'
+                    : 'text-muted-foreground hover:text-foreground hover:bg-white/5'
+                }`}
+                title="Color by node type"
+              >
+                <Palette className="w-3 h-3" /> Type
+              </button>
+            </div>
+            <button
+              onClick={handleFullscreen}
+              className="p-1.5 rounded-md bg-black/50 backdrop-blur-sm border border-white/10 text-muted-foreground hover:text-foreground hover:bg-white/10 transition"
+              title={isFullscreen ? 'Exit fullscreen' : 'Fullscreen'}
+            >
+              {isFullscreen ? <Minimize2 className="w-3.5 h-3.5" /> : <Maximize2 className="w-3.5 h-3.5" />}
+            </button>
+          </div>
+
+          {/* Type filter chips — bottom-left, doesn't compete with hover tooltip */}
+          {typeChips.length > 0 && (
+            <div className="absolute bottom-3 right-3 z-10 flex flex-wrap gap-1.5 max-w-[60%] justify-end">
+              {typeChips.map(({ type, label, color, count }) => {
+                const visible = isTypeVisible(type)
+                return (
+                  <button
+                    key={type}
+                    onClick={() => toggleType(type)}
+                    className={`flex items-center gap-1.5 px-2 py-1 rounded-md text-xs border transition ${
+                      visible
+                        ? 'bg-white/10 border-white/20 text-foreground'
+                        : 'bg-black/40 border-white/10 text-muted-foreground/60 line-through'
+                    }`}
+                    title={`${count.toLocaleString()} ${label.toLowerCase()}`}
+                  >
+                    <span
+                      className="w-2 h-2 rounded-full"
+                      style={{ backgroundColor: visible ? color : '#52525b' }}
+                    />
+                    {label}
+                    <span className="text-[10px] text-muted-foreground">
+                      {count.toLocaleString()}
+                    </span>
+                  </button>
+                )
+              })}
+            </div>
+          )}
+
           <GraphErrorBoundary>
             <BusinessGraphVisualization
+              ref={vizRef}
               graphData={(filteredData ?? { nodes: [], links: [] }) as any}
               onNodeSelect={handleNodeSelect}
               selectedCommunity={selectedCommunity}
               minConfidence={confidenceMin}
+              visibleTypes={visibleTypes.size > 0 ? visibleTypes : undefined}
+              colorMode={colorMode}
             />
           </GraphErrorBoundary>
         </div>

--- a/frontend/components/knowledge/BusinessGraphVisualization.tsx
+++ b/frontend/components/knowledge/BusinessGraphVisualization.tsx
@@ -1,26 +1,32 @@
 "use client";
 
 /**
- * Business Graph Visualization Component
- * Canvas/WebGL force-directed graph for the workspace knowledge graph.
+ * Business Graph Visualization — WebGL/Canvas force-directed graph.
  *
- * Renderer: react-force-graph-2d (same d3-force physics under the hood,
- * Canvas-based rendering — handles 25k+ nodes smoothly where SVG d3 chokes
- * around 5k). Matches Obsidian's approach for large knowledge graphs.
- *
- * Features kept from the previous SVG implementation:
- *  - Community-based coloring
- *  - Node size proportional to degree ("god-node scaling")
- *  - Click-to-select with selected-community highlighting
- *  - Confidence-score edge filtering
+ * Features (PRD-009 Phase-2 polish):
+ *  - Color modes: by node type OR by community (toggleable from panel)
+ *  - Per-type visibility filtering (panel-controlled)
+ *  - Click-to-focus: clicked node becomes the center, the rest dims unless
+ *    it's in the 1-hop neighbourhood. ESC / second click clears focus.
+ *  - Hover tooltip: label + type + degree
+ *  - Edge directional particles ("data flow" feel) on focused subgraph
+ *  - God-node halo for the top-5 highest-degree nodes
+ *  - Adaptive labels: only top-degree nodes labelled at low zoom; expand
+ *    as the user zooms in
+ *  - Imperative ref forwarded so the panel can trigger zoomToFit / focus
  */
 
-import React, { useCallback, useMemo, useRef, useEffect, useState } from "react";
+import React, {
+  useCallback,
+  useMemo,
+  useRef,
+  useEffect,
+  useState,
+  forwardRef,
+  useImperativeHandle,
+} from "react";
 import dynamic from "next/dynamic";
 
-// SSR-disabled dynamic import — react-force-graph needs window/canvas. Next 15
-// can mis-resolve the default export for ESM-only packages when you go via
-// .then(m => m.default), so let Next handle the resolution itself.
 const ForceGraph2D = dynamic(() => import("react-force-graph-2d"), {
   ssr: false,
   loading: () => (
@@ -31,10 +37,10 @@ const ForceGraph2D = dynamic(() => import("react-force-graph-2d"), {
 }) as any;
 
 // ---------------------------------------------------------------------------
-// Types — same shape the existing BusinessGraphPanel feeds in.
+// Types
 // ---------------------------------------------------------------------------
 
-interface GraphNode {
+export interface GraphNode {
   id: string;
   label: string;
   file_type: string;
@@ -42,7 +48,7 @@ interface GraphNode {
   source_file?: string;
 }
 
-interface GraphLink {
+export interface GraphLink {
   source: string;
   target: string;
   relation: string;
@@ -50,79 +56,89 @@ interface GraphLink {
   confidence_score: number;
 }
 
-interface BusinessGraphVisualizationProps {
-  graphData: {
-    nodes: GraphNode[];
-    links: GraphLink[];
-  };
-  onNodeSelect?: (node: GraphNode) => void;
+export type ColorMode = "type" | "community";
+
+export interface BusinessGraphVisualizationProps {
+  graphData: { nodes: GraphNode[]; links: GraphLink[] };
+  onNodeSelect?: (node: GraphNode | null) => void;
   selectedCommunity?: number | null;
   minConfidence?: number;
+  /** Which node `file_type` values to display. Undefined = show all. */
+  visibleTypes?: Set<string>;
+  /** Coloring strategy. */
+  colorMode?: ColorMode;
 }
 
-// Runtime-augmented node — degree added per render for sizing.
+export interface BusinessGraphHandle {
+  zoomToFit: () => void;
+  resetFocus: () => void;
+}
+
 interface VizNode extends GraphNode {
   degree: number;
+  x?: number;
+  y?: number;
+  vx?: number;
+  vy?: number;
 }
 
 // ---------------------------------------------------------------------------
-// Visual constants
+// Palette — Automatos-aligned, picked to maximise contrast across the
+// node types we see in a Shopify catalog graph. Stable color per type.
 // ---------------------------------------------------------------------------
 
-const COMMUNITY_COLORS = [
-  "#e6194b", "#f58231", "#ffe119", "#3cb44b", "#42d4f4", "#4363d8",
-  "#911eb4", "#f032e6", "#fabebe", "#9a6324", "#800000", "#aaffc3",
-  "#469990", "#bfef45", "#fffac8", "#dcbeff", "#9A6324", "#fffac8",
-];
-
-const communityColor = (community: number | undefined): string => {
-  if (community == null) return "#6b7280";
-  return COMMUNITY_COLORS[community % COMMUNITY_COLORS.length];
+const TYPE_COLORS: Record<string, string> = {
+  shopify_product: "#ff7849",      // brand orange
+  shopify_variant: "#fdba74",      // light orange
+  shopify_vendor: "#a78bfa",       // violet
+  shopify_collection: "#34d399",   // emerald
+  shopify_metafield: "#60a5fa",    // sky blue
+  // Catch-alls
+  product: "#ff7849",
+  variant: "#fdba74",
+  vendor: "#a78bfa",
+  collection: "#34d399",
+  metafield: "#60a5fa",
 };
 
-const DIMMED_OPACITY = 0.18;
+// Soft, distinguishable cluster palette (12 colors cycled).
+const COMMUNITY_COLORS = [
+  "#ff7849", "#34d399", "#60a5fa", "#a78bfa",
+  "#fbbf24", "#f472b6", "#22d3ee", "#fb7185",
+  "#84cc16", "#818cf8", "#facc15", "#2dd4bf",
+];
+
+const colorByType = (t: string | undefined): string =>
+  TYPE_COLORS[t ?? ""] ?? "#94a3b8";
+
+const colorByCommunity = (c: number | undefined): string =>
+  c == null ? "#64748b" : COMMUNITY_COLORS[c % COMMUNITY_COLORS.length];
 
 // ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
 
-const BusinessGraphVisualization: React.FC<BusinessGraphVisualizationProps> = ({
-  graphData,
-  onNodeSelect,
-  selectedCommunity = null,
-  minConfidence = 0,
-}) => {
+const BusinessGraphVisualization = forwardRef<
+  BusinessGraphHandle,
+  BusinessGraphVisualizationProps
+>(function BusinessGraphVisualization(
+  {
+    graphData,
+    onNodeSelect,
+    selectedCommunity = null,
+    minConfidence = 0,
+    visibleTypes,
+    colorMode = "community",
+  },
+  ref,
+) {
   const containerRef = useRef<HTMLDivElement>(null);
   const fgRef = useRef<any>(null);
-  const [size, setSize] = useState<{ w: number; h: number }>({ w: 800, h: 600 });
+  const [size, setSize] = useState({ w: 800, h: 600 });
+  const [hoverNode, setHoverNode] = useState<VizNode | null>(null);
+  const [focusNodeId, setFocusNodeId] = useState<string | null>(null);
 
-  // ── Filter links + compute degree per node ──────────────────────────────
-
-  const data = useMemo(() => {
-    const filteredLinks = graphData.links.filter(
-      (l) => l.confidence_score >= minConfidence,
-    );
-    const degree = new Map<string, number>();
-    for (const l of filteredLinks) {
-      const s = typeof l.source === "string" ? l.source : (l.source as any).id;
-      const t = typeof l.target === "string" ? l.target : (l.target as any).id;
-      degree.set(s, (degree.get(s) ?? 0) + 1);
-      degree.set(t, (degree.get(t) ?? 0) + 1);
-    }
-    const nodes: VizNode[] = graphData.nodes.map((n) => ({
-      ...n,
-      degree: degree.get(n.id) ?? 0,
-    }));
-    return { nodes, links: filteredLinks };
-  }, [graphData, minConfidence]);
-
-  // For node sizing — relative to the max-degree node in the current view.
-  const maxDegree = useMemo(
-    () => Math.max(1, ...data.nodes.map((n) => n.degree)),
-    [data.nodes],
-  );
-
-  // ── Resize observer keeps the canvas filling its container ─────────────
+  // ── Resize observer ────────────────────────────────────────────────────
 
   useEffect(() => {
     if (!containerRef.current) return;
@@ -134,85 +150,242 @@ const BusinessGraphVisualization: React.FC<BusinessGraphVisualizationProps> = ({
     return () => ro.disconnect();
   }, []);
 
-  // ── Node visual: filled circle, color by community, size by degree.
-  // For dense graphs (25k+) drawing per-node labels is too noisy — only
-  // show labels for high-degree nodes ("god nodes") and when zoomed in.
+  // ── ESC clears focus ───────────────────────────────────────────────────
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setFocusNodeId(null);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
+  // ── Filter + augment ───────────────────────────────────────────────────
+
+  const data = useMemo(() => {
+    const wantedTypes = visibleTypes;
+    const allowed = (n: GraphNode) =>
+      !wantedTypes || wantedTypes.size === 0 || wantedTypes.has(n.file_type);
+
+    const nodes = graphData.nodes.filter(allowed);
+    const nodeIds = new Set(nodes.map((n) => n.id));
+    const links = graphData.links.filter(
+      (l) =>
+        l.confidence_score >= minConfidence &&
+        nodeIds.has(typeof l.source === "string" ? l.source : (l.source as any).id) &&
+        nodeIds.has(typeof l.target === "string" ? l.target : (l.target as any).id),
+    );
+
+    const degree = new Map<string, number>();
+    for (const l of links) {
+      const s = typeof l.source === "string" ? l.source : (l.source as any).id;
+      const t = typeof l.target === "string" ? l.target : (l.target as any).id;
+      degree.set(s, (degree.get(s) ?? 0) + 1);
+      degree.set(t, (degree.get(t) ?? 0) + 1);
+    }
+    const vizNodes: VizNode[] = nodes.map((n) => ({
+      ...n,
+      degree: degree.get(n.id) ?? 0,
+    }));
+    return { nodes: vizNodes, links };
+  }, [graphData, visibleTypes, minConfidence]);
+
+  const maxDegree = useMemo(
+    () => Math.max(1, ...data.nodes.map((n) => n.degree)),
+    [data.nodes],
+  );
+
+  // ── 1-hop neighbourhood of the focused node ────────────────────────────
+
+  const focusNeighbourhood = useMemo(() => {
+    if (!focusNodeId) return null;
+    const neighbours = new Set<string>([focusNodeId]);
+    for (const l of data.links) {
+      const s = typeof l.source === "object" ? (l.source as any).id : l.source;
+      const t = typeof l.target === "object" ? (l.target as any).id : l.target;
+      if (s === focusNodeId) neighbours.add(t);
+      if (t === focusNodeId) neighbours.add(s);
+    }
+    return neighbours;
+  }, [focusNodeId, data.links]);
+
+  // Top-5 god nodes by degree — get the halo.
+  const godNodeIds = useMemo(() => {
+    const sorted = [...data.nodes].sort((a, b) => b.degree - a.degree);
+    return new Set(sorted.slice(0, 5).map((n) => n.id));
+  }, [data.nodes]);
+
+  // ── Coloring ───────────────────────────────────────────────────────────
+
+  const getColor = useCallback(
+    (n: VizNode): string =>
+      colorMode === "type" ? colorByType(n.file_type) : colorByCommunity(n.community),
+    [colorMode],
+  );
+
+  // ── Per-node canvas draw ───────────────────────────────────────────────
 
   const nodeCanvasObject = useCallback(
     (node: any, ctx: CanvasRenderingContext2D, globalScale: number) => {
-      const baseR = 2 + 6 * (node.degree / maxDegree);  // 2–8px radius
-      const dim = selectedCommunity != null && node.community !== selectedCommunity;
-      ctx.globalAlpha = dim ? DIMMED_OPACITY : 0.95;
+      const n = node as VizNode;
+      const baseR = 2 + 7 * (n.degree / maxDegree);
 
+      // Dim if community filtered OR outside focus neighbourhood
+      const dimmedByCommunity =
+        selectedCommunity != null && n.community !== selectedCommunity;
+      const dimmedByFocus =
+        focusNeighbourhood != null && !focusNeighbourhood.has(n.id);
+      const dimmed = dimmedByCommunity || dimmedByFocus;
+      ctx.globalAlpha = dimmed ? 0.12 : 0.95;
+
+      const fill = getColor(n);
+
+      // God-node halo (top-5 by degree)
+      if (godNodeIds.has(n.id) && !dimmed) {
+        ctx.beginPath();
+        ctx.arc(node.x, node.y, baseR + 6, 0, 2 * Math.PI);
+        const halo = ctx.createRadialGradient(
+          node.x, node.y, baseR,
+          node.x, node.y, baseR + 6,
+        );
+        halo.addColorStop(0, fill + "AA");
+        halo.addColorStop(1, fill + "00");
+        ctx.fillStyle = halo;
+        ctx.fill();
+      }
+
+      // Hover/focus emphasis ring
+      const isHover = hoverNode?.id === n.id;
+      const isFocus = focusNodeId === n.id;
+      if (isHover || isFocus) {
+        ctx.beginPath();
+        ctx.arc(node.x, node.y, baseR + 3, 0, 2 * Math.PI);
+        ctx.lineWidth = 2 / globalScale;
+        ctx.strokeStyle = "#ffffff";
+        ctx.stroke();
+      }
+
+      // The node itself
       ctx.beginPath();
       ctx.arc(node.x, node.y, baseR, 0, 2 * Math.PI);
-      ctx.fillStyle = communityColor(node.community);
+      ctx.fillStyle = fill;
       ctx.fill();
       ctx.lineWidth = 0.5 / globalScale;
-      ctx.strokeStyle = "rgba(255,255,255,0.4)";
+      ctx.strokeStyle = "rgba(255,255,255,0.35)";
       ctx.stroke();
 
-      // Only label when zoomed enough AND node is significant — avoids
-      // unreadable text-spaghetti at low zoom on big graphs.
-      const showLabel = globalScale > 1.5 || node.degree > maxDegree * 0.6;
-      if (showLabel && node.label) {
-        const fontSize = Math.max(8, 12 / globalScale);
+      // Label — only at higher zoom OR for god-nodes OR for hovered/focused
+      const showLabel =
+        isHover || isFocus || godNodeIds.has(n.id) || globalScale > 1.8;
+      if (showLabel && n.label) {
+        const fontSize = Math.max(9, 13 / globalScale);
         ctx.font = `${fontSize}px Inter, ui-sans-serif`;
-        ctx.fillStyle = "#e5e7eb";
+        ctx.fillStyle = "#f1f5f9";
         ctx.textBaseline = "middle";
-        ctx.fillText(node.label, node.x + baseR + 2, node.y);
+        // Subtle text shadow for readability over dense edge fields
+        ctx.shadowColor = "rgba(0,0,0,0.85)";
+        ctx.shadowBlur = 3;
+        ctx.fillText(n.label, node.x + baseR + 3, node.y);
+        ctx.shadowBlur = 0;
       }
       ctx.globalAlpha = 1;
     },
-    [maxDegree, selectedCommunity],
+    [maxDegree, selectedCommunity, focusNeighbourhood, getColor, godNodeIds, hoverNode, focusNodeId],
   );
 
-  // Click hit-area: extend slightly past the visible radius so it's easy
-  // to click small nodes on a dense graph.
   const nodePointerAreaPaint = useCallback(
     (node: any, color: string, ctx: CanvasRenderingContext2D) => {
-      const baseR = 2 + 6 * (node.degree / maxDegree);
+      const baseR = 2 + 7 * ((node as VizNode).degree / maxDegree);
       ctx.fillStyle = color;
       ctx.beginPath();
-      ctx.arc(node.x, node.y, baseR + 3, 0, 2 * Math.PI);
+      ctx.arc(node.x, node.y, baseR + 4, 0, 2 * Math.PI);
       ctx.fill();
     },
     [maxDegree],
   );
 
+  // ── Link styling ───────────────────────────────────────────────────────
+
   const linkColor = useCallback(
     (l: any) => {
-      // Dim links that don't touch the selected community.
-      if (selectedCommunity != null) {
-        const s = typeof l.source === "object" ? l.source : null;
-        const t = typeof l.target === "object" ? l.target : null;
-        const touches = s?.community === selectedCommunity || t?.community === selectedCommunity;
-        return touches ? "rgba(180,180,200,0.45)" : `rgba(180,180,200,${DIMMED_OPACITY})`;
+      const s = typeof l.source === "object" ? l.source : null;
+      const t = typeof l.target === "object" ? l.target : null;
+
+      // Focus dim
+      if (focusNeighbourhood) {
+        const touches =
+          focusNeighbourhood.has(s?.id) && focusNeighbourhood.has(t?.id);
+        return touches ? "rgba(180,200,255,0.55)" : "rgba(120,130,150,0.06)";
       }
-      return "rgba(180,180,200,0.30)";
+      // Community dim
+      if (selectedCommunity != null) {
+        const touches =
+          s?.community === selectedCommunity || t?.community === selectedCommunity;
+        return touches ? "rgba(180,200,255,0.45)" : "rgba(120,130,150,0.10)";
+      }
+      return "rgba(160,170,190,0.28)";
     },
-    [selectedCommunity],
+    [selectedCommunity, focusNeighbourhood],
   );
+
+  // Directional particles only on the focused neighbourhood edges — keeps
+  // the "data flow" feel without overwhelming a 30k-edge graph.
+  const linkParticleCount = useCallback(
+    (l: any) => {
+      if (!focusNeighbourhood) return 0;
+      const s = typeof l.source === "object" ? l.source : null;
+      const t = typeof l.target === "object" ? l.target : null;
+      return s && t && focusNeighbourhood.has(s.id) && focusNeighbourhood.has(t.id)
+        ? 2
+        : 0;
+    },
+    [focusNeighbourhood],
+  );
+
+  // ── Click handlers ─────────────────────────────────────────────────────
 
   const handleNodeClick = useCallback(
     (node: any) => {
-      if (!onNodeSelect) return;
-      const { degree, ...plain } = node;
-      onNodeSelect(plain as GraphNode);
+      const n = node as VizNode;
+      // Click same node again = clear focus.
+      const next = focusNodeId === n.id ? null : n.id;
+      setFocusNodeId(next);
+
+      if (next && fgRef.current?.centerAt && typeof n.x === "number") {
+        fgRef.current.centerAt(n.x, n.y, 600);
+        fgRef.current.zoom(Math.max(2.5, fgRef.current.zoom() ?? 1), 600);
+      }
+
+      onNodeSelect?.(next ? (n as GraphNode) : null);
     },
-    [onNodeSelect],
+    [focusNodeId, onNodeSelect],
   );
 
-  // ── Zoom to fit on first load / when data changes substantially ────────
+  const handleBgClick = useCallback(() => {
+    setFocusNodeId(null);
+    onNodeSelect?.(null);
+  }, [onNodeSelect]);
+
+  // ── Imperative API ─────────────────────────────────────────────────────
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      zoomToFit: () => fgRef.current?.zoomToFit?.(500, 40),
+      resetFocus: () => setFocusNodeId(null),
+    }),
+    [],
+  );
+
+  // ── Auto zoom-to-fit on data change ────────────────────────────────────
 
   useEffect(() => {
     if (!fgRef.current || data.nodes.length === 0) return;
-    // Let the simulation settle a bit before zooming.
     const timer = setTimeout(() => {
       try {
-        fgRef.current.zoomToFit(400, 40);
+        fgRef.current.zoomToFit(500, 40);
       } catch {
-        /* ignore — graph not mounted */
+        /* ignore */
       }
     }, 600);
     return () => clearTimeout(timer);
@@ -221,7 +394,7 @@ const BusinessGraphVisualization: React.FC<BusinessGraphVisualizationProps> = ({
   // ── Render ─────────────────────────────────────────────────────────────
 
   return (
-    <div ref={containerRef} className="w-full h-full min-h-[500px]">
+    <div ref={containerRef} className="relative w-full h-full min-h-[500px]">
       {data.nodes.length === 0 ? (
         <div className="flex items-center justify-center h-full text-sm text-muted-foreground">
           No nodes match the current filters.
@@ -232,24 +405,56 @@ const BusinessGraphVisualization: React.FC<BusinessGraphVisualizationProps> = ({
           graphData={data}
           width={size.w}
           height={size.h}
-          backgroundColor="#0f1117"
+          backgroundColor="#0a0d14"
           nodeRelSize={4}
           nodeCanvasObject={nodeCanvasObject}
           nodePointerAreaPaint={nodePointerAreaPaint}
           linkColor={linkColor}
-          linkWidth={0.5}
-          // Force config tuned for large graphs — quicker cooldown so we
-          // don't burn CPU rebalancing 25k nodes forever.
-          cooldownTicks={120}
-          d3AlphaDecay={0.03}
+          linkWidth={(l: any) => {
+            if (!focusNeighbourhood) return 0.5;
+            const s = typeof l.source === "object" ? l.source : null;
+            const t = typeof l.target === "object" ? l.target : null;
+            return s && t && focusNeighbourhood.has(s.id) && focusNeighbourhood.has(t.id) ? 1.5 : 0.4;
+          }}
+          linkDirectionalParticles={linkParticleCount}
+          linkDirectionalParticleSpeed={0.006}
+          linkDirectionalParticleWidth={2}
+          linkDirectionalParticleColor={() => "#ffffff"}
+          cooldownTicks={140}
+          d3AlphaDecay={0.025}
           d3VelocityDecay={0.35}
           warmupTicks={20}
           enableNodeDrag={false}
           onNodeClick={handleNodeClick}
+          onNodeHover={(n: any) => setHoverNode(n)}
+          onBackgroundClick={handleBgClick}
         />
+      )}
+
+      {/* Hover tooltip */}
+      {hoverNode && (
+        <div className="pointer-events-none absolute top-3 left-3 max-w-xs rounded-md border border-white/10 bg-black/80 backdrop-blur-sm px-3 py-2 text-xs text-foreground shadow-lg">
+          <div className="font-medium text-sm text-white">{hoverNode.label}</div>
+          <div className="text-muted-foreground mt-0.5">
+            {hoverNode.file_type.replace(/_/g, " ")}
+          </div>
+          <div className="text-muted-foreground">
+            {hoverNode.degree} relation{hoverNode.degree === 1 ? "" : "s"}
+            {hoverNode.community != null && (
+              <span className="ml-2">· cluster {hoverNode.community}</span>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Focus hint */}
+      {focusNodeId && (
+        <div className="absolute bottom-3 left-3 rounded-md border border-white/10 bg-black/70 backdrop-blur-sm px-3 py-1.5 text-xs text-muted-foreground">
+          Focused on neighbourhood — press <kbd className="px-1 rounded bg-white/10 text-white">Esc</kbd> or click background to clear
+        </div>
       )}
     </div>
   );
-};
+});
 
 export default BusinessGraphVisualization;


### PR DESCRIPTION
Goes from 'renders the dots' to 'actually useful exploration tool'.

Visualization (BusinessGraphVisualization.tsx):
- Forwarded ref + imperative handle (zoomToFit, resetFocus)
- Two color modes: 'community' (default, soft 12-color palette) — see clusters 'type' (Automatos-aligned: orange products, violet vendors, etc.) — see structure
- Click node → centers it, zooms in, highlights 1-hop neighbourhood, dims everything else, draws directional flow particles on its edges. Click background OR press Esc to clear focus.
- Hover tooltip: label, node type, degree, cluster id
- God-node halo: top-5 highest-degree nodes get a soft radial glow
- Hover/focus emphasis ring on the active node
- Adaptive labels (only zoomed-in / god-nodes / hovered get labelled — no text-spaghetti at low zoom)
- Subtle text shadow on labels for readability over dense edges
- Background tightened to #0a0d14 for higher contrast

Panel (BusinessGraphPanel.tsx):
- Type filter chips bottom-right (Products / Variants / Vendors / Collections / Metafields with live counts; click to toggle, strike- through when hidden; first click switches from 'all visible' sentinel into explicit mode)
- Color-mode toggle top-right (Cluster | Type)
- Fullscreen button top-right (native HTML5 fullscreen API on the graph container; icon toggles Maximize2 ↔ Minimize2; syncs with ESC-out via fullscreenchange listener)
- All controls hover-glass with backdrop-blur — readable over the graph
- Same data fetch + caching, no backend change

Total LOC: ~390 in viz, ~110 added to panel.