### PR TITLE
hotfix(frontend): bust Docker layer cache to force clean rebuild

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -73,6 +73,13 @@ ENV NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL=${NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL}
 # Install ALL dependencies (including devDependencies for build)
 RUN npm install --legacy-peer-deps
 
+# Cache bust marker — bump this value (or pass --build-arg FRONTEND_CACHE_BUST=...)
+# to force a clean rebuild of the COPY + npm run build layers. Used when
+# Railway's Docker layer cache produces stale or inconsistent output, e.g.
+# .next/static missing chunks the standalone server HTML references.
+ARG FRONTEND_CACHE_BUST=2026-05-28T13-00-00Z
+RUN echo "Frontend cache bust: $FRONTEND_CACHE_BUST"
+
 # Copy source code (Dockerfile is in frontend/, so copy from current dir)
 COPY . .
 


### PR DESCRIPTION
Adds FRONTEND_CACHE_BUST ARG + RUN echo before COPY . . in the builder stage. Any change to the ARG value (default or via --build-arg) invalidates the COPY + npm run build layers, forcing next build to emit fresh chunks.

Why: production deploy of automotas-ai-frontend has been serving HTML that references webpack-*.js, app/layout-*.js, and a shared 9320-*.js chunk that all return 404 on origin. Same broken chunk hashes reproduce across separate Railway builds, indicating cached/partial build artifacts being reused. Cache bust forces a fresh build.

No behavioural change. Future cache busts: bump the ARG default.