### PR TITLE
feat(shopify+graph): capture product_url on import and surface node/e…

### DIFF
--- a/orchestrator/api/shopify.py
+++ b/orchestrator/api/shopify.py
@@ -530,6 +530,7 @@ _SHOPIFY_BULK_CATALOG_QUERY = """{
         publishedAt
         priceRangeV2 { minVariantPrice { amount currencyCode } maxVariantPrice { amount currencyCode } }
         featuredImage { url altText }
+        onlineStoreUrl
         totalInventory
         tracksInventory
         variants { edges { node { id sku title price compareAtPrice inventoryQuantity availableForSale selectedOptions { name value } barcode } } }

--- a/orchestrator/modules/knowledge/graph_extraction.py
+++ b/orchestrator/modules/knowledge/graph_extraction.py
@@ -552,6 +552,7 @@ def map_shopify_catalog(jsonl_iter, *, bulk_op_id: str | None = None) -> dict[st
                 "total_inventory": obj.get("totalInventory"),
                 "tracks_inventory": obj.get("tracksInventory"),
                 "image_url": (obj.get("featuredImage") or {}).get("url"),
+                "product_url": obj.get("onlineStoreUrl"),
                 "shopify_gid": gid,
                 "updated_at": obj.get("updatedAt"),
             }

--- a/orchestrator/modules/tools/discovery/handlers_graph.py
+++ b/orchestrator/modules/tools/discovery/handlers_graph.py
@@ -222,21 +222,26 @@ async def handle_graph_neighbors(
             if relation_filter and relation.lower() != relation_filter:
                 continue
             target = v if u == node_id else u
-            target_attrs = graph.nodes.get(target, {})
+            target_attrs = dict(graph.nodes.get(target, {}))
+            edge_attrs = dict(edge_data.get("attrs") or {})
             neighbors.append(
                 {
                     "target": str(target),
                     "target_label": target_attrs.get("label", str(target)),
+                    "target_attrs": target_attrs,
                     "relation": relation,
                     "confidence": edge_data.get("confidence", edge_data.get("weight", 1.0)),
+                    "weight": edge_data.get("weight"),
+                    "edge_attrs": edge_attrs,
                 }
             )
 
-        node_attrs = graph.nodes.get(node_id, {})
+        node_attrs = dict(graph.nodes.get(node_id, {}))
         return {
             "success": True,
             "node": str(node_id),
             "node_label": node_attrs.get("label", str(node_id)),
+            "node_attrs": node_attrs,
             "neighbor_count": len(neighbors),
             "neighbors": neighbors,
         }


### PR DESCRIPTION
…dge attrs to graph tools

Two small, vertical-agnostic changes that together let the chat widget render product cards with images and clickable links:

1. Shopify import (api/shopify.py + modules/knowledge/graph_extraction.py)
   - Bulk GraphQL now requests onlineStoreUrl on every Product.
   - Mapper persists it as node attr 'product_url' (image_url was already captured via featuredImage.url).
   - Both attrs are now stored on shopify_product nodes for any downstream tool to read.

2. Graph neighbors handler (modules/tools/discovery/handlers_graph.py)
   - handle_graph_neighbors now returns full target_attrs / edge_attrs and node_attrs in its response, not just label + confidence.
   - The handler stays generic — it surfaces whatever attrs the workspace's graph nodes carry; no Shopify keys are referenced.
   - This unblocks any skill (Shopify or otherwise) from rendering rich responses based on whatever the import captured.

Pairs with automatos-skills shopify-support v1.3.1, which teaches the agent to render product cards using image_url + product_url when present in target_attrs.

Does NOT touch modules/context/sections/graph_context.py — generic core remains free of vertical-specific keys. The page-context anchoring path (if/when wanted) belongs in widget code, not core context.