### PR TITLE
fix(widget): restore callback form + unblock streaming from Mem0 writes

### DIFF
--- a/orchestrator/consumers/chatbot/service.py
+++ b/orchestrator/consumers/chatbot/service.py
@@ -696,6 +696,7 @@ class StreamingChatService:
         plan_mode: bool = False,
         attachment_ids: Optional[List[str]] = None,
         model_id: Optional[str] = None,
+        force_text_only: bool = False,
     ) -> Tuple[List[Dict[str, Any]], Optional[List[Dict[str, Any]]], Any]:
         """
         Prepare LLM messages with orchestration, persona, CTO override, and context guard.
@@ -721,6 +722,13 @@ class StreamingChatService:
             if complexity_assessment
             else Complexity.MOLECULE
         )
+        # Proactive openers (force_text_only) are self-contained: page-context
+        # directive in, one line of text out. They carry no complexity_assessment,
+        # so without this they'd default to MOLECULE and take the full
+        # ContextService path (internal tool load + Mem0 read) — exactly the
+        # work stream_response_with_agent already decided to skip. Pin to ATOM.
+        if force_text_only:
+            _complexity = Complexity.ATOM
 
         if _complexity == Complexity.ATOM:
             llm_messages, use_tools, orchestrated = await self._prepare_atom_path(
@@ -728,6 +736,7 @@ class StreamingChatService:
                 atom_tools=all_tools,
                 attachment_ids=attachment_ids,
                 model_id=model_id,
+                force_text_only=force_text_only,
             )
         else:
             llm_messages, use_tools, orchestrated = await self._prepare_full_path(
@@ -803,9 +812,18 @@ class StreamingChatService:
         atom_tools: Optional[List[Dict[str, Any]]] = None,
         attachment_ids: Optional[List[str]] = None,
         model_id: Optional[str] = None,
+        force_text_only: bool = False,
     ) -> Tuple[List[Dict[str, Any]], Optional[List[Dict[str, Any]]], None]:
-        """ATOM path: lightweight memory only, but keeps platform_execute tool."""
-        logger.info("[PRD-68] ATOM path — lightweight (tools=%d), retrieving memory", len(atom_tools or []))
+        """ATOM path: lightweight memory only, but keeps platform_execute tool.
+
+        force_text_only (proactive openers) skips memory retrieval entirely —
+        the opener is self-contained and the Mem0 read only adds latency.
+        """
+        logger.info(
+            "[PRD-68] ATOM path — lightweight (tools=%d, memory=%s)",
+            len(atom_tools or []),
+            "skipped" if force_text_only else "on",
+        )
         _now = datetime.utcnow()
         _time_ctx = (
             "Good morning" if _now.hour < 12
@@ -820,7 +838,12 @@ class StreamingChatService:
                  if isinstance(m, dict) and m.get("role") == "user"),
                 ""
             )
-            if _user_msg and smart_chat.orchestrator and smart_chat.orchestrator.memory_manager:
+            if (
+                not force_text_only
+                and _user_msg
+                and smart_chat.orchestrator
+                and smart_chat.orchestrator.memory_manager
+            ):
                 _mem_result = await smart_chat.orchestrator.memory_manager.retrieve_memories(
                     workspace_id=str(self.workspace_id),
                     agent_id=agent_runtime.agent_id,
@@ -1972,6 +1995,7 @@ class StreamingChatService:
                 plan_mode=plan_mode,
                 attachment_ids=_attachment_ids,
                 model_id=_model_id,
+                force_text_only=force_text_only,
             )
 
             if orchestrated:

--- a/orchestrator/consumers/chatbot/smart_orchestrator.py
+++ b/orchestrator/consumers/chatbot/smart_orchestrator.py
@@ -27,6 +27,29 @@ from .intent_classifier import Intent, IntentResult, get_intent_classifier
 
 logger = logging.getLogger(__name__)
 
+# Strong references to in-flight fire-and-forget tasks. Without this the event
+# loop only holds a weak reference and a background write can be garbage
+# collected mid-flight ("Task was destroyed but it is pending").
+_BACKGROUND_TASKS: set = set()
+
+
+def _spawn_background(coro, *, label: str) -> None:
+    """Schedule a coroutine fire-and-forget, retaining a strong reference.
+
+    Memory writes (Mem0 fact extraction, daily summary, L1/L2 persistence) are
+    network-bound and must never block the streaming response. They run on the
+    module-level UnifiedMemoryService, so they are safe to outlive the request's
+    DB session.
+    """
+    try:
+        task = asyncio.create_task(coro)
+    except RuntimeError:
+        # No running event loop (shouldn't happen on the async request path).
+        logger.debug("[Orchestrator] No event loop for background task '%s' — skipping", label)
+        return
+    _BACKGROUND_TASKS.add(task)
+    task.add_done_callback(_BACKGROUND_TASKS.discard)
+
 
 @dataclass
 class OrchestratedRequest:
@@ -347,7 +370,9 @@ class SmartChatOrchestrator:
         """
         Store a conversation exchange in memory.
 
