### PR TITLE
feat(widget): ground regular chat turns on page_context

### DIFF
--- a/orchestrator/api/widgets/chat.py
+++ b/orchestrator/api/widgets/chat.py
@@ -305,6 +305,36 @@ async def widget_chat(
         "%s HISTORY_LOADED: %d messages", log_extra, len(message_history)
     )
 
+    # PRD-141: a plugin MAY return a per-turn grounding preamble (e.g. the
+    # page the visitor is viewing). It rides on `system_preamble`, not
+    # `message`, so the persisted transcript and title stay the verbatim
+    # user text — we prepend it to the latest user turn in-memory only.
+    # Fully vertical-agnostic: chat.py never inspects the preamble's shape.
+    if (
+        plugin_result.system_preamble
+        and message_history
+        and message_history[-1].get("role") == "user"
+    ):
+        _last_parts = message_history[-1].get("parts") or [{"type": "text", "text": ""}]
+        _orig_text = next(
+            (p.get("text", "") for p in _last_parts
+             if isinstance(p, dict) and p.get("type") == "text"),
+            "",
+        )
+        message_history = message_history[:-1] + [{
+            "role": "user",
+            "parts": [{
+                "type": "text",
+                "text": f"{plugin_result.system_preamble}\n\n{_orig_text}",
+            }],
+        }]
+        logger.info(
+            "%s PAGE_CONTEXT_GROUNDED: vertical=%s preamble_len=%d",
+            log_extra,
+            vertical,
+            len(plugin_result.system_preamble),
+        )
+
     # API key can lock the agent — ignore client-provided agent_id when set
     # Resolve public_id (UUID) or legacy int to internal id
     from core.utils.agent_resolver import resolve_agent_id as _resolve_aid

--- a/orchestrator/integrations/__init__.py
+++ b/orchestrator/integrations/__init__.py
@@ -46,6 +46,13 @@ class WidgetPluginResult:
     surface (e.g. "applied shopify proactive_opener rewrite"). It is not
     sent to the agent.
 
+    `system_preamble` is an optional grounding block the dispatcher injects
+    into the LLM message history for the CURRENT turn only — prepended to
+    the latest user message in-memory. Unlike `message`, it is never
+    persisted to the transcript nor used for conversation titling, so it
+    grounds the agent fresh each turn without polluting stored history or
+    accumulating stale context. `None` (the default) means no grounding.
+
     `telemetry` is a free-form dict for the dispatcher to attach to its
     structured log line (e.g. counts of related products resolved,
     fixture identifiers used). Plugins should keep keys short and
@@ -54,6 +61,7 @@ class WidgetPluginResult:
 
     message: str
     context_note: Optional[str] = None
+    system_preamble: Optional[str] = None
     telemetry: Dict[str, Any] = field(default_factory=dict)
 
 

--- a/orchestrator/integrations/shopify/tests/test_widget_proactive.py
+++ b/orchestrator/integrations/shopify/tests/test_widget_proactive.py
@@ -4,10 +4,15 @@ This test file pins three things:
 
 * Registration — importing ``integrations`` populates
   ``PLUGIN_REGISTRY["shopify"]`` with this module.
