### PR TITLE
feat(harness): apply approved board tasks behind self-management flag…

### DIFF
--- a/orchestrator/services/harness_service.py
+++ b/orchestrator/services/harness_service.py
@@ -39,6 +39,12 @@ _MIN_DATA_DAYS = 7
 _AUTO_APPLY_MAX_RISK = 2
 _HIGH_PRIORITY_RISK = 4
 
+# Sentinel proposed_value meaning "a human must supply the real value" — emitted
+# by _phase_prescribe for changes it can detect but not safely decide (model,
+# description). The apply layer MUST refuse it: writing it literally would set an
+# agent's model/description to the string "review_needed".
+_PLACEHOLDER_PROPOSED_VALUE = "review_needed"
+
 # Convergence thresholds
 _CONVERGED_DELTA = 2.0
 _CONVERGED_VARIANCE = 0.02
@@ -644,7 +650,7 @@ class HarnessService:
                             "target_name": agent_name,
                             "change_type": "model_change_same_tier",
                             "current_value": {"model": agent.get("model", "unknown")},
-                            "proposed_value": {"model": "review_needed"},
+                            "proposed_value": {"model": _PLACEHOLDER_PROPOSED_VALUE},
                             "risk_score": 3,
                             "expected_improvement": f"Potential cost reduction — cost up {cost_delta:.0f}% while success rate is healthy at {success_rate:.0f}%",
                             "rationale": (
@@ -668,7 +674,7 @@ class HarnessService:
                             "target_name": agent_name,
                             "change_type": "description_update",
                             "current_value": {"description": agent.get("description", "")[:100]},
-                            "proposed_value": {"description": "review_needed"},
+                            "proposed_value": {"description": _PLACEHOLDER_PROPOSED_VALUE},
                             "risk_score": 1,
                             "expected_improvement": "Align agent description with actual workload to improve routing",
                             "rationale": (
@@ -772,7 +778,7 @@ class HarnessService:
                     })
 
         # Apply previously approved board tasks (status=done, tag=harness)
