### PR TITLE
fix(prd-009 phase 2): orders sync — read total_orders BEFORE import_g…

### DIFF
--- a/orchestrator/api/shopify.py
+++ b/orchestrator/api/shopify.py
@@ -866,16 +866,19 @@ async def start_orders_sync(
                 fresh_data = nx.node_link_data(existing_graph)
                 await gs._import_graph_unlocked(workspace_id, fresh_data, merge=False)
 
+        # Pull total_orders BEFORE import_graph — that call mutates the dict
+        # in place (renames "edges" -> "links" for NetworkX 3.x compat),
+        # so reading graph_delta["edges"] AFTER would KeyError. Defensive
+        # .get() either way.
+        total_orders = 0
+        delta_edges = graph_delta.get("edges") or graph_delta.get("links") or []
+        if delta_edges:
+            total_orders = int(delta_edges[0].get("attrs", {}).get("total_orders", 0))
+
         # Merge into the existing workspace graph (catalog nodes already
         # there from the products sync; we only add FBT edges).
         gs = GraphifyService()
         meta = await gs.import_graph(workspace_id, graph_delta, merge=True)
-
-        # Count total orders analysed from the first edge's attrs (mapper
-        # writes the same value into every edge).
-        total_orders = 0
-        if graph_delta["edges"]:
-            total_orders = int(graph_delta["edges"][0].get("attrs", {}).get("total_orders", 0))
 
         duration = time.time() - t0
         settings["orders_sync"] = {


### PR DESCRIPTION
…raph mutates the dict

KeyError: 'edges' at line 877 after import_graph(merge=True) ran. The GraphifyService normalises graph_data by renaming 'edges' → 'links' in place (NetworkX 3.x compatibility), so any subsequent read of graph_delta['edges'] blows up.

Move the total_orders extraction BEFORE the import_graph call, and use defensive .get() with a fallback to 'links' in case the dict already went through normalisation elsewhere. Also surfaces the stale UI error issue: workspace.settings.orders_sync was last written with the OLD Composio 401, but the actual sync attempt now succeeds end-to-end so the next run wipes that stale 'error' state cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the orders sync endpoint to defensively handle variations in data structure and edge cases, improving overall reliability and preventing potential sync failures.

* **Refactor**
  * Reorganized order analysis processing to validate data earlier in the synchronization workflow for improved efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AutomatosAI/automatos-ai/pull/369?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->