-* Pass-through gating — the plugin matches chat.py's old
-  ``is_proactive`` guard: anything other than
-  ``trigger_reason in ("proactive_opener", "cart_idle")`` AND
-  ``page_context is not None`` returns the message unchanged.
+* Gating — for a proactive trigger
+  (``proactive_opener`` / ``cart_idle``) with ``page_context`` the
+  plugin rewrites the message into a directive. For a REGULAR turn with
+  ``page_context`` the message is returned verbatim but a
+  ``system_preamble`` is attached so the agent is grounded on the page
+  the shopper is viewing (the dispatcher injects it into history for
+  that turn only — never persisted, so the stored transcript keeps the
+  shopper's words). Only when ``page_context`` is ``None`` — or carries
+  nothing renderable — is there no grounding at all.
 * Wiring contract — when the plugin DOES rewrite, it calls the
   matching resolver + builder with the right arguments and returns the
   builder's output verbatim as ``message``. All four helpers live in
@@ -156,11 +161,13 @@ async def test_no_trigger_no_context_passes_through(db, workspace_id):
 
 
 @pytest.mark.asyncio
-async def test_no_trigger_with_context_passes_through(db, workspace_id):
-    # Mid-conversation message on a Shopify workspace: the Shopify
-    # plugin must NOT prepend an opaque "(Context: ...)" JSON block.
-    # That behaviour is owned by the generic plugin only — Shopify's
-    # context-handling lives in the skill prompt + proactive directive.
+async def test_no_trigger_with_context_grounds_via_preamble(db, workspace_id):
+    # Mid-conversation message on a Shopify workspace WITH page context.
+    # The persisted `message` stays the shopper's verbatim words — the
+    # Shopify plugin still never prepends an opaque "(Context: ...)" block
+    # to it (that is the generic plugin's job). Instead the page facts
+    # ride on `system_preamble`, which the dispatcher injects into the LLM
+    # history for this turn only.
     result = await widget_proactive.handle_widget_message(
         message="Tell me about Hochiki detectors",
         page_context={"productHandle": "hochiki-aln", "productTitle": "Hochiki ALN"},
@@ -168,12 +175,20 @@ async def test_no_trigger_with_context_passes_through(db, workspace_id):
         workspace_id=workspace_id,
         db=db,
     )
+    # Message unchanged — this is what gets persisted and titled.
     assert result.message == "Tell me about Hochiki detectors"
-    assert result.context_note is None
+    # Grounding attached out-of-band.
+    assert result.context_note == "shopify: page_context grounding"
+    assert result.system_preamble is not None
+    assert 'product="Hochiki ALN"' in result.system_preamble
+    assert "product_handle=hochiki-aln" in result.system_preamble
+    assert result.telemetry == {}
 
 
 @pytest.mark.asyncio
-async def test_unknown_trigger_passes_through(db, workspace_id):
+async def test_unknown_trigger_with_context_grounds_via_preamble(db, workspace_id):
+    # An unknown trigger is treated as a regular turn: message stays
+    # verbatim, page context rides on system_preamble.
     result = await widget_proactive.handle_widget_message(
         message="agent will see this verbatim",
         page_context={"pageType": "product"},
@@ -182,7 +197,26 @@ async def test_unknown_trigger_passes_through(db, workspace_id):
         db=db,
     )
     assert result.message == "agent will see this verbatim"
+    assert result.context_note == "shopify: page_context grounding"
+    assert result.system_preamble is not None
+    assert "page_type=product" in result.system_preamble
+
+
+@pytest.mark.asyncio
+async def test_regular_turn_empty_context_passes_through(db, workspace_id):
+    # Regular turn, page_context present but nothing renderable (all
+    # empty/zero/false values, plus an unknown key) → no grounding.
+    result = await widget_proactive.handle_widget_message(
+        message="just a question",
+        page_context={"productTitle": "", "cartItemCount": 0, "unknownKey": "x"},
+        trigger_reason=None,
+        workspace_id=workspace_id,
+        db=db,
+    )
+    assert result.message == "just a question"
     assert result.context_note is None
+    assert result.system_preamble is None
+    assert result.telemetry == {}
 
 
 @pytest.mark.asyncio
@@ -401,3 +435,73 @@ async def test_no_context_no_rewrite(trigger, db, workspace_id):
     assert result.message == "user message verbatim"
     assert result.context_note is None
     assert result.telemetry == {}
+
+
+# ---- Regular-turn grounding (preamble builder) -------------------------------
+#
+# `_build_page_context_preamble` is the pure function behind the
+# `system_preamble` returned for regular Shopify turns. It reuses the same
+# `_OPENER_CONTEXT_FIELDS` / `_format_opener_context_value` machinery as the
+# proactive opener, so a product page grounds the agent on the same facts
+# whether it opened proactively or the shopper typed first — but it carries
+# NO tool/output directives (it rides on a real user message).
+
+
+def test_build_page_context_preamble_renders_product_facts():
+    preamble = widget_proactive._build_page_context_preamble({
+        "pageType": "product",
+        "productTitle": "Hochiki ALN",
+        "productVendor": "Hochiki",
+        "productPrice": "42.00",
+        "productAvailable": True,
+        "productHandle": "hochiki-aln",
+    })
+    assert preamble is not None
+    # Multiword string values are quoted; single-token values are bare.
+    assert 'product="Hochiki ALN"' in preamble
+    assert "vendor=Hochiki" in preamble
+    assert "product_handle=hochiki-aln" in preamble
+    assert "page_type=product" in preamble
+    # Boolean True renders (only False/0/"" are skipped).
+    assert "in_stock=True" in preamble
+
+
+def test_build_page_context_preamble_has_deixis_and_anti_invention():
+    preamble = widget_proactive._build_page_context_preamble({"productTitle": "Widget"})
+    assert preamble is not None
+    # Deixis resolution instruction for "this"/"it".
+    assert '"this"' in preamble
+    assert '"it"' in preamble
+    # Anti-invention guardrail.
+    assert "do not invent" in preamble.lower()
+    # No proactive/opener directive leaks in — this rides on a real user turn.
+    assert "PROACTIVE_OPENER" not in preamble
+    assert "RETURN PLAIN TEXT" not in preamble
+
+
+def test_build_page_context_preamble_skips_empty_zero_false():
+    preamble = widget_proactive._build_page_context_preamble({
+        "productTitle": "Widget",
+        "productPrice": "",         # empty → skipped
+        "cartItemCount": 0,         # zero → skipped
+        "productAvailable": False,  # false → skipped
+        "shopCurrency": "GBP",      # kept
+    })
+    assert preamble is not None
+    assert "product=Widget" in preamble
+    assert "currency=GBP" in preamble
+    assert "price" not in preamble
+    assert "cart_item_count" not in preamble
+    assert "in_stock" not in preamble
+
+
+def test_build_page_context_preamble_none_when_nothing_usable():
+    # Empty dict, and a dict whose every known field is empty/zero/false
+    # (plus an unknown key the field map ignores) both yield None.
+    assert widget_proactive._build_page_context_preamble({}) is None
+    assert widget_proactive._build_page_context_preamble({
+        "productTitle": "",
+        "cartItemCount": 0,
+        "productAvailable": False,
+        "unknownKey": "ignored",
+    }) is None

--- a/orchestrator/integrations/shopify/widget_proactive.py
+++ b/orchestrator/integrations/shopify/widget_proactive.py
@@ -379,6 +379,41 @@ def _build_cart_idle_opener_message(
     )
 
 
+def _build_page_context_preamble(page_context: dict) -> Optional[str]:
+    """Render the Shopify page context into a grounding preamble for a
+    regular (non-proactive) chat turn.
+
+    Reuses the same ordered field map and value formatter as the proactive
+    opener (:data:`_OPENER_CONTEXT_FIELDS`,
+    :func:`_format_opener_context_value`) so a product page grounds the
+    agent on identical facts whether it opened proactively or the shopper
+    typed first. Empty / zero / false fields are skipped by the formatter.
+
+    Returns ``None`` when nothing usable is present (e.g. a bare cart page
+    with no populated fields) — the caller then passes the turn through
+    ungrounded rather than emitting an empty ``Currently viewing:`` line.
+
+    Unlike :func:`_build_proactive_opener_message`, this carries NO tool /
+    output directives: it is prepended to a real user message, so it must
+    only supply facts and deixis resolution, never hijack the turn into
+    opener mode.
+    """
+    parts: list[str] = []
+    for src_key, label in _OPENER_CONTEXT_FIELDS:
+        rendered = _format_opener_context_value(label, (page_context or {}).get(src_key))
+        if rendered is not None:
+            parts.append(rendered)
+    if not parts:
+        return None
+    return (
+        "[PAGE_CONTEXT] The visitor is viewing this page right now. Treat "
+        'references like "this", "this product", "it" as the item below, and '
+        "use these as ground-truth facts — do not invent specs, pricing, or "
+        "availability beyond them. "
+        f"Currently viewing: {', '.join(parts)}."
+    )
+
+
 async def handle_widget_message(
     *,
     message: str,
@@ -395,19 +430,34 @@ async def handle_widget_message(
       (mirrors chat.py's ``PROACTIVE_TRIGGER_REASONS`` frozenset) AND
       ``page_context`` is not ``None`` → call the matching resolver +
       builder and return the rewritten directive as ``message``.
-    * any other case (no trigger, unknown trigger, missing context) →
-      return ``message`` unchanged. This includes mid-conversation
-      messages: the Shopify vertical does NOT prepend an opaque
-      ``(Context: ...)`` block — that behaviour is owned by the
-      generic plugin only.
+    * a regular turn (no / unknown trigger) WITH ``page_context`` → leave
+      ``message`` untouched and attach a ``system_preamble`` so the agent
+      is grounded on the page the shopper is looking at. The preamble is
+      injected into the LLM history for this turn only; it is never
+      persisted, so the stored transcript keeps the shopper's verbatim
+      words. The Shopify vertical still does NOT prepend an opaque
+      ``(Context: ...)`` block to the persisted ``message`` — that
+      behaviour is owned by the generic plugin only.
+    * ``page_context`` is ``None`` (or carries nothing renderable) →
+      return ``message`` unchanged with no grounding.
 
     ``telemetry`` carries the counts chat.py's ``PROACTIVE_REWRITE``
     log line surfaces (``trigger_reason``, ``related_count``) so the
     dispatcher rebuilds the log line from the plugin result without
     losing observability.
     """
-    if page_context is None or trigger_reason not in ("proactive_opener", "cart_idle"):
+    if page_context is None:
         return WidgetPluginResult(message=message)
+
+    if trigger_reason not in ("proactive_opener", "cart_idle"):
+        preamble = _build_page_context_preamble(page_context)
+        if preamble is None:
+            return WidgetPluginResult(message=message)
+        return WidgetPluginResult(
+            message=message,
+            context_note="shopify: page_context grounding",
+            system_preamble=preamble,
+        )
 
     workspace_str = str(workspace_id)
 

--- a/orchestrator/integrations/tests/test_registry_contract.py
+++ b/orchestrator/integrations/tests/test_registry_contract.py
@@ -47,13 +47,14 @@ def test_widget_plugin_result_is_a_dataclass():
 
 def test_widget_plugin_result_field_names():
     names = {f.name for f in fields(WidgetPluginResult)}
-    assert names == {"message", "context_note", "telemetry"}
+    assert names == {"message", "context_note", "system_preamble", "telemetry"}
 
 
 def test_widget_plugin_result_defaults():
     result = WidgetPluginResult(message="hello")
     assert result.message == "hello"
     assert result.context_note is None
+    assert result.system_preamble is None
     assert result.telemetry == {}
 
 
@@ -61,9 +62,11 @@ def test_widget_plugin_result_accepts_full_construction():
     result = WidgetPluginResult(
         message="rewritten",
         context_note="applied shopify rewrite",
+        system_preamble="[PAGE_CONTEXT] Currently viewing: product=Widget.",
         telemetry={"related": 3},
     )
     assert result.context_note == "applied shopify rewrite"
+    assert result.system_preamble == "[PAGE_CONTEXT] Currently viewing: product=Widget."
     assert result.telemetry == {"related": 3}
 
 


### PR DESCRIPTION
## Summary

Regular widget chat turns previously passed through the Shopify plugin **ungrounded** — only proactive openers / cart-idle directives received page facts. A shopper asking *"does this come in blue?"* on a product page left the agent with no idea which product they meant.

This adds per-turn page-context grounding for regular Shopify turns, implemented cleanly on top of the PRD-141 plugin architecture (rebased onto `main` after the US-005–US-015 refactor landed).

## How

- **`WidgetPluginResult.system_preamble`** (new optional field) — a grounding block the dispatcher injects into the LLM message history for the **current turn only**. Unlike `message`, it is never persisted to the transcript nor used for conversation titling.
- **Shopify plugin** renders the live `page_context` into a `[PAGE_CONTEXT]` block for regular turns, reusing the proactive opener's `_OPENER_CONTEXT_FIELDS` / `_format_opener_context_value` (minus tool/output directives — it rides on a real user message). Returns `None` when nothing renderable, so empty contexts pass through.
- **`chat.py` dispatcher** prepends the preamble to the latest user turn **in-memory**. Stays fully vertical-agnostic: it only checks *whether* a preamble exists, never its shape.

## Why this shape

- Persisted transcript + title keep the shopper's verbatim words.
- Grounding is fresh each turn — no stale context accumulation.
- Generic plugin unaffected (`system_preamble` defaults to `None`).
- **US-012 gate passes** — zero Shopify keys in generic surfaces.

## Companion change

End-to-end this also needs the SDK to forward `page_context` on regular `sendMessage` calls — `automatos-widget-sdk` PR #16 (v0.4.0). Both must land for the feature to work live.

## Test plan

- [x] `integrations/` test tree — 37 passed (contract + Shopify plugin + generic, no regressions)
- [x] Byte-equality snapshot tests still pass (proactive/cart-idle paths unchanged by the guard split)
- [x] New coverage: 2 dispatch tests updated to assert grounding, 1 empty-context pass-through, 4 pure-function tests for `_build_page_context_preamble`
- [x] US-012 CI gate (`check-no-shopify-in-generic.sh`) — OK, no Shopify identifiers in generic surfaces
- [ ] Verify live on Railway after merge (regular product-page turn grounds; transcript stays clean)