-        await self._apply_approved_board_tasks(executor, changelog)
+        await self._apply_approved_board_tasks(executor, workspace_id, changelog)
 
         logger.info(
             "[HARNESS] APPLY done — %d applied, %d queued, %d failed",
@@ -1147,6 +1153,20 @@ class HarnessService:
         target_id = rx.get("target_id")
         proposed = rx.get("proposed_value", {})
 
+        # Refuse placeholder prescriptions — _phase_prescribe emits
+        # {"model"|"description": "review_needed"} when it can flag a problem but
+        # not decide the fix. Applying the sentinel literally would corrupt the
+        # agent. This guard protects BOTH the low-risk auto-apply path and the
+        # approved-board-task path, which both flow through here.
+        if isinstance(proposed, dict) and _PLACEHOLDER_PROPOSED_VALUE in proposed.values():
+            return {
+                "success": False,
+                "error": (
+                    f"proposed_value is a placeholder ('{_PLACEHOLDER_PROPOSED_VALUE}') "
+                    "requiring human input — not auto-applicable"
+                ),
+            }
+
         try:
             if change_type == "heartbeat_tune":
                 result = await executor.execute("platform_configure_agent_heartbeat", {
@@ -1178,9 +1198,26 @@ class HarnessService:
             return {"success": False, "error": str(exc)}
 
     async def _apply_approved_board_tasks(
-        self, executor: "PlatformActionExecutor", changelog: Dict[str, List[Dict[str, Any]]]
+        self,
+        executor: "PlatformActionExecutor",
+        workspace_id: UUID,
+        changelog: Dict[str, List[Dict[str, Any]]],
     ) -> None:
-        """Apply previously approved (done) HARNESS board tasks."""
+        """Auto-apply previously approved (done) HARNESS board tasks.
+
+        Gated on HARNESS_SELF_MANAGEMENT_ENABLED — when off this is a pure no-op,
+        so Phase 5 stays inert by default. When on, each done [HARNESS] task that
+        has not already been applied is parsed, its pre-change value snapshotted
+        (for US-022 rollback), and applied via _auto_apply_prescription. Applied
+        task ids are persisted to /harness/applied_tasks.json; that ledger is the
+        idempotency key because board tasks have no tag-mutation tool, so a task
+        is never re-applied on a later weekly tick.
+        """
+        from config import config
+
+        if not config.HARNESS_SELF_MANAGEMENT_ENABLED:
+            return
+
         try:
             result = await executor.execute("platform_list_tasks", {
                 "tags": ["harness"],
@@ -1191,18 +1228,159 @@ class HarnessService:
             tasks = result.get("data", result.get("tasks", []))
             if not isinstance(tasks, list):
                 return
+
+            ledger = self._read_applied_tasks(workspace_id)
+            # Normalise ids to str: a task id round-trips through JSON and the
+            # task API, so the ledger and the live list could disagree on
+            # int-vs-str. One canonical type makes both the membership check and
+            # the sorted() in _write_applied_tasks total.
+            applied_ids = {str(i) for i in ledger.get("applied_task_ids", [])}
+            agents_by_name = await self._resolve_agents_by_name(executor)
+
+            newly_applied: List[Dict[str, Any]] = []
             for task in tasks:
-                logger.warning(
-                    "[HARNESS] Approved board task not yet auto-applied (v1 limitation): %s",
-                    task.get("title", ""),
+                raw_id = task.get("id")
+                if raw_id is None:
+                    continue
+                task_id = str(raw_id)
+                if task_id in applied_ids:
+                    continue
+
+                rx = self._parse_harness_task(task, agents_by_name=agents_by_name)
+                if not rx or rx.get("target_id") is None:
+                    # Never apply a change to an unresolved / guessed target.
+                    changelog.setdefault("skipped", []).append({
+                        "task_id": task_id,
+                        "title": task.get("title", ""),
+                        "reason": "unparseable or unresolved target",
+                    })
+                    continue
+
+                current_before = self._snapshot_current_value(rx)
+                apply_result = await self._auto_apply_prescription(executor, rx)
+
+                if apply_result.get("success"):
+                    entry = {
+                        "task_id": task_id,
+                        "prescription_id": rx.get("prescription_id"),
+                        "target_id": rx.get("target_id"),
+                        "target_name": rx.get("target_name"),
+                        "change_type": rx.get("change_type"),
+                        "current_value_before": current_before,
+                        "proposed_value": rx.get("proposed_value"),
+                        "applied_at": datetime.now(timezone.utc).isoformat(),
+                    }
+                    applied_ids.add(task_id)
+                    newly_applied.append(entry)
+                    changelog.setdefault("applied_from_approved", []).append(entry)
+                else:
+                    changelog.setdefault("failed", []).append({
+                        "task_id": task_id,
+                        "title": task.get("title", ""),
+                        "error": apply_result.get("error", "unknown"),
+                    })
+
+            if newly_applied:
+                await self._write_applied_tasks(
+                    executor, workspace_id, ledger, applied_ids, newly_applied
                 )
-                changelog.setdefault("approved_pending", []).append({
-                    "task_id": task.get("id"),
-                    "title": task.get("title", ""),
-                    "note": "Approved but not auto-applied — manual action required (v1)",
-                })
         except Exception as exc:
-            logger.warning("[HARNESS] Failed to check approved board tasks: %s", exc)
+            # A failure here means human-approved changes were silently dropped —
+            # surface the trace rather than bury it in a warning.
+            logger.error(
+                "[HARNESS] Failed to apply approved board tasks: %s",
+                exc, exc_info=True,
+            )
+
+    async def _resolve_agents_by_name(
+        self, executor: "PlatformActionExecutor"
+    ) -> Dict[str, Any]:
+        """Build a {agent_name: agent_id} map for resolving board-task targets."""
+        try:
+            result = await executor.execute("platform_list_agents", {})
+        except Exception as exc:
+            logger.warning("[HARNESS] Failed to list agents for self-management: %s", exc)
+            return {}
+        agents = self._extract_agents_list({"agents": result})
+        return {
+            a.get("name"): a.get("id")
+            for a in agents
+            if isinstance(a, dict) and a.get("name") and a.get("id") is not None
+        }
+
+    def _snapshot_current_value(self, rx: Dict[str, Any]) -> Dict[str, Any]:
+        """Capture the value an approved change is about to overwrite.
+
+        Uses the prescription's parsed current_value — the producer wrote it in
+        the same shape _auto_apply_prescription consumes, so it round-trips
+        exactly with no agent-schema coupling. Recorded as current_value_before
+        so US-022 can roll back to it on regression.
+        """
+        current = rx.get("current_value")
+        return current if isinstance(current, dict) else {}
+
+    @staticmethod
+    def _applied_tasks_path(workspace_id: UUID) -> str:
+        from config import config
+        import os
+
+        return os.path.join(
+            config.WORKSPACE_VOLUME_PATH,
+            str(workspace_id),
+            "harness",
+            "applied_tasks.json",
+        )
+
+    def _read_applied_tasks(self, workspace_id: UUID) -> Dict[str, Any]:
+        """Read the cumulative ledger of auto-applied HARNESS board task ids.
+
+        This is the idempotency key for self-management — board tasks have no
+        tag-mutation tool, so a task recorded here is never re-applied. A missing
+        or unreadable ledger yields an empty one; failing open is safe because
+        every applicable change_type sets an absolute value (so re-applying is a
+        harmless no-op) and placeholder prescriptions are refused by
+        _auto_apply_prescription before any write.
+        """
+        import os
+
+        try:
+            path = self._applied_tasks_path(workspace_id)
+            if os.path.exists(path):
+                with open(path, "r") as f:
+                    data = json.load(f)
+                if isinstance(data, dict):
+                    data.setdefault("applied_task_ids", [])
+                    data.setdefault("entries", [])
+                    return data
+        except Exception:
+            logger.warning(
+                "[HARNESS] Failed to read applied_tasks.json for %s",
+                workspace_id, exc_info=True,
+            )
+        return {"applied_task_ids": [], "entries": []}
+
+    async def _write_applied_tasks(
+        self,
+        executor: "PlatformActionExecutor",
+        workspace_id: UUID,
+        ledger: Dict[str, Any],
+        applied_ids: set,
+        newly_applied: List[Dict[str, Any]],
+    ) -> None:
+        """Persist the applied-tasks ledger via the workspace file store."""
+        ledger["applied_task_ids"] = sorted(applied_ids)
+        ledger.setdefault("entries", []).extend(newly_applied)
+        ledger["updated_at"] = datetime.now(timezone.utc).isoformat()
+        try:
+            await executor.execute("workspace_write_file", {
+                "path": "/harness/applied_tasks.json",
+                "content": json.dumps(ledger, indent=2),
+            })
+        except Exception as exc:
+            logger.warning(
+                "[HARNESS] Failed to persist applied_tasks ledger for %s: %s",
+                workspace_id, exc,
+            )
 
     def _parse_harness_task(
         self,

--- a/orchestrator/services/harness_service.py
+++ b/orchestrator/services/harness_service.py
@@ -1293,7 +1293,27 @@ class HarnessService:
                     "agent_id": target_id,
                     "model_config": {"model": proposed.get("model")},
                 })
+            elif change_type == "tool_assignment_add":
+                # Verified against actions_assignments.py: the param is app_name
+                # (the Composio app identifier), NOT tool_name. Idempotent —
+                # re-activates a previously deactivated assignment.
+                result = await executor.execute("platform_assign_tool_to_agent", {
+                    "agent_id": target_id,
+                    "app_name": proposed.get("app_name"),
+                })
+            elif change_type == "tool_assignment_remove":
+                # Deactivates the assignment (is_active=False) by default, keeping
+                # the audit trail. app_name is accepted by both assign/unassign.
+                result = await executor.execute("platform_unassign_tool_from_agent", {
+                    "agent_id": target_id,
+                    "app_name": proposed.get("app_name"),
+                })
             else:
+                # power_mode_upgrade/downgrade and routing_rule_add are intentionally
+                # NOT handled: agents have no power_mode attribute (power mode is
+                # mission-run scoped via run_config + system_settings, never read off
+                # an agent), and no platform_create_routing_rule action exists. Both
+                # would need net-new platform work outside this PRD.
                 return {"success": False, "error": f"Unknown auto-apply change_type: {change_type}"}
             return result if isinstance(result, dict) else {"success": True}
         except Exception as exc:

--- a/orchestrator/services/harness_service.py
+++ b/orchestrator/services/harness_service.py
@@ -549,6 +549,13 @@ class HarnessService:
 
             health_cards[agent_id] = card
 
+        # US-022: queue rollbacks for auto-applied changes whose target agent
+        # has now regressed (skipped on first run — no prior changes exist).
+        if not is_first_run:
+            issues.extend(
+                self._detect_auto_applied_regressions(baseline, health_cards)
+            )
+
         # Org-level diagnosis
         org_diagnosis = self._compute_org_diagnosis(metrics, baseline)
 
@@ -683,6 +690,34 @@ class HarnessService:
                             ),
                         })
 
+        # US-022: emit risk-1 rollback prescriptions for any auto-applied change
+        # whose target regressed (flagged by _phase_diagnose). These revert to the
+        # snapshot and bypass the rejected-signature filter — a rollback is a
+        # safety action, not a new proposal. current_value is left empty so the
+        # rollback is not itself snapshotted, which prevents rollback-of-rollback
+        # oscillation (a rollback can never become a rollback target).
+        for issue in diagnosis.get("issues", []):
+            if issue.get("root_cause") != "auto_applied_regression":
+                continue
+            spec = issue.get("rollback_spec") or {}
+            if not spec.get("change_type") or not spec.get("revert_to"):
+                continue
+            seq += 1
+            prescriptions.append({
+                "prescription_id": f"rx-{today}-{seq:03d}",
+                "target_type": "agent",
+                "target_id": spec.get("target_id"),
+                "target_name": issue.get("agent_name", "unknown"),
+                "change_type": spec["change_type"],
+                "current_value": {},
+                "proposed_value": spec["revert_to"],
+                "risk_score": 1,
+                "expected_improvement": "Revert auto-applied change that preceded a regression",
+                "rationale": issue.get(
+                    "detail", "Auto-applied change regressed; reverting to prior value."
+                ),
+            })
+
         # Sort: risk ascending, then by prescription_id
         prescriptions.sort(key=lambda p: (p["risk_score"], p["prescription_id"]))
 
@@ -736,8 +771,12 @@ class HarnessService:
                 if result.get("success"):
                     changelog["applied"].append({
                         "prescription_id": rx_id,
+                        "target_id": rx.get("target_id"),
                         "target_name": target_name,
                         "change_type": change_type,
+                        # Snapshot so US-022 can revert this change if the agent
+                        # regresses on the next tick.
+                        "current_value_before": self._snapshot_current_value(rx),
                         "result": "applied",
                     })
                 else:
@@ -846,7 +885,11 @@ class HarnessService:
                 "prev_delta_magnitude": prev_delta,
                 "status": convergence_status,
             },
-            "applied_changes": changelog.get("applied", []),
+            # Persist approved-task applications alongside low-risk auto-applies
+            # so the next tick's DIAGNOSE can roll back either kind on regression.
+            "applied_changes": (
+                changelog.get("applied", []) + changelog.get("applied_from_approved", [])
+            ),
             "queued_changes": changelog.get("queued", []),
         }
 
