### PR TITLE
fix(sync ui): poll status while running so UI doesn't strand on long …

### DIFF
--- a/frontend/components/sites/SyncPanel.tsx
+++ b/frontend/components/sites/SyncPanel.tsx
@@ -86,6 +86,13 @@ function ShopifySyncCard({ site, workspaceId }: { site: Site; workspaceId: strin
     refreshStatus()
   }, [workspaceId])
 
+  // Poll while running — see ShopifyOrdersSyncCard for the rationale.
+  useEffect(() => {
+    if (status?.status !== 'running' || !workspaceId) return
+    const interval = setInterval(refreshStatus, 5000)
+    return () => clearInterval(interval)
+  }, [status?.status, workspaceId])
+
   // No front-end readiness gate — Composio connection status lives at the
   // workspace level (composio_connections table) and isn't exposed on the
   // Site row. The backend's POST /api/shopify/sync/products/start returns a
@@ -244,6 +251,16 @@ function ShopifyOrdersSyncCard({ workspaceId }: { workspaceId: string | null }) 
   }
 
   useEffect(() => { refreshStatus() }, [workspaceId])
+
+  // Poll while running — the original POST request may have been cut by
+  // the browser's fetch timeout while the server kept working. Polling
+  // the GET /status endpoint surfaces completion even if the in-flight
+  // POST never resolved. Stops the moment we see a terminal status.
+  useEffect(() => {
+    if (status?.status !== 'running' || !workspaceId) return
+    const interval = setInterval(refreshStatus, 5000)
+    return () => clearInterval(interval)
+  }, [status?.status, workspaceId])
 
   // Same stuck-state detection as catalog card
   const isStuckRunning =


### PR DESCRIPTION
…syncs

If a sync runs longer than the browser's fetch timeout (commonly ~30s) the in-flight POST never resolves but the server keeps working. The panel was stuck on 'Running…' even after the server-side sync completed because we only fetched status once on mount.

Add a setInterval(refreshStatus, 5000) that runs while status==='running' and clears the moment a terminal status (complete/error) is observed. Mirrors the catalog card so both syncs behave consistently.