-        Call this after the LLM responds to save the exchange.
+        Call this after the LLM responds to save the exchange. All writes are
+        scheduled fire-and-forget so the response is never held open on memory
+        persistence.
 
         Args:
             user_message: The user's message
@@ -355,64 +380,64 @@ class SmartChatOrchestrator:
             chat_id: Optional chat session ID
 
         Returns:
-            Success status
+            True once the writes have been scheduled (not a persistence ack).
         """
-        stored = await self.memory_manager.store_conversation(
-            workspace_id=self.workspace_id,
-            agent_id=self.agent_id,
-            user_message=user_message,
-            assistant_response=assistant_response,
-            chat_id=chat_id,
-            widget_mode=self.widget_mode
+        # All memory writes are fire-and-forget. Mem0 fact extraction runs a
+        # synchronous server-side LLM call (seconds), and awaiting it here blocks
+        # the streaming generator — and therefore the HTTP connection — long
+        # after the user has seen the full response. None of these writes feed
+        # back into the current turn, so schedule them and return immediately.
+
+        # Mem0 distilled facts (two-tier global/agent memory)
+        _spawn_background(
+            self.memory_manager.store_conversation(
+                workspace_id=self.workspace_id,
+                agent_id=self.agent_id,
+                user_message=user_message,
+                assistant_response=assistant_response,
+                chat_id=chat_id,
+                widget_mode=self.widget_mode,
+            ),
+            label="store_conversation",
         )
 
-        try:
-            await self.memory_manager.store_daily_summary(
+        # Daily activity log entry
+        _spawn_background(
+            self.memory_manager.store_daily_summary(
                 workspace_id=self.workspace_id,
                 user_message=user_message,
                 assistant_response=assistant_response,
                 agent_id=self.agent_id,
-            )
-        except Exception as exc:
-            logger.debug("[Orchestrator] Daily summary storage skipped: %s", exc)
+            ),
+            label="store_daily_summary",
+        )
 
-        # L2: Store raw exchange in Postgres (fire-and-forget — must not block TTFT)
-        try:
-            asyncio.create_task(
-                self._unified_memory.store_exchange(
+        # L2: raw exchange in Postgres
+        _spawn_background(
+            self._unified_memory.store_exchange(
+                workspace_id=self.workspace_id,
+                agent_id=self.agent_id,
+                user_msg=user_message,
+                assistant_msg=assistant_response,
+                conversation_id=chat_id,
+            ),
+            label="l2_store_exchange",
+        )
+
+        # L1: session in Redis
+        if chat_id:
+            _spawn_background(
+                self._unified_memory.update_session(
                     workspace_id=self.workspace_id,
-                    agent_id=self.agent_id,
+                    conversation_id=chat_id,
                     user_msg=user_message,
                     assistant_msg=assistant_response,
-                    conversation_id=chat_id,
-                )
-            )
-        except Exception:
-            logger.warning(
-                "[Orchestrator] L2 store_exchange failed ws=%s — skipping",
-                self.workspace_id,
-                exc_info=True,
+                ),
+                label="l1_update_session",
             )
 
-        # Update L1 session in Redis (fire-and-forget — must not block response)
-        if chat_id:
-            try:
-                asyncio.create_task(
-                    self._unified_memory.update_session(
-                        workspace_id=self.workspace_id,
-                        conversation_id=chat_id,
-                        user_msg=user_message,
-                        assistant_msg=assistant_response,
-                    )
-                )
-            except Exception:
-                logger.warning(
-                    "[Orchestrator] Session update failed for chat_id=%s — skipping",
-                    chat_id,
-                    exc_info=True,
-                )
-
-        return stored
+        # Writes are scheduled; the turn does not wait on their outcome.
+        return True
 
     def get_user_name(self) -> Optional[str]:
         """Get the user's name if known."""