@@ -1145,6 +1188,66 @@ class HarnessService:
                         rejected.add(f"{parts[0].strip()}:{parts[1].strip()}")
         return rejected
 
+    def _detect_auto_applied_regressions(
+        self,
+        baseline: Optional[Dict[str, Any]],
+        health_cards: Dict[str, Dict[str, Any]],
+    ) -> List[Dict[str, Any]]:
+        """Find auto-applied changes whose target agent is now REGRESSION.
+
+        Reads the previous tick's applied_changes (low-risk auto-applies plus
+        approved-task applications — both carry current_value_before). For each
+        whose target agent's current card is REGRESSION, emit an
+        'auto_applied_regression' issue carrying a rollback_spec that
+        _phase_prescribe turns into a risk-1 revert. Entries without a target_id
+        or a non-empty snapshot are skipped — there is nothing safe to revert to
+        (this also tolerates pre-US-022 baselines that lack the snapshot).
+        """
+        issues: List[Dict[str, Any]] = []
+        if not baseline:
+            return issues
+        # Dedupe by (target_id, change_type): one tick can apply the same field
+        # twice (a low-risk auto-apply plus an approved-task apply both land in
+        # applied_changes), and we must revert each field once — not emit a
+        # duplicate rollback for the same field.
+        seen: set = set()
+        for change in baseline.get("applied_changes", []):
+            if not isinstance(change, dict):
+                continue
+            target_id = change.get("target_id")
+            revert_to = change.get("current_value_before")
+            change_type = change.get("change_type")
+            # An empty snapshot ({}/None) is how a rollback prescription marks
+            # itself ineligible for further rollback (it is written with
+            # current_value={}); skipping it here is what prevents
+            # rollback-of-rollback oscillation.
+            if target_id is None or not revert_to or not change_type:
+                continue
+            dedupe_key = (str(target_id), change_type)
+            if dedupe_key in seen:
+                continue
+            card = health_cards.get(str(target_id))
+            if not card or card.get("classification") != "REGRESSION":
+                continue
+            seen.add(dedupe_key)
+            target_name = change.get("target_name", card.get("agent_name", "unknown"))
+            issues.append({
+                "agent_id": str(target_id),
+                "agent_name": target_name,
+                "root_cause": "auto_applied_regression",
+                "severity": "high",
+                "detail": (
+                    f"{target_name} regressed after HARNESS auto-applied "
+                    f"{change_type} — reverting to prior value"
+                ),
+                "rollback_spec": {
+                    "change_type": change_type,
+                    "target_id": target_id,
+                    "revert_to": revert_to,
+                },
+            })
+        return issues
+
     async def _auto_apply_prescription(
         self, executor: "PlatformActionExecutor", rx: Dict[str, Any]
     ) -> Dict[str, Any]:
