### PR TITLE
feat(prd-009 phase 2): Shopify orders → FREQUENTLY_BOUGHT_WITH edges

### DIFF
--- a/frontend/components/sites/SyncPanel.tsx
+++ b/frontend/components/sites/SyncPanel.tsx
@@ -1,14 +1,20 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import { Loader2, RefreshCw, CheckCircle2, AlertCircle, ShoppingBag } from 'lucide-react'
+import {
+  Loader2, RefreshCw, CheckCircle2, AlertCircle,
+  ShoppingBag, Network,
+} from 'lucide-react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import {
   getShopifySyncStatus,
   startShopifySync,
+  getShopifyOrdersSyncStatus,
+  startShopifyOrdersSync,
   type ShopifySyncStatus,
+  type ShopifyOrdersSyncStatus,
 } from '@/lib/sites/api'
 import type { Site } from '@/lib/sites/types'
 
@@ -45,6 +51,7 @@ export function SyncPanel({ site, workspaceId }: SyncPanelProps) {
           merchant if not. Add WooCommerce/BigCommerce/Amazon cards here as
           their integrations land. */}
       <ShopifySyncCard site={site} workspaceId={workspaceId} />
+      <ShopifyOrdersSyncCard workspaceId={workspaceId} />
     </div>
   )
 }
