### PR TITLE
feat(shopify+graph): re-land product_url + node attrs surfacing

### DIFF
--- a/orchestrator/api/shopify.py
+++ b/orchestrator/api/shopify.py
@@ -530,6 +530,7 @@ _SHOPIFY_BULK_CATALOG_QUERY = """{
         publishedAt
         priceRangeV2 { minVariantPrice { amount currencyCode } maxVariantPrice { amount currencyCode } }
         featuredImage { url altText }
+        onlineStoreUrl
         totalInventory
         tracksInventory
         variants { edges { node { id sku title price compareAtPrice inventoryQuantity availableForSale selectedOptions { name value } barcode } } }

--- a/orchestrator/modules/knowledge/graph_extraction.py
+++ b/orchestrator/modules/knowledge/graph_extraction.py
@@ -552,6 +552,7 @@ def map_shopify_catalog(jsonl_iter, *, bulk_op_id: str | None = None) -> dict[st
                 "total_inventory": obj.get("totalInventory"),
                 "tracks_inventory": obj.get("tracksInventory"),
                 "image_url": (obj.get("featuredImage") or {}).get("url"),
+                "product_url": obj.get("onlineStoreUrl"),
                 "shopify_gid": gid,
                 "updated_at": obj.get("updatedAt"),
             }

--- a/orchestrator/modules/tools/discovery/handlers_graph.py
+++ b/orchestrator/modules/tools/discovery/handlers_graph.py
@@ -222,21 +222,26 @@ async def handle_graph_neighbors(
             if relation_filter and relation.lower() != relation_filter:
                 continue
             target = v if u == node_id else u
-            target_attrs = graph.nodes.get(target, {})
+            target_attrs = dict(graph.nodes.get(target, {}))
+            edge_attrs = dict(edge_data.get("attrs") or {})
             neighbors.append(
                 {
                     "target": str(target),
                     "target_label": target_attrs.get("label", str(target)),
+                    "target_attrs": target_attrs,
                     "relation": relation,
                     "confidence": edge_data.get("confidence", edge_data.get("weight", 1.0)),
+                    "weight": edge_data.get("weight"),
+                    "edge_attrs": edge_attrs,
                 }
             )
 
-        node_attrs = graph.nodes.get(node_id, {})
+        node_attrs = dict(graph.nodes.get(node_id, {}))
         return {
             "success": True,
             "node": str(node_id),
             "node_label": node_attrs.get("label", str(node_id)),
+            "node_attrs": node_attrs,
             "neighbor_count": len(neighbors),
             "neighbors": neighbors,
         }


### PR DESCRIPTION
## Re-land of reverted PR #380

Earlier today this exact 3-file change was reverted via PR #381 during the frontend cache-bust incident. The change was confirmed not to be the cause — identical broken chunk hashes appeared on builds with AND without it. The frontend cache poison was fixed in PR #382 (cache-bust ARG); re-landing the shopify work now.

## What this does

**Shopify import** — `api/shopify.py` + `modules/knowledge/graph_extraction.py`
- Bulk catalog GraphQL pulls `onlineStoreUrl` on every Product.
- Mapper persists it as node attr `product_url` alongside the existing `image_url` (from `featuredImage.url`).

**Graph neighbors handler** — `modules/tools/discovery/handlers_graph.py`
- `handle_graph_neighbors` returns full `target_attrs` / `edge_attrs` / `node_attrs` in its response, not just label + confidence.
- Stays vertical-agnostic — surfaces whatever attrs the workspace's graph carries; no Shopify keys in core.

## Pairs with

`automatos-skills` `shopify-support` v1.3.1 (pushed on branch `feat/prd-007-opener-mode-uses-graph`, needs its own PR + merge) — teaches the agent to render markdown product cards using `image_url` + `product_url` from the tool response.

## Does NOT touch

`modules/context/sections/graph_context.py` — generic core stays free of vertical-specific keys.

## After merge

1. Railway rebuilds backend (clean — frontend untouched, so frontend cache stays warm).
2. Trigger a Shopify re-sync on INBUILD's workspace via `POST /api/shopify/sync/products/start?workspace_id=…` to backfill `product_url` on existing nodes.
3. Test on INBUILD product page — agent calls `platform_query_graph`, renders cards with images + clickable links.