@@ -1317,7 +1420,19 @@ class HarnessService:
         so US-022 can roll back to it on regression.
         """
         current = rx.get("current_value")
-        return current if isinstance(current, dict) else {}
+        if isinstance(current, dict):
+            return current
+        # Rollback prescriptions legitimately carry current_value={} (a dict), so
+        # reaching here means a non-dict slipped through (e.g. a mis-parsed board
+        # task). The change stays safe — it just becomes ineligible for rollback —
+        # but log it so the dropped snapshot is visible rather than silent.
+        if current is not None:
+            logger.warning(
+                "[HARNESS] prescription %s has non-dict current_value (%s); "
+                "recording empty snapshot — change will be ineligible for rollback",
+                rx.get("prescription_id"), type(current).__name__,
+            )
+        return {}
 
     @staticmethod
     def _applied_tasks_path(workspace_id: UUID) -> str:

--- a/orchestrator/services/harness_service.py
+++ b/orchestrator/services/harness_service.py
@@ -1277,9 +1277,11 @@ class HarnessService:
                     "interval_minutes": proposed.get("interval_minutes"),
                 })
             elif change_type == "temperature_adjust":
+                # update_agent reads temperature as a top-level param (it folds it
+                # into model_config itself); a nested model_config is ignored.
                 result = await executor.execute("platform_update_agent", {
                     "agent_id": target_id,
-                    "model_config": {"temperature": proposed.get("temperature")},
+                    "temperature": proposed.get("temperature"),
                 })
             elif change_type in ("tag_update", "description_update"):
                 update_params = {"agent_id": target_id}
@@ -1289,9 +1291,12 @@ class HarnessService:
                     update_params["description"] = proposed.get("description", "")
                 result = await executor.execute("platform_update_agent", update_params)
             elif change_type == "model_change_same_tier":
+                # update_agent reads the new model as the top-level model_id param
+                # (a nested model_config is ignored). The prescription carries it
+                # under "model", so map model -> model_id here.
                 result = await executor.execute("platform_update_agent", {
                     "agent_id": target_id,
-                    "model_config": {"model": proposed.get("model")},
+                    "model_id": proposed.get("model"),
                 })
             elif change_type == "tool_assignment_add":
                 # Verified against actions_assignments.py: the param is app_name

--- a/orchestrator/tests/test_harness_self_management.py
+++ b/orchestrator/tests/test_harness_self_management.py
@@ -409,3 +409,83 @@ def test_applied_rollback_is_not_itself_rolled_back():
     cards = {"42": {"agent_id": "42", "agent_name": "ScribeAgent", "classification": "REGRESSION"}}
     # Still REGRESSION, but the empty snapshot makes it ineligible — no rollback.
     assert svc._detect_auto_applied_regressions(baseline, cards) == []
+
+
+# ---------------------------------------------------------------------------
+# US-023: expanded prescription vocabulary (correct action names)
+# ---------------------------------------------------------------------------
+
+
+def test_tool_assignment_add_prescription():
+    """tool_assignment_add applies via platform_assign_tool_to_agent using the
+    VERIFIED param app_name (not tool_name)."""
+    svc = HarnessService()
+    ex = _FakeExecutor(tasks=[], agents=[])
+    rx = {
+        "prescription_id": "rx-tool-add",
+        "change_type": "tool_assignment_add",
+        "target_id": 42,
+        "proposed_value": {"app_name": "GMAIL"},
+    }
+    result = asyncio.run(svc._auto_apply_prescription(ex, rx))
+
+    assert result["success"] is True
+    assert (
+        "platform_assign_tool_to_agent",
+        {"agent_id": 42, "app_name": "GMAIL"},
+    ) in ex.calls
+
+
+def test_tool_assignment_remove_prescription():
+    """tool_assignment_remove applies via platform_unassign_tool_from_agent."""
+    svc = HarnessService()
+    ex = _FakeExecutor(tasks=[], agents=[])
+    rx = {
+        "prescription_id": "rx-tool-rm",
+        "change_type": "tool_assignment_remove",
+        "target_id": 42,
+        "proposed_value": {"app_name": "GITHUB"},
+    }
+    result = asyncio.run(svc._auto_apply_prescription(ex, rx))
+
+    assert result["success"] is True
+    assert (
+        "platform_unassign_tool_from_agent",
+        {"agent_id": 42, "app_name": "GITHUB"},
+    ) in ex.calls
+
+
+def test_power_mode_change_type_is_not_implemented():
+    """Agents have no power_mode attribute (it is mission-run scoped), so
+    power_mode_* prescriptions are refused, not applied to platform_update_agent."""
+    svc = HarnessService()
+    ex = _FakeExecutor(tasks=[], agents=[])
+    for change_type in ("power_mode_upgrade", "power_mode_downgrade"):
+        rx = {
+            "prescription_id": f"rx-{change_type}",
+            "change_type": change_type,
+            "target_id": 42,
+            "proposed_value": {"power_mode": "max"},
+        }
+        result = asyncio.run(svc._auto_apply_prescription(ex, rx))
+        assert result["success"] is False
+        assert "Unknown auto-apply change_type" in result["error"]
+    # Nothing was written to any agent.
+    assert "platform_update_agent" not in ex.actions()
+
+
+def test_routing_rule_add_is_not_implemented():
+    """routing_rule_add is excluded — no platform_create_routing_rule exists."""
+    svc = HarnessService()
+    ex = _FakeExecutor(tasks=[], agents=[])
+    rx = {
+        "prescription_id": "rx-route",
+        "change_type": "routing_rule_add",
+        "target_id": 42,
+        "proposed_value": {"rule": "x->y"},
+    }
+    result = asyncio.run(svc._auto_apply_prescription(ex, rx))
+
+    assert result["success"] is False
+    assert "Unknown auto-apply change_type" in result["error"]
+    assert ex.calls == []

--- a/orchestrator/tests/test_harness_self_management.py
+++ b/orchestrator/tests/test_harness_self_management.py
@@ -284,3 +284,128 @@ def test_placeholder_proposed_value_is_refused(monkeypatch):
     assert "placeholder" in changelog["failed"][0]["error"]
     # Not applied -> not ledgered.
     assert "workspace_write_file" not in ex.actions()
+
+
+# ---------------------------------------------------------------------------
+# US-022: auto-rollback on regression
+# ---------------------------------------------------------------------------
+
+
+def test_rollback_on_regression():
+    """An auto-applied change whose target agent is now REGRESSION yields an
+    auto_applied_regression issue with a rollback_spec; a non-regressing target
+    yields nothing."""
+    svc = HarnessService()
+    baseline = {
+        "applied_changes": [
+            {
+                "target_id": 42,
+                "target_name": "ScribeAgent",
+                "change_type": "heartbeat_tune",
+                "current_value_before": {"interval_minutes": 30},
+            },
+        ]
+    }
+    cards = {"42": {"agent_id": "42", "agent_name": "ScribeAgent", "classification": "REGRESSION"}}
+    issues = svc._detect_auto_applied_regressions(baseline, cards)
+
+    assert len(issues) == 1
+    assert issues[0]["root_cause"] == "auto_applied_regression"
+    assert issues[0]["rollback_spec"]["change_type"] == "heartbeat_tune"
+    assert issues[0]["rollback_spec"]["revert_to"] == {"interval_minutes": 30}
+
+    # A STABLE target produces no rollback.
+    cards["42"]["classification"] = "STABLE"
+    assert svc._detect_auto_applied_regressions(baseline, cards) == []
+
+    # An entry with no snapshot is skipped (nothing safe to revert to).
+    cards["42"]["classification"] = "REGRESSION"
+    baseline["applied_changes"][0]["current_value_before"] = {}
+    assert svc._detect_auto_applied_regressions(baseline, cards) == []
+
+
+def test_rollback_reverts_to_snapshot():
+    """_phase_prescribe turns an auto_applied_regression issue into a risk-1
+    prescription whose proposed_value is the snapshot."""
+    svc = HarnessService()
+    diagnosis = {
+        "is_first_run": False,
+        "health_cards": {},
+        "issues": [{
+            "agent_id": "42",
+            "agent_name": "ScribeAgent",
+            "root_cause": "auto_applied_regression",
+            "severity": "high",
+            "detail": "ScribeAgent regressed",
+            "rollback_spec": {
+                "change_type": "heartbeat_tune",
+                "target_id": 42,
+                "revert_to": {"interval_minutes": 30},
+            },
+        }],
+    }
+    prescriptions = asyncio.run(
+        svc._phase_prescribe(_WS_ID, diagnosis, {"agents": []}, db=None)
+    )
+
+    rollbacks = [p for p in prescriptions if p.get("risk_score") == 1]
+    assert len(rollbacks) == 1
+    assert rollbacks[0]["change_type"] == "heartbeat_tune"
+    assert rollbacks[0]["target_id"] == 42
+    assert rollbacks[0]["proposed_value"] == {"interval_minutes": 30}
+
+
+def test_duplicate_applied_changes_emit_single_rollback():
+    """The same field can land in applied_changes twice in one tick (a low-risk
+    auto-apply plus an approved-task apply). A regressing target must yield ONE
+    rollback for that field, not a duplicate."""
+    svc = HarnessService()
+    baseline = {
+        "applied_changes": [
+            {
+                "target_id": 42,
+                "target_name": "ScribeAgent",
+                "change_type": "heartbeat_tune",
+                "current_value_before": {"interval_minutes": 30},
+            },
+            {
+                "target_id": 42,
+                "target_name": "ScribeAgent",
+                "change_type": "heartbeat_tune",
+                "current_value_before": {"interval_minutes": 45},
+            },
+        ]
+    }
+    cards = {"42": {"agent_id": "42", "agent_name": "ScribeAgent", "classification": "REGRESSION"}}
+    issues = svc._detect_auto_applied_regressions(baseline, cards)
+
+    assert len(issues) == 1
+    # First-seen snapshot wins — the true pre-change value, before any same-tick edit.
+    assert issues[0]["rollback_spec"]["revert_to"] == {"interval_minutes": 30}
+
+    # Distinct change_types on the same agent each get their own rollback.
+    baseline["applied_changes"][1]["change_type"] = "description_update"
+    baseline["applied_changes"][1]["current_value_before"] = {"description": "old"}
+    assert len(svc._detect_auto_applied_regressions(baseline, cards)) == 2
+
+
+def test_applied_rollback_is_not_itself_rolled_back():
+    """Oscillation guard: an applied rollback is recorded with current_value={},
+    so even if its target stays REGRESSION on the next tick it must NOT spawn
+    another rollback (rollback-of-rollback)."""
+    svc = HarnessService()
+    # This is what a previously-applied rollback looks like in applied_changes:
+    # _snapshot_current_value({"current_value": {}}) -> {} stored as the snapshot.
+    baseline = {
+        "applied_changes": [
+            {
+                "target_id": 42,
+                "target_name": "ScribeAgent",
+                "change_type": "heartbeat_tune",
+                "current_value_before": {},
+            },
+        ]
+    }
+    cards = {"42": {"agent_id": "42", "agent_name": "ScribeAgent", "classification": "REGRESSION"}}
+    # Still REGRESSION, but the empty snapshot makes it ineligible — no rollback.
+    assert svc._detect_auto_applied_regressions(baseline, cards) == []

--- a/orchestrator/tests/test_harness_self_management.py
+++ b/orchestrator/tests/test_harness_self_management.py
@@ -5,6 +5,7 @@ takes no DB. Dummy POSTGRES_* satisfies the lazy create_engine in the config
 import chain without opening a connection. The self-management flag is popped
 before import so test_flag_defaults_false sees the real default.
 """
