### PR TITLE
fix(prd-007): force text-only path for proactive widget openers

### DIFF
--- a/orchestrator/api/widgets/chat.py
+++ b/orchestrator/api/widgets/chat.py
@@ -557,13 +557,14 @@ async def widget_chat(
                 agent_id=effective_agent_id,
                 user_id=user_id,
                 team=agent_team,
-                # PRD-007 fix: proactive openers must NOT call Composio tools.
-                # The skill prompt forbids them (rule 5), but the LLM has been
-                # ignoring the directive and calling tools anyway — yielding
-                # data_event chunks but zero text (STREAM_NO_TEXT). Skipping
-                # Composio injection at the source forces text-only output and
-                # keeps openers within their <2s latency budget.
+                # PRD-007 v0.5 — proactive openers must produce plain text only.
+                # `skip_composio` alone wasn't enough: the agent still had ~45
+                # platform tools loaded from its skill and would call one (40s
+                # with text_count=0). force_text_only=True clears use_tools
+                # entirely so the LLM can only emit text. Keeps openers within
+                # the <2s latency budget.
                 skip_composio=is_proactive,
+                force_text_only=is_proactive,
             ):
                 counts["total"] += 1
                 if first_chunk_at is None:

--- a/orchestrator/consumers/chatbot/service.py
+++ b/orchestrator/consumers/chatbot/service.py
@@ -1821,6 +1821,7 @@ class StreamingChatService:
         plan_mode: bool = False,
         team: Optional[str] = None,
         suggest_mission: bool = False,
+        force_text_only: bool = False,
     ) -> AsyncGenerator[str, None]:
         """
         Stream a chat response produced by the specified agent.
@@ -1912,6 +1913,11 @@ class StreamingChatService:
                 if complexity_assessment
                 else Complexity.MOLECULE
             )
+            # PRD-007 v0.5 — proactive openers force ATOM path. The 45-tool
+            # discovery in _get_tools() takes ~12s and the agent doesn't need
+            # tools to produce a one-sentence opener from the directive.
+            if force_text_only:
+                _complexity = Complexity.ATOM
             agent_ctx = await self._load_agent_context(agent_runtime)
             all_tools = []
             if _complexity != Complexity.ATOM:
@@ -1942,7 +1948,9 @@ class StreamingChatService:
                         exclude_admin=True,
                         allowed_names=_allowed,
                     )
-                    all_tools = [_dispatcher]
+                    # PRD-007 v0.5: proactive openers get zero tools — directive
+                    # is self-contained (page context + graph related products).
+                    all_tools = [] if force_text_only else [_dispatcher]
                 except Exception:
                     logger.debug("[chat] Could not load platform_execute for ATOM path")
 
@@ -2009,6 +2017,17 @@ class StreamingChatService:
                     agent_id, agent_runtime, skip_composio, complexity_assessment,
                 )
             else:
+                _composio_result = None
+
+            # PRD-007 v0.5 — proactive openers must produce plain text, never tool calls.
+            # The skill forbids tools, but with 40+ tools wired in the agent still calls
+            # one and emits 0 text chars (STREAM_NO_TEXT). Force-clear here so the LLM
+            # literally has nothing to call.
+            if force_text_only and use_tools:
+                logger.info(
+                    f"[force_text_only] Clearing {len(use_tools)} tools for text-only generation"
+                )
+                use_tools = None
                 _composio_result = None
 
             # Generate LLM response


### PR DESCRIPTION
## Summary

- Adds `force_text_only` param to `stream_response_with_agent`
- Wired from `widgets/chat.py` with `force_text_only=is_proactive` (mirrors `skip_composio=is_proactive`)
- When set:
  1. Pins complexity to ATOM (skips 12s tool router + SmartChat orchestration)
  2. Returns `all_tools=[]` even for ATOM dispatcher
  3. Force-clears `use_tools` after Composio injection step (backstop)

## Why

Production smoke for the graph-grounded opener returned `STREAM_NO_TEXT — text_count=0, data_event=2` after 40s. The agent was calling tools despite the skill telling it not to — SmartToolRouter classified the directive as `multi_step requires_tools=True` and the LLM picked a tool over plain text. Storefront popup ended up showing the canned SDK fallback instead of the FBT-grounded opener.

Other callers (`api/chat.py`, `api/chat_voice.py`) default to `false` and are unaffected.

## Test plan

- [ ] Deploy to Railway
- [ ] Open inbuilduk.com product page; wait 20s for opener
- [ ] Confirm popup shows FBT-grounded text (not "Need a hand finding the right product?")
- [ ] Railway logs show `[force_text_only] Clearing N tools` and `text_count > 0`, `text_chars > 0`
- [ ] Total stream time < 2000ms on warm path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Proactive-opener chat requests now strictly enforce text-only output mode, preventing accidental invocation of external tools or platform operations. This enhancement ensures that system-initiated messages reliably produce plain text responses without attempting tool calls, improving overall reliability and predictability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AutomatosAI/automatos-ai/pull/373?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->