### PR TITLE
fix(sites): auto-upgrade Shopify-connected workspace's Site to type=shopify

### DIFF
--- a/orchestrator/api/shopify.py
+++ b/orchestrator/api/shopify.py
@@ -349,6 +349,19 @@ async def connect_shopify_store(
 
     logger.info("Stored Shopify credentials for workspace %s", workspace.id)
 
+    # Ensure the workspace has a Site of type=shopify. Without this, the
+    # dashboard's cart-aware panels (cart-idle, callback) never light up
+    # even though the workspace IS connected. Idempotent — no-op when the
+    # Site already exists with the right type.
+    try:
+        from services.sites import ensure_shopify_site_for_workspace
+        ensure_shopify_site_for_workspace(db, workspace)
+    except Exception as e:  # noqa: BLE001 — never fail connect on heal error
+        logger.warning(
+            "ensure_shopify_site_for_workspace failed for workspace %s: %s",
+            workspace.id, e,
+        )
+
     return {"status": "connected", "shop": request.shop_domain}
 
 

--- a/orchestrator/api/sites.py
+++ b/orchestrator/api/sites.py
@@ -42,6 +42,7 @@ from services.destinations.dispatcher import dispatch_callback_for_site
 from services.sites import (
     USER_SETTABLE_STATUSES,
     create_site,
+    ensure_shopify_site_for_workspace,
     get_site,
     list_sites,
     public_site_dict,
@@ -86,6 +87,18 @@ async def list_sites_route(
     ctx: RequestContext = Depends(get_request_context_hybrid),
     db: Session = Depends(get_db),
 ):
+    # Self-heal: a Shopify-connected workspace that ended up with a
+    # mis-typed Site (legacy install path didn't create one) gets upgraded
+    # to type=shopify on the next dashboard load. Idempotent — returns
+    # immediately when the Site is already correct.
+    from core.models.workspace import Workspace
+    workspace = db.query(Workspace).get(ctx.workspace_id)
+    if workspace is not None:
+        try:
+            ensure_shopify_site_for_workspace(db, workspace)
+        except Exception as e:  # noqa: BLE001 — never fail list on heal error
+            logger.warning("ensure_shopify_site_for_workspace failed: %s", e)
+
     rows = list_sites(db, ctx.workspace_id)
     return {"sites": [public_site_dict(s) for s in rows]}
 

--- a/orchestrator/services/sites.py
+++ b/orchestrator/services/sites.py
@@ -11,12 +11,15 @@ is treated as not-found (no existence leak).
 from __future__ import annotations
 
 import copy
+import logging
 from typing import Optional
 from uuid import UUID
 
 from sqlalchemy.orm import Session
 
 from core.models.sites import Site, SITE_TYPES, derive_default_capabilities
+
+logger = logging.getLogger(__name__)
 
 
 # Mutable status values a merchant can set via PATCH. Backend-managed
@@ -180,3 +183,65 @@ def public_site_dict(site: Site) -> dict:
         "created_at": site.created_at.isoformat() if site.created_at else None,
         "updated_at": site.updated_at.isoformat() if site.updated_at else None,
     }
+
+
+def ensure_shopify_site_for_workspace(db: Session, workspace) -> Optional[Site]:
+    """Heal Sites that don't reflect the workspace's connected platform.
+
+    The Shopify install path historically didn't create a Site row, so
+    early workspaces ended up with a stub `type=custom` Site (or none).
+    That hides cart-aware features like cart-idle from the dashboard
+    even though the workspace IS connected to Shopify.
+
+    Single-tenant invariant: each workspace has at most ONE Site, and
+    its type must match the connected platform. This helper:
+
+    * No-op if the workspace isn't Shopify-connected.
+    * Creates a Site if none exist.
+    * Upgrades the existing Site's type + capabilities + external_id
+      if it's mis-typed (e.g. `custom` → `shopify`).
+
+    Idempotent: returning early when the Site is already correct keeps
+    the dashboard's list-sites endpoint fast on the happy path.
+    """
+    settings = workspace.settings or {}
+    shopify_domain = settings.get("shopify_domain")
+    if not shopify_domain:
+        return None  # Not a Shopify workspace — leave alone.
+
+    sites = (
+        db.query(Site)
+        .filter(Site.workspace_id == workspace.id)
+        .order_by(Site.created_at.asc())
+        .all()
+    )
+
+    if not sites:
+        site = create_site(
+            db,
+            workspace_id=workspace.id,
+            type="shopify",
+            display_name=workspace.name or shopify_domain,
+            external_id=shopify_domain,
+        )
+        logger.info(
+            "ensure_shopify_site: created shopify Site %s for workspace %s (%s)",
+            site.id, workspace.id, shopify_domain,
+        )
+        return site
+
+    site = sites[0]
+    if site.type == "shopify" and site.external_id == shopify_domain:
+        return site  # Already correct.
+
+    prev_type = site.type
+    site.type = "shopify"
+    site.external_id = shopify_domain
+    site.capabilities = derive_default_capabilities("shopify")
+    db.commit()
+    db.refresh(site)
+    logger.info(
+        "ensure_shopify_site: upgraded Site %s from %s → shopify for workspace %s (%s)",
+        site.id, prev_type, workspace.id, shopify_domain,
+    )
+    return site


### PR DESCRIPTION
## Summary

The dashboard's Cart-idle / Callback panels never lit up for the inbuilduk workspace because its single Site is typed \`custom\` instead of \`shopify\`. Root cause: \`POST /api/shopify/connect\` stores creds on the Workspace but never creates a Site row, so whatever Site exists came from a different path with the wrong type.

## What changes

New helper \`ensure_shopify_site_for_workspace\` in \`services/sites.py\`:
- Reads \`workspace.settings.shopify_domain\` as the trigger
- Creates a Site with \`type=shopify\` if none exist
- Upgrades the existing Site's type + capabilities + external_id if mis-typed (\`custom\` → \`shopify\`)
- No-op when already correct

Called from:
1. **\`GET /api/sites\`** — self-heals every existing workspace the next time someone opens the dashboard. **This fixes inbuilduk automatically** as soon as the user reloads Settings → Widget SDK.
2. **\`POST /api/shopify/connect\`** — new installs get the right Site type immediately.

Single-tenant assumption baked in: each workspace has at most one Site (per user constraint "we will never have more than one Site").

## Test plan

- [ ] Deploy to Railway
- [ ] Open ui.automatos.app/settings → Widget SDK → Cart-idle
- [ ] Expected: card now shows the enable toggle + Idle threshold + Greeting fields (instead of "This Site type (custom) doesn't expose cart events…")
- [ ] Railway logs show \`ensure_shopify_site: upgraded Site <uuid> from custom → shopify for workspace <uuid>\`
- [ ] Reload again: no further upgrade log (idempotent)