+import asyncio
 import json
 import os
 import sys
@@ -121,3 +122,165 @@ def test_parse_harness_task_unresolved_target_id_is_none():
 
 def test_flag_defaults_false():
     assert config.HARNESS_SELF_MANAGEMENT_ENABLED is False
+
+
+# ---------------------------------------------------------------------------
+# US-021: execute approved board tasks (flag-gated) + snapshot
+# ---------------------------------------------------------------------------
+
+_WS_ID = "00000000-0000-0000-0000-000000000001"
+# A path that does not exist, so _read_applied_tasks finds no ledger and treats
+# every task as un-applied. The ledger WRITE goes through the fake executor's
+# workspace_write_file (in-memory), so no real filesystem I/O occurs.
+_MISSING_VOLUME = "/tmp/harness-self-mgmt-test-no-such-volume"
+
+
+class _FakeExecutor:
+    """Records every execute() call and returns canned results for the actions
+    _apply_approved_board_tasks invokes (list tasks/agents, apply, write file)."""
+
+    def __init__(self, tasks, agents):
+        self._tasks = tasks
+        self._agents = agents
+        self.calls = []
+
+    async def execute(self, action, params):
+        self.calls.append((action, params))
+        if action == "platform_list_tasks":
+            return {"data": self._tasks}
+        if action == "platform_list_agents":
+            return {"data": self._agents}
+        # apply actions + workspace_write_file all report success
+        return {"success": True}
+
+    def actions(self):
+        return [action for action, _ in self.calls]
+
+
+def test_approved_tasks_noop_when_flag_off(monkeypatch):
+    """Flag off -> pure no-op: nothing is listed, nothing is applied."""
+    monkeypatch.setattr(config, "HARNESS_SELF_MANAGEMENT_ENABLED", False)
+    svc = HarnessService()
+    ex = _FakeExecutor(
+        tasks=[_harness_task(task_id=7)],
+        agents=[{"id": 42, "name": "ScribeAgent"}],
+    )
+    changelog = {}
+    asyncio.run(svc._apply_approved_board_tasks(ex, _WS_ID, changelog))
+
+    assert ex.calls == []
+    assert changelog == {}
+
+
+def test_approved_tasks_are_executed(monkeypatch):
+    """Flag on -> a done [HARNESS] task is parsed, its target resolved, and the
+    change applied via _auto_apply_prescription, then the ledger is persisted."""
+    monkeypatch.setattr(config, "HARNESS_SELF_MANAGEMENT_ENABLED", True)
+    monkeypatch.setattr(config, "WORKSPACE_VOLUME_PATH", _MISSING_VOLUME)
+    svc = HarnessService()
+    task = _harness_task(
+        change_type="heartbeat_tune",
+        target_name="ScribeAgent",
+        current={"interval_minutes": 30},
+        proposed={"interval_minutes": 90},
+        task_id=7,
+    )
+    ex = _FakeExecutor(tasks=[task], agents=[{"id": 42, "name": "ScribeAgent"}])
+    changelog = {}
+    asyncio.run(svc._apply_approved_board_tasks(ex, _WS_ID, changelog))
+
+    # The heartbeat change was actually applied to the resolved agent id.
+    assert (
+        "platform_configure_agent_heartbeat",
+        {"agent_id": 42, "interval_minutes": 90},
+    ) in ex.calls
+    applied = changelog.get("applied_from_approved", [])
+    assert len(applied) == 1
+    assert applied[0]["task_id"] == "7"
+    assert applied[0]["target_id"] == 42
+    assert applied[0]["change_type"] == "heartbeat_tune"
+    # Idempotency ledger was persisted via the workspace file store.
+    assert "workspace_write_file" in ex.actions()
+
+
+def test_snapshot_recorded_before_apply(monkeypatch):
+    """The pre-change value is captured as current_value_before so US-022 has a
+    rollback target."""
+    monkeypatch.setattr(config, "HARNESS_SELF_MANAGEMENT_ENABLED", True)
+    monkeypatch.setattr(config, "WORKSPACE_VOLUME_PATH", _MISSING_VOLUME)
+    svc = HarnessService()
+    task = _harness_task(
+        change_type="heartbeat_tune",
+        target_name="ScribeAgent",
+        current={"interval_minutes": 30},
+        proposed={"interval_minutes": 90},
+        task_id=7,
+    )
+    ex = _FakeExecutor(tasks=[task], agents=[{"id": 42, "name": "ScribeAgent"}])
+    changelog = {}
+    asyncio.run(svc._apply_approved_board_tasks(ex, _WS_ID, changelog))
+
+    entry = changelog["applied_from_approved"][0]
+    assert entry["current_value_before"] == {"interval_minutes": 30}
+    assert entry["proposed_value"] == {"interval_minutes": 90}
+
+
+def test_already_applied_task_is_skipped(monkeypatch):
+    """A task whose id is in the ledger is never re-applied (idempotency)."""
+    monkeypatch.setattr(config, "HARNESS_SELF_MANAGEMENT_ENABLED", True)
+    svc = HarnessService()
+    monkeypatch.setattr(
+        svc, "_read_applied_tasks",
+        lambda ws: {"applied_task_ids": [7], "entries": []},
+    )
+    task = _harness_task(change_type="heartbeat_tune", target_name="ScribeAgent", task_id=7)
+    ex = _FakeExecutor(tasks=[task], agents=[{"id": 42, "name": "ScribeAgent"}])
+    changelog = {}
+    asyncio.run(svc._apply_approved_board_tasks(ex, _WS_ID, changelog))
+
+    assert "platform_configure_agent_heartbeat" not in ex.actions()
+    assert changelog.get("applied_from_approved", []) == []
+    # Nothing applied -> no ledger write.
+    assert "workspace_write_file" not in ex.actions()
+
+
+def test_unresolved_target_is_skipped_not_applied(monkeypatch):
+    """A task whose target_name is not in the agents map is skipped, never
+    applied against a guessed/null target."""
+    monkeypatch.setattr(config, "HARNESS_SELF_MANAGEMENT_ENABLED", True)
+    monkeypatch.setattr(config, "WORKSPACE_VOLUME_PATH", _MISSING_VOLUME)
+    svc = HarnessService()
+    task = _harness_task(change_type="heartbeat_tune", target_name="GhostAgent", task_id=9)
+    ex = _FakeExecutor(tasks=[task], agents=[{"id": 42, "name": "ScribeAgent"}])
+    changelog = {}
+    asyncio.run(svc._apply_approved_board_tasks(ex, _WS_ID, changelog))
+
+    assert "platform_configure_agent_heartbeat" not in ex.actions()
+    assert changelog.get("applied_from_approved", []) == []
+    assert len(changelog.get("skipped", [])) == 1
+    assert changelog["skipped"][0]["task_id"] == "9"
+
+
+def test_placeholder_proposed_value_is_refused(monkeypatch):
+    """An approved task whose proposed_value is the 'review_needed' placeholder
+    is never applied — applying it literally would corrupt the agent."""
+    monkeypatch.setattr(config, "HARNESS_SELF_MANAGEMENT_ENABLED", True)
+    monkeypatch.setattr(config, "WORKSPACE_VOLUME_PATH", _MISSING_VOLUME)
+    svc = HarnessService()
+    task = _harness_task(
+        change_type="description_update",
+        target_name="ScribeAgent",
+        current={"description": "old"},
+        proposed={"description": "review_needed"},
+        task_id=11,
+    )
+    ex = _FakeExecutor(tasks=[task], agents=[{"id": 42, "name": "ScribeAgent"}])
+    changelog = {}
+    asyncio.run(svc._apply_approved_board_tasks(ex, _WS_ID, changelog))
+
+    assert "platform_update_agent" not in ex.actions()
+    assert changelog.get("applied_from_approved", []) == []
+    assert len(changelog.get("failed", [])) == 1
+    assert "placeholder" in changelog["failed"][0]["error"]
+    # Not applied -> not ledgered.
+    assert "workspace_write_file" not in ex.actions()

