### PR TITLE
feat(prd-009): orders window selector + relation chips in graph viz

### DIFF
--- a/frontend/components/knowledge/BusinessGraphPanel.tsx
+++ b/frontend/components/knowledge/BusinessGraphPanel.tsx
@@ -78,6 +78,7 @@ export function BusinessGraphPanel() {
 
   // PRD-009 Phase-2 polish state
   const [visibleTypes, setVisibleTypes] = useState<Set<string>>(new Set())  // empty = all
+  const [visibleRelations, setVisibleRelations] = useState<Set<string>>(new Set())  // empty = all
   const [colorMode, setColorMode] = useState<ColorMode>('community')
   const [isFullscreen, setIsFullscreen] = useState(false)
   const vizRef = useRef<BusinessGraphHandle>(null)
@@ -309,6 +310,60 @@ export function BusinessGraphPanel() {
   const isTypeVisible = useCallback(
     (t: string) => visibleTypes.size === 0 || visibleTypes.has(t),
     [visibleTypes],
+  )
+
+  // Relation chips — toggle catalog vs order-relationship edges.
+  // Counts derived from graphData.links (lazy — empty until data loads).
+  const relationCounts = useMemo(() => {
+    if (!graphData?.links) return new Map<string, number>()
+    const m = new Map<string, number>()
+    for (const l of graphData.links) {
+      const r = l.relation ?? 'related_to'
+      m.set(r, (m.get(r) ?? 0) + 1)
+    }
+    return m
+  }, [graphData])
+
+  const RELATION_DISPLAY: Record<string, { label: string; color: string; order: number }> = {
+    frequently_bought_with: { label: 'Order pairs',  color: '#ff3d8c', order: 1 },
+    variant_of:             { label: 'Variants',     color: '#ffb347', order: 2 },
+    in_collection:          { label: 'Collections',  color: '#10e89e', order: 3 },
+    by_vendor:              { label: 'Vendors',      color: '#c084fc', order: 4 },
+    has_metafield:          { label: 'Metafields',   color: '#38bdf8', order: 5 },
+  }
+
+  const relationChips = useMemo(() => {
+    return Array.from(relationCounts.entries())
+      .map(([r, n]) => ({
+        relation: r,
+        count: n,
+        label: RELATION_DISPLAY[r]?.label ?? r.replace(/_/g, ' '),
+        color: RELATION_DISPLAY[r]?.color ?? '#94a3b8',
+        order: RELATION_DISPLAY[r]?.order ?? 99,
+      }))
+      .sort((a, b) => a.order - b.order || b.count - a.count)
+  }, [relationCounts])
+
+  const toggleRelation = useCallback((r: string) => {
+    setVisibleRelations((prev) => {
+      const next = new Set(prev)
+      if (next.size === 0) {
+        for (const cr of relationChips) {
+          if (cr.relation !== r) next.add(cr.relation)
+        }
+      } else if (next.has(r)) {
+        next.delete(r)
+      } else {
+        next.add(r)
+      }
+      if (next.size === relationChips.length) next.clear()
+      return next
+    })
+  }, [relationChips])
+
+  const isRelationVisible = useCallback(
+    (r: string) => visibleRelations.size === 0 || visibleRelations.has(r),
+    [visibleRelations],
   )
 
   // Native HTML5 fullscreen on the graph container.
@@ -603,33 +658,75 @@ export function BusinessGraphPanel() {
             </button>
           </div>
 
-          {/* Type filter chips — bottom-left, doesn't compete with hover tooltip */}
-          {typeChips.length > 0 && (
-            <div className="absolute bottom-3 right-3 z-10 flex flex-wrap gap-1.5 max-w-[60%] justify-end">
-              {typeChips.map(({ type, label, color, count }) => {
-                const visible = isTypeVisible(type)
-                return (
-                  <button
-                    key={type}
-                    onClick={() => toggleType(type)}
-                    className={`flex items-center gap-1.5 px-2 py-1 rounded-md text-xs border transition ${
-                      visible
-                        ? 'bg-white/10 border-white/20 text-foreground'
-                        : 'bg-black/40 border-white/10 text-muted-foreground/60 line-through'
-                    }`}
-                    title={`${count.toLocaleString()} ${label.toLowerCase()}`}
-                  >
-                    <span
-                      className="w-2 h-2 rounded-full"
-                      style={{ backgroundColor: visible ? color : '#52525b' }}
-                    />
-                    {label}
-                    <span className="text-[10px] text-muted-foreground">
-                      {count.toLocaleString()}
-                    </span>
-                  </button>
-                )
-              })}
+          {/* Filter chips — Nodes (top row) + Relations (bottom row).
+              Bottom-right so they don't compete with the hover tooltip. */}
+          {(typeChips.length > 0 || relationChips.length > 0) && (
+            <div className="absolute bottom-3 right-3 z-10 flex flex-col items-end gap-1.5 max-w-[65%]">
+              {typeChips.length > 0 && (
+                <div className="flex flex-wrap gap-1.5 justify-end">
+                  <span className="text-[10px] uppercase tracking-wider text-muted-foreground/70 self-center mr-1">
+                    Nodes
+                  </span>
+                  {typeChips.map(({ type, label, color, count }) => {
+                    const visible = isTypeVisible(type)
+                    return (
+                      <button
+                        key={type}
+                        onClick={() => toggleType(type)}
+                        className={`flex items-center gap-1.5 px-2 py-1 rounded-md text-xs border transition ${
+                          visible
+                            ? 'bg-white/10 border-white/20 text-foreground'
+                            : 'bg-black/40 border-white/10 text-muted-foreground/60 line-through'
+                        }`}
+                        title={`${count.toLocaleString()} ${label.toLowerCase()}`}
+                      >
+                        <span
+                          className="w-2 h-2 rounded-full"
+                          style={{ backgroundColor: visible ? color : '#52525b' }}
+                        />
+                        {label}
+                        <span className="text-[10px] text-muted-foreground">
+                          {count.toLocaleString()}
+                        </span>
+                      </button>
+                    )
+                  })}
+                </div>
+              )}
+              {relationChips.length > 0 && (
+                <div className="flex flex-wrap gap-1.5 justify-end">
+                  <span className="text-[10px] uppercase tracking-wider text-muted-foreground/70 self-center mr-1">
+                    Edges
+                  </span>
+                  {relationChips.map(({ relation, label, color, count }) => {
+                    const visible = isRelationVisible(relation)
+                    // FBT chip gets a slightly bigger 'pop' since that's the
+                    // recommendation surface — pulse subtly when visible.
+                    const isFbt = relation === 'frequently_bought_with'
+                    return (
+                      <button
+                        key={relation}
+                        onClick={() => toggleRelation(relation)}
+                        className={`flex items-center gap-1.5 px-2 py-1 rounded-md text-xs border transition ${
+                          visible
+                            ? `bg-white/10 border-white/20 text-foreground ${isFbt ? 'shadow-[0_0_8px_rgba(255,61,140,0.25)]' : ''}`
+                            : 'bg-black/40 border-white/10 text-muted-foreground/60 line-through'
+                        }`}
+                        title={`${count.toLocaleString()} ${label.toLowerCase()} edges`}
+                      >
+                        <span
+                          className="w-2 h-2 rounded-full"
+                          style={{ backgroundColor: visible ? color : '#52525b' }}
+                        />
+                        {label}
+                        <span className="text-[10px] text-muted-foreground">
+                          {count.toLocaleString()}
+                        </span>
+                      </button>
+                    )
+                  })}
+                </div>
+              )}
             </div>
           )}
 
@@ -641,6 +738,7 @@ export function BusinessGraphPanel() {
               selectedCommunity={selectedCommunity}
               minConfidence={confidenceMin}
               visibleTypes={visibleTypes.size > 0 ? visibleTypes : undefined}
+              visibleRelations={visibleRelations.size > 0 ? visibleRelations : undefined}
               colorMode={colorMode}
             />
           </GraphErrorBoundary>

--- a/frontend/components/knowledge/BusinessGraphVisualization.tsx
+++ b/frontend/components/knowledge/BusinessGraphVisualization.tsx
@@ -65,6 +65,8 @@ export interface BusinessGraphVisualizationProps {
   minConfidence?: number;
   /** Which node `file_type` values to display. Undefined = show all. */
   visibleTypes?: Set<string>;
+  /** Which edge `relation` values to display. Undefined = show all. */
+  visibleRelations?: Set<string>;
   /** Coloring strategy. */
   colorMode?: ColorMode;
 }
@@ -150,6 +152,7 @@ const BusinessGraphVisualization = forwardRef<
     selectedCommunity = null,
     minConfidence = 0,
     visibleTypes,
+    visibleRelations,
     colorMode = "community",
   },
   ref,
@@ -191,9 +194,13 @@ const BusinessGraphVisualization = forwardRef<
 
     const nodes = graphData.nodes.filter(allowed);
     const nodeIds = new Set(nodes.map((n) => n.id));
+    const wantedRels = visibleRelations;
+    const relAllowed = (l: GraphLink) =>
+      !wantedRels || wantedRels.size === 0 || wantedRels.has(l.relation);
     const links = graphData.links.filter(
       (l) =>
         l.confidence_score >= minConfidence &&
+        relAllowed(l) &&
         nodeIds.has(typeof l.source === "string" ? l.source : (l.source as any).id) &&
         nodeIds.has(typeof l.target === "string" ? l.target : (l.target as any).id),
     );
@@ -210,7 +217,7 @@ const BusinessGraphVisualization = forwardRef<
       degree: degree.get(n.id) ?? 0,
     }));
     return { nodes: vizNodes, links };
-  }, [graphData, visibleTypes, minConfidence]);
+  }, [graphData, visibleTypes, visibleRelations, minConfidence]);
 
   const maxDegree = useMemo(
     () => Math.max(1, ...data.nodes.map((n) => n.degree)),

--- a/frontend/components/sites/SyncPanel.tsx
+++ b/frontend/components/sites/SyncPanel.tsx
@@ -217,11 +217,21 @@ function ShopifySyncCard({ site, workspaceId }: { site: Site; workspaceId: strin
 // between products so the agent can recommend "customers who bought X
 // also bought Y". Requires the catalog sync to have run first.
 
+// Window presets — merchant picks before clicking Sync. days=0 means
+// all-time (omit the date filter in the bulk-op GraphQL).
+const WINDOW_OPTIONS: Array<{ days: number; label: string; hint: string }> = [
+  { days: 90,  label: '90 days', hint: 'Last quarter' },
+  { days: 180, label: '180 days', hint: 'Last 6 months' },
+  { days: 365, label: '1 year',  hint: 'Last 12 months' },
+  { days: 0,   label: 'All time', hint: 'Every order ever' },
+]
+
 function ShopifyOrdersSyncCard({ workspaceId }: { workspaceId: string | null }) {
   const [status, setStatus] = useState<ShopifyOrdersSyncStatus | null>(null)
   const [loading, setLoading] = useState(true)
   const [syncing, setSyncing] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [windowDays, setWindowDays] = useState<number>(90)
 
   async function refreshStatus() {
     if (!workspaceId) { setLoading(false); return }
@@ -245,7 +255,11 @@ function ShopifyOrdersSyncCard({ workspaceId }: { workspaceId: string | null }) 
     if (!workspaceId) return
     setSyncing(true); setError(null)
     try {
-      const result = await startShopifyOrdersSync(workspaceId, { days: 90, minSupport: 2 })
+      // Auto-tune min_support to the window size: tiny window → 1 (any
+      // co-occurrence counts), big window → higher floor so noise filters
+      // out. Floor at 2 except for explicitly tight windows.
+      const minSupport = windowDays === 0 || windowDays >= 365 ? 3 : 2
+      const result = await startShopifyOrdersSync(workspaceId, { days: windowDays, minSupport })
       setStatus(result)
     } catch (e: any) {
       setError(e?.message ?? 'Sync failed')
@@ -277,9 +291,35 @@ function ShopifyOrdersSyncCard({ workspaceId }: { workspaceId: string | null }) 
       <CardContent className="space-y-3 text-sm">
         <p className="text-xs text-muted-foreground">
           Adds <strong>frequently-bought-together</strong> relationships between products by analysing
-          your last 90 days of orders. Only product IDs are read — no customer data, email,
+          your order history. Only product IDs are read — no customer data, email,
           address, or phone touches the graph.
         </p>
+
+        {/* Window selector. For test stores: pick All time. For high-volume
+            stores: shorter windows = faster syncs, less drift from current
+            ranges. */}
+        <div className="space-y-1">
+          <div className="text-[11px] uppercase tracking-wider text-muted-foreground/70">
+            Analyse orders from the last…
+          </div>
+          <div className="inline-flex bg-black/30 backdrop-blur-sm border border-white/10 rounded-md overflow-hidden">
+            {WINDOW_OPTIONS.map(({ days, label, hint }, i) => (
+              <button
+                key={days}
+                onClick={() => setWindowDays(days)}
+                disabled={syncing}
+                title={hint}
+                className={`px-3 py-1.5 text-xs transition ${i > 0 ? 'border-l border-white/10' : ''} ${
+                  windowDays === days
+                    ? 'bg-white/15 text-foreground'
+                    : 'text-muted-foreground hover:text-foreground hover:bg-white/5'
+                }`}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        </div>
 
         {loading && (
           <div className="flex items-center text-muted-foreground">

--- a/orchestrator/api/shopify.py
+++ b/orchestrator/api/shopify.py
@@ -720,17 +720,30 @@ async def get_product_sync_status(
 
 
 def _orders_bulk_query(days: int = 90) -> str:
-    """Build the orders bulk-op GraphQL string. Window in days from now."""
+    """Build the orders bulk-op GraphQL string.
+
+    Args:
+        days: rolling window in days. 0 (or negative) = all-time, no filter.
+              90/180/365 are the common selectable presets in the UI.
+    """
     from datetime import datetime, timedelta, timezone
-    cutoff = (datetime.now(timezone.utc) - timedelta(days=days)).strftime("%Y-%m-%d")
-    # Note: Shopify's Bulk Op GraphQL doesn't support variables, so we inline
-    # the cutoff date. Safe — it's a controlled date string, not user input.
-    return (
-        "{ orders(query: \"created_at:>=" + cutoff + "\") "
-        "{ edges { node { id createdAt currencyCode cancelledAt "
+
+    inner = (
+        "edges { node { id createdAt currencyCode cancelledAt "
         "lineItems { edges { node { id quantity "
-        "variant { id product { id } } } } } } } } }"
+        "variant { id product { id } } } } } } }"
     )
+
+    if days and days > 0:
+        cutoff = (datetime.now(timezone.utc) - timedelta(days=days)).strftime("%Y-%m-%d")
+        # Note: Shopify's Bulk Op GraphQL doesn't support variables, so we inline
+        # the cutoff date. Safe — controlled date string, not user input.
+        return "{ orders(query: \"created_at:>=" + cutoff + "\") { " + inner + " } }"
+
+    # All-time: omit the filter. Shopify's bulk-op streams everything.
+    # For very large merchants this may approach file-size limits; we'll
+    # handle chunking in a follow-up if anyone actually hits it.
+    return "{ orders { " + inner + " } }"
 
 
 class OrdersSyncResponse(BaseModel):


### PR DESCRIPTION
Two related additions in one PR.

(1) Orders Sync — pick analysis window
- Backend: _orders_bulk_query accepts days=0 (all-time) — omits the created_at filter in the GraphQL bulk-op. days>0 keeps the rolling window behaviour.
- SyncPanel: button group 90 days / 180 days / 1 year / All time. Selection drives the next sync run. min_support auto-tunes (1yr+ and all-time bump from 2 to 3 to filter noise as the window widens).
- Helps low-volume / test stores (use All time to maximise signal) and long-cycle B2B merchants like InbuildUK where 90 days fragments multi-month project orders.

(2) Business Graph — relation-filter chips
- New visibleRelations prop on the viz component, defaults to 'show all'.
- Panel renders two chip rows bottom-right now: Nodes (existing types)
  + Edges (new — relation types). Each chip shows count, click toggles that relation's visibility. Same sentinel-empty-set pattern as types.
- Order pairs (frequently_bought_with) is first and gets a subtle magenta glow when active — it's the recommendation surface and deserves the visual hierarchy.
- Lets merchants flip just FBT on to see customer-behaviour graph alone, or flip it off to see only catalog structure.

No backend graph-data changes — the data has always been there, the UI just couldn't surface it differently.