### PR TITLE
feat(harness): self-management flag + approved-task parser (PRD-141 U…

### DIFF
--- a/orchestrator/config.py
+++ b/orchestrator/config.py
@@ -435,6 +435,10 @@ class Config:
     RECIPE_SCHEDULER_ENABLED: bool = os.getenv("RECIPE_SCHEDULER_ENABLED", "true").lower() == "true"
     COORDINATOR_ENABLED: bool = os.getenv("COORDINATOR_ENABLED", "true").lower() == "true"
     HARNESS_ENABLED: bool = os.getenv("HARNESS_ENABLED", "true").lower() == "true"
+    # PRD-141 Phase 5: gates HARNESS self-management (auto-applying approved
+    # config changes back onto the platform). HIGH RISK — default OFF. Nothing
+    # in Phase 5 may take effect unless this is true.
+    HARNESS_SELF_MANAGEMENT_ENABLED: bool = os.getenv("HARNESS_SELF_MANAGEMENT_ENABLED", "false").lower() == "true"
 
     # =============================================================================
     # PRD-130 — Business Intake Wizard (PoC)

--- a/orchestrator/services/harness_service.py
+++ b/orchestrator/services/harness_service.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import re
 import time
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
@@ -1202,6 +1203,86 @@ class HarnessService:
                 })
         except Exception as exc:
             logger.warning("[HARNESS] Failed to check approved board tasks: %s", exc)