--- a/orchestrator/tests/test_harness_self_management.py
+++ b/orchestrator/tests/test_harness_self_management.py
@@ -489,3 +489,38 @@ def test_routing_rule_add_is_not_implemented():
     assert result["success"] is False
     assert "Unknown auto-apply change_type" in result["error"]
     assert ex.calls == []
+
+
+def test_temperature_adjust_uses_top_level_param():
+    """update_agent reads temperature top-level; a nested model_config is ignored,
+    so the handler must pass temperature directly or the change is a silent no-op."""
+    svc = HarnessService()
+    ex = _FakeExecutor(tasks=[], agents=[])
+    rx = {
+        "prescription_id": "rx-temp",
+        "change_type": "temperature_adjust",
+        "target_id": 42,
+        "proposed_value": {"temperature": 0.4},
+    }
+    asyncio.run(svc._auto_apply_prescription(ex, rx))
+
+    assert ("platform_update_agent", {"agent_id": 42, "temperature": 0.4}) in ex.calls
+
+
+def test_model_change_uses_model_id_param():
+    """update_agent reads the new model as top-level model_id (not nested, not
+    'model'), so the handler must map proposed['model'] -> model_id."""
+    svc = HarnessService()
+    ex = _FakeExecutor(tasks=[], agents=[])
+    rx = {
+        "prescription_id": "rx-model",
+        "change_type": "model_change_same_tier",
+        "target_id": 42,
+        "proposed_value": {"model": "claude-sonnet-4-6"},
+    }
+    asyncio.run(svc._auto_apply_prescription(ex, rx))
+
+    assert (
+        "platform_update_agent",
+        {"agent_id": 42, "model_id": "claude-sonnet-4-6"},
+    ) in ex.calls


