### PR TITLE
fix(widget): per-product proactive opener via product_session cap scope

### DIFF
--- a/orchestrator/api/shopify.py
+++ b/orchestrator/api/shopify.py
@@ -112,7 +112,10 @@ DEFAULT_WIDGET_PROACTIVE_CONFIG: dict = {
     "triggers": [
         {"type": "time_on_page", "seconds": 20},
     ],
-    "frequency_cap": {"scope": "session", "max_pops": 1},
+    # product_session keys the frequency-cap slot by product handle, so the
+    # opener fires once PER product per session rather than once for the whole
+    # session across every product page (the old "session" behaviour).
+    "frequency_cap": {"scope": "product_session", "max_pops": 1},
     "greeting_source": "agent_with_canned_fallback",
     "canned_fallback": "Need a hand finding the right product?",
     "agent_timeout_ms": 1500,

--- a/orchestrator/tests/test_widget_proactive_prd007.py
+++ b/orchestrator/tests/test_widget_proactive_prd007.py
@@ -40,7 +40,7 @@ def test_default_widget_proactive_shape():
     assert cfg["enabled"] is False, "must default to OFF — opt-in"
     assert cfg["page_types"] == ["product"]
     assert cfg["triggers"] == [{"type": "time_on_page", "seconds": 20}]
-    assert cfg["frequency_cap"] == {"scope": "session", "max_pops": 1}
+    assert cfg["frequency_cap"] == {"scope": "product_session", "max_pops": 1}
     assert cfg["greeting_source"] == "agent_with_canned_fallback"
     assert cfg["canned_fallback"] == "Need a hand finding the right product?"
     assert cfg["agent_timeout_ms"] == 1500


### PR DESCRIPTION
## Summary
- The proactive opener fired only **once per session** across every product page, so visiting a second product never re-triggered the popup.
- Root cause: `DEFAULT_WIDGET_PROACTIVE_CONFIG.frequency_cap.scope` was `"session"` — the SDK's `buildSlotKey` keys a `session`-scoped cap by `pageType` alone, giving one shared slot for all products.
- Fix: default scope → `"product_session"`. The SDK then keys the slot by `pageType_productHandle` (`proactive-engine.ts:51`), so the opener fires **once per product per session**.

## Important: existing stores need a backfill
The widget config serve path returns the **stored** config as-is (no default merge). This PR fixes the default for **new** stores only. Live stores still carry the old `scope: "session"` and need their stored `widget_proactive.frequency_cap.scope` flipped to `product_session` via `PATCH /api/sites/{site_id}/settings` (handled separately).

## Test plan
- [x] `tests/test_widget_proactive_prd007.py::test_default_widget_proactive_shape` updated + passing
- [x] Verified SDK `buildSlotKey` honors `product_session` (keys by product handle)
- [ ] Confirm live store config backfilled before verifying on a real product page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated Shopify widget frequency cap behavior to limit pop-ups on a per-product per-session basis instead of per-entire-session basis.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AutomatosAI/automatos-ai/pull/396?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->