+
+    def _parse_harness_task(
+        self,
+        task: Dict[str, Any],
+        agents_by_name: Optional[Dict[str, Any]] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Reconstruct a prescription from an approved [HARNESS] board task.
+
+        Inverse of the producer in _phase_apply(): parses the
+        '[HARNESS] {change_type} for {target_name}' title and the
+        '**Current:** {json}' / '**Proposed:** {json}' description sections,
+        and resolves target_id from target_name via agents_by_name (name -> id).
+        Returns None for any task that is not a well-formed HARNESS task.
+
+        target_id is None when the name cannot be resolved — callers MUST treat
+        an unresolved (None) target as non-applicable and skip it, never apply a
+        change to a guessed/null target.
+        """
+        title = (task.get("title") or "").strip()
+        prefix = "[HARNESS] "
+        if not title.startswith(prefix):
+            return None
+
+        # change_type is a space-free snake_case identifier, so partitioning on
+        # the first " for " cleanly splits it from target_name (which may itself
+        # contain spaces or even " for ").
+        change_type, sep, target_name = title[len(prefix):].partition(" for ")
+        change_type = change_type.strip()
+        target_name = target_name.strip()
+        if not sep or not change_type or not target_name:
+            return None
+
+        description = task.get("description") or ""
+        agents_by_name = agents_by_name or {}
+
+        return {
+            "prescription_id": f"rx-task-{task.get('id')}",
+            "target_type": "agent",
+            "target_id": agents_by_name.get(target_name),
+            "target_name": target_name,
+            "change_type": change_type,
+            "current_value": self._extract_json_section(description, "Current"),
+            "proposed_value": self._extract_json_section(description, "Proposed"),
+            "risk_score": self._extract_risk_score(description, task.get("tags")),
+            "rationale": self._extract_text_section(description, "Rationale"),
+            "expected_improvement": self._extract_text_section(description, "Expected Improvement"),
+        }
+
+    @staticmethod
+    def _extract_json_section(description: str, label: str) -> Dict[str, Any]:
+        """Pull a single-line '**{label}:** {json}' section and json.loads it."""
+        match = re.search(rf"\*\*{re.escape(label)}:\*\*\s*(.+)", description)
+        if not match:
+            return {}
+        try:
+            value = json.loads(match.group(1).strip())
+        except (ValueError, TypeError):
+            return {}
+        return value if isinstance(value, dict) else {}
+
+    @staticmethod
+    def _extract_text_section(description: str, label: str) -> str:
+        """Pull the trailing text of a '**{label}:** {text}' section."""
+        match = re.search(rf"\*\*{re.escape(label)}:\*\*\s*(.+)", description)
+        return match.group(1).strip() if match else ""
+
+    @staticmethod
+    def _extract_risk_score(description: str, tags: Optional[List[str]]) -> int:
+        """Recover the risk score from the description, falling back to a
+        'risk-{n}' tag. Unknown -> 5 (max risk; never qualifies for auto-apply)."""
+        match = re.search(r"\*\*Risk Score:\*\*\s*(\d+)", description)
+        if match:
+            return int(match.group(1))
+        for tag in (tags or []):
+            if isinstance(tag, str) and tag.startswith("risk-"):
+                try:
+                    return int(tag.split("-", 1)[1])
+                except ValueError:
+                    continue
+        return 5
 
     def _compute_convergence_status(
         self,

--- a/orchestrator/tests/test_harness_self_management.py
+++ b/orchestrator/tests/test_harness_self_management.py
@@ -1,0 +1,123 @@
+"""PRD-141 US-020: HARNESS self-management flag + approved-task parser.
+
+Pure unit tests — _parse_harness_task does no I/O, and HarnessService.__init__
+takes no DB. Dummy POSTGRES_* satisfies the lazy create_engine in the config
+import chain without opening a connection. The self-management flag is popped
+before import so test_flag_defaults_false sees the real default.
+"""
+import json
+import os
+import sys
+import types
+
+os.environ.pop("HARNESS_SELF_MANAGEMENT_ENABLED", None)
+os.environ.setdefault("POSTGRES_USER", "test")
+os.environ.setdefault("POSTGRES_PASSWORD", "test")
+os.environ.setdefault("POSTGRES_HOST", "localhost")
+os.environ.setdefault("POSTGRES_PORT", "5432")
+os.environ.setdefault("POSTGRES_DB", "test")
+
+
+def _install_fake_apscheduler():
+    """harness_service imports apscheduler at module top for its cron, but the
+    parser under test never uses it. Stub the names so import succeeds without
+    the (prod-only) dependency installed locally."""
+    if "apscheduler" in sys.modules:
+        return
+    aps = types.ModuleType("apscheduler")
+    schedulers = types.ModuleType("apscheduler.schedulers")
+    asyncio_mod = types.ModuleType("apscheduler.schedulers.asyncio")
+    asyncio_mod.AsyncIOScheduler = type("AsyncIOScheduler", (), {})
+    jobstores = types.ModuleType("apscheduler.jobstores")
+    memory_mod = types.ModuleType("apscheduler.jobstores.memory")
+    memory_mod.MemoryJobStore = type("MemoryJobStore", (), {})
+    aps.schedulers = schedulers
+    aps.jobstores = jobstores
+    schedulers.asyncio = asyncio_mod
+    jobstores.memory = memory_mod
+    sys.modules.update({
+        "apscheduler": aps,
+        "apscheduler.schedulers": schedulers,
+        "apscheduler.schedulers.asyncio": asyncio_mod,
+        "apscheduler.jobstores": jobstores,
+        "apscheduler.jobstores.memory": memory_mod,
+    })
+
+
+_install_fake_apscheduler()
+
+from config import config
+from services.harness_service import HarnessService
+
+
+def _harness_task(
+    change_type="heartbeat_tune",
+    target_name="ScribeAgent",
+    current=None,
+    proposed=None,
+    risk=2,
+    task_id="task-1",
+    tags=None,
+):
+    """Build a board task exactly as _phase_apply() produces it."""
+    current = {"interval_minutes": 30} if current is None else current
+    proposed = {"interval_minutes": 90} if proposed is None else proposed
+    return {
+        "id": task_id,
+        "title": f"[HARNESS] {change_type} for {target_name}",
+        "description": (
+            f"**Risk Score:** {risk}/5\n\n"
+            f"**Change Type:** {change_type}\n\n"
+            f"**Current:** {json.dumps(current)}\n\n"
+            f"**Proposed:** {json.dumps(proposed)}\n\n"
+            f"**Rationale:** because reasons\n\n"
+            f"**Expected Improvement:** save tokens"
+        ),
+        "tags": ["harness", "org-review", f"risk-{risk}"] if tags is None else tags,
+    }
+
+
+def test_parse_harness_task_valid():
+    svc = HarnessService()
+    rx = svc._parse_harness_task(_harness_task(), agents_by_name={"ScribeAgent": 42})
+
+    assert rx is not None
+    assert rx["change_type"] == "heartbeat_tune"
+    assert rx["target_name"] == "ScribeAgent"
+    assert rx["target_id"] == 42
+    assert rx["target_type"] == "agent"
+    assert rx["current_value"] == {"interval_minutes": 30}
+    assert rx["proposed_value"] == {"interval_minutes": 90}
+    assert rx["risk_score"] == 2
+    assert rx["rationale"] == "because reasons"
+    assert rx["expected_improvement"] == "save tokens"
+    assert rx["prescription_id"] == "rx-task-task-1"
+
+
+def test_parse_harness_task_invalid():
+    svc = HarnessService()
+    # Non-HARNESS title -> None
+    assert svc._parse_harness_task({"id": "t", "title": "Buy milk", "description": ""}) is None
+    # HARNESS prefix but missing ' for {target}' -> None
+    assert svc._parse_harness_task(
+        {"id": "t", "title": "[HARNESS] heartbeat_tune", "description": ""}
+    ) is None
+    # Empty / missing title -> None
+    assert svc._parse_harness_task({"id": "t", "title": "", "description": ""}) is None
+    assert svc._parse_harness_task({"id": "t"}) is None
+
+
+def test_parse_harness_task_unresolved_target_id_is_none():
+    """A target_name not present in the agents map yields target_id=None
+    (US-021 must treat an unresolved target as non-applicable, never guess)."""
+    svc = HarnessService()
+    rx = svc._parse_harness_task(
+        _harness_task(target_name="GhostAgent"), agents_by_name={"ScribeAgent": 42}
+    )
+    assert rx is not None
+    assert rx["target_name"] == "GhostAgent"
+    assert rx["target_id"] is None
+
+
+def test_flag_defaults_false():
+    assert config.HARNESS_SELF_MANAGEMENT_ENABLED is False


### PR DESCRIPTION
…S-020)

First (safe) step of Phase 5. Adds HARNESS_SELF_MANAGEMENT_ENABLED to config (default OFF — nothing in Phase 5 takes effect unless it is true) and a pure _parse_harness_task() that reconstructs a prescription dict from an approved [HARNESS] board task. No execution yet.

The parser is the exact inverse of the producer in _phase_apply(): it reads the '[HARNESS] {change_type} for {target_name}' title and the markdown '**Risk Score/Current/Proposed/Rationale/Expected Improvement:**' sections, and resolves target_id from target_name via an injected agents map. Fail-safe defaults: unparseable JSON -> {}, unknown risk -> 5 (max, never auto-applies), unresolved target -> target_id None (consumers must skip, never guess).

4 tests in new tests/test_harness_self_management.py (valid, invalid, unresolved-target, flag-defaults-false). python-reviewer: all checks PASS, no CRITICAL/HIGH.