### PR DESCRIPTION
… (US-021)

Replace the warning-only stub in _apply_approved_board_tasks with real execution, gated entirely on HARNESS_SELF_MANAGEMENT_ENABLED (default off, so Phase 5 stays inert). When on, each human-approved (done) [HARNESS] board task is parsed, its pre-change value snapshotted for rollback (US-022), and applied via the existing _auto_apply_prescription.

- Idempotency via a cumulative /harness/applied_tasks.json ledger (board tasks have no tag-mutation tool); task ids normalised to str so the membership check and sorted() are total across JSON/API round-trips.
- Unresolved targets (name not in agents map) are skipped, never applied against a null target.
- Guard _auto_apply_prescription against the 'review_needed' placeholder sentinel so neither the approved-task path nor the existing low-risk auto-apply path can write it literally to an agent's model/description.
- Surface apply failures at error level with traceback.

6 new tests cover flag-off no-op, execution, snapshot, idempotent skip, unresolved-target skip, and placeholder refusal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Auto-applied configuration changes that regress are now automatically detected and rolled back to their previous state.
  * Approved board tasks are automatically applied with built-in safety checks and idempotency tracking to prevent duplicate applications.

* **Bug Fixes**
  * Enhanced auto-apply behavior to prevent incomplete or placeholder configurations from being applied, improving system stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AutomatosAI/automatos-ai/pull/393?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->