@@ -196,6 +203,149 @@ function ShopifySyncCard({ site, workspaceId }: { site: Site; workspaceId: strin
         <p className="text-[11px] text-muted-foreground">
           The sync pulls every product, variant, metafield, and collection from Shopify in one
           Bulk Operation. Webhooks keep the graph fresh between manual syncs.
+        </p>
+      </CardContent>
+    </Card>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Orders card — PRD-009 Phase 2
+// ---------------------------------------------------------------------------
+// Pulls order history (PII-stripped — only product co-occurrence, NO
+// customer / email / phone / address). Adds FREQUENTLY_BOUGHT_WITH edges
+// between products so the agent can recommend "customers who bought X
+// also bought Y". Requires the catalog sync to have run first.
+
+function ShopifyOrdersSyncCard({ workspaceId }: { workspaceId: string | null }) {
+  const [status, setStatus] = useState<ShopifyOrdersSyncStatus | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [syncing, setSyncing] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function refreshStatus() {
+    if (!workspaceId) { setLoading(false); return }
+    try {
+      const s = await getShopifyOrdersSyncStatus(workspaceId)
+      setStatus(s); setError(null)
+    } catch (e: any) {
+      setError(e?.message ?? 'Failed to load orders sync status')
+    } finally { setLoading(false) }
+  }
+
+  useEffect(() => { refreshStatus() }, [workspaceId])
+
+  // Same stuck-state detection as catalog card
+  const isStuckRunning =
+    status?.status === 'running' &&
+    !!status.started_at &&
+    Date.now() / 1000 - status.started_at > 600  // orders can be slower than catalog
+
+  async function handleSync() {
+    if (!workspaceId) return
+    setSyncing(true); setError(null)
+    try {
+      const result = await startShopifyOrdersSync(workspaceId, { days: 90, minSupport: 2 })
+      setStatus(result)
+    } catch (e: any) {
+      setError(e?.message ?? 'Sync failed')
+    } finally { setSyncing(false) }
+  }
+
+  return (
+    <Card className="glass-card">
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-2 text-base">
+          <Network className="w-4 h-4" /> Order patterns
+          {status?.status === 'complete' && (
+            <Badge variant="outline" className="ml-auto text-emerald-400 border-emerald-400/30">
+              <CheckCircle2 className="w-3 h-3 mr-1" /> Synced
+            </Badge>
+          )}
+          {status?.status === 'running' && !isStuckRunning && (
+            <Badge variant="outline" className="ml-auto text-amber-400 border-amber-400/30">
+              <Loader2 className="w-3 h-3 mr-1 animate-spin" /> Running
+            </Badge>
+          )}
+          {status?.status === 'error' && (
+            <Badge variant="outline" className="ml-auto text-destructive border-destructive/30">
+              <AlertCircle className="w-3 h-3 mr-1" /> Error
+            </Badge>
+          )}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3 text-sm">
+        <p className="text-xs text-muted-foreground">
+          Adds <strong>frequently-bought-together</strong> relationships between products by analysing
+          your last 90 days of orders. Only product IDs are read — no customer data, email,
+          address, or phone touches the graph.
+        </p>
+
+        {loading && (
+          <div className="flex items-center text-muted-foreground">
+            <Loader2 className="w-4 h-4 mr-2 animate-spin" /> Loading status…
+          </div>
+        )}
+
+        {!loading && status?.status === 'complete' && (
+          <div className="grid grid-cols-2 gap-y-1.5 text-xs">
+            <span className="text-muted-foreground">FBT relations added</span>
+            <span className="text-foreground">{status.fbt_edges_added?.toLocaleString() ?? '—'}</span>
+            <span className="text-muted-foreground">Orders analysed</span>
+            <span className="text-foreground">{status.total_orders_analysed?.toLocaleString() ?? '—'}</span>
+            <span className="text-muted-foreground">Window</span>
+            <span className="text-foreground">{status.days_window ?? status.days ?? 90} days</span>
+            <span className="text-muted-foreground">Last sync duration</span>
+            <span className="text-foreground">
+              {status.duration_seconds ? `${status.duration_seconds.toFixed(1)}s` : '—'}
+            </span>
+          </div>
+        )}
+
+        {!loading && status?.status === 'never_synced' && (
+          <p className="text-xs text-muted-foreground">
+            Orders haven't been synced yet. Click <span className="text-foreground">Sync now</span> to
+            build customer co-purchase patterns. Sync the catalog first if you haven't.
+          </p>
+        )}
+
+        {!loading && status?.status === 'error' && (
+          <div className="text-xs text-destructive bg-destructive/10 border border-destructive/30 rounded p-2">
+            {status.error || 'Previous sync failed.'}
+          </div>
+        )}
+
+        {error && (
+          <div className="text-xs text-destructive bg-destructive/10 border border-destructive/30 rounded p-2">
+            {error}
+          </div>
+        )}
+
+        {isStuckRunning && (
+          <div className="text-xs text-amber-400 bg-amber-400/10 border border-amber-400/30 rounded p-2">
+            Previous sync didn't finish cleanly. You can re-run it now.
+          </div>
+        )}
+
+        <Button
+          onClick={handleSync}
+          disabled={!workspaceId || syncing || (status?.status === 'running' && !isStuckRunning)}
+          size="sm"
+          className="gap-2"
+        >
+          {syncing ? (
+            <>
+              <Loader2 className="w-3.5 h-3.5 animate-spin" /> Analysing orders… (1-2 min)
+            </>
+          ) : (
+            <>
+              <RefreshCw className="w-3.5 h-3.5" /> Sync orders
+            </>
+          )}
+        </Button>
+        <p className="text-[11px] text-muted-foreground">
+          GDPR-safe by design: only product IDs and order counts touch the graph.
+          Customer records stay in Shopify as the system of record.
         </p>
       </CardContent>
     </Card>

--- a/frontend/lib/sites/api.ts
+++ b/frontend/lib/sites/api.ts
@@ -112,3 +112,40 @@ export async function startShopifySync(workspaceId: string): Promise<ShopifySync
     {},
   );
 }
+
+// PRD-009 Phase 2 — orders → FREQUENTLY_BOUGHT_WITH edges
+export interface ShopifyOrdersSyncStatus {
+  status: 'never_synced' | 'running' | 'complete' | 'error';
+  bulk_operation_id?: string;
+  object_count?: number;
+  file_size?: number;
+  fbt_edges_added?: number;
+  total_orders_analysed?: number;
+  days?: number;
+  days_window?: number;
+  min_support?: number;
+  duration_seconds?: number;
+  started_at?: number;
+  completed_at?: number;
+  errored_at?: number;
+  error?: string;
+}
+
+export async function getShopifyOrdersSyncStatus(workspaceId: string): Promise<ShopifyOrdersSyncStatus> {
+  return apiClient.get<ShopifyOrdersSyncStatus>(
+    `/api/shopify/sync/orders/status?workspace_id=${encodeURIComponent(workspaceId)}`,
+  );
+}
+
+export async function startShopifyOrdersSync(
+  workspaceId: string,
+  opts: { days?: number; minSupport?: number } = {},
+): Promise<ShopifyOrdersSyncStatus> {
+  const params = new URLSearchParams({ workspace_id: workspaceId });
+  if (opts.days) params.set('days', String(opts.days));
+  if (opts.minSupport) params.set('min_support', String(opts.minSupport));
+  return apiClient.post<ShopifyOrdersSyncStatus>(
+    `/api/shopify/sync/orders/start?${params.toString()}`,
+    {},
+  );
+}

--- a/orchestrator/api/shopify.py
+++ b/orchestrator/api/shopify.py
@@ -706,3 +706,213 @@ async def get_product_sync_status(
     if not workspace:
         raise HTTPException(status_code=404, detail="Workspace not found")
     return (workspace.settings or {}).get("product_sync") or {"status": "never_synced"}
+
+
+# ===================================================================
+# PRD-009 Phase 2 — Orders → FREQUENTLY_BOUGHT_WITH edges
+# ===================================================================
+# Privacy by design: GraphQL query requests only order id, createdAt,
+# cancelledAt, currencyCode, and lineItems[].variant.product.id. NO
+# customer / email / phone / address / note fields are requested, so they
+# can never leak into the graph regardless of mapper bugs. The mapper
+# produces ONLY Product↔Product co-occurrence edges; no Customer or Order
+# nodes ever land in workspace_graphs.
+
+
+def _orders_bulk_query(days: int = 90) -> str:
+    """Build the orders bulk-op GraphQL string. Window in days from now."""
+    from datetime import datetime, timedelta, timezone
+    cutoff = (datetime.now(timezone.utc) - timedelta(days=days)).strftime("%Y-%m-%d")
+    # Note: Shopify's Bulk Op GraphQL doesn't support variables, so we inline
+    # the cutoff date. Safe — it's a controlled date string, not user input.
+    return (
+        "{ orders(query: \"created_at:>=" + cutoff + "\") "
+        "{ edges { node { id createdAt currencyCode cancelledAt "
+        "lineItems { edges { node { id quantity "
+        "variant { id product { id } } } } } } } } }"
+    )
+
+
+class OrdersSyncResponse(BaseModel):
+    status: str
+    workspace_id: str
+    bulk_operation_id: Optional[str] = None
+    object_count: Optional[int] = None
+    file_size: Optional[int] = None
+    fbt_edges_added: Optional[int] = None
+    total_orders_analysed: Optional[int] = None
+    days_window: Optional[int] = None
+    duration_seconds: Optional[float] = None
+    error: Optional[str] = None
+
+
+@router.post("/sync/orders/start", response_model=OrdersSyncResponse)
+async def start_orders_sync(
+    workspace_id: Optional[str] = None,
+    days: int = 90,
+    min_support: int = 2,
+    db: Session = Depends(get_db),
+):
+    """
+    Run a Shopify orders sync → FBT edges merged into the workspace graph.
+
+    Args:
+        workspace_id: target workspace.
+        days: time window for orders (default 90). Older orders less
+              relevant for current customer co-purchase patterns.
+        min_support: minimum number of orders a (Product A, Product B) pair
+                     must co-occur in before we emit an edge (default 2).
+    """
+    import time
+    import httpx
+
+    from core.composio.client import get_composio_client
+    from core.composio.entity_manager import EntityManager
+    from modules.knowledge.graph_extraction import map_shopify_orders
+    from modules.knowledge.graph_service import GraphifyService
+
+    if not workspace_id:
+        raise HTTPException(status_code=400, detail="workspace_id required")
+
+    workspace = db.query(Workspace).get(workspace_id)
+    if not workspace:
+        raise HTTPException(status_code=404, detail="Workspace not found")
+
+    em = EntityManager(db)
+    entity = em.get_or_create_entity(workspace_id)
+    entity_id = entity.get("composio_entity_id")
+    if not entity_id:
+        raise HTTPException(status_code=400, detail="No Composio entity for workspace")
+
+    client = get_composio_client()
+    if not client.composio:
+        raise HTTPException(status_code=503, detail="Composio not configured")
+
+    t0 = time.time()
+    from sqlalchemy.orm.attributes import flag_modified
+    settings = dict(workspace.settings or {})
+    settings["orders_sync"] = {
+        "status": "running",
+        "started_at": time.time(),
+        "days": days,
+        "min_support": min_support,
+    }
+    workspace.settings = settings
+    flag_modified(workspace, "settings")
+    db.commit()
+
+    try:
+        bulk = client.composio.tools.execute(
+            "SHOPIFY_BULK_QUERY_OPERATION",
+            user_id=entity_id,
+            arguments={"query": _orders_bulk_query(days=days)},
+        )
+        bulk_dict = bulk if isinstance(bulk, dict) else {
+            "successful": getattr(bulk, "successful", None),
+            "data": getattr(bulk, "data", None),
+            "error": getattr(bulk, "error", None),
+        }
+        if not bulk_dict.get("successful"):
+            raise HTTPException(
+                status_code=502,
+                detail=f"Bulk Op failed: {bulk_dict.get('error') or bulk_dict}",
+            )
+        bulk_data = bulk_dict.get("data") or {}
+        download_url = bulk_data.get("url")
+        bulk_op_id = bulk_data.get("bulk_operation_id")
+        object_count = int(bulk_data.get("object_count") or 0)
+        file_size = int(bulk_data.get("file_size") or 0)
+        if not download_url:
+            raise HTTPException(
+                status_code=502,
+                detail=f"Bulk Op did not return a download URL — data={bulk_data}",
+            )
+
+        async with httpx.AsyncClient(timeout=180.0) as http:
+            resp = await http.get(download_url)
+            resp.raise_for_status()
+            jsonl_text = resp.text
+
+        # Pure-function map: yields only edges, never customer/order nodes.
+        graph_delta = map_shopify_orders(
+            jsonl_text.splitlines(),
+            bulk_op_id=bulk_op_id,
+            min_support=min_support,
+        )
+        fbt_edges = len(graph_delta.get("edges", []))
+
+        # Merge into the existing workspace graph (catalog nodes already
+        # there from the products sync; we only add FBT edges).
+        gs = GraphifyService()
+        meta = await gs.import_graph(workspace_id, graph_delta, merge=True)
+
+        # Count total orders analysed from the first edge's attrs (mapper
+        # writes the same value into every edge).
+        total_orders = 0
+        if graph_delta["edges"]:
+            total_orders = int(graph_delta["edges"][0].get("attrs", {}).get("total_orders", 0))
+
+        duration = time.time() - t0
+        settings["orders_sync"] = {
+            "status": "complete",
+            "bulk_operation_id": bulk_op_id,
+            "object_count": object_count,
+            "file_size": file_size,
+            "days": days,
+            "min_support": min_support,
+            "fbt_edges_added": fbt_edges,
+            "total_orders_analysed": total_orders,
+            "duration_seconds": duration,
+            "completed_at": time.time(),
+        }
+        workspace.settings = settings
+        flag_modified(workspace, "settings")
+        db.commit()
+
+        logger.info(
+            "PRD-009 orders sync complete: workspace=%s edges=%s orders=%s duration=%.1fs",
+            workspace_id, fbt_edges, total_orders, duration,
+        )
+
+        return OrdersSyncResponse(
+            status="complete",
+            workspace_id=str(workspace_id),
+            bulk_operation_id=bulk_op_id,
+            object_count=object_count,
+            file_size=file_size,
+            fbt_edges_added=fbt_edges,
+            total_orders_analysed=total_orders,
+            days_window=days,
+            duration_seconds=duration,
+        )
+    except HTTPException as he:
+        settings["orders_sync"] = {
+            "status": "error",
+            "error": str(he.detail) if isinstance(he.detail, str) else f"HTTP {he.status_code}",
+            "errored_at": time.time(),
+        }
+        workspace.settings = settings
+        flag_modified(workspace, "settings")
+        db.commit()
+        raise
+    except Exception as e:  # noqa: BLE001
+        logger.exception("PRD-009 orders sync failed for workspace %s", workspace_id)
+        settings["orders_sync"] = {"status": "error", "error": str(e), "errored_at": time.time()}
+        workspace.settings = settings
+        flag_modified(workspace, "settings")
+        db.commit()
+        raise HTTPException(status_code=500, detail=f"Sync failed: {e}")
+
+
+@router.get("/sync/orders/status")
+async def get_orders_sync_status(
+    workspace_id: Optional[str] = None,
+    db: Session = Depends(get_db),
+):
+    """Return the current orders_sync state stored on the workspace."""
+    if not workspace_id:
+        raise HTTPException(status_code=400, detail="workspace_id required")
+    workspace = db.query(Workspace).get(workspace_id)
+    if not workspace:
+        raise HTTPException(status_code=404, detail="Workspace not found")
+    return (workspace.settings or {}).get("orders_sync") or {"status": "never_synced"}

--- a/orchestrator/modules/knowledge/graph_extraction.py
+++ b/orchestrator/modules/knowledge/graph_extraction.py
@@ -676,3 +676,123 @@ def _strip_html(html: str | None) -> str:
     # Drop tags, collapse whitespace. Good enough for embedding.
     no_tags = re.sub(r"<[^>]+>", " ", html)
     return re.sub(r"\s+", " ", no_tags).strip()
+
+
+# ---------------------------------------------------------------------------
+# PRD-009 Phase 2 — Shopify orders → FREQUENTLY_BOUGHT_WITH edges
+# ---------------------------------------------------------------------------
+# Privacy by design: this mapper accepts ONLY order id, createdAt, line items
+# with product references. Even if a customer-identifying field were
+# accidentally included in the JSONL we ignore it — no customer or order
+# nodes are created. Only aggregated Product↔Product co-occurrence edges.
+
+_ORDERS_SOURCE = "shopify://orders"
+
+
+def map_shopify_orders(
+    jsonl_iter,
+    *,
+    bulk_op_id: str | None = None,
+    min_support: int = 2,
+) -> dict[str, list]:
+    """Map a Shopify Orders Bulk Op JSONL stream into FBT edges.
+
+    Args:
+        jsonl_iter: Iterable of decoded dicts OR JSON strings (auto-detected).
+        bulk_op_id: Optional Bulk Operation id for the source_file tag.
+        min_support: Minimum number of orders a (Product A, Product B) pair
+                     must co-appear in before we emit an edge. Filters one-off
+                     coincidences. Default 2 = appeared in 2+ orders.
+
+    Output:
+        ``{nodes: [], edges: [...], hyperedges: []}`` — only edges; nodes are
+        assumed to already exist in the workspace graph (from the catalog
+        sync). Edge fields:
+          source = shopify_product_<id_A>  (canonical: lower id first)
+          target = shopify_product_<id_B>
+          relation = "frequently_bought_with"
+          confidence_score = co_count / total_orders   (0..1)
+          weight = co_count                            (raw)
+          attrs = {co_count, total_orders}
+    """
+    source_tag = f"{_ORDERS_SOURCE}#{bulk_op_id}" if bulk_op_id else _ORDERS_SOURCE
+
+    # Build: order_id → set(product_ids). We collect line items grouped by
+    # their parent order. The JSONL stream interleaves Orders + LineItems
+    # in arbitrary order; LineItems carry __parentId pointing at their Order.
+    order_products: dict[str, set[str]] = {}
+    cancelled_orders: set[str] = set()
+
+    for item in jsonl_iter:
+        if isinstance(item, (bytes, str)):
+            line = item.decode() if isinstance(item, bytes) else item
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+        elif isinstance(item, dict):
+            obj = item
+        else:
+            continue
+
+        gid = obj.get("id") or ""
+        kind_match = re.match(r"gid://shopify/([A-Za-z]+)/", gid)
+        if not kind_match:
+            continue
+        kind = kind_match.group(1)
+
+        if kind == "Order":
+            # Skip cancelled orders from co-occurrence math — they don't
+            # represent revealed customer preference.
+            if obj.get("cancelledAt"):
+                cancelled_orders.add(gid)
+            else:
+                order_products.setdefault(gid, set())
+            continue
+
+        if kind == "LineItem":
+            parent_order = obj.get("__parentId", "")
+            if not parent_order or parent_order in cancelled_orders:
+                continue
+            product_gid = (obj.get("variant") or {}).get("product", {}).get("id")
+            if not product_gid:
+                continue
+            product_tail = product_gid.rsplit("/", 1)[-1]
+            order_products.setdefault(parent_order, set()).add(product_tail)
+
+    # Filter out single-item orders — they contribute nothing to co-occurrence
+    valid_orders = {oid: pids for oid, pids in order_products.items() if len(pids) >= 2}
+    total_orders = len(valid_orders)
+
+    # Pair counts: (sorted_tuple_of_product_ids) → co_occurrence_count
+    from itertools import combinations
+    pair_counts: dict[tuple[str, str], int] = {}
+    for pids in valid_orders.values():
+        for a, b in combinations(sorted(pids), 2):
+            pair_counts[(a, b)] = pair_counts.get((a, b), 0) + 1
+
+    result = _empty_graph()
+    if total_orders == 0:
+        return result
+
+    for (a, b), count in pair_counts.items():
+        if count < min_support:
+            continue
+        src = _make_id("shopify_product", a)
+        tgt = _make_id("shopify_product", b)
+        confidence = count / total_orders
+        edge = _edge(
+            source=src,
+            target=tgt,
+            relation="frequently_bought_with",
+            source_file=source_tag,
+            confidence_score=confidence,
+            weight=float(count),
+        )
+        edge["attrs"] = {"co_count": count, "total_orders": total_orders}
+        result["edges"].append(edge)
+
+    return result


### PR DESCRIPTION
Adds the second half of PRD-009: customer co-purchase intelligence distilled from orders, PII-stripped at the GraphQL layer so customer data never lands in the graph.

Backend:
- modules/knowledge/graph_extraction.map_shopify_orders — pure function that takes a Shopify Bulk Op orders JSONL stream and returns {nodes: [], edges: [...]}: Product↔Product 'frequently_bought_with' edges with confidence_score = co_count / total_orders. Canonical pair ordering (lower id first) dedups A↔B and B↔A. Cancelled orders ignored. Single-item orders ignored. min_support threshold filters one-off coincidences (default 2). No customer or order nodes ever produced even if a customer-identifying field appeared in the JSONL.
- api/shopify POST /sync/orders/start — mirror of /products/start. GraphQL query requests ONLY order id, createdAt, cancelledAt, currencyCode, lineItems[].variant.product.id, lineItems[].quantity — no customer, email, phone, address, note. 90-day window default (configurable via ?days=). Merges FBT edges into the existing workspace graph via GraphifyService.import_graph(merge=True). Status persisted in workspace.settings.orders_sync, same error-state recovery pattern as the products sync.
- api/shopify GET /sync/orders/status — read state for the dashboard.

Frontend:
- lib/sites/api.ts — getShopifyOrdersSyncStatus + startShopifyOrdersSync.
- components/sites/SyncPanel.tsx — second card 'Order patterns' alongside the Catalog card. Shows FBT edges added, orders analysed, window in days. Same stuck-state detection (10 min cutoff vs 5 min — orders syncs slower than catalogs at scale).

No new tools needed for agents — existing platform_graph_neighbors (handle_graph_neighbors) supports relation_filter='frequently_bought_with' out of the box, returning ranked neighbors with weight + confidence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Shopify orders synchronization to automatically generate "Frequently Bought Together" product relationships from customer purchase patterns.
  * New sync control panel displays sync status, statistics (FBT relationships added, orders analyzed), and allows manual sync triggering with customizable parameters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AutomatosAI/automatos-ai/pull/366?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->