### PR TITLE
feat(business-graph): noise control — kill label spam, hide on drill-…

### DIFF
--- a/frontend/components/knowledge/BusinessGraphPanel.tsx
+++ b/frontend/components/knowledge/BusinessGraphPanel.tsx
@@ -552,43 +552,14 @@ export function BusinessGraphPanel() {
 
       {/* Main Layout: Sidebar + Graph */}
       {vizSafe && <div className="flex flex-col md:flex-row gap-4 min-h-[500px]">
-        {/* Community Sidebar */}
-        <div className="w-full md:w-48 shrink-0 glass-card bg-white/5 backdrop-blur-sm border border-white/10 rounded-lg p-3 space-y-1 max-h-[500px] overflow-y-auto">
-          <div className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-2 flex items-center gap-1.5">
-            <Layers className="w-3.5 h-3.5" />
-            Communities
-          </div>
-
-          <button
-            onClick={() => setSelectedCommunity(null)}
-            className={`w-full text-left text-sm px-2 py-1.5 rounded transition-colors ${
-              selectedCommunity === null
-                ? 'bg-primary/20 text-primary'
-                : 'text-muted-foreground hover:bg-white/5'
-            }`}
-          >
-            All clusters
-          </button>
-
-          {communities.map(({ id, count }) => (
-            <button
-              key={id}
-              onClick={() =>
-                setSelectedCommunity(selectedCommunity === id ? null : id)
-              }
-              className={`w-full text-left text-sm px-2 py-1.5 rounded flex items-center justify-between transition-colors ${
-                selectedCommunity === id
-                  ? 'bg-primary/20 text-primary'
-                  : 'text-muted-foreground hover:bg-white/5'
-              }`}
-            >
-              <span>Cluster {id}</span>
-              <Badge variant="secondary" className="text-[10px] h-5">
-                {count}
-              </Badge>
-            </button>
-          ))}
-        </div>
+        {/* Community Sidebar — at 800+ clusters a flat list is useless. We
+            hide tiny long-tail clusters (<5 nodes) and cap the visible
+            list at 30. 'Show all' expands. Sorted by size descending. */}
+        <ClusterSidebar
+          communities={communities}
+          selectedCommunity={selectedCommunity}
+          onSelect={setSelectedCommunity}
+        />
 
         {/* Graph Visualization + controls — wrapped in a localised error
             boundary so a renderer-level exception doesn't take down the
@@ -774,6 +745,108 @@ export function BusinessGraphPanel() {
               </div>
             </div>
           )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ─── Cluster Sidebar ───────────────────────────────────────────────────
+// Lives in this file because it's panel-specific and shares the same
+// types. At 800+ clusters a flat list is unusable. Filters tiny clusters,
+// sorts by size, paginates, and offers a search box.
+
+interface ClusterSidebarProps {
+  communities: Array<{ id: number; count: number }>
+  selectedCommunity: number | null
+  onSelect: (id: number | null) => void
+}
+
+function ClusterSidebar({ communities, selectedCommunity, onSelect }: ClusterSidebarProps) {
+  const [query, setQuery] = useState('')
+  const [showAll, setShowAll] = useState(false)
+  const MIN_SIZE = 5  // hide singleton/pair clusters — pure long-tail noise
+  const PAGE = 30
+
+  const filtered = useMemo(() => {
+    const min = communities.filter((c) => c.count >= MIN_SIZE)
+    const q = query.trim()
+    if (!q) return min
+    // Allow searching by cluster id (e.g. "47") or size threshold ">100".
+    if (/^>\s*\d+$/.test(q)) {
+      const threshold = parseInt(q.replace(/^>\s*/, ''), 10)
+      return min.filter((c) => c.count > threshold)
+    }
+    return min.filter((c) => String(c.id).includes(q))
+  }, [communities, query])
+
+  const visible = showAll ? filtered : filtered.slice(0, PAGE)
+  const totalNodes = communities.reduce((a, b) => a + b.count, 0)
+  const hiddenLongTail = communities.length - filtered.length
+
+  return (
+    <div className="w-full md:w-56 shrink-0 glass-card bg-white/5 backdrop-blur-sm border border-white/10 rounded-lg p-3 space-y-2 max-h-[500px] overflow-y-auto">
+      <div className="text-xs font-medium text-muted-foreground uppercase tracking-wider flex items-center gap-1.5">
+        <Layers className="w-3.5 h-3.5" />
+        Clusters
+        <span className="ml-auto text-[10px] text-muted-foreground/70">
+          {communities.length} total
+        </span>
+      </div>
+
+      <div className="relative">
+        <Search className="w-3.5 h-3.5 absolute left-2 top-1/2 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search… or >100"
+          className="h-8 pl-7 text-xs bg-black/30 border-white/10"
+        />
+      </div>
+
+      <button
+        onClick={() => onSelect(null)}
+        className={`w-full text-left text-xs px-2 py-1.5 rounded transition-colors ${
+          selectedCommunity === null
+            ? 'bg-primary/25 text-primary'
+            : 'text-muted-foreground hover:bg-white/5'
+        }`}
+      >
+        All clusters
+        <span className="ml-1.5 text-[10px] text-muted-foreground/70">
+          {totalNodes.toLocaleString()} nodes
+        </span>
+      </button>
+
+      {visible.map(({ id, count }) => (
+        <button
+          key={id}
+          onClick={() => onSelect(selectedCommunity === id ? null : id)}
+          className={`w-full text-left text-xs px-2 py-1.5 rounded flex items-center justify-between transition-colors ${
+            selectedCommunity === id
+              ? 'bg-primary/25 text-primary'
+              : 'text-muted-foreground hover:bg-white/5'
+          }`}
+        >
+          <span>Cluster {id}</span>
+          <Badge variant="secondary" className="text-[10px] h-5">
+            {count}
+          </Badge>
+        </button>
+      ))}
+
+      {!showAll && filtered.length > PAGE && (
+        <button
+          onClick={() => setShowAll(true)}
+          className="w-full text-xs px-2 py-1.5 rounded text-muted-foreground hover:bg-white/5 transition-colors"
+        >
+          + {filtered.length - PAGE} more clusters
+        </button>
+      )}
+
+      {hiddenLongTail > 0 && (
+        <div className="text-[10px] text-muted-foreground/60 px-2 pt-1 border-t border-white/5">
+          {hiddenLongTail} tiny clusters hidden (&lt;{MIN_SIZE} nodes each)
         </div>
       )}
     </div>

--- a/frontend/components/knowledge/BusinessGraphVisualization.tsx
+++ b/frontend/components/knowledge/BusinessGraphVisualization.tsx
@@ -293,19 +293,39 @@ const BusinessGraphVisualization = forwardRef<
       ctx.strokeStyle = "rgba(255,255,255,0.35)";
       ctx.stroke();
 
-      // Label — only at higher zoom OR for god-nodes OR for hovered/focused
+      // Label policy — at 24k nodes, labels become text-soup. Tight rules:
+      //   - Always: hovered, focused (clicked), or in the focus 1-hop.
+      //   - Zoom > 3.5: top god-nodes (top-5).
+      //   - Zoom > 5:   any node with degree above ~30% of max.
+      //   - Otherwise: no label.
+      // Net effect: at default zoom users see ONLY the node they're
+      // pointing at; the rest of the graph is colour-coded shapes.
+      const inFocusHood = focusNeighbourhood?.has(n.id);
       const showLabel =
-        isHover || isFocus || godNodeIds.has(n.id) || globalScale > 1.8;
+        isHover ||
+        isFocus ||
+        inFocusHood ||
+        (globalScale > 3.5 && godNodeIds.has(n.id)) ||
+        (globalScale > 5 && n.degree > maxDegree * 0.3);
       if (showLabel && n.label) {
-        const fontSize = Math.max(9, 13 / globalScale);
+        const fontSize = Math.max(10, 13 / globalScale);
         ctx.font = `${fontSize}px Inter, ui-sans-serif`;
         ctx.fillStyle = "#f1f5f9";
         ctx.textBaseline = "middle";
-        // Subtle text shadow for readability over dense edge fields
-        ctx.shadowColor = "rgba(0,0,0,0.85)";
-        ctx.shadowBlur = 3;
-        ctx.fillText(n.label, node.x + baseR + 3, node.y);
-        ctx.shadowBlur = 0;
+        // Background pill so the label is readable over dense edges.
+        const padding = 3 / globalScale;
+        const metrics = ctx.measureText(n.label);
+        const pillX = node.x + baseR + 4;
+        const pillY = node.y - fontSize / 2 - padding / 2;
+        ctx.fillStyle = "rgba(10,13,20,0.85)";
+        ctx.fillRect(
+          pillX - 2,
+          pillY,
+          metrics.width + 4,
+          fontSize + padding,
+        );
+        ctx.fillStyle = "#f1f5f9";
+        ctx.fillText(n.label, pillX, node.y);
       }
       ctx.globalAlpha = 1;
     },