--- a/orchestrator/consumers/chatbot/smart_tool_router.py
+++ b/orchestrator/consumers/chatbot/smart_tool_router.py
@@ -91,7 +91,18 @@ class SmartToolRouter:
     })
 
     # Promoted platform tools that bypass intent filtering —
-    # always included regardless of detected intent (PRD-122 US-010)
+    # always included regardless of detected intent (PRD-122 US-010).
+    #
+    # widget_open_callback_form is a native *signal* tool: when present in
+    # available_tools (only when the Site has callback.enabled — gated upstream
+    # by validate_tool_access), it MUST survive intent filtering. Without it the
+    # LLM, instructed by its skill to open the form, improvises a
+    # composio_execute(action="widget_open_callback_form") call that fails with
+    # "'WIDGET' is not assigned to agent N". Pinning it here keeps the affordance
+    # available on every widget turn regardless of the classified intent.
+    # Literal (not imported) to keep this hot-path module free of the heavy
+    # modules.tools.* import chain; canonical name lives in
+    # modules/tools/widget_callback.py::WIDGET_OPEN_CALLBACK_FORM_NAME.
     ALWAYS_INCLUDE = frozenset({
         "platform_list_agents",
         "platform_get_agent",
@@ -99,6 +110,7 @@ class SmartToolRouter:
         "platform_store_memory",
         "platform_field_query",
         "platform_field_inject",
+        "widget_open_callback_form",
     })
 
     def __init__(self):

--- a/orchestrator/tests/test_smart_orchestrator_store_exchange.py
+++ b/orchestrator/tests/test_smart_orchestrator_store_exchange.py
@@ -1,0 +1,117 @@
+"""Regression tests for fire-and-forget memory writes in SmartChatOrchestrator.
+
+PRD-141 widget latency fix: store_exchange() must never block the streaming
+response on Mem0 fact extraction (a multi-second, server-side LLM call). Every
+write — distilled facts, daily summary, L2 transcript, L1 session — is scheduled
+fire-and-forget and the turn returns without waiting on the outcome.
+
+The orchestrator is exercised via its *unbound* store_exchange method bound to a
+lightweight fake ``self``. This deliberately skips ``__init__`` (which lazily
+imports ``.smart_memory`` / the unified memory service) so the test stays fully
+isolated from sys.modules state mutated by sibling test modules.
+"""
+import asyncio
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+# `camelot` is an optional PDF table-extraction dep pulled in transitively when
+# `consumers` is imported. It isn't installed in the unit-test env; stub it so
+# the import chain resolves.
+sys.modules.setdefault("camelot", types.ModuleType("camelot"))
+
+from consumers.chatbot.smart_orchestrator import SmartChatOrchestrator  # noqa: E402
+
+# Unbound coroutine function — invoked with an explicit fake ``self`` below.
+store_exchange = SmartChatOrchestrator.store_exchange
+
+
+def _make_fake_self():
+    """A stand-in for an initialised SmartChatOrchestrator.
+
+    store_exchange only touches these attributes, so we provide them directly
+    rather than running the real constructor.
+    """
+    return SimpleNamespace(
+        workspace_id="ws-test",
+        agent_id=1,
+        widget_mode=False,
+        memory_manager=MagicMock(
+            store_conversation=AsyncMock(return_value=True),
+            store_daily_summary=AsyncMock(return_value=True),
+        ),
+        _unified_memory=MagicMock(
+            store_exchange=AsyncMock(return_value=None),
+            update_session=AsyncMock(return_value=None),
+        ),
+    )
+
+
+async def _drain_background():
+    """Await all fire-and-forget tasks scheduled on this test's event loop."""
+    current = asyncio.current_task()
+    pending = [t for t in asyncio.all_tasks() if t is not current and not t.done()]
+    if pending:
+        await asyncio.gather(*pending, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_store_exchange_does_not_block_on_slow_mem0_write():
+    """store_exchange returns before a slow Mem0 write completes."""
+    fake = _make_fake_self()
+
+    gate = asyncio.Event()
+    write_started = asyncio.Event()
+
+    async def blocking_store_conversation(**kwargs):
+        write_started.set()
+        await gate.wait()  # would hang store_exchange if awaited inline
+        return True
+
+    fake.memory_manager.store_conversation = blocking_store_conversation
+
+    # If the Mem0 write were awaited inline, `gate` is never set before
+    # store_exchange awaits it, so wait_for would raise TimeoutError. Because the
+    # write is backgrounded, store_exchange returns immediately.
+    result = await asyncio.wait_for(
+        store_exchange(fake, "what are your opening hours?", "We're open 9-5.", chat_id="c1"),
+        timeout=2.0,
+    )
+    assert result is True
+    assert write_started.is_set()  # the write was scheduled and started running
+
+    gate.set()
+    await _drain_background()
+
+
+@pytest.mark.asyncio
+async def test_store_exchange_schedules_all_memory_tiers():
+    """All four memory writes are scheduled (facts, daily log, L2, L1)."""
+    fake = _make_fake_self()
+
+    result = await store_exchange(fake, "remember I prefer tea", "Noted!", chat_id="c1")
+    assert result is True
+
+    await _drain_background()
+
+    fake.memory_manager.store_conversation.assert_awaited_once()
+    fake.memory_manager.store_daily_summary.assert_awaited_once()
+    fake._unified_memory.store_exchange.assert_awaited_once()
+    fake._unified_memory.update_session.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_store_exchange_skips_l1_session_without_chat_id():
+    """L1 session update only fires when a chat_id is present."""
+    fake = _make_fake_self()
+
+    result = await store_exchange(fake, "hello there friend", "Hi!", chat_id=None)
+    assert result is True
+
+    await _drain_background()
+
+    fake._unified_memory.update_session.assert_not_awaited()
+    fake._unified_memory.store_exchange.assert_awaited_once()

--- a/orchestrator/tests/test_us015_registry_intent_filter.py
+++ b/orchestrator/tests/test_us015_registry_intent_filter.py
@@ -184,3 +184,32 @@ def test_no_categories_no_suggested_returns_all(registry_env):
     filtered = r._filter_tools_by_intent(tools, intent)
 
     assert {t["function"]["name"] for t in filtered} == {"a", "b"}
+
+
+# ---------------------------------------------------------------------------
+# Widget callback signal tool survives filtering (production regression)
+# ---------------------------------------------------------------------------
+
+def test_widget_callback_tool_survives_multi_step_filter(registry_env):
+    """The widget callback signal tool must NOT be filtered out of a widget turn.
+
+    Production regression: "Can someone call me back" classified as MULTI_STEP,
+    the registry's mapped categories did not surface widget_open_callback_form,
+    and it was dropped from the LLM's toolset. The LLM then improvised
+    composio_execute(action="widget_open_callback_form"), which fails with
+    "'WIDGET' is not assigned to agent N". Pinning the tool in ALWAYS_INCLUDE
+    guarantees it survives whenever it is present in available_tools (it is only
+    present when the Site has callback.enabled — gated upstream).
+    """
+    # Registry returns categories that do NOT include the widget tool, mirroring
+    # production: nothing in the mapped categories surfaces it.
+    registry_env["by_category"]["agents"] = [SimpleNamespace(name="platform_list_agents")]
+    r = SmartToolRouter()
+    intent = _intent_result(primary=Intent.MULTI_STEP, suggested=[])
+    tools = [_tool("widget_open_callback_form"), _tool("some_unrelated_tool")]
+
+    filtered = r._filter_tools_by_intent(tools, intent)
+
+    names = {t["function"]["name"] for t in filtered}
+    assert "widget_open_callback_form" in names
+    assert "some_unrelated_tool" not in names

--- a/orchestrator/tests/test_widget_proactive_prd007.py
+++ b/orchestrator/tests/test_widget_proactive_prd007.py
@@ -343,10 +343,16 @@ def test_public_widget_config_keys_whitelist_is_minimal():
 
     Keeps the surface area visible during code review so nobody silently
     leaks an internal setting.
+
+    Public keys (all browser-readable feature config, no internal settings):
+    - widget_proactive: PRD-007 product-page opener config
+    - cart_idle:        PRD-008-A C1 cart-idle popup (must be whitelisted or
+                        the SDK silently no-ops and the popup never arms)
+    - callback:         PRD-008-A B/C1 callback-form config
     """
     from api.widgets.config import PUBLIC_WIDGET_CONFIG_KEYS
 
-    assert PUBLIC_WIDGET_CONFIG_KEYS == ("widget_proactive",)
+    assert PUBLIC_WIDGET_CONFIG_KEYS == ("widget_proactive", "cart_idle", "callback")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Two production widget fixes for the INBUILD Shopify PoC, stacked on the
already-merged page_context work (PR #390). Both touch only chatbot/widget
files — disjoint from the in-flight PRD-141 harness/routing commits, so this
merges cleanly.

### 1. Callback form regression — `'WIDGET' is not assigned to agent N`
PR #389 (US-014/US-015) rewrote `SmartToolRouter` to filter the LLM's toolset
to `GraphRouter chains ∪ CORE_TOOLS ∪ ALWAYS_INCLUDE ∪ suggested`. The native
signal tool `widget_open_callback_form` was in none of those sets, so on a
"can someone call me back" turn (classified `multi_step`) it was dropped. The
model — still told by its skill to open the form — improvised
`composio_execute(action="widget_open_callback_form")`, which the composio
executor parses as app `WIDGET` and rejects: *"'WIDGET' is not assigned to
agent 541"*. Production logs confirmed this exact chain.

**Fix:** pin `widget_open_callback_form` in `ALWAYS_INCLUDE` so it survives
both routing paths. Safe — the tool only enters `available_tools` when the
Site has `callback.enabled` (gated upstream by `validate_tool_access`);
`ALWAYS_INCLUDE` only re-includes already-present tools.

### 2. Widget streaming blocked ~12s on Mem0 writes
`store_exchange` awaited four memory writes inline (distilled facts, daily
summary, L2 transcript, L1 session) — including a multi-second server-side
Mem0 fact-extraction LLM call — before the turn returned. All four are now
scheduled fire-and-forget. Proactive openers are pinned to the ATOM path and
skip memory retrieval (they don't need it), eliminating the ~12s prep waste
seen in logs.

Also refreshes a stale `PUBLIC_WIDGET_CONFIG_KEYS` trip-wire test (`cart_idle`
+ `callback` were whitelisted in 16cbc1c62 but the assertion was never
updated).

## Not in scope (SDK-side)
The "second proactive / recommendation" and "abandon-cart popup" reports are
**not** orchestrator bugs: the backend whitelist, config resolution, and
`cart_idle` handler are correct and deployed, there is no backend
once-per-session guard, and **zero** `cart_idle` requests reach the backend in
the logs. The trigger originates in `automatos-widget-sdk` (`bootstrapCartIdle`)
or a Site-settings toggle.

## Test plan
- [x] `tests/test_us014_graph_router_delegation.py` + `tests/test_us015_registry_intent_filter.py` (14 passed) — includes new regression asserting the widget tool survives a `multi_step` filter
- [x] `tests/test_smart_orchestrator_store_exchange.py` (3 passed) — fire-and-forget writes don't block the turn
- [x] `tests/test_widget_proactive_prd007.py` (refreshed trip-wire green)
- [ ] Deploy to Railway, confirm "can someone call me back" opens the inline form on the live widget
- [ ] Confirm proactive opener latency drops (no ~12s prep)

Note: branch is behind `main` (continued PRD-141 ralph work) but touches
disjoint files — merges without conflict.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Widget callback form is now guaranteed to be available during tool routing.

* **Bug Fixes**
  * Improved non-blocking behavior for conversation storage, reducing response latency.
  * Enhanced text-only mode handling in message preparation.
  * Expanded public widget configuration to include additional whitelisted settings.

* **Tests**
  * Added comprehensive regression tests for conversation storage and tool routing reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AutomatosAI/automatos-ai/pull/395?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->