@@ -444,6 +464,25 @@ const BusinessGraphVisualization = forwardRef<
           nodeRelSize={4}
           nodeCanvasObject={nodeCanvasObject}
           nodePointerAreaPaint={nodePointerAreaPaint}
+          // When a community is selected, hide everything outside it
+          // entirely — at 24k+ nodes dimming alone leaves too much noise.
+          // Same logic for the focused-node 1-hop neighbourhood.
+          nodeVisibility={(n: any) => {
+            if (selectedCommunity != null && n.community !== selectedCommunity) return false;
+            if (focusNeighbourhood && !focusNeighbourhood.has(n.id)) return false;
+            return true;
+          }}
+          linkVisibility={(l: any) => {
+            const s = typeof l.source === "object" ? l.source : null;
+            const t = typeof l.target === "object" ? l.target : null;
+            if (selectedCommunity != null) {
+              return s?.community === selectedCommunity && t?.community === selectedCommunity;
+            }
+            if (focusNeighbourhood) {
+              return !!(s && t && focusNeighbourhood.has(s.id) && focusNeighbourhood.has(t.id));
+            }
+            return true;
+          }}
           linkColor={linkColor}
           linkWidth={(l: any) => {
             if (!focusNeighbourhood) return 0.5;


### PR DESCRIPTION
…in, sidebar UX

At 24k nodes / 884 clusters the previous pass was a text-soup hairball. Three concrete fixes:

1) Label policy tightened.
   Was: any node labelled at zoom > 1.8 → everything visible at default.
   Now: labels suppressed except hover, focus, in focus-neighbourhood,
   god-nodes at zoom > 3.5, or high-degree at zoom > 5. Plus dark pill
   background behind labels for readability over dense edges.

2) Drill-by-cluster ACTUALLY hides.
   Was: clicked-cluster dimmed others — still visible noise at 24k.
   Now: nodeVisibility / linkVisibility hide non-cluster everything,
   leaving just the selected cluster visible. Same for click-to-focus
   1-hop neighbourhood. Use the cluster sidebar to drill in, ESC or
   'All clusters' to zoom back out.

3) Cluster sidebar UX (new ClusterSidebar component).
   Was: flat list of 884 cluster ids — unusable.
   Now: filter tiny clusters (< 5 nodes — pure long-tail noise),
   sort by size desc (already was), search box (id substring OR '>N'
   threshold filter), paginated 30-at-a-time with 'show more', and a
   summary line showing how many tiny clusters were hidden.

Net effect: at default load you see colour-coded shapes only. Hover to identify a node, click a cluster in the sidebar to drill in, ESC or 'All clusters' to back out. No more text-soup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added cluster search functionality with text filtering and size-based thresholds in the sidebar
  * Implemented cluster pagination for better navigation
  * Added expandable section to view hidden clusters summary

* **Improvements**
  * Enhanced label readability with improved background styling on graph labels
  * Improved node and link visibility management based on selected community and focus interactions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AutomatosAI/automatos-ai/pull/364?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->