### PR TITLE
docs(prd-142): core design review + Wave 0 measurement build spec

### DIFF
--- a/docs/PRDS/PRD-142-CORE-DESIGN-REVIEW.md
+++ b/docs/PRDS/PRD-142-CORE-DESIGN-REVIEW.md
@@ -1,0 +1,299 @@
+# PRD-142: Automatos Core Design Review — Rewrite vs Fix
+
+**Status:** Draft for decision (design review, not yet a build PRD)
+**Author:** Claude (design review session 2026-05-29), commissioned by Gerard Kavanagh
+**Priority:** P0 — this is the gate the production roadmap runs through
+**Scope:** The entire platform surface — every primitive, the connective tissue, the data layer, the frontend — across **all seven repositories** (§4A), not just `automatos-ai`
+**Method:** Knowledge-graph mining (`graphify-out/graph.json`, 20,323 nodes / 24,103 edges) + every PRD (1–142) + vision/design docs + code-health sweep + six fresh subsystem maps + a survey of the six companion repos. Claims are graph-verified where a number appears.
+**Design spec it ratifies:** `docs/architecture/BRAIN-BLUEPRINT.md`, `DIAGRAMS.md`, `GUARDRAILS.md`, `TEST-PLAN.md`
+**Companion design docs:** `docs/architecture/PLAYBOOK-ENGINE-DESIGN.md`, `docs/architecture/KNOWLEDGE-GRAPH-CANONICAL.md`
+**Supersedes:** the "Rock-Solid" working title in memory (`prd142-rock-solid-plan`). The six waves there become this PRD's execution roadmap (§12).
+**Build branch:** TBD on approval (this document is docs-only)
+**Depends on:** both PRD-141s merged to main (Platform Reliability + Widget Vertical-Agnostic Refactor)
+
+---
+
+## 1. The question this PRD answers
+
+Automatos works. It is at PRD-141+, has run real missions, real chat, real widget conversations, a real Shopify integration. But it was built fast, largely by one developer, and it carries the debt of that velocity: 116 tables, 103 routers, ~945 backend files, ~670 frontend files, two tool loops, three playbook engines, ~1,970 broad exception handlers, and one frontend test.
+
+So the question is **not** "does it work" — it does. The question is:
+
+> **Treating today's Automatos as a working MVP, and designing the production target as if we were building an enterprise platform from scratch — which subsystems do we rewrite, and which do we fix in place?**
+
+This document gives the answer, per subsystem, with the evidence. The design target itself is specified in `BRAIN-BLUEPRINT.md`; this PRD is the **decision layer** on top of it: what is sound, what is salvageable, what is rotten, what is dead. No functionality is removed — only dead code and duplicate paths are cut. New features are explicitly out of scope.
+
+---
+
+## 2. How the verdict was reached
+
+This is not an opinion. Each subsystem was assessed against four evidence streams:
+
+1. **Contract** — is the boundary/interface right? (from `BRAIN-BLUEPRINT.md` §3 primitive contracts)
+2. **Coupling** — graph-mined inbound/outbound edges. Pathological coupling is a rewrite signal; a clean blast radius is a harden signal.
+3. **Implementation health** — file size, test ratio, duplication, fire-and-forget, fail-open paths (code-health sweep).
+4. **Intent lineage** — what the PRDs *meant* the subsystem to be vs what it became (PRD archaeology 1–142).
+
+The graph was queried directly (the CLI is on a stale format; the JSON was mined with Python) to verify the three highest-stakes claims: the Playbook consolidation surface, dead-code cut safety, and the moat's store dependencies. Those numbers appear inline below and are flagged **(graph-verified)**.
+
+---
+
+## 3. The decision framework
+
+Every subsystem gets exactly one verdict:
+
+| Verdict | Meaning | Trigger |
+|---|---|---|
+| **KEEP** | Contract right **and** implementation healthy | Sound design, low debt. Hygiene only (file splits). |
+| **HARDEN** | Contract right, implementation has fixable debt | Good boundary, but god-files / missing tests / swallowed errors / scattered config. |
+| **REWRITE** | The contract itself is wrong, or coupling is pathological | One concept with multiple implementations; user-visible work that can't survive restart. |
+| **CUT** | Dead weight | No real dependents; superseded; duplicate. |
+
+**The prior I opened the review with, and the evidence confirmed:** a platform at PRD-141 with real functionality is almost never a big-bang rewrite. You harden most, rewrite the two or three rotten cores, cut the dead weight. The evidence did not move me off that.
+
+---
+
+## 4. The verdict
+
+> **FIX, don't rewrite.** The platform's *contracts* are mostly right — the Arc (one loop, many front doors), DB-as-system-of-record, vertical-agnostic core, markdown-deliverables-in-S3. The rot is implementation debt and duplication, not architecture.
+
+The whole platform reduces to:
+
+- **0 rewrites** — the biggest single piece is the Playbook engine **consolidate + harden** (§6): one scattered-but-live engine (recipe = playbook) unified into one clean durable flow, not rebuilt.
+- **1 design decision** — the knowledge-graph canonical store, already 90% settled (§7).
+- **1 test-net rebuild** — the frontend, at enterprise bar (§9).
+- **3 P0 fixes that gate everything** — session leak, migration safety, fail-open authz (§10).
+- **Harden-in-place** — chat, memory, RAG, NL2SQL, tools, config, data layer.
+- **Keep** — missions, routing, channels, widgets, agents/factory.
+- **Cut** — the dead-weight inventory (§11).
+
+This is a strangler-fig program, not a teardown.
+
+---
+
+## 4A. Platform topology — seven repos, one platform
+
+Automatos is **not a monorepo**. The design target spans **seven repositories**, and the platform's production-readiness is gated by the *weakest* of them. The core review (§5) is `automatos-ai`; the satellites carry their own verdicts and their own debt.
+
+| Repo | Role | Stack | Size | Test / CI posture | Verdict |
+|---|---|---|---|---|---|
+| **automatos-ai** | Core: the Arc, primitives, orchestrator, frontend | Python + Next.js | ~945 py / ~670 ts | 1 FE test; backend thin | per §5 (HARDEN + 1 consolidation) |
+| **automatos-mem0** | L3 long-term memory — **self-hosted fork of `mem0ai/mem0`** | Python | 869 files / 154 tests | upstream tests; on `fix/pool-exhaustion` | **KEEP (fork) + HARDEN** — pool health + a fork-maintenance strategy |
+| **automatos-widget-sdk** | Embeddable storefront widget (Shadow DOM, ~9KB) — **defines the widget API contract** | TS monorepo (pnpm/turbo) | 76 files / 16 tests | tests + **pre-merge CI** (newest) | **KEEP** — most mature satellite; add cross-repo contract tests |
+| **automatos-shopify** | Merchant-facing Shopify app + extensions (the distribution wedge) | Remix/React-Router + Prisma | 17 files | **0 tests** | **KEEP + HARDEN** — needs tests; vertical front-end only (core logic stays in `automatos-ai`) |
+| **automatos-skills** | Skill library (PRD-120) — markdown/content, loaded by the platform | content (0 code) | ~18 domains | n/a | **KEEP** — confirm load path is DB-backed, not a runtime file-hack (GUARDRAILS D3) |
+| **automatos-voice** | Voice services + pipeline (L7) | Python + Railway | 16 files | **0 tests** | **KEEP (peripheral) + light HARDEN** — low priority |
+| **automatos-testing** | Central test harness — **black-box, prod-hitting, 5-phase smoke** | Python + n8n | 45 files / 34 tests | **stale: master last 2025-08-31** | **HARVEST then RETIRE** — see §9 |
+
+**Three cross-repo truths this surfaces:**
+
+1. **Test posture is wildly inconsistent.** widget-sdk has CI; shopify and voice have zero tests; the central testing repo is 9 months stale and tests a *renamed* surface (`/api/workflows/*`, pre-Mission/Playbook) including the now-dead `neural_field`. "Production-ready" can't be claimed per-repo — it needs one bar across all seven.
+2. **Real cross-repo contracts have no contract tests.** SDK ↔ widget API (the `page_context` change on the current branch is exactly this seam), shopify app ↔ core widget API, skills ↔ platform loader, voice ↔ core. These integration seams are where drift hides.
+3. **The L3 memory is a maintained fork.** `automatos-mem0` forks `mem0ai/mem0` and self-hosts on Railway — an upstream-drift cost plus its own reliability surface (it's on a pool-exhaustion fix branch, the same connection-health theme as P0 **G1**). The Memory verdict (§5) is two halves: the async *client* in `automatos-ai` (PRD-141 Phase 1) and the forked *server* here.
+
+---
+
+## 5. Per-subsystem verdict
+
+| Subsystem | Grade | Verdict | Primary evidence |
+|---|---|---|---|
+| **Missions** (Sequential Coordinator 82A) | A− | **KEEP** | DB-authoritative, 5s tick, restart-durable. The reference implementation for the whole platform. Debt: `coordinator_service.py` 3,020 lines (split); retry doesn't feed verifier critique (G5). |
+| **Routing** (UniversalRouter) | B | **KEEP** | Tiers 0–3 clean. Minor: negative routing signals (already in PRD-141-reliability Phase 4). |
+| **Channels** (11 adapters) | B | **KEEP** | Consistent adapter pattern, no structural debt. |
+| **Widgets** | B | **KEEP** | Vertical-agnostic refactor fully landed (PRD-141-widget). Debt: hardcoded `users.id=1` at `api/widgets/chat.py:89` (G14). |
+| **Agents / Factory** | B− | **KEEP** | Already rewritten clean (2,716→1,507 lines). Agents = DB rows. Healthy. |
+| **Chat** | C | **HARDEN** | Contract right (the Arc). `consumers/chatbot/service.py` 2,276-line god service; **two tool loops** vs AgentFactory (G6); 0.00 test ratio. |
+| **Memory** | C | **HARDEN** | 3 real layers, sound. `unified_memory_service.py` 2,202 lines; dual L3 write paths (G12); Mem0 sync→async mid-flight (PRD-141-reliability Phase 1). L3 *server* is a self-hosted fork (`automatos-mem0` — see §4A); this verdict covers the async **client** in `automatos-ai`, the fork carries its own. |
+| **RAG / KB** | C+ | **HARDEN** | Genuinely strong retrieval (RRF + rerank + parent-expand + knapsack). `documents.py` 1,924 lines; 0.05 test ratio. |
+| **NL2SQL** | C | **HARDEN** | Works. Credential-handling discipline (D4); test-thin. Lower priority. |
+| **Tools** | C+ | **HARDEN** | 3-file pattern + ActionRegistry + prefix dispatch is the right contract. `tool_registry.py` 1,528 lines. |
+| **Config / Secrets / Authz** | C− | **HARDEN (P0 slice)** | `os.getenv` outside config.py (G7); **fail-open authz** (G3). Sweep + flip to fail-closed. |
+| **Data / Sessions / Migrations** | D+ | **HARDEN (P0 slice)** | `get_db()` never commits/rolls back → 9hr idle-in-tx blocks DDL (G1); migrations one giant txn, no lock_timeout (G2). Contract fine; plumbing leaks. |
+| **Knowledge Graph** (the moat) | C | **DESIGN DECISION** | Canonical store already single-sourced (`graph_service.py` + `graph_storage.py`, graph-verified). Needs a documented boundary + storage-format scalability path. See §7. |
+| **Frontend** | F (tests) | **HARDEN code / REWRITE test posture** | 1 test / 670 files. `api-client.ts` 2,687 lines. Keep every surface; rebuild the test net at enterprise bar (§9). |
+| **Playbooks / Workflows / Recipes** | F | **CONSOLIDATE + HARDEN** | One live concept (recipe = playbook) scattered across ~5,400 LOC + a dead `modules/workflows/` twin. Fire-and-forget `asyncio.create_task` dies on restart (G4). Not a rewrite — unify + make durable. See §6. |
+
+Detailed evidence and per-subsystem Definition of Done live in `BRAIN-BLUEPRINT.md` §3 and `GUARDRAILS.md` §H.
+
+---
+
+## 6. The one consolidation — Playbook engine (consolidate + harden)
+
+**Why this is consolidate-and-harden, not a rewrite.** "Recipe" and "playbook" are the **same thing** (recipe = the pre-rename name; the FE now says playbook). The execution logic is **live and working**, just scattered: the loop in `api/recipe_executor.py` (1,997 lines), the launch front door in `api/workflow_recipes.py` (1,872 lines, despite its name), with a dead `modules/workflows/` twin alongside. The *contract is right.* Two fixable defects: (1) it's **scattered** across files that diverge in dedup/retry/streaming — consolidate to one clean flow; (2) the launch path is **not restart-durable** — `asyncio.create_task` fire-and-forget means an in-flight playbook silently dies on a process restart (G4) — harden by porting the Mission durability model. No new engine, no wrong contract → **not a rewrite**. (`PLAYBOOK-ENGINE-DESIGN.md` §1.)
+
+**Why it's feasible (code-verified).** The consolidation surface is large internally — **506 nodes across ~30 files** — but the **execution-launch blast radius is just six call sites** behind two entry points (`launch_recipe_task`, `execute_recipe_direct`): the workflow API (`workflow_recipes.py:905`), the Composio trigger (`composio.py:886`), the workspace webhook (`webhooks.py:682`), the platform-tool executor (`handlers_playbooks.py:487`), the playbook scheduler (`playbook_scheduler.py:208`), and the task reconciler (`task_reconciler.py:273`). The broader ~36-edge / ~21-file graph coupling is mostly shared utils and type imports — `channels/__init__.py` and `action_registry.py` import **no** execution path at all. The engine consolidates behind a stable interface without rippling across the platform.
+
+**The design.** Collapse the triplet into one durable, DB-backed engine that **borrows the Mission coordinator's durability model** (DB tick, restart recovery, state in Postgres not a process dict). Missions already solved this exact problem (KEEP, grade A−); the playbook engine should reuse that pattern rather than invent a third.
+
+Full design — interface, state model, migration order, deletion plan — in **`docs/architecture/PLAYBOOK-ENGINE-DESIGN.md`**.
+
+**Gerard's decision (2026-05-29):** it is **not a rewrite** — "playbooks used to be called recipes before we renamed [on] the front end; workflows was old and mostly should have been removed... is it just scattered and we need to clean up to one clean flow?" Yes. Approved as a **consolidate-and-harden**, *as design* — no code until the build is green-lit.
+
+---
+
+## 7. The moat — knowledge-graph canonical store
+
+The knowledge graph is the strategic moat (the merchant's products, orders, FBT relationships, business memory — the thing that compounds and can't be exported to a competitor). The gap analysis flagged "two graph stores, no single source" (G11). Investigation **downgraded** that concern:
+
+**The moat is already single-sourced.** Business facts live in `workspace_graphs` (the Graphify pipeline → `graph_service.py` + `graph_storage.py`, graph-verified as the canonical writer/reader). Shopify FBT edges are written and read *only* here. There is **zero sync** to the `knowledge_nodes/edges` tables — so there is no active corruption, only a *latent* risk if someone starts dual-writing later. Fix = a documented boundary, not a migration.
+
+**Five graphs, named apart so they never collide again:**
+
+| Concern | Store | Verdict |
+|---|---|---|
+| Business Knowledge Graph (THE MOAT) | `workspace_graphs` (Graphify) | **CANONICAL** |
+| Agent learning / inference | `knowledge_nodes` / `knowledge_edges` | KEEP with hard boundary (learning-only, never business entities); fold into HARNESS; **Wave 4 wires the dead loop — fix, not cut (2026-05-29)** |
+| Mission coordination field | `vector_field.py` → Qdrant `field_memory` | KEEP |
+| (dead twin of above) | `neural_field/` (112 nodes; **only consumer is the dead workflow-era `AgentExecutionManager`** — see §11) | **CUT** (resolves G13) |
+| Code intelligence | `codegraph_symbols` | KEEP (orthogonal) |
+
+**Enterprise-bar flag:** the moat currently serialises the whole graph as a JSON blob loaded into NetworkX *in memory per request*. Fine for a small merchant; won't hold at enterprise scale. Storage-format evolution (blob → queryable edge tables or a graph DB) is a named HARDEN item — not a blocker.
+
+Full taxonomy, the boundary contract, and the scalability path in **`docs/architecture/KNOWLEDGE-GRAPH-CANONICAL.md`**.
+
+**Gerard's decision (2026-05-29):** recommend the canonical store (done above); HARNESS stays (see §8).
+
+---
+
+## 8. HARNESS — kept, gated, sequenced last
+
+HARNESS (PRD-121/140 — the self-learning / self-management loop) **stays**. It is a named differentiator. The earlier "cut-or-quarantine" flag was about the *current implementation*, not the capability: an immature loop that can self-modify (reassign tools, change power modes, auto-rollback) is precisely the thing that destabilises the cores we are hardening.
+
+**Verdict: KEEP, behind `HARNESS_SELF_MANAGEMENT_ENABLED` (default false), hardened last** — after the cores soak. This is already how PRD-141-reliability Phase 5 and the Wave 4 sequencing read. The `knowledge_nodes/edges` learning graph (§7) is its natural substrate — a dead loop today, **fixed (wired) in Wave 4, not cut** (decided 2026-05-29).
+
+**Gerard's decision (2026-05-29):** keep HARNESS, full scope, gated and last.
+
+---
+
+## 9. Frontend — enterprise test bar
+
+The frontend is grade F on **test debt alone** (1 test / 670 files). The components are sound and **every surface stays** (Command Center, Activity, kanban, analytics, widgets — per the standing rule). This is a *test-net rebuild*, not a feature rewrite, plus splitting the 2,687-line `api-client.ts`.
+
+**Standard: production-ready enterprise.** Full Playwright coverage across all ten golden journeys (J1–J10 in `TEST-PLAN.md`), not a critical-path subset. Vitest (present, unused) is wired for unit/component; Playwright for E2E.
+
+**Gerard's decision (2026-05-29):** full Playwright, enterprise bar — locked.
+
+### 9A. Cross-repo test posture — one bar across seven repos
+
+"Production-ready" is a property of the *platform*, not of `automatos-ai` alone (§4A). Three rules close the cross-repo test gap:
+
+1. **Tests co-locate with the code they cover.** Each repo owns its own unit/integration suite next to its source — `automatos-shopify` (0 tests) and `automatos-voice` (0 tests) get suites; `automatos-widget-sdk` (already has CI) is the template; the core suites land in Wave 2.
+2. **Contract tests guard the real seams.** The integration boundaries between repos have *no* tests today and that is where drift hides: SDK ↔ widget API (the `page_context` change on the current branch is exactly this seam), Shopify app ↔ core widget API, skills ↔ platform loader, voice ↔ core. These get versioned contract tests in the consuming repo's CI.
+3. **`automatos-testing` is harvested, then retired.** It is a black-box, prod-hitting, 5-phase smoke harness that is **9 months stale** (master last 2025-08-31), tests a *renamed* surface (`/api/workflows/*`, pre-Mission/Playbook) and the now-**dead** `neural_field`. It does **not** rescue the test gap. Action: **harvest** its five journey definitions as golden-journey seeds (they map onto J1–J10), re-home live smoke as a **post-deploy CI check**, then **retire the repo**. Do not revive it as a standalone stale mirror.
+
+---
+
+## 10. The three P0s that gate everything
+
+These are not subsystem rewrites. They are urgent and they block the rest of the program:
+
+| ID | Defect | Location | Why it gates |
+|---|---|---|---|
+| **G1** | `get_db()` never commits/rolls back → 9hr idle-in-tx | `core/database/database.py:105` | Blocks DDL/deploys. Every migration in the hardening plan stalls behind it. |
+| **G2** | Migrations wrapped in one transaction, no `lock_timeout` | `alembic/env.py:31` | Combined with G1, deploys hard-block. |
+| **G3** | Fail-open authz (`_check_agent_permission`, `validate_composio_action` return True on error) | per `GUARDRAILS.md` E3 | Latent privilege escalation. Must fail closed before anything ships. |
+
+Fix these first or the rest of the work fights them.
+
+---
+
+## 11. CUT list (dead weight — graph-verified)
+
+No functionality is removed; these are dead code, superseded scaffolding, and duplicate paths. Per Gerard's standing rule, **verify every match before deletion**.
+
+| Item | Evidence | Action |
+|---|---|---|
+| `core/neural_field/` (6 files, 112 nodes) **+ `AgentExecutionManager`** (`execution_manager.py`) | Workflow-era unit: neural_field's **only** importer is `AgentExecutionManager.execute_workflow_subtasks`, which is **never instantiated** (the `AgentService.execution_manager` property that builds it is never read) and **has zero callers** (code-verified 2026-05-29). Superseded by `AgentFactory.execute_with_prompt`. | **CUT as one unit** (resolves G13) |
+| `api/chatbot_llm.py` (547 lines) | Mounted "legacy" `main.py:1052`; **6 inbound edges from 5 files** (graph-verified) | **CUT after migrating** `recipe_executor`, `board_tasks`, `pandas_ai_service` + 2 others |
+| `_stream_workflow_bridge` (`chat.py:37`) | Zero call sites (Explore-confirmed; graph predates it) | **CUT** (re-verify on current branch) |
+| `chatbot_router` | Still mounted in `main.py` | **CUT** with `chatbot_llm` |
+| `seed_recipes_marketplace_v2.py` | Superseded seed | **CUT** |
+| ~53 / 200 dead tables | Graph-mining (2026-04-10 snapshot) | **CUT after re-verify** (graph stale; confirm on live schema) |
+| ~198 unreferenced routes | Graph-mining | **CUT after re-verify** |
+| Context Forge remnants (PRD-33/34/35) | Superseded by Composio (PRD-36) | **CUT** |
+| PRD-20 400+ MCP scaffolding, PRD-12 stubbed Playbook miner | Superseded / never wired | **CUT** |
+
+The cut list is sequenced **after** the test net (Wave 5), so tests guard the survivors before deletions land.
+
+---
+
+## 12. Execution roadmap
+
+Maps onto the six waves from the `prd142-rock-solid-plan` memory, now anchored to verified verdicts. Each wave ends with a code-reviewer gate; risky waves add a canary soak.
+
+| Wave | Theme | Contents | Gate |
+|---|---|---|---|
+| **0** | Measurement first (~1wk) | Extend PRD-141 Phase 0 telemetry into one "Is it working?" dashboard: activation, mission success, per-primitive health, error rate by subsystem, widget engagement. | Dashboard answers the founding question with a number. |
+| **1** | Stop the bleeding (~2wk) | **P0s: G1 sessions, G2 migrations, G3 authz** (§10). Unblock deploys, close the security hole. | Deploys unblocked; authz fails closed; canary soak. |
+| **2** | Test net (~2–3wk) | Golden journeys J1–J10 (`TEST-PLAN.md`); contract tests on hot routers; **full Playwright frontend** (§9). | 100% of golden journeys covered. |
+| **3** | Primitive hardening (~3–4wk) | Each HARDEN subsystem against its `GUARDRAILS.md` §H Definition of Done: split god-files (chat, memory, RAG, tools), unify the tool loop (G6), sweep `os.getenv` (G7), moat boundary + storage path (§7). | Per-primitive dashboard tile green. |
+| **3R** | The consolidation (within Wave 3) | Playbook engine consolidate + harden (§6, `PLAYBOOK-ENGINE-DESIGN.md`). Build behind interface, migrate the 6 launch call sites, consolidate the scattered engine, delete the dead `modules/workflows/` twin. | Restart-durability test passes; dead paths deleted. |
+| **4** | Self-learning / HARNESS (gated, last) | PRD-141-reliability Phase 5; `knowledge_nodes/edges` learning graph wired. Flag-gated, after soak. | Canary on one workspace; rollback verified. |
+| **5** | Execute the cut list (~2wk) | Execute the §11 cut list (tests now guarding survivors); remove dead tables/routes/modules. **Shopify hero workflows + one-click onboarding are UNBUNDLED (2026-05-29) → separate `automatos-shopify` vertical PRD; out of scope for this core review.** | Cut greps return zero; survivors green under the test net. |
+
+~12 weeks, zero new features, a number on "working" from week one.
+
+---
+
+## 13. Definition of Done (per subsystem)
+
+A subsystem is "production-ready" when it meets its `BRAIN-BLUEPRINT.md` §3 contract **and** the `GUARDRAILS.md` §H checklist:
+
+- [ ] Golden-journey test exists and passes (`TEST-PLAN.md`).
+- [ ] Failure path tested — degrades or errors visibly, never silently.
+- [ ] Restart-safe — no user-visible work lost on process restart.
+- [ ] Observable — emits the telemetry the dashboard needs.
+- [ ] Tenant-isolated — proven by a cross-workspace test.
+- [ ] One source of truth — no dual write paths.
+- [ ] Dashboard tile — a number answering "is this primitive working right now?"
+
+---
+
+## 14. Risks
+
+| Risk | Mitigation |
+|---|---|
+| Playbook consolidation regresses a live execution path | Build behind a stable interface; strangler-fig migration of the 6 launch call sites; restart-durability test before any delete; dead paths deleted only after parity proven. |
+| Graph snapshot is stale (2026-04-10, pre-PRD-141) | Cut-list deletions (dead tables/routes) re-verified against the live schema before execution. Recommend `/graphify --update` before Wave 5. |
+| `os.getenv`/bare-except sweeps introduce regressions | Opportunistic, not big-bang (per PRD-141-reliability precedent); each change is a pure widening, code-reviewer gate. |
+| HARNESS destabilises hardened cores | Flag-gated, default false, Wave 4 only, canary + rollback (§8). |
+| Frontend rebuild scope creep | Scope is tests + `api-client.ts` split only — no component rewrites; surfaces preserved. |
+| Cross-repo contract drift (SDK ↔ widget API, Shopify ↔ core, skills ↔ loader, voice ↔ core) | Versioned contract tests on each seam in the consumer's CI (§9A); the stale central harness is retired, not relied on. |
+| Mem0 fork (`automatos-mem0`) drifts from upstream / carries its own reliability surface | Pin an upstream baseline + document a fork-maintenance cadence; the pool-exhaustion fix it's mid-flight on is the same connection-health theme as P0 **G1** — treat as P0-adjacent. |
+
+---
+
+## 15. Success metrics
+
+| Metric | Current | Target | How measured |
+|---|---|---|---|
+| Idle-in-tx events blocking DDL | recurring | 0 | connection-leak test + deploy logs |
+| Fail-open authz branches | ≥2 | 0 | grep gate (every authz else-branch denies) |
+| Playbook engines | 3 | 1 | grep for the triplet routers after 3R |
+| Playbook restart-durability | dies on restart | recovers from DB | restart test (US in build PRD) |
+| Golden journeys covered | ~0 | 10 / 10 | `TEST-PLAN.md` J1–J10 |
+| Frontend tests | 1 / 670 | enterprise Playwright suite | CI |
+| Business-graph stores (moat) | 1 canonical + 1 latent | 1 canonical + bounded learning graph | boundary doc + grep |
+| Dead code (neural_field + execution_manager, chatbot_llm, bridge) | present | deleted | cut greps return zero |
+| "Is it working?" dashboard | none | live from Wave 0 | Grafana tile per primitive |
+
+---
+
+## 16. What's locked vs open
+
+**Locked (Gerard, 2026-05-29):**
+- Overall: fix-not-rewrite — **zero rewrites**; the Playbook consolidate+harden is the biggest single piece (§6), as design only.
+- HARNESS kept, gated, last.
+- Frontend at full-Playwright enterprise bar.
+- Moat canonical = `workspace_graphs`; recommendation accepted.
+
+**Open for discussion before the build PRD:**
+- Playbook engine interface shape (`PLAYBOOK-ENGINE-DESIGN.md` is the proposal).
+- `knowledge_nodes/edges` fate — **RESOLVED 2026-05-29: fix, not cut.** Wave 4 (HARNESS) wires the dead learning loop; keep the tables/schema as the starting point, reshape only if HARNESS requirements demand.
+- Whether to run `/graphify --update` before Wave 5 to refresh the cut-list evidence.
+- Cross-repo test strategy: co-locate per-repo + contract tests on the seams, harvest-then-retire `automatos-testing` (recommended, §9A) vs reviving the central harness.
+- Mem0 fork strategy: how long to carry `automatos-mem0` as a fork — pin-and-maintain, upstream our fixes, or track a cadence.
+
+---
+
+**This PRD is the decision. The build PRDs (per wave) come after it's approved.**

--- a/docs/PRDS/PRD-142-WAVE0-MEASUREMENT.md
+++ b/docs/PRDS/PRD-142-WAVE0-MEASUREMENT.md
@@ -1,0 +1,229 @@
+# PRD-142 Wave 0 — Measurement First ("Is It Working?" Dashboard)
+
+> **Parent:** `PRD-142-CORE-DESIGN-REVIEW.md` §12, Wave 0.
+> **Status:** Build-PRD — drafted 2026-05-29. Gerard signed off the design review; the build
+> gate (both PRD-141s merged to `main`: #394 platform-reliability, #395 widget-vertical, #396
+> widget fix) is **CLEARED**. This is the first wave's build spec.
+> **Type:** Extension + instrumentation. Backend + a single frontend dashboard section. **No new
+> features, no new frontend page.** Reuse-first per CLAUDE.md §2.
+> **Verified against:** branch `docs/prd-142-design-and-wave0`, code reads 2026-05-29.
+> **Ralph config:** `scripts/ralph/prd-142-wave0.json`.
+
+---
+
+## 1. The founding question
+
+The design review's whole premise is that we cannot today answer **"is the vision working?"** with a
+number. Wave 0 fixes exactly that — and nothing else. It extends the PRD-141 Phase-0 telemetry
+foundation (`record_error`, `widget_event_log`, `heartbeat_results`) into **one dashboard section
+that answers the founding question** and gives every later wave a measurable before/after.
+
+Five metrics, in priority order:
+
+| # | Metric | The question it answers | Status today | Wave 0 action |
+|---|---|---|---|---|
+| 1 | **Error rate by subsystem** | "What is actually failing, and where?" | `record_error` logs to the `automatos.errors` logger only — **no queryable sink** (`core/utils/exception_telemetry.py:22,68`) | Add a queryable sink + aggregation endpoint |
+| 2 | **Mission success rate** | "Do the things users start actually finish?" | **Real** endpoint exists, workspace-scoped, union of missions+workflows w/ 7-day trend (`api/analytics_real.py:53`) — but the dashboard card shows a **fake `85.0`** (`core/services/analytics_engine.py:118`) | Surface the real one; **delete the placeholder** |
+| 3 | **Widget engagement** | "Are the widgets we ship being used?" | `widget_event_log` table + writer exist (9 event types, indexed) — **no aggregation endpoint** (`core/models/widget_event_log.py`, `modules/widgets/telemetry.py`) | Add an aggregation endpoint over the existing index |
+| 4 | **Activation** | "Do new workspaces reach first value?" | **GAP** — no definition, no query | Define + compute first-successful-mission rate |
+| 5 | **Per-primitive health** | "Which of the 8 primitives is green right now?" | **Partial** — `heartbeat_results` + `GET /api/heartbeat/analytics` exist (`api/heartbeat.py`) | Roll heartbeat findings up per primitive |
+
+Then one capstone: **assemble the five into a dashboard section** on the **existing** dashboard page.
+
+---
+
+## 2. Reuse map (read before writing a line of code)
+
+Everything below already exists. Wave 0 **extends** it; it does not rebuild it.
+
+| Concern | Reuse this | Verdict |
+|---|---|---|
+| Structured error emit | `record_error(*, subsystem, operation, error, workspace_id, agent_id, action_name, extra)` → `automatos.errors` logger, `structured_error` extra dict (`core/utils/exception_telemetry.py:29`) | **Extend** — give it a queryable sink; do **not** change its signature or its never-raises contract |
+| Widget events | `WidgetEventLog` + `WIDGET_EVENT_TYPES` (9 types) + `idx_widget_event_log_type_created` (`core/models/widget_event_log.py`); writer `log_widget_event` (`modules/widgets/telemetry.py:35`) | **Reuse** — read-only aggregation; no schema change |
+| Mission success rate | `GET /api/analytics/dashboard/success-rate` (`api/analytics_real.py:53`) — already unions `OrchestrationRun` + `WorkflowExecution`, 7-day trend, workspace-scoped | **Reuse as-is** |
+| Real workflow/mission metrics | `AnalyticsEngine._get_workflow_metrics` (`core/services/analytics_engine.py:144-174`) — real `OrchestrationRun.state=="completed"` / `OrchestrationTask.state=="verified"` | **Reuse** the real half; **delete** the fake `_get_agent_metrics` placeholders (`:118-121`) |
+| Per-primitive health | `heartbeat_results` table + `GET /api/heartbeat/analytics` (`api/heartbeat.py:284`) | **Reuse** — roll up, don't rebuild |
+| Dashboard page | `frontend/app/dashboard/page.tsx` → `frontend/components/dashboard/dashboard.tsx` (`Dashboard`, `MetricCards`, recharts, `useSystemHealth`/`useAllMetrics`) | **Extend** — add ONE section to this page; **no new route** |
+| Analytics hooks | `frontend/hooks/use-analytics-api.ts`, `use-unified-analytics.ts` | **Extend** — add hooks for the new endpoints |
+
+**Canonical-term note:** the live tables are still named `Workflow`/`WorkflowExecution`. Wave 0 reads
+them where the existing union already does, but every **user-facing tile label** uses the canonical
+noun **Mission**. The legacy tables are migrated-and-dropped in **Wave 3** (per
+`PLAYBOOK-ENGINE-DESIGN.md` §4.2) — **out of scope here**. Do not add new `WorkflowExecution` reads.
+
+---
+
+## 3. Definition of Done (the whole wave)
+
+- [ ] The dashboard shows **five real numbers** for the founding question — zero placeholders.
+- [ ] The fake `successRate: 85.0` (and the sibling hardcoded `avgExecutionTime`/`totalTokensUsed`/
+      `recentExecutions` placeholders) are **deleted** from `analytics_engine.py`. A grep gate proves it.
+- [ ] Error-rate-by-subsystem is queryable from a persisted sink, not just log scraping.
+- [ ] Widget engagement and activation each have one endpoint backed by a real query.
+- [ ] Per-primitive health rolls up from `heartbeat_results` with no rebuild of the heartbeat system.
+- [ ] The dashboard section lives on the **existing** dashboard page — **no new route, no new page**.
+- [ ] Every new endpoint is workspace-scoped and has a pytest; tenant-isolation is asserted.
+- [ ] Type checks pass; `pytest` green; existing suites stay green.
+
+---
+
+## 4. User stories
+
+### Phase A — Error rate by subsystem (the one true gap in telemetry)
+
+**US-001 — Persist `record_error` to a queryable sink**
+- *As the platform, I need structured errors stored in a queryable table so the dashboard can show
+  error rate by subsystem instead of scraping logs.*
+- **Reuse-checked:** no existing error-event table exists (verified 2026-05-29); the closest is the
+  `automatos.errors` logger. Follow the `widget_event_log` / `ToolExecutionLog` single-table-JSONB
+  append-only pattern for consistency.
+- AC:
+  - Create `error_events` table (Alembic migration): `id BIGSERIAL PK`, `subsystem VARCHAR(64) NOT NULL`,
+    `operation VARCHAR(128) NOT NULL`, `error_type VARCHAR(128)`, `error_message VARCHAR(500)`,
+    `workspace_id UUID NULL`, `agent_id INT NULL`, `action_name VARCHAR(128) NULL`,
+    `event_data JSONB NOT NULL DEFAULT '{}'`, `created_at TIMESTAMP NOT NULL DEFAULT now()`.
+  - Index `idx_error_events_subsystem_created (subsystem, created_at)` and
+    `idx_error_events_workspace_created (workspace_id, created_at)`.
+  - Add an opt-in persistence path so `record_error` rows also land in `error_events` **without**
+    changing `record_error`'s signature or its **never-raises** contract — a buffered/best-effort
+    writer (mirroring `log_widget_event`: catch-all, rollback, swallow). The logger emit stays.
+  - `record_error` is migration-safe: if the table/sink is unavailable, it logs and returns (no crash).
+  - Test `orchestrator/tests/test_error_events_sink.py`: `test_record_error_persists_row`,
+    `test_record_error_sink_failure_is_swallowed`, `test_record_error_truncates_message_in_db`,
+    `test_none_workspace_persists`.
+  - Type checks pass; `pytest orchestrator/tests/test_error_events_sink.py` green.
+
+**US-002 — Error-rate-by-subsystem aggregation endpoint**
+- *As an operator, I need one endpoint that returns error counts grouped by subsystem over a window.*
+- AC:
+  - `GET /api/analytics/errors/by-subsystem?window=24h` (workspace-scoped via
+    `get_request_context_hybrid`) returns `{ window, total, by_subsystem: [{subsystem, count, rate}], generated_at }`.
+  - `rate` = subsystem count ÷ total over the window (0 when total is 0; no divide-by-zero).
+  - Query uses `idx_error_events_subsystem_created`; no full-table scan.
+  - Test `orchestrator/tests/test_errors_by_subsystem_endpoint.py`: `test_groups_by_subsystem`,
+    `test_window_filtering`, `test_empty_window_returns_zero`, `test_workspace_isolation`.
+  - Type checks pass; `pytest` green.
+
+### Phase B — Reuse + de-fake the metrics that already exist
+
+**US-003 — Delete the fake agent-metrics placeholders**
+- *As a user, I need the dashboard to show real numbers, not a hardcoded 85%.*
+- AC:
+  - In `core/services/analytics_engine.py` `_get_agent_metrics` (`:107`): remove the hardcoded
+    `successRate: 85.0`, `avgExecutionTime: 2.5`, `totalTokensUsed: 0`, `recentExecutions: 0`.
+  - Replace with real values where a real source exists (mission success via the same union as
+    `/api/analytics/dashboard/success-rate`); **omit** any field with no real source rather than fake it.
+  - `grep -n "85.0\|2.5.*Placeholder\|# Placeholder" orchestrator/core/services/analytics_engine.py`
+    returns **zero** matches.
+  - Test `orchestrator/tests/test_analytics_engine_real_metrics.py`: `test_agent_metrics_no_placeholders`,
+    `test_success_rate_matches_orchestration_runs`.
+  - Type checks pass; `pytest` green; existing analytics tests green.
+
+**US-004 — Widget-engagement aggregation endpoint**
+- *As an operator, I need widget engagement counts so I can see if shipped widgets are used.*
+- **Reuse-checked:** `widget_event_log` + `idx_widget_event_log_type_created` exist; only the read side is missing.
+- AC:
+  - `GET /api/analytics/widget-engagement?window=7d` (workspace-scoped; resolve sites for the
+    workspace) returns `{ window, by_event_type: [{event_type, count}], sessions, generated_at }`
+    grouped over `WIDGET_EVENT_TYPES`.
+  - Query uses `idx_widget_event_log_type_created`; read-only (no writes to `widget_event_log`).
+  - Test `orchestrator/tests/test_widget_engagement_endpoint.py`: `test_groups_by_event_type`,
+    `test_window_filtering`, `test_workspace_site_scoping`, `test_empty_returns_zero`.
+  - Type checks pass; `pytest` green.
+
+### Phase C — Fill the two real gaps
+
+**US-005 — Activation metric (define + compute)**
+- *As a founder, I need an activation number so I know whether new workspaces reach first value.*
+- AC:
+  - **Definition (documented in the endpoint docstring):** a workspace is *activated* when it has
+    ≥1 `OrchestrationRun` with `state == "completed"`. Activation rate = activated workspaces ÷
+    provisioned workspaces.
+  - `GET /api/analytics/activation` returns `{ activated, total_workspaces, rate, generated_at }`.
+  - Computed from `OrchestrationRun` (no new table; no fake fallback — 0 when no data).
+  - Test `orchestrator/tests/test_activation_endpoint.py`: `test_activation_counts_completed_missions`,
+    `test_rate_zero_when_no_workspaces`, `test_workspace_with_no_completed_run_not_activated`.
+  - Type checks pass; `pytest` green.
+
+**US-006 — Per-primitive health rollup**
+- *As an operator, I need each of the 8 primitives shown green/degraded/down from existing heartbeats.*
+- **Reuse-checked:** `heartbeat_results` + `GET /api/heartbeat/analytics` (`api/heartbeat.py:284`) exist.
+- AC:
+  - `GET /api/analytics/primitive-health` rolls the latest `heartbeat_results` findings into a
+    per-primitive status (chat, memory, RAG, NL2SQL, graph, missions, playbooks, channels):
+    `{ primitives: [{name, status, last_checked}], generated_at }`, `status ∈ {green, degraded, down, unknown}`.
+  - Primitives with no heartbeat coverage report `unknown` (honest — not faked green).
+  - No change to the heartbeat writer or schedule; read-only rollup.
+  - Test `orchestrator/tests/test_primitive_health_endpoint.py`: `test_maps_findings_to_primitives`,
+    `test_missing_coverage_is_unknown`, `test_latest_result_wins`.
+  - Type checks pass; `pytest` green.
+
+### Phase D — Assemble the dashboard section (capstone)
+
+**US-007 — "Is it working?" section on the existing dashboard page**
+- *As a user, I need the five metrics on one screen, on the dashboard I already use.*
+- AC:
+  - Add **one** section to `frontend/components/dashboard/dashboard.tsx` (or a new child component
+    rendered by it) titled "Is it working?" with five tiles: Activation, Mission success rate,
+    Per-primitive health, Error rate by subsystem, Widget engagement.
+  - **No new route, no new page.** `grep -rn "app/.*health.*page\|new dashboard route"` style check: no
+    new `page.tsx` is added under `frontend/app/`.
+  - Add hooks to `frontend/hooks/use-analytics-api.ts` (or `use-unified-analytics.ts`) calling the
+    four new endpoints + the existing `/dashboard/success-rate`. Reuse the existing `Card` /
+    `MetricCards` / recharts patterns and the `ApiResponse<T>` envelope.
+  - Tile labels use canonical nouns (**Mission**, not Workflow). Loading + empty states handled
+    (no crash on zero data); no `console.log`; no hardcoded metric values in the component.
+  - Type checks pass (`tsc`). Full Playwright E2E for this section is **Wave 2** (TEST-PLAN J-series),
+    not here — Wave 0 verifies live in US-008.
+
+### Gate
+
+**US-008 — Live verification gate (operational, not code)**
+- *As Gerard, I need to see five real numbers on a live workspace before Wave 0 is done.*
+- AC:
+  - On the deployed Railway frontend, the dashboard "Is it working?" section renders five real values
+    for a workspace with real data (push → Railway → verify live URL; no localhost).
+  - `grep -rn "85.0\|# Placeholder" orchestrator/core/services/analytics_engine.py` returns zero.
+  - All four new endpoints return 200 with real shapes for that workspace; tenant isolation spot-checked
+    (a second workspace sees its own numbers).
+  - `passes` flips only after the live screen is confirmed.
+
+---
+
+## 5. Sequencing & dependencies
+
+- **US-001 → US-002** (sink before aggregation).
+- **US-003** independent (de-fake) — can land first; it is the cheapest honesty win.
+- **US-004, US-005, US-006** independent of each other; all backend.
+- **US-007** depends on US-002/003/004/005/006 (renders all five).
+- **US-008** is the gate; depends on US-007 deployed.
+
+Suggested order: US-003 (de-fake) → US-001/002 (error sink) → US-004/005/006 (the other tiles) →
+US-007 (assemble) → US-008 (verify live).
+
+---
+
+## 6. Out of scope (explicit — do not let Ralph wander)
+
+- **No new frontend page or route.** Extend the existing dashboard only.
+- **No migrate-and-drop of `WorkflowExecution`/`Workflow`.** That is Wave 3 (`PLAYBOOK-ENGINE-DESIGN.md`
+  §4.2). Wave 0 only *reads* via the existing union; it adds **no new** `WorkflowExecution` reads.
+- **No Grafana board.** PRD-142 §12 mentions a Grafana tile per primitive as the *eventual* shape;
+  Wave 0 ships the in-app dashboard section. Grafana wiring is later.
+- **No HARNESS / learning-loop work.** `knowledge_nodes/edges` is Wave 4 (fix, not cut). The 3
+  learning `COUNT(*)` tiles stay hidden/labelled until the loop is live (`KNOWLEDGE-GRAPH-CANONICAL.md` §8).
+- **No new exception-handler adoption sweep.** `record_error` already exists; Wave 0 only gives it a
+  sink. Mass-adopting it across handlers is out of scope (as it was in PRD-141 US-001).
+- **No full Playwright net.** That is Wave 2.
+
+---
+
+## 7. Risk notes
+
+- **`record_error` must never start raising.** US-001's sink is best-effort and swallows everything,
+  exactly like `log_widget_event`. A telemetry write that crashes a business path is a regression.
+- **`error_events` growth.** Append-only; size is bounded by error volume. A retention/rollup job is a
+  *follow-up* (note it; do not build it in Wave 0). Indexes keep the window queries cheap meanwhile.
+- **Touching `analytics_engine.py`.** It is read by the live dashboard. US-003 deletes placeholders but
+  must keep the return shape stable for fields the frontend already consumes — verify against
+  `MetricCards` before removing a key the UI reads.

--- a/docs/architecture/BRAIN-BLUEPRINT.md
+++ b/docs/architecture/BRAIN-BLUEPRINT.md
@@ -1,0 +1,308 @@
+# Automatos — Brain Blueprint
+
+> The architecture constitution. How the platform *should* work, as if written from
+> scratch, with a gap analysis against today's code. Every future PRD checks itself
+> against this document. Companion docs: `DIAGRAMS.md`, `GUARDRAILS.md`, `TEST-PLAN.md`.
+>
+> **Status:** baseline draft — 2026-05-29. Verified against source at branch
+> `feat/widget-page-context-on-regular-chat`. Supersedes nothing yet; this is the
+> reference the Rock-Solid PRD will be cut from.
+
+---
+
+## 0. North star
+
+Automatos is an **operating system for AI agents that can run a business**. A user
+brings their business (its data, tools, and goals); Automatos gives them a workforce of
+agents that perceive (memory + RAG + graph), reason (router + agent runtime), act (tools
++ channels), and coordinate (missions + playbooks) — all isolated per workspace.
+
+Two things must stay true at all times:
+
+1. **The core is vertical-agnostic.** It can, on paper, run *any* business. Verticals
+   (Shopify first) are folder-isolated plugins, never baked into the core. This is the
+   "can run any business" promise — losing it collapses the product into a Shopify app.
+2. **The moat is the knowledge graph + business memory**, not the widgets. Widgets are
+   the distribution wedge (Shopify App Store → 4.6M stores). The defensible asset is the
+   compounding model of a merchant's business — products, orders, FBT relationships, how
+   their shipping/refunds actually work, past campaigns, learned playbooks. That can't be
+   exported to a competitor. Lead with it.
+
+If a change makes the core know about Shopify, or makes the moat shallower, it is wrong
+regardless of how much it helps one demo.
+
+---
+
+## 1. The Arc — one request, end to end
+
+Every interaction, whatever the surface, runs the same loop. This is the brain.
+
+```
+INPUT  →  CONTEXT  →  ASSESS  →  ROUTE  →  RUNTIME  →  TOOL LOOP  →  PERSIST  →  OUTPUT
+(chat/    (Request-   (Auto-    (Univ.   (Agent-     (Unified-     (memory +   (deliverable
+ channel/  Context:   Brain:    Router:  Factory     ToolExec:     graph       .md → S3,
+ widget/   tenancy    complex-  tiers    builds      prefix        write)      stream to
+ mission/  spine)     ity)      0→3)     runtime)    dispatch)                 surface)
+ schedule)
+```
+
+**Canonical happy path (chat):**
+
+1. `POST /api/chat` → `stream_chat()` (`orchestrator/api/chat.py`). `get_request_context_hybrid`
+   injects a **`RequestContext`** (workspace_id, user, auth_type) — the tenancy spine that
+   threads through every layer below.
+2. Message persisted; history loaded; `StreamingChatService` constructed bound to the workspace.
+3. **Assess** — `AutoBrain.assess()` (`consumers/chatbot/auto.py`) returns a complexity verdict
+   (ATOM→ORGANISM) and an action: `RESPOND` / `DELEGATE` / `MISSION`. 3-tier: cache → regex → LLM.
+4. **Route** — for DELEGATE/MISSION, `UniversalRouter.route()` (`core/routing/engine.py`) resolves an
+   agent through ordered tiers: `0` override → `1` Redis cache → `2a` rules → `2b` trigger →
+   `2.5` semantic embeddings → `2c` keyword `IntentClassifier` → `3` LLM fallback.
+5. **Runtime** — `AgentFactory.activate_agent()` (`modules/agents/factory/agent_factory.py`) builds an
+   `AgentRuntime`: resolves the LLM provider/key (BYOK → platform → env), loads Composio apps,
+   attaches a `UnifiedToolExecutor`.
+6. **Tool loop** — tools assembled via `get_tools_for_agent()`; the loop calls the LLM with tool
+   schemas, dispatches each tool call through `ToolRouter.execute_and_format()` →
+   `UnifiedToolExecutor.execute_tool()` (`modules/tools/execution/unified_executor.py`), which routes
+   **by name-prefix**: `platform_*` → ActionRegistry, `workspace_*` → WorkspaceClient,
+   `composio_*` → ComposioToolExecutor, file/shell → exec modules.
+7. **Persist** — after the turn, memory is written (5-layer stack, §4.2) and, where relevant, the
+   knowledge graph updated.
+8. **Output** — final text streamed back as AI-SDK chunks; any deliverable is written as a markdown
+   file to S3 (§4.6). The assistant message is persisted.
+
+The same loop serves channels (adapter → `RequestEnvelope` → router → runtime), widgets (plugin
+dispatch → `ChatService`), and missions (coordinator drives the runtime per task). **One loop, many
+front doors.** Keeping it that way is the single most important structural rule.
+
+---
+
+## 2. The platform in layers
+
+Read bottom-up; each layer may only depend on the ones below it.
+
+| Layer | Name | What lives here | Key entry points |
+|---|---|---|---|
+| **L7** | Ops | Observability, voice | `core/monitoring/*`, `voice-service`, `voice-pipeline` |
+| **L6** | SaaS surface | Marketplace, onboarding, tenancy admin, Next.js frontend | `api/marketplace.py`, wizard, `frontend/lib/api-client.ts` |
+| **L5** | Reach | Channels (11 adapters), widgets, integrations/Composio, vertical plugins | `channels/`, `api/widgets/`, `integrations/`, `core/composio/` |
+| **L4** | Orchestration | Missions, playbooks, tasks, scheduler | `services/coordinator_service.py`, `api/recipe_executor.py` |
+| **L3** | Knowledge | Memory stack, RAG, knowledge graph, NL2SQL | `modules/memory/`, `modules/rag/`, `modules/knowledge/`, `modules/nl2sql/` |
+| **L2** | Cognitive core | Router, AgentFactory, tool executor, ActionRegistry | `core/routing/`, `modules/agents/factory/`, `modules/tools/` |
+| **L1** | Core services | Config, auth/RequestContext, DB sessions, LLM manager | `config.py`, `core/auth/`, `core/database/`, `core/llm/` |
+| **L0** | Substrate | Postgres, S3, S3 Vectors, Qdrant, Redis, Mem0 | (external stores) |
+
+**Dependency rule:** L2 must never import L4/L5/L6. The cognitive core does not know what a Shopify
+widget is, what a marketplace is, or what a mission's UI looks like. It knows agents, tools, context.
+Today this mostly holds (the widget CI gate enforces it for generic widget code); §8 lists where it leaks.
+
+---
+
+## 3. The eight primitives — contracts
+
+Each primitive is defined by a **contract**: what it owns, what it depends on, the interface others
+use, and an ideal **definition of done** (DoD). The DoD is what "rock solid" means for that primitive —
+it's the acceptance bar the test plan asserts.
+
+### 3.1 Chat
+- **Owns:** `chats`, `messages`; the streaming response contract (AI-SDK chunks).
+- **Depends on:** router (agent selection), runtime (execution), memory (context).
+- **Interface:** `POST /api/chat` → SSE stream. One endpoint, one streaming format.
+- **DoD:** every turn is assessed, routed deterministically where a rule exists, streamed without
+  dropping tool events, and persisted. No turn silently fails; errors surface to the user.
+
+### 3.2 Memory
+- **Owns:** the 5-layer stack (§4.2): L1 Redis session, L2 Postgres short-term (Ebbinghaus decay),
+  L3 Mem0 long-term facts.
+- **Depends on:** Mem0 service, Redis, Postgres.
+- **Interface:** `UnifiedMemoryService.store_transcript()` (write-after-turn),
+  `retrieve_context()` (read-before-turn) → budget-capped `ContextBundle`.
+- **DoD:** exactly one write path per layer (no double-store, no write-only); reads are
+  budget-bounded and degrade gracefully when Mem0 is down (circuit breaker, already built).
+
+### 3.3 RAG / Knowledge Base
+- **Owns:** `documents`, `document_chunks`; S3 raw docs; S3 Vectors index (`documents-index`, 2048-dim).
+- **Depends on:** S3, S3 Vectors, embeddings, chunker.
+- **Interface:** `RAGService.retrieve()` (exposed to agents as a tool, not pre-fetched).
+- **DoD:** ingest → chunk → embed → index is atomic per document; retrieval is reranked and
+  parent-expanded; a document deleted from Postgres is removed from the index (no orphan vectors).
+
+### 3.4 NL2SQL
+- **Owns:** `database_knowledge_sources`, `nl2sql_training_examples`, schema metadata.
+- **Depends on:** the user's connected DB (creds decrypted at query time), LLM.
+- **Interface:** `DatabaseKnowledgeService.query_database()` → generate → **validate** → execute →
+  self-correct (≤2 retries) → auto-save training example.
+- **DoD:** generated SQL is always validated/rewritten before execution (read-only enforcement);
+  no query runs unvalidated; creds never logged.
+
+### 3.5 Knowledge Graph (the moat)
+- **Owns:** the workspace graph (NetworkX → S3 JSON), Shopify entity edges (`frequently_bought_with`),
+  `document_relationships`.
+- **Depends on:** sources (Shopify sync, documents), LLM/deterministic extraction.
+- **Interface:** `GraphifyService.build_graph()` / `load_graph()` (BFS/DFS, `subgraph_to_text`).
+- **DoD:** rebuildable from sources idempotently; FBT/collection/vendor edges queryable for proactive
+  openers; graph state survives restart (persisted, not in-memory only).
+
+### 3.6 Missions
+- **Owns:** `orchestration_runs`, `orchestration_tasks`, `orchestration_task_dependencies`,
+  `orchestration_events`, `orchestration_archive`; mirrored to `board_tasks` via the board bridge.
+- **Depends on:** agents (runtime), tools, memory, the shared APScheduler.
+- **Interface:** `CoordinatorService` 5s tick: planner → dispatcher → reconciler → verifier.
+- **DoD:** **DB-authoritative and restart-durable** (already true — §8.2); stalled tasks re-dispatched;
+  retries feed verifier critique back into the next attempt (NOT yet true — gap).
+
+### 3.7 Playbooks
+- **Owns:** `workflow_templates` (steps), `recipe_executions`.
+- **Depends on:** agents, scheduler.
+- **Interface:** `handlers_playbooks` + `api/recipe_executor.py`; one skill per step.
+- **DoD:** an execution survives a process restart (NOT true today — fire-and-forget, §8.2);
+  canonical noun is **Playbook**, not Recipe (massively violated today, §8.3).
+
+### 3.8 Channels
+- **Owns:** `channel_connections` (creds, mode, activity).
+- **Depends on:** router, runtime.
+- **Interface:** `BaseChannelAdapter` (`_to_envelope()` → `handle_message()` → `send_message()`).
+  11 adapters: telegram, slack, discord, teams, google_chat, signal, imessage, irc, matrix, line, whatsapp.
+- **DoD:** every adapter implements the same contract; a new channel is a new adapter file, zero core
+  changes; inbound/outbound counts tracked.
+
+---
+
+## 4. The connective tissue — how everything connects
+
+This is the part the user asked for: *how tools, agents, graphs, files all connect.*
+
+### 4.1 Agents
+Agents are **database rows** (`agents` table), not files. `AgentFactory` builds an `AgentRuntime` from
+the row at activation: system prompt (assembled by `ContextService`), tool set, LLM provider/key
+(BYOK → platform → env), Composio apps. Runtime is cached in-process (`active_agents`) but
+**`workspace_id` is passed per-execution** (the cross-tenant fix), not read off the cache.
+
+### 4.2 Memory (5-layer)
+- **L1 Redis** — rolling session summary (`mem:session:*`).
+- **L2 Postgres** — verbatim short-term (`memory_short_term`), Ebbinghaus decay, hourly consolidation.
+- **L3 Mem0** — extracted long-term facts, namespaced `mem:{ws}[:agent:{id}]`, async httpx client with
+  per-workspace circuit breaker (PRD-141), 5-min Redis-cached search.
+- **Write** = `store_transcript()` after a turn. **Read** = `retrieve_context()` → `ContextRouter`
+  selects layers → budget-capped `ContextBundle` injected via `MemorySection`.
+
+### 4.3 Tools
+The **3-file registration pattern** is the only sanctioned extension point. Tools surface to agents via
+`get_tools_for_agent()`, are described by the `ActionRegistry` singleton (platform actions →
+`platform_execute` schema), and **all execute through one `UnifiedToolExecutor`** that dispatches by
+name-prefix. Platform / Composio / workspace / file / shell are branches of that one executor. This is
+the single most reused contract in the system — extend it, never fork it.
+
+### 4.4 Graph
+Built from sources (Shopify catalog via `map_shopify_catalog`, documents) → extraction → NetworkX →
+clustered/scored → **exported as JSON to workspace files in S3** + an LRU cache. Queried via
+`load_graph()` with BFS/DFS and `subgraph_to_text` for injection into prompts. The Shopify plugin walks
+FBT/collection/vendor edges to generate proactive widget openers — the moat made visible.
+
+### 4.5 Tenancy spine
+`workspace_id` originates in `RequestContext` (from the validated `X-Workspace-ID` header / Clerk JWT)
+and threads through router → runtime → tools → memory → graph → output. Server-side membership
+validation (`_user_has_workspace_access`) blocks header spoofing. **Nothing below L1 fabricates a
+workspace_id**; it is always carried, never guessed (except a dev-only env fallback that must die — §8).
+
+### 4.6 Files / deliverables
+Every agent-produced artifact is a **markdown file in S3** (`workspaces/{ws}/generated-documents/*.md`,
+agent reports under `reports/`). **Rendering is the consumer's job**, never the API's or a content
+transformer's. The file is the source of truth; the UI renders it. This keeps output portable and the
+backend dumb about presentation.
+
+### 4.7 Vertical plugins
+The generic core dispatches verticals through `integrations/__init__.py` `PLUGIN_REGISTRY` keyed on
+`workspaces.settings.vertical`. A plugin implements the `WidgetPlugin` protocol
+(`handle_widget_message(...) → WidgetPluginResult`). Today: `generic` + `shopify`. A CI gate
+(`scripts/ci/check-no-shopify-in-generic.sh`) keeps Shopify identifiers out of generic widget code.
+New vertical = new folder under `integrations/`, register in the map, zero core edits.
+
+---
+
+## 5. State — where everything lives
+
+Single source of truth per concern (full map in `DIAGRAMS.md §7`):
+
+- **Postgres** — system of record. 116 tables across ~12 domains (agents, tenancy, missions,
+  workflows, memory, documents/RAG, tools/composio, marketplace, channels/widgets, credentials,
+  telemetry, config).
+- **S3** — markdown documents + deliverables + marketplace bundles + harness changelog.
+- **S3 Vectors** — document RAG embeddings (`documents-index`).
+- **Qdrant** — `field_memory` (mission-scoped agent knowledge sharing, PRD-108 single collection).
+- **Redis** — session memory, cache, task queue, rate-limit, workflow pub/sub.
+- **Mem0** — external long-term memory service.
+
+---
+
+## 6. The ideal request, restated as invariants
+
+These are the load-bearing truths the rest of the constitution protects:
+
+1. **One cognitive loop**, many front doors (§1).
+2. **One tool executor**, prefix-dispatched (§4.3).
+3. **DB is the system of record**; in-memory state is a cache, never the truth (§5).
+4. **workspace_id is carried, never guessed** (§4.5).
+5. **Deliverables are markdown in S3; consumers render** (§4.6).
+6. **The core is vertical-agnostic; verticals are plugins** (§4.7).
+7. **The moat is the graph + memory**, not the surface (§0).
+8. **No user-visible work is fire-and-forget** — it survives a restart (§3.6/3.7).
+
+---
+
+## 7. Vertical-agnostic core + plugin boundary (detail)
+
+The PRD-141 widget refactor **fully landed** on the current branch and is the reference
+implementation for how every future vertical integrates:
+
+- `chat.py` (widget entry) contains **zero** Shopify identifiers; it resolves the vertical from
+  workspace settings and dispatches through `PLUGIN_REGISTRY`.
+- Shopify logic (proactive openers, graph-related products) lives entirely in
+  `integrations/shopify/`.
+- The contract is `WidgetPluginResult` (rewritten message + optional system preamble).
+- **Known incompleteness:** `api/shopify.py` (catalog sync) is deliberately excluded from the CI gate
+  as a "pre-PRD-141 surface" — it still lives outside `integrations/`. Rehousing it is the next
+  vertical-isolation step, not done yet.
+
+---
+
+## 8. Gap analysis — ideal vs today (the PRD backlog)
+
+Severity: **P0** breaks the invariants / data-safety; **P1** reliability; **P2** consistency/debt;
+**P3** latent risk / documentation only. This table is the bridge to PRD-142 — each row is a
+candidate work item. (Verdicts reconciled against PRD-142's code-verified review, 2026-05-29.)
+
+| # | Sev | Gap | Where | Invariant violated |
+|---|---|---|---|---|
+| G1 | **P0** | `get_db()` closes but never commits/rolls back → SELECT-hydrated `Agent` held across `await` leaves a 9hr "idle in transaction" that blocks DDL/migrations | `core/database/database.py:105` | DB integrity |
+| G2 | **P0** | Migrations wrap ALL versions in one transaction, no `lock_timeout`/`statement_timeout`; `env.py` reads `DATABASE_URL` raw → idle-in-tx hard-blocks any online deploy | `alembic/env.py:31` | Migration safety |
+| G3 | **P0** | Fail-open security: `_check_agent_permission()` and `validate_composio_action()` return `True` on error/unknown ("fail open for now") | `agent_factory.py`, composio | Authz |
+| G4 | **P1** | **Playbooks/recipes are not durable** — `launch_recipe_task` does genuine `asyncio.create_task` with an in-process dict; a stuck execution has no startup recovery. **The one REWRITE** (PRD-142 §6): consolidate the triplet onto the mission durability model; execution-launch blast radius is **6 call sites** (code-verified) behind 2 entry points — see `PLAYBOOK-ENGINE-DESIGN.md` | `api/recipe_executor.py:903`, `api/workflow_recipes.py:905` | Inv. 8 (no fire-and-forget) |
+| G5 | **P1** | Retry without critique — dispatcher re-queues failed tasks storing only `failure_detail`; verifier feedback not injected into the next attempt | `modules/coordination/dispatcher.py:733` | Mission DoD |
+| G6 | **P1** | Two parallel tool loops (chat `_run_tool_loop` vs AgentFactory `execute_with_prompt`) — converge on one executor but dedup/retry/truncation logic drifts | `consumers/chatbot/service.py`, `agent_factory.py` | Inv. 1 |
+| G7 | **P1** | `os.getenv`/`os.environ` outside `config.py`: ~20 calls across 8 runtime files (worst: whole `core/monitoring/` module) + `database.py` `load_dotenv()` at import | grep set | Config discipline |
+| G8 | **P1** | Pervasive bare `except Exception:` then continue/pass (router Tier 2.5, decision logging, `_load_agent_tools`, api_tracking) — masks failures | multiple | Error handling |
+| G9 | **P2** | **Recipe naming** — ~1,682 "recipe" references; Playbook is skin-deep (model `WorkflowTemplate`, executions `RecipeExecution`, `api/recipe_executor.py`). Canonical-term drift at scale | repo-wide | Canonical terms |
+| G10 | **P2** | Verification is advisory-only (PRD-103) but reconciler docstring still claims a `VERIFIED/RETRYING/FAILED` verdict path — doc/code drift | `modules/coordination/reconciler.py` | Consistency |
+| G11 | ~~P2~~ → **P3** | **Downgraded.** The moat is *already* single-sourced in `workspace_graphs` (Postgres, not S3) via `GraphifyService`; Shopify FBT writes there and **nowhere else**, with **zero** dual-write to `knowledge_nodes/edges` (code-verified). Risk is *latent*, not live. Fix = a documented/enforced boundary + a named storage-format scale path (JSON blob → queryable edge tables) — see `KNOWLEDGE-GRAPH-CANONICAL.md` | `modules/knowledge/graph_service.py`, `core/graph_storage.py` | Graph DoD |
+| G12 | **P2** | Dual L3 memory write paths (`store_exchange` skips Mem0, smart_memory writes it) → double-store / miss risk; L1 summary is naive `[-500:]` truncation | `modules/memory/` | Memory DoD |
+| G13 | **CUT** | `core/neural_field/` (PRD-59) is a **dead twin** of the live `vector_field.py` (PRD-108) — its **only** importer is the workflow-era `AgentExecutionManager`, which is **never instantiated** (its `AgentService.execution_manager` builder property is never read) and **has zero callers** (code-verified 2026-05-29). Superseded by `AgentFactory`. Cut as one unit with `execution_manager`. On the PRD-142 §11 cut list | `core/neural_field/` + `AgentExecutionManager` | Clarity / dead weight |
+| G14 | **P2** | Widget conversation owner hardcoded to `users.id=1` | `api/widgets/chat.py:89` | Tenancy hygiene |
+| G15 | **P2** | `api/shopify.py` catalog sync still outside `integrations/` (excluded from CI gate) | `api/shopify.py` | Inv. 6 |
+| G16 | **P2** | Dev-only `WORKSPACE_ID`/`DEFAULT_WORKSPACE_ID` env fallback in `hybrid.py` — historical cross-tenant leak source | `core/auth/hybrid.py` | Inv. 4 |
+| G17 | **P0(test)** | **Testing void** — 1 frontend test across 721 TS/TSX files; no functional RAG test; router tiers / AutoBrain / tool loop / reconciler / recipe-durability untested | repo-wide | "Rock solid" is unmeasurable |
+
+**Corrections to prior assumptions (worth noting):** missions are *already* restart-durable (Mission
+Zero P1 is stale for missions; the durability gap is in playbooks, G4). Tenancy is *already* handled
+correctly per-execution (the residual risk is the env fallback, G16). The widget refactor is *done*, not
+half-landed. The **moat is already single-sourced** (G11 downgraded P2→P3 — the dual-store fear was
+latent, not live); `core/neural_field/` is **dead, not just mis-named** (G13 → cut; its only consumer is the never-instantiated workflow-era `AgentExecutionManager`).
+
+---
+
+## 9. How this doc is used
+
+- **Before any PRD:** classify the change against §2 layers and §6 invariants. If it violates one,
+  redesign before estimating.
+- **During build:** `GUARDRAILS.md` is the enforceable checklist derived from §6.
+- **For "rock solid":** `TEST-PLAN.md` turns each §3 DoD into golden-journey tests; §8 is the backlog.
+- **For the pitch:** §0 (moat) and the corrected scale facts in §5 are the receipts.

--- a/docs/architecture/DIAGRAMS.md
+++ b/docs/architecture/DIAGRAMS.md
@@ -1,0 +1,289 @@
+# Automatos — Architecture Diagrams
+
+> Mermaid diagrams for the brain. Companion to `BRAIN-BLUEPRINT.md` (section refs below
+> point there). Render in any Mermaid-aware viewer (GitHub, VS Code, Obsidian).
+> **Status:** baseline — 2026-05-29, verified against branch `feat/widget-page-context-on-regular-chat`.
+
+---
+
+## 1. System context (who talks to Automatos)
+
+```mermaid
+flowchart TB
+    user["End user / merchant"]
+    store["Storefront visitor (widget)"]
+    chans["Channel users (Slack, Telegram, ...)"]
+
+    subgraph automatos["Automatos Platform"]
+        fe["Next.js frontend"]
+        api["FastAPI orchestrator"]
+        workers["Background workers + scheduler"]
+    end
+
+    llm["LLM providers (BYOK / platform / OpenRouter)"]
+    composio["Composio (100+ external APIs)"]
+    shopify["Shopify (catalog + orders)"]
+    mem0["Mem0 (long-term memory)"]
+    stores["Postgres / S3 / S3 Vectors / Qdrant / Redis"]
+
+    user --> fe --> api
+    store -->|"widget SDK"| api
+    chans -->|"adapter webhook/poll"| api
+    api --> workers
+    api --> llm
+    api --> composio
+    api --> shopify
+    api --> mem0
+    api --> stores
+    workers --> stores
+```
+
+---
+
+## 2. Layered container view (dependency direction is downward)
+
+```mermaid
+flowchart TB
+    subgraph L7["L7 · Ops"]
+        obs["Monitoring: Prometheus/Loki/Grafana"]
+        voice["Voice service + pipeline"]
+    end
+    subgraph L6["L6 · SaaS surface"]
+        mkt["Marketplace"]
+        onb["Onboarding wizard (VOYAGER/BLUEPRINT/SCRIBE/FORGE)"]
+        fec["Frontend (api-client.ts, hooks)"]
+    end
+    subgraph L5["L5 · Reach"]
+        chadapt["11 channel adapters"]
+        widg["Widget API"]
+        plug["Vertical plugins (generic, shopify)"]
+        comp["Composio gateway"]
+    end
+    subgraph L4["L4 · Orchestration"]
+        coord["CoordinatorService (missions)"]
+        pb["Playbook/recipe executor"]
+    end
+    subgraph L3["L3 · Knowledge"]
+        mem["Memory stack (L1/L2/L3)"]
+        rag["RAG"]
+        kg["Knowledge graph"]
+        nl["NL2SQL"]
+    end
+    subgraph L2["L2 · Cognitive core"]
+        router["Universal Router"]
+        af["AgentFactory"]
+        ute["UnifiedToolExecutor"]
+        ar["ActionRegistry"]
+    end
+    subgraph L1["L1 · Core services"]
+        cfg["config.py"]
+        auth["auth / RequestContext"]
+        db["DB sessions"]
+        llmm["LLM manager"]
+    end
+    subgraph L0["L0 · Substrate"]
+        pg["Postgres"]
+        s3["S3 + S3 Vectors"]
+        qd["Qdrant"]
+        rd["Redis"]
+        m0["Mem0"]
+    end
+
+    L6 --> L5 --> L4 --> L3 --> L2 --> L1 --> L0
+    L7 -.observes.-> L1
+```
+
+---
+
+## 3. Sequence — one chat turn (the Arc, BRAIN §1)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant U as User
+    participant API as api/chat.py
+    participant RC as RequestContext
+    participant Auto as AutoBrain
+    participant R as UniversalRouter
+    participant AF as AgentFactory
+    participant TL as Tool loop
+    participant UTE as UnifiedToolExecutor
+    participant Mem as Memory
+    U->>API: POST /api/chat (message)
+    API->>RC: inject (workspace_id, user, auth)
+    API->>Mem: load history + context bundle
+    API->>Auto: assess(message)
+    Auto-->>API: verdict {complexity, RESPOND|DELEGATE|MISSION}
+    alt DELEGATE or MISSION
+        API->>R: route(envelope)
+        R-->>API: agent_id (tier 0..3)
+    end
+    API->>AF: activate_agent(agent_id, workspace_id)
+    AF-->>API: AgentRuntime (LLM key, tools, executor)
+    loop until no more tool calls
+        API->>TL: generate_response(tools)
+        TL->>UTE: execute_tool(name, args)
+        UTE-->>TL: result (prefix-dispatched)
+    end
+    API->>Mem: store_transcript() + graph update
+    API-->>U: stream final text (SSE)
+```
+
+---
+
+## 4. Sequence — mission lifecycle (BRAIN §3.6; DB-authoritative, restart-durable)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Caller as chat/api
+    participant Co as CoordinatorService (5s tick)
+    participant Pl as MissionPlanner
+    participant Di as MissionDispatcher
+    participant AF as AgentFactory
+    participant Re as MissionReconciler
+    participant DB as Postgres
+    Caller->>Co: create_mission(goal)
+    Co->>DB: OrchestrationRun = PENDING
+    Co->>Pl: decompose(goal)
+    Pl->>DB: tasks + dependency rows + BoardTasks
+    Co->>DB: run = AWAITING_APPROVAL
+    Caller->>Co: approve_plan()
+    Co->>DB: run = RUNNING; ready tasks = QUEUED
+    loop every 5s while RUNNING (re-read from DB)
+        Co->>Di: dispatch_ready()
+        Di->>AF: execute_with_prompt(task)
+        AF-->>Di: output
+        Di->>DB: record_task_completion (or re-queue)
+        Co->>Re: reconcile()
+        Re->>DB: COMPLETED -> VERIFIED; re-dispatch stalls
+    end
+    Co->>DB: run = VERIFYING -> AWAITING_HUMAN
+    Caller->>Co: review_mission(accept)
+    Co->>DB: run = COMPLETED; deliverable saved (.md -> S3)
+```
+
+---
+
+## 5. Sequence — widget message with vertical plugin dispatch (BRAIN §4.7, §7)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant SDK as Storefront SDK
+    participant W as api/widgets/chat.py
+    participant Auth as widget_auth
+    participant Reg as PLUGIN_REGISTRY
+    participant P as Plugin (generic|shopify)
+    participant KG as Knowledge graph
+    participant CS as ChatService
+    SDK->>W: POST /api/widgets/chat (message, page_context, trigger_reason)
+    W->>Auth: resolve API key/JWT
+    Auth-->>W: WidgetAuthContext (workspace_id, perms)
+    W->>W: vertical = workspace.settings.vertical
+    W->>Reg: lookup(vertical)
+    Reg-->>W: plugin
+    W->>P: handle_widget_message(...)
+    opt shopify
+        P->>KG: FBT / collection / vendor edges
+        KG-->>P: related products
+    end
+    P-->>W: WidgetPluginResult (message, system_preamble?)
+    W->>CS: run agent (generic core)
+    CS-->>SDK: SSE stream (text + tool events)
+```
+
+Note: generic core (`chat.py`) holds **zero** Shopify identifiers — CI gate
+`check-no-shopify-in-generic.sh` enforces it.
+
+---
+
+## 6. Flow — memory write & read (BRAIN §4.2)
+
+```mermaid
+flowchart LR
+    subgraph write["Write (after turn)"]
+        t["transcript"] --> l2w["L2 Postgres memory_short_term (verbatim)"]
+        t --> l3w["L3 Mem0 add() (fact extraction)"]
+        t --> l1w["L1 Redis session summary"]
+        l2w -.hourly.-> decay["Ebbinghaus decay + consolidation"]
+    end
+    subgraph read["Read (before turn)"]
+        q["query"] --> cr["ContextRouter analyse"]
+        cr --> l1r["L1 session"]
+        cr --> l2r["L2 ILIKE/time search"]
+        cr --> l3r["L3 Mem0 search (5min Redis cache)"]
+        l1r --> bun["budget-capped ContextBundle"]
+        l2r --> bun
+        l3r --> bun
+        bun --> sec["MemorySection -> system prompt"]
+    end
+```
+
+---
+
+## 7. Flow — RAG ingest & retrieve (BRAIN §3.3)
+
+```mermaid
+flowchart LR
+    subgraph ingest["Ingest"]
+        up["upload_document"] --> row["Postgres documents row"]
+        row --> s3u["S3 raw upload"]
+        s3u --> chunk["semantic chunk"]
+        chunk --> emb["embed (2048-dim)"]
+        emb --> idx["S3 Vectors add_documents (external_file_id = documents.id)"]
+    end
+    subgraph retrieve["Retrieve (agent tool)"]
+        query["query"] --> enh["enhance (HyDE / decomp)"]
+        enh --> cand["embed + S3 Vectors search"]
+        cand --> rrf["RRF + rerank + parent-expand + knapsack"]
+        rrf --> ctx["context into prompt"]
+    end
+```
+
+---
+
+## 8. Data substrate map (BRAIN §5)
+
+```mermaid
+flowchart TB
+    subgraph pg["Postgres — system of record (116 tables)"]
+        d1["agents / personas / blueprints"]
+        d2["workspaces / members / users"]
+        d3["orchestration_* / board_tasks"]
+        d4["workflow_templates / recipe_executions"]
+        d5["memory_short_term / knowledge_*"]
+        d6["documents / document_chunks"]
+        d7["tools / composio_* / routing_*"]
+        d8["marketplace_* / skills / llm_models"]
+        d9["channel_connections / widget_* / sites"]
+        d10["credentials / audit_logs / sdk_api_keys"]
+    end
+    s3["S3 — markdown deliverables, raw docs, marketplace bundles, harness changelog"]
+    s3v["S3 Vectors — documents-index (RAG)"]
+    qd["Qdrant — field_memory (mission-scoped)"]
+    rd["Redis — session, cache, queue, rate-limit, pub/sub"]
+    m0["Mem0 — long-term facts (external service)"]
+```
+
+---
+
+## 9. State machine — OrchestrationTask (BRAIN §3.6)
+
+```mermaid
+stateDiagram-v2
+    [*] --> PENDING
+    PENDING --> QUEUED: dependencies met
+    QUEUED --> ASSIGNED: dispatcher picks agent
+    ASSIGNED --> RUNNING: agent starts
+    RUNNING --> COMPLETED: output recorded
+    RUNNING --> QUEUED: error (re-queue)
+    ASSIGNED --> QUEUED: stall > 60s (re-dispatch)
+    RUNNING --> QUEUED: stall > 300s (re-dispatch)
+    COMPLETED --> VERIFIED: reconciler (advisory verify)
+    VERIFIED --> [*]
+```
+
+> Gap (BRAIN §8, G5/G10): re-queue on error stores only `failure_detail` — verifier
+> critique is **not** fed back into the retry. Verification is advisory-only (PRD-103);
+> the reconciler docstring still claims a verdict path — doc/code drift to fix.

--- a/docs/architecture/GUARDRAILS.md
+++ b/docs/architecture/GUARDRAILS.md
@@ -1,0 +1,245 @@
+# Automatos — Development Guardrails
+
+> The enforceable checklist every change to Automatos must pass. Derived from the
+> invariants in `BRAIN-BLUEPRINT.md §6`, the project's `CLAUDE.md`, and divergences found
+> in the 2026-05-29 architecture review. If a PR violates a **MUST**, it does not merge.
+>
+> **Status:** baseline — 2026-05-29. These are rules, not suggestions.
+
+---
+
+## How to read this
+
+Each guardrail has a **rule**, a **why**, and a **check** (how to verify, ideally automatable).
+`MUST` = blocking. `SHOULD` = strong default, deviation requires a note in the PR.
+
+---
+
+## A. Architecture invariants (the non-negotiables)
+
+### A1 — One cognitive loop, many front doors `MUST`
+- **Rule:** chat, channels, widgets, and missions all flow through the same router → runtime →
+  tool-loop path. Do not build a parallel reasoning pipeline for a new surface.
+- **Why:** divergent loops drift in dedup/retry/truncation behaviour (we already have two —
+  `BRAIN §8 G6`). Every fork doubles the test surface and the bug surface.
+- **Check:** new entry points construct a `RequestEnvelope`/`RequestContext` and call the existing
+  router/runtime; they don't re-implement tool dispatch.
+
+### A2 — One tool executor, prefix-dispatched `MUST`
+- **Rule:** all tools execute through `UnifiedToolExecutor.execute_tool()`. New tool classes are new
+  prefixes/branches, never a new executor.
+- **Why:** the executor is the single most reused contract in the system; forking it fragments
+  permissions, telemetry, and error handling.
+- **Check:** grep for new tool-execution entry points; there should be none.
+
+### A3 — DB is the system of record `MUST`
+- **Rule:** durable truth lives in Postgres. In-memory dicts/caches (`active_agents`,
+  `_running_executions`) are caches — the system must reconstruct correct state from the DB after a
+  restart.
+- **Why:** `BRAIN §8 G4` — playbook executions die on restart because state lived only in a process
+  dict. This is how user work silently vanishes.
+- **Check:** "if the process restarts mid-operation, does it recover from the DB?" must be answerable
+  "yes" for any user-visible operation.
+
+### A4 — workspace_id is carried, never guessed `MUST`
+- **Rule:** `workspace_id` originates in `RequestContext` and is passed explicitly down the stack. No
+  layer below L1 fabricates or defaults it.
+- **Why:** the historical cross-tenant leak. A fabricated/defaulted workspace_id is a data-breach
+  primitive.
+- **Check:** no new `DEFAULT_WORKSPACE_ID`/`WORKSPACE_ID` fallbacks (`BRAIN §8 G16` is the one to
+  kill, not copy). Cached runtimes take workspace_id per-execution.
+
+### A5 — Deliverables are markdown in S3; consumers render `MUST`
+- **Rule:** agent output is written as `.md` to S3. The API returns the file/reference; rendering is
+  the consumer's job.
+- **Why:** keeps output portable and the backend ignorant of presentation. Rendering in the API
+  couples content to one UI.
+- **Check:** no HTML/markdown-to-X transformers in the API layer for deliverables.
+
+### A6 — Core is vertical-agnostic; verticals are plugins `MUST`
+- **Rule:** the cognitive core (L2) and generic surfaces know nothing about Shopify or any vertical.
+  Verticals live in `integrations/<vertical>/` and register in `PLUGIN_REGISTRY`.
+- **Why:** the "can run any business" promise and the moat strategy both depend on it.
+- **Check:** CI gate `scripts/ci/check-no-shopify-in-generic.sh` (extend it to new generic surfaces).
+  New vertical = new folder + registry entry + zero core edits.
+
+---
+
+## B. Reuse & cleanliness (this is a mature codebase, not greenfield)
+
+### B1 — Reuse before build `MUST`
+- **Rule:** before writing a new component/hook/table/endpoint/tool, search the graph
+  (`graphify-out/`), the codebase, and memory. The burden is on you to justify why the existing one
+  isn't enough.
+- **Why:** 116 tables and 103 routers exist because "new" kept winning over "reuse."
+- **Check:** PR description names what was searched and why new code was necessary.
+
+### B2 — Delete what you replace `MUST`
+- **Rule:** when a PR replaces a surface, the old one is deleted in the same PR. No `_legacy` suffix
+  that lives forever, no dual paths "just in case."
+- **Why:** the dead `chatbot_router` ("kept for backward compatibility") and deprecated
+  `_stream_workflow_bridge` are exactly this debt.
+- **Check:** no orphaned old path; callers migrated; imports cleaned. Exception: high-risk prod-data
+  migration may keep both *temporarily* with a documented sunset date.
+
+### B3 — No backward-compat shims `MUST`
+- **Rule:** fix the pattern cleanly; don't add a compatibility layer to avoid touching callers.
+- **Why:** project standing rule (`feedback-no-backward-compat`). Shims become permanent.
+
+### B4 — Many small files over few large ones `SHOULD`
+- **Rule:** 200–400 lines typical, 800 max. `coordinator_service.py` (3021) and
+  `agent_factory.py` (1507) and `api-client.ts` (2687) are over budget — don't add to them, extract.
+- **Why:** cohesion, testability, review-ability.
+
+---
+
+## C. Canonical terms (drift costs the user)
+
+### C1 — Use the canonical noun `MUST` (new code) / `SHOULD` (cleanup)
+| Use | Never |
+|---|---|
+| **Playbook** | ~~Recipe~~ |
+| **Mission** | ~~Workflow~~, ~~Job~~ |
+| **Task** (`BoardTask`; mission sub-tasks `OrchestrationTask`) | — |
+| **Deliverable** | ~~Output~~, ~~Artifact~~, ~~Workspace file~~ |
+| **Knowledge Graph** | ~~Business Graph~~ |
+| **Command Center** | ~~Activity~~ |
+| **Auto** (proper noun) | "the assistant" |
+
+- **Why:** `BRAIN §8 G9` — ~1,682 "recipe" references make the Playbook rename skin-deep. New code
+  must not add to the debt; touched files should be migrated opportunistically.
+- **Check:** a `canonical-term-checker` pass on the diff before PR.
+
+---
+
+## D. Config & secrets
+
+### D1 — config.py is the only place env vars are read `MUST`
+- **Rule:** no `os.getenv()`/`os.environ` outside `orchestrator/config.py`. Everything reads from the
+  `Config` object.
+- **Why:** `BRAIN §8 G7` — ~20 violations across 8 files (worst: the whole `core/monitoring/`
+  module). Scattered env reads make config unauditable and break in deploy.
+- **Check:** CI grep gate for `os.getenv`/`os.environ` outside `config.py` (and `alembic/env.py`,
+  which also needs fixing).
+
+### D2 — No hardcoded values `MUST`
+- **Rule:** tunables go through `config.py` or `system_settings`. No magic constants, no hardcoded
+  IDs (`users.id=1` in the widget path, `BRAIN §8 G14`, is the anti-pattern).
+- **Why:** `feedback-no-hardcoded-values`.
+
+### D3 — No file hacks for DB data `MUST`
+- **Rule:** personas, agent definitions, configs live in the database, not loaded from files at
+  runtime.
+- **Why:** `feedback-no-file-hacks-for-db-data`.
+
+### D4 — Secrets never logged, never in args `MUST`
+- **Rule:** credentials decrypted at point of use, never logged; tokens in env/secret store, not
+  command-line args.
+- **Check:** secret-scan on diff; NL2SQL creds and Composio keys never appear in logs.
+
+---
+
+## E. Reliability
+
+### E1 — No fire-and-forget for user-visible work `MUST`
+- **Rule:** anything a user is waiting on (mission, playbook, long task) must be DB-backed and
+  recoverable on restart. `asyncio.create_task` for user work without durable state is banned.
+- **Why:** `BRAIN §8 G4`. Missions got this right (DB tick); playbooks did not.
+- **Check:** startup recovery scans for stuck `running`/`pending` rows and resumes or fails them.
+
+### E2 — No bare `except Exception: pass/continue` `MUST`
+- **Rule:** catch specifically; on a broad catch, record via the error-telemetry path (PRD-141
+  Phase 0 `record_error()`) and decide explicitly to degrade or fail. Never silently swallow.
+- **Why:** `BRAIN §8 G8` — masked failures are unobservable failures.
+- **Check:** CI gate counting bare excepts (PRD-141 sets this up); count must not increase.
+
+### E3 — Fail closed on authz `MUST`
+- **Rule:** permission/authorization checks return **deny** on error or unknown, never allow.
+- **Why:** `BRAIN §8 G3` — `_check_agent_permission()` and `validate_composio_action()` currently
+  "fail open for now." That's a latent privilege-escalation path.
+- **Check:** every authz function's error/else branch denies.
+
+### E4 — Retries must learn `SHOULD`
+- **Rule:** when a task is retried, feed the failure/verifier critique into the next attempt's prompt.
+- **Why:** `BRAIN §8 G5` — blind re-queue repeats the same failure.
+
+---
+
+## F. Data & migrations
+
+### F1 — Sessions commit/rollback and close `MUST`
+- **Rule:** `get_db()` and every session path must commit or roll back, then close. Never hold a
+  transaction open across an `await` that does I/O.
+- **Why:** `BRAIN §8 G1` — the 9hr idle-in-transaction leak that blocks DDL.
+- **Check:** connection-leak test in CI (none today).
+
+### F2 — Migrations are online-safe `MUST`
+- **Rule:** set `lock_timeout`/`statement_timeout`; avoid long table locks; no blanket
+  NOT-NULL/`ALTER` on large tables without a backfill plan. Per-migration transactions, not one giant
+  wrap.
+- **Why:** `BRAIN §8 G2` — current `alembic/env.py` wraps everything in one transaction with no
+  timeouts, so the idle-in-tx leak hard-blocks deploys.
+- **Check:** `migration-reviewer` pass on any `alembic/versions/` change.
+
+### F3 — One source of truth per concern `MUST`
+- **Rule:** don't store the same fact in two places with two write paths (the dual L3 memory write,
+  `BRAIN §8 G12`; two graph stores, `G11`). Pick the canonical store; others derive.
+- **Why:** divergent copies are silent-corruption generators.
+
+---
+
+## G. Tools, agents, frontend
+
+### G1 — Tools use the 3-file registration pattern `MUST`
+- **Rule:** new platform tools register via the canonical 3-file pattern (handler + registry entry +
+  schema). Don't bypass `ActionRegistry`.
+- **Why:** it's the proven extension point; bypassing it breaks discovery and permissions.
+
+### G2 — No duplicate hooks `MUST`
+- **Rule:** if `useDeliverables` exists, don't add `useDeliverablesV2`. Refactor the existing hook.
+  (Versioned *API* surfaces like `use-memory-v1-api` are fine — that's a real API version, not a dup.)
+- **Why:** `feedback-no-backward-compat` applied to the frontend.
+
+### G3 — Frontend calls go through api-client `MUST`
+- **Rule:** all backend calls route through `frontend/lib/api-client.ts` (carries Clerk JWT +
+  `X-Workspace-ID`). No ad-hoc `fetch` to the backend.
+- **Why:** tenancy header + auth consistency.
+
+### G4 — Don't kill valued surfaces `MUST`
+- **Rule:** Command Center, Activity, kanban board, analytics, and widgets are kept. A
+  consolidation/refactor may rehouse them but must not remove them.
+- **Why:** `feedback-dont-kill-valued-surfaces`.
+
+---
+
+## H. Definition of Done (every primitive must meet this)
+
+Before a primitive (chat/memory/RAG/NL2SQL/graph/missions/playbooks/channels) is called "rock
+solid," it satisfies its `BRAIN §3` contract **and**:
+
+- [ ] **Golden-journey test** exists and passes (the happy path end-to-end) — see `TEST-PLAN.md`.
+- [ ] **Failure path tested** — the primitive degrades or errors visibly, never silently.
+- [ ] **Restart-safe** — no user-visible work lost on process restart (E1).
+- [ ] **Observable** — emits the telemetry/metrics needed for the "Is it working?" dashboard.
+- [ ] **Tenant-isolated** — proven by a cross-workspace test (A4).
+- [ ] **One source of truth** — no dual write paths (F3).
+- [ ] **Dashboard tile** — a number that answers "is this primitive working right now?"
+
+---
+
+## I. Process
+
+### I1 — Plan before code for non-trivial PRDs `MUST`
+Map the existing surface → identify reuse candidates → surface ambiguities → propose the plan. Never
+go "request → code."
+
+### I2 — Ask before assuming `MUST`
+If "build X" looks like it already exists, or a name is ambiguous, or a config dial would do — ask.
+30 seconds beats half a day.
+
+### I3 — Update memory after learning `SHOULD`
+New architectural patterns, bug root-causes, corrected mistakes, and project decisions go to the
+auto-memory index. Don't save what `git log`/grep already know.
+
+### I4 — Never push to main without explicit approval `MUST`
+Main is the deploy branch. One branch per session; bundle session work.

--- a/docs/architecture/KNOWLEDGE-GRAPH-CANONICAL.md
+++ b/docs/architecture/KNOWLEDGE-GRAPH-CANONICAL.md
@@ -1,0 +1,176 @@
+# Knowledge Graph — Canonical Store & Boundary
+
+> The design spec for the **one design decision** in `PRD-142-CORE-DESIGN-REVIEW.md` §7:
+> name the moat's canonical store, draw the boundary so the five different "graphs" in the
+> codebase never collide, cut the dead twin, and name the scalability path.
+>
+> **Status:** Design decision — recommendation accepted (PRD-142 §7, Gerard 2026-05-29).
+> **Author:** Design review session 2026-05-29.
+> **Resolves gaps:** `BRAIN-BLUEPRINT.md` §8 **G11** (downgraded) and **G13** (cut).
+> **Verified against:** branch `feat/widget-page-context-on-regular-chat`, code reads 2026-05-29.
+
+---
+
+## 1. The concern, and why it downgrades
+
+The gap analysis flagged **G11 — "two graph stores, no single source of truth"** as a P2 corruption
+risk. Investigation **downgrades it to a documentation task**, because the moat is *already*
+single-sourced and there is *no active dual-write*. The risk is **latent**, not live: it only
+materialises if someone *starts* dual-writing business entities into the learning store later. The
+fix is therefore a **documented, enforced boundary** — not a migration, not a rewrite.
+
+This document draws that boundary so it can't be crossed by accident.
+
+---
+
+## 2. There are five "graphs" — name them apart
+
+"Knowledge graph" has been used loosely for five distinct concerns with five distinct stores. They
+are not duplicates of each other; conflating them is what produced the G11/G13 confusion.
+
+| # | Concern | Store | Module / writer | Verdict |
+|---|---|---|---|---|
+| 1 | **Business Knowledge Graph — THE MOAT** (products, orders, FBT, business memory) | `workspace_graphs` table | `modules/knowledge/graph_service.py` (`GraphifyService`) via `core/graph_storage.py` (`DbWorkspaceClient`) | **CANONICAL** |
+| 2 | **Agent learning / inference** (experience, feedback, learned relations) | `knowledge_nodes` / `knowledge_edges` | `modules/memory/storage/knowledge_system.py` (`KnowledgeGraph.add_knowledge`, `LearningEngine.learn_from_feedback`) | **KEEP, hard boundary** — learning-only, never business entities |
+| 3 | **Mission coordination field** (mission-scoped working memory) | Qdrant `field_memory` | `vector_field.py` | **KEEP** (orthogonal) |
+| 4 | **Dead twin of #3** | `core/neural_field/` (6 files, 112 nodes) | only importer = dead workflow-era `AgentExecutionManager` | **CUT** as one unit with `execution_manager` (§5) |
+| 5 | **Code intelligence** (symbol graph of this codebase) | `codegraph_symbols` | `codegraph_service.py` | **KEEP** (orthogonal — about code, not the business) |
+
+#1 and #2 are the only two that *look* like the same thing. They are not: #1 is the merchant's
+business; #2 is the agent's learning. §4 makes the line concrete.
+
+---
+
+## 3. The canonical store — `workspace_graphs`
+
+**What it is.** The business graph is persisted as **path-keyed JSON artefacts** in the
+`workspace_graphs` table — columns `(workspace_id, path, content, updated_at)`, composite key
+`(workspace_id, path)` (`core/graph_storage.py`). `DbWorkspaceClient` is a drop-in filesystem client:
+`GraphifyService` writes the graph via `_write_json` / reads via `_read_json`, so `content` is a
+serialised graph artefact (the graph JSON), keyed per workspace.
+
+**Why Postgres, not the workspace worker.** The worker container is only provisioned on demand;
+wizard-created workspaces have none, so every graph write used to 404 and the in-memory graph
+evaporated (`graph_storage.py` docstring). Persisting to Postgres keyed to the tenant row made the
+write path deterministic for every workspace — and incidentally put the moat in the system of record
+(`GUARDRAILS.md` A3).
+
+**Single-writer, single-reader, proven.** Shopify's `frequently_bought_with` (FBT) edges — the
+clearest piece of accumulated business value — are written and read **only** through
+`GraphifyService` into `workspace_graphs` (`api/shopify.py:484, 582, 801`; the sync at `:785` merges
+FBT via `import_graph(merge=True)`, strips-and-re-adds stale FBT at `:882–891`; the comment at
+`:733` is explicit that "nodes ever land in workspace_graphs"). There is **zero** write of business
+entities to `knowledge_nodes/edges`. The moat is single-sourced today.
+
+**Verdict:** `workspace_graphs` is **CANONICAL** for all business graph data. Everything else derives
+or stays out.
+
+---
+
+## 4. The boundary contract (the enforceable rule)
+
+> **Business entities live in `workspace_graphs` (via `GraphifyService`) and nowhere else.
+> `knowledge_nodes` / `knowledge_edges` is the agent-learning substrate and stores learning only —
+> never products, orders, customers, or FBT relations.**
+
+Why the two must never merge:
+
+- **Different lifecycles.** Business data is imported/synced from the merchant's systems (Shopify,
+  uploads) and is *authoritative*. Learning data is *derived* from agent experience and feedback
+  (`LearningEngine.learn_from_feedback`, `knowledge_system.py:1003`) and is *advisory*.
+- **Different blast radius on corruption.** A wrong business edge mis-sells to a customer; a wrong
+  learning edge mis-routes an agent. Mixing them lets an advisory write corrupt authoritative data —
+  exactly the latent G11 risk.
+- **Different module ownership.** #1 lives in `modules/knowledge/`; #2 in `modules/memory/storage/`.
+  The module boundary already reflects the concern boundary — keep it.
+
+**How to enforce (proposed):**
+1. A CI grep gate: no writes to `knowledge_nodes`/`knowledge_edges` from `modules/knowledge/`,
+   `api/shopify.py`, or any vertical integration; no business-entity writes (`product`, `order`,
+   `frequently_bought_with`) into the learning store.
+2. A one-line docstring on both stores pointing at this contract.
+3. The `knowledge_nodes/edges` store folds into HARNESS (its natural home — agent self-learning,
+   PRD-142 §8). **Decided 2026-05-29 (Gerard): fix, not cut.** It is the self-learning capability the
+   platform is committed to — a *dead loop* today (`add_knowledge`/`learn_from_feedback` have zero
+   callers, the classes are never instantiated), not junk. **Wave 4 wires the loop**; keep the tables
+   and schema as the starting point and reshape only if HARNESS's real requirements demand it. Until
+   then the boundary (§4) holds so it never collides with the moat.
+
+---
+
+## 5. The dead twin — `core/neural_field/` is CUT (resolves G13)
+
+`core/neural_field/` (6 files, 112 nodes) is a dead twin of the live mission-coordination field
+(`vector_field.py` → Qdrant `field_memory`, #3). Its **only** importer is the workflow-era
+`AgentExecutionManager` (`execution_manager.py:184`, neural-field write at `:348–356`), and that
+class is itself dead: it is **never instantiated** (the `AgentService.execution_manager` property
+that would build it is never read) and its main method `execute_workflow_subtasks` has **zero
+callers** (code-verified 2026-05-29). It was superseded by `AgentFactory.execute_with_prompt`, which
+Missions / Playbooks / Chat all use. So neural_field is reachable **only through dead code** — the
+honest framing is "its one importer is dead," **not** "0 importers" (that earlier claim came off the
+stale graph and was wrong). On the PRD-142 §11 **CUT** list.
+
+> **Do not confuse with `vector_field`.** `vector_field.py` → Qdrant `field_memory` (#3, PRD-108) is
+> the **live** Mission semantic field — 100% alive, **KEEP / FIX, never CUT**. `neural_field` is the
+> *Redis*-backed PRD-59 predecessor. Different store, different era. If anything in the Mission field
+> is unwired, that is a FIX, never a cut.
+
+**Action:** cut `core/neural_field/` **together with** `AgentExecutionManager` and the dead
+`AgentService.execution_manager` property — they are one workflow-era unit. Verify the
+`channels/__init__.py` re-export is a no-op import first. This collapses the "two coordination
+fields" confusion (G13) to one.
+
+---
+
+## 6. Code intelligence — `codegraph_symbols` stays separate
+
+`codegraph_service.py` (`codegraph_symbols`, 55 nodes) graphs **this codebase's symbols**, not the
+merchant's business. It is orthogonal to the moat and to learning — a developer/agent tool for
+navigating code. **KEEP, unchanged.** It is named here only so it is never folded into the moat by
+mistake.
+
+---
+
+## 7. Enterprise-scale flag — the storage-format path
+
+**The honest limitation.** The moat serialises the *whole graph* as a JSON blob in
+`workspace_graphs.content` and loads it into **NetworkX in memory, per request** (the
+`DbWorkspaceClient` filesystem-in-a-table pattern, §3). For a small merchant this is fine and fast.
+At enterprise scale — tens of thousands of products, deep order history, dense FBT — loading and
+parsing the entire graph on every query will not hold.
+
+**The path (named HARDEN, not a blocker):**
+
+| Stage | Storage | When |
+|---|---|---|
+| **Today** | JSON blob in `content`, NetworkX in memory per request | works for current merchants |
+| **Next** | Queryable **edge tables** (`graph_nodes` / `graph_edges` keyed by workspace) — load subgraphs, not the whole blob; index by relation/type | when a single workspace's graph stops fitting comfortably in a request |
+| **If needed** | A dedicated graph engine (e.g. Postgres + `pgRouting`/recursive CTEs, or a graph DB) | only if traversal patterns demand it — earn it with evidence |
+
+This evolves the *storage*, not the *contract* — `GraphifyService` stays the single writer/reader, so
+the boundary (§4) holds across the migration. **Not a blocker for production**; it is a named item
+on the moat's HARDEN list (PRD-142 §7) with a measurable trigger (graph load time per request).
+
+---
+
+## 8. Definition of Done
+
+- [ ] **One canonical store named** — `workspace_graphs` documented as the sole business-graph store (this doc).
+- [ ] **Boundary enforced** — CI gate rejects business-entity writes to `knowledge_nodes/edges` (§4).
+- [ ] **Dead twin cut** — `core/neural_field/` deleted, `channels/__init__.py` re-export removed (§5).
+- [ ] **Learning store has a home + fix commitment** — folded into HARNESS; Wave 4 wires the dead loop (§4). The 3 `COUNT(*)` dashboard tiles are hidden/labelled until the loop is live, so the Wave-0 dashboard doesn't imply a running system.
+- [ ] **Scalability trigger instrumented** — graph load time per request emitted to the dashboard; the edge-table migration is specced (not built) when it crosses threshold (§7).
+- [ ] **Tenant isolation** — graph reads/writes keyed by `workspace_id`; cross-workspace test proves no leak.
+
+---
+
+## 9. Open questions (for discussion before the build PRD)
+
+1. **`knowledge_nodes/edges` fate — RESOLVED 2026-05-29 (Gerard): fix, not cut.** Wave 4 (HARNESS) wires the dead learning loop; keep the tables + schema as the starting point, reshape only if HARNESS's requirements demand. Cut-trigger removed.
+2. **Edge-table migration timing** — proactively spec it now, or wait for the load-time trigger to fire? (Leaning: spec on trigger, instrument now.)
+3. **Boundary enforcement mechanism** — CI grep gate (cheap, proposed) vs a typed repository layer that makes a business-entity write to the learning store impossible by construction (stronger, more work).
+
+---
+
+**This is a design decision and a boundary, not a migration.** The moat is already single-sourced;
+this document keeps it that way and names the scale path. No code until the build PRD is approved.

--- a/docs/architecture/PLAYBOOK-ENGINE-DESIGN.md
+++ b/docs/architecture/PLAYBOOK-ENGINE-DESIGN.md
@@ -1,0 +1,244 @@
+# Playbook Engine — Consolidation Design
+
+> The design spec for the **consolidate-and-harden** of the execution engine in
+> `PRD-142-CORE-DESIGN-REVIEW.md` §6: unify the scattered-but-live recipe/playbook execution path
+> into one clean DB-backed flow, and make it restart-durable by borrowing the Mission coordinator's
+> proven model. **Not a rewrite** — the engine exists and works; it is scattered and not restart-safe.
+>
+> **Status:** Design proposal — docs phase, no code until build is green-lit.
+> **Author:** Design review session 2026-05-29 (Gerard Kavanagh).
+> **Decision it implements:** PRD-142 §6 ("approved as a consolidate-and-harden, as design").
+> **Depends on:** PRD-142 §10 P0s (G1 sessions, G2 migrations) landed first — this engine adds a
+> table and a migration, and must not deploy behind the idle-in-tx leak.
+> **Verified against:** branch `feat/widget-page-context-on-regular-chat`, code reads 2026-05-29.
+
+---
+
+## 1. Why this is consolidate-and-harden, not a rewrite
+
+"Recipe" and "playbook" are the **same thing** — recipe is the pre-rename name; the front end now
+says playbook. The execution logic is **live and working**, just scattered: the loop lives in
+`recipe_executor.py`, the launch front door in `workflow_recipes.py` (despite its name), with dead
+`modules/workflows/` remnants alongside. The *contract is right*. Two things are wrong, and both are
+fixable **without inventing a new engine**:
+
+1. **Scattered, not unified.** One concept ("playbook", née recipe) is spread across files that
+   diverge in dedup, retry, and streaming behaviour. The fix is **consolidate to one clean flow +
+   one execution-state table** — and delete the dead `modules/workflows/` duplication.
+2. **Not restart-durable (the real defect).** The launch path uses `asyncio.create_task(...)` and
+   lives only in the process. Restart mid-run → the user's playbook silently dies
+   (`GUARDRAILS.md` E1/G4). The fix is **HARDEN**: port the durability model in §3.
+
+Missions already solved the durability problem and scored grade **A−** for it (PRD-82A, the
+Sequential Coordinator). This is **not a rewrite** — we are not replacing a wrong contract or
+building a new engine. We are **unifying scattered-but-live code and porting a proven durability
+pattern** onto it. (Gerard, 2026-05-29: "is it just scattered and we need to clean up to one clean
+flow?" — yes.)
+
+---
+
+## 2. Current state (code-verified)
+
+### 2.1 Three engines
+
+| Engine | File | ~Lines | Role today |
+|---|---|---|---|
+| Recipe executor | `orchestrator/api/recipe_executor.py` | 1,997 | Primary execution loop; `asyncio.create_task(_safe_execute())` at **:903**. |
+| Workflow recipes API | `orchestrator/api/workflow_recipes.py` | 1,872 | `launch_recipe_task()` at **:905** — the API front door. |
+| Workflows module | `orchestrator/modules/workflows/` + `consumers/workflows/streaming.py` | rest of ~5,400 | Step models + in-memory SSE manager. |
+
+### 2.2 Two persistence tables, no recovery
+
+- **`recipe_executions`** (`core.py:1468–1517`) — the richer one. Columns:
+  `status` (pending/running/completed/failed), `current_stage`, `current_step`, `step_results`,
+  `error_message`, `attempt_count`, `retry_of`.
+- **`workflow_executions`** (`core.py:523–546`) — the execution log. **Decided 2026-05-29 (Gerard):
+  migrate and drop — "workflows don't exist."** 4 writer sites (`chat.py:92`, `composio.py:899`,
+  `workflows.py:983`/`:1092`) and ~20 readers (analytics, monitoring, execution-history, agent-
+  performance, nl2sql) **fold onto `playbook_executions`** — live writers repoint, dead-path writers
+  delete with their files, history backfills. One execution table. Columns: `status`, `execution_log`,
+  `error_message`.
+- **Restart recovery: NONE.** No startup scan for `running`/`pending` rows. A crash mid-execution
+  orphans the row in `running` forever.
+
+### 2.3 Streaming is in-memory only
+
+`consumers/workflows/streaming.py:20–80` — `WorkflowStreamManager` holds per-execution event queues
+**in memory**, with replay. No DB backlog → on restart, in-flight SSE streams are lost and cannot
+resume. **Note:** this manager is **kept** — it is the live chat-streaming manager (`api/chat.py:65`
+imports `get_stream_manager`), not workflow-only dead code. We *harden* it (persist events), we do
+**not** delete it.
+
+### 2.4 The launch surface is SIX call sites (graph-verified, then code-confirmed)
+
+The graph showed ~36 inbound edges from ~21 files, but most are *symbol* coupling (type imports,
+shared utils like `_composio_scope_message`). The **execution-launch** surface — the only thing the
+migration must repoint — is **six call sites**:
+
+| # | Caller | Site | Path |
+|---|---|---|---|
+| 1 | Workflow API endpoint | `api/workflow_recipes.py:905` | `launch_recipe_task()` |
+| 2 | Composio trigger | `api/composio.py:886` | `execute_recipe_direct()` |
+| 3 | Workspace webhook | `api/webhooks.py:682–683` | `create_task(execute_recipe_direct())` |
+| 4 | Platform tool executor | `modules/tools/discovery/handlers_playbooks.py:487` | `launch_recipe_task()` |
+| 5 | Scheduler (cron playbooks) | `services/playbook_scheduler.py:208` | `launch_recipe_task()` |
+| 6 | Task reconciler (retry) | `services/task_reconciler.py:273` | `launch_recipe_task()` |
+
+Confirmed **non-callers** (they only import shared utils, not execution): `channels/__init__.py`,
+`core/action_registry.py`. The execution blast radius is therefore **bounded to two entry points**
+(`launch_recipe_task` and `execute_recipe_direct`) behind which all six callers sit.
+
+---
+
+## 3. The durability pattern to borrow (Mission coordinator)
+
+This is the proven model (`coordinator_service.py`, grade A−). The playbook engine adopts its shape.
+
+| Mechanism | Where (mission) | What it buys |
+|---|---|---|
+| Scheduled tick | `coordinator_service.py:843–850` — APScheduler `add_job(self.tick, "interval", seconds=Config.COORDINATOR_TICK_INTERVAL_SECONDS)` (default 5s) | Progress is driven by a loop that re-reads the DB, not by an in-process task. |
+| Re-read state each tick | tick method `coordinator_service.py:867–944` — reads all `RUNNING` runs from DB | After a restart, the next tick picks up in-flight work automatically — **the durability primitive**. |
+| Stall detection / re-dispatch | `modules/coordination/reconciler.py:687–759` — ASSIGNED>60s → STALLED, RUNNING>300s → STALLED → back to ASSIGNED | A row left `running` by a crash is detected and re-dispatched, not orphaned. |
+| Durable state columns | `orchestration_runs` (`orchestration.py:39–157`), `orchestration_tasks` (`:159–292`): `state` enum, `version_id` (optimistic lock), `started_at`/`completed_at`/`updated_at`, `attempt_number`/`max_retries`, `failure_reason_code` | State lives in Postgres; the process holds none of it. |
+
+**Key insight:** mission recovery is *continuous via the tick*, not a one-shot startup call. The
+playbook engine inherits the same property, and adds one improvement (below).
+
+---
+
+## 4. Target design
+
+### 4.1 Structural choice (the open decision)
+
+Three ways to "reuse the pattern." **Decided 2026-05-29 (Gerard): C-lite.** A and B stay below so the
+trade-off is on record.
+
+| Option | Shape | Pro | Con |
+|---|---|---|---|
+| **A — Playbook *is* a Mission** | Run a playbook as a linear-DAG mission on the existing coordinator. | Zero new durability code; literally one loop. | Forces playbook semantics into mission semantics (approval gates, verification, board tasks, agent-decomposition) that a deterministic step-DAG doesn't want. Overloads the A− subsystem. |
+| **B — Separate engine, copied pattern** | New `PlaybookEngine` with its own tick, table, state machine — same *shape* as the coordinator. | Clean semantic separation. | A second durable loop to maintain; risk of the two drifting (the exact failure we're consolidating away from). |
+| **C-lite — Shared durability substrate (DECIDED)** | Extract the proven primitive (DB-state + scheduled tick + stall detection + recovery) into a small shared `DurableRunner`; missions keep their semantics on top, playbooks get a thin step-executor on top. | One durability implementation, two semantic layers; honors "reuse over build" without conflating concepts. | Modest refactor of the coordinator to sit on the shared base — **mitigated by sequencing: the Wave-2 test net lands before this Wave-3 refactor, so the A− coordinator is covered before we touch it.** |
+
+C-lite keeps a playbook a *deterministic step DAG* (distinct from a mission's adaptive,
+agent-decomposed plan) while guaranteeing both recover identically.
+
+### 4.2 One table replaces two
+
+A single canonical **`playbook_executions`** table (resolving the recipe/workflow naming debt, G9),
+seeded from the union of today's two tables and the coordinator's durability columns:
+
+| Column | Source | Purpose |
+|---|---|---|
+| `id`, `playbook_id`, `workspace_id` | both | identity + tenancy (workspace_id carried, never defaulted — `GUARDRAILS.md` A4) |
+| `state` (enum: PENDING/RUNNING/COMPLETED/FAILED/STALLED) | from `recipe_executions.status` + mission state-machine | durable status |
+| `current_step`, `step_results` | `recipe_executions` | step progress (verbatim, for SSE rebuild) |
+| `version_id` | mission `orchestration_*` | optimistic lock against double-dispatch |
+| `attempt_number`, `max_retries`, `retry_of` | `recipe_executions.attempt_count`/`retry_of` + mission | retry accounting |
+| `failure_reason_code`, `error_message` | mission + `recipe_executions` | typed failure for retry-with-learning |
+| `started_at`, `completed_at`, `updated_at`, `heartbeat_at` | mission | stall detection + recovery |
+
+Both of today's tables fold into `playbook_executions`. `recipe_executions` (the live, richer
+execution-state table) **evolves into** it — matching the recipe→playbook rename — and
+`workflow_executions` is **migrated and dropped** (decided 2026-05-29, Gerard: "workflows don't
+exist"). Live writers repoint to the new table; the ~20 analytics/history/nl2sql readers (§2.2)
+move onto `playbook_executions`; dead-path writers delete with their files. **One** execution
+table, one source of truth per `GUARDRAILS.md` F3 — no separate analytics log survives.
+
+### 4.3 The interface (the stable seam the six callers use)
+
+```
+PlaybookEngine.launch(playbook_id, workspace_id, inputs, *, trigger) -> execution_id   # enqueues a DB row, returns immediately
+PlaybookEngine.status(execution_id) -> PlaybookExecutionState                          # reads DB
+PlaybookEngine.stream(execution_id) -> AsyncIterator[StepEvent]                         # rebuild-from-DB then tail live
+PlaybookEngine.cancel(execution_id) -> None                                            # state -> FAILED(cancelled)
+```
+
+`launch()` **does not** `create_task` the work — it inserts a `PENDING` row and returns. The shared
+`DurableRunner` tick advances it. This is the whole fix: the process no longer owns the execution.
+
+All six call sites collapse onto `launch()` (the two webhook/composio direct paths included).
+
+### 4.4 Streaming becomes restart-safe
+
+**Harden** (not replace) the in-memory `WorkflowStreamManager` — it stays as the live chat-streaming
+manager (`chat.py:65`). Back it with **step events persisted to the execution row** (append to
+`step_results` / a child events table). `stream()` reconnect = rebuild from DB state, then tail live
+updates the tick writes. An SSE client that drops during a restart **resumes** instead of losing the
+stream. The in-memory queue becomes a cache over the durable log, not the source of truth.
+
+### 4.5 Retry that learns (closes G5/E4)
+
+The mission side already carries `failure_reason_code`. The new engine **feeds the prior attempt's
+failure into the next attempt's prompt** rather than blind re-queue. The data exists today
+(`attempt_count`, `retry_of`, `error_message`); the engine must *use* it.
+
+### 4.6 One improvement over the mission model
+
+Missions recover *only* via the continuous tick. The playbook engine adds an **explicit startup
+reconcile**: on boot, scan `playbook_executions` for `RUNNING`/`PENDING` and re-enqueue them
+immediately (don't wait up to one tick + one stall window). Cheap, and it tightens recovery latency
+for user-visible work. (Worth back-porting to missions later — out of scope here.)
+
+---
+
+## 5. Migration & deletion plan (strangler-fig)
+
+No dual paths left alive (`GUARDRAILS.md` B2/B3). Order:
+
+1. **Build** the shared `DurableRunner` + `PlaybookEngine` behind the §4.3 interface, with the new
+   `playbook_executions` table (online-safe migration, `lock_timeout` set — `GUARDRAILS.md` F2).
+2. **Backfill** today's execution rows into `playbook_executions` (one-time data migration):
+   in-flight `recipe_executions` rows plus `workflow_executions` history, so the ~20 analytics/
+   history/nl2sql readers keep continuity when they repoint. Low-risk — live state is
+   small/ephemeral and the log is append-only.
+3. **Repoint** the six call sites (§2.4) to `PlaybookEngine.launch()`, one at a time, each behind a
+   code-reviewer gate. The two entry-point functions (`launch_recipe_task`, `execute_recipe_direct`)
+   become thin shims that call `launch()`, then are inlined and removed.
+4. **Prove parity** — the restart-durability test (§6) passes; SSE resume works; retry feeds the
+   critique.
+5. **Delete the dead duplication and both legacy tables:** `recipe_executor.py` +
+   `workflow_recipes.py` execution loops (consolidated into the one engine) and the dead
+   `modules/workflows/` execution code. Drop **both** `recipe_executions` and `workflow_executions`
+   once `playbook_executions` is proven and every reader/writer is repointed (decided 2026-05-29).
+   **Keep** `WorkflowStreamManager` (live chat consumer, now DB-backed per §4.4). Remove orphan
+   imports.
+
+This is Wave **3R** in PRD-142 §12 (inside primitive hardening; gated on the P0s and the test net).
+
+---
+
+## 6. Definition of Done
+
+Per `GUARDRAILS.md` §H, plus the consolidation bar:
+
+- [ ] **One engine.** `recipe_executor.py` + `workflow_recipes.py` execution loops consolidated into one flow; dead `modules/workflows/` execution code deleted; grep for the duplicate loops returns zero.
+- [ ] **One execution table.** `recipe_executions` and `workflow_executions` both fold into `playbook_executions` (sole store for execution state + history); the ~20 analytics/history/nl2sql readers and all live writers repointed; both legacy tables dropped.
+- [ ] **Restart-durable (the headline test).** Launch a multi-step playbook, kill the process mid-step, restart — it resumes and completes from the DB. No orphaned `running` rows.
+- [ ] **SSE resumes** across a restart (rebuild-from-DB + tail).
+- [ ] **Retry learns** — a forced step failure feeds `failure_reason_code` into the next attempt's prompt (not blind re-queue).
+- [ ] **Tenant-isolated** — workspace_id carried end-to-end; cross-workspace test passes.
+- [ ] **Six callers migrated**, both legacy entry-point functions removed.
+- [ ] **Dashboard tile** — playbook success rate + stuck-execution count (feeds PRD-142 Wave 0 dashboard).
+
+---
+
+## 7. Open questions (for discussion before the build PRD)
+
+1. **Structural option — RESOLVED 2026-05-29 (Gerard): C-lite** (shared `DurableRunner`). It touches
+   the A− mission coordinator, so the refactor is gated on Wave-2 test coverage landing first.
+2. **Tick cadence & isolation** — share the coordinator's 5s scheduler job, or a separate playbook
+   tick? (Shared scheduler, separate handler is the leaning.)
+3. **Events storage** — append to `step_results` JSON vs a dedicated `playbook_execution_events`
+   child table for the SSE log. Child table scales better; JSON is simpler.
+4. **Scheduler/webhook trigger semantics** — `playbook_scheduler` and the workspace webhook both
+   launch; confirm they want the same at-least-once / dedup behaviour the mission dispatcher uses.
+5. **`workflow_executions` disposition — RESOLVED 2026-05-29 (Gerard): migrate and drop.**
+   "Workflows don't exist." The 4 live writers (`chat.py:92`, `composio.py:899`, `workflows.py:983`/
+   `:1092`) repoint to `playbook_executions`; the ~20 readers (analytics, monitoring, execution-
+   history, agent-performance, nl2sql) move with them; dead-path writers delete with their files. No
+   separate analytics log survives.
+
+---
+
+**This is design only.** No code, no migration, no deletion until the build PRD is approved
+(PRD-142 §6, Gerard 2026-05-29).

--- a/docs/architecture/TEST-PLAN.md
+++ b/docs/architecture/TEST-PLAN.md
@@ -1,0 +1,211 @@
+# Automatos — Test Suite Plan
+
+> How we make "rock solid" measurable. Turns each primitive's Definition of Done
+> (`BRAIN-BLUEPRINT.md §3`, `GUARDRAILS.md §H`) into tests. Companion to the Brain
+> Blueprint, Diagrams, and Guardrails.
+>
+> **Status:** baseline plan — 2026-05-29. **Sequencing gate:** the *implementation* of this
+> plan waits until BOTH PRD-141s (Platform Reliability + Widget Vertical-Agnostic) are
+> merged to main — tests written before then would be thrown away (mem0 async, chat.py
+> Shopify-func deletion). This document is design; it can be written now.
+
+---
+
+## 1. Why this exists
+
+Today we cannot answer "is the platform working?" with a number. Backend has real but uneven
+coverage; the frontend has **1 test file across 721 TS/TSX files**. A hardening effort with no test
+net is just hope. The goal of this plan is a **test net that proves each primitive meets its contract**
+and a CI gate that keeps it that way.
+
+---
+
+## 2. Current state (honest map)
+
+Verified 2026-05-29. ✅ = real coverage, ⚠️ = thin/partial, ❌ = none found.
+
+| Primitive / area | State | Evidence |
+|---|---|---|
+| Mission coordinator / dispatcher / planner | ✅ | `test_coordinator_parallel`, `test_dispatcher_parallel`, `test_parallel_decomposition`, `test_synthesis_executor`, `test_complexity_detection`, `test_82c_wiring`, `test_budget_gate`, `test_prd108_scenarios` |
+| Memory stack (L1/L2/L3, Mem0 async, circuit breaker) | ✅ | `test_unified_memory`, `test_mem0_async_client`, `test_mem0_circuit_breaker`, `test_mem0_load`, `test_hierarchical_memory`, `test_memory_section` |
+| Tenancy / workspace isolation | ✅ | `test_workspaces`, `test_workspace_errors`, `test_workspace_isolation` (regression — pins the X-Workspace-ID spoof fix), `test_onboarding_journey` |
+| Action registry / tool routing models | ✅ | `test_us013/014/015`, `test_action_registry_filtered`, `test_action_semantic_index`, `test_tool_router_semantic` |
+| Widgets / vertical plugins / channels | ✅ | `test_registry_contract`, shopify+generic `test_widget_proactive`, `test_prd008a*`, `test_prd008a4_channel_*` |
+| Field memory (Qdrant) | ✅ | `test_vector_field` |
+| NL2SQL validator (security) | ⚠️ | `test_validator`, `security/test_nl2sql_validator` — validator only, not end-to-end query |
+| Knowledge graph build/query | ⚠️ | `test_graph_router`, `test_eval_graph_mode` — routing, not build idempotency |
+| **Universal Router tiers** (`route()` 0→3) | ❌ | no direct test |
+| **AutoBrain.assess()** | ❌ | no test |
+| **IntentClassifier / SmartIntentClassifier** | ❌ | no test |
+| **Core tool loop** (both chat + AgentFactory loops) | ❌ | exercised only incidentally via fixtures |
+| **RAG functional** (ingest→retrieve) | ❌ | `modules/rag/tests/` has only `__init__.py` |
+| **MissionReconciler / VerificationService** | ❌ | no direct test |
+| **Playbook/recipe execution durability** | ❌ | only `test_recipe_scheduler` (cron), nothing for execution recovery |
+| **Composio executor** | ❌ | no unit test found |
+| **DB connection-leak / pool** | ❌ | none (the idle-in-tx leak has no regression test) |
+| **Alembic up/down** | ❌ | only PRD-specific `test_prd008a_sites_migration` |
+| **Frontend (everything)** | ❌ | 1 file: `playbook-schedule-config.test.tsx`; Vitest configured, unused |
+
+**Read:** the orchestration and tenancy spines are tested; the **reasoning entry path (router →
+assess → tool loop), RAG, mission verification, playbook durability, and the entire frontend are
+the holes.** Those holes map almost 1:1 onto the `BRAIN §8` gap list — fixing a gap and writing its
+test are the same work item.
+
+---
+
+## 3. Philosophy
+
+1. **Golden journeys first, line-coverage second.** Cover 100% of the paths that matter (the journeys
+   in §5) before chasing 80% of lines. A green golden-journey suite is the real "is it working" signal.
+2. **TDD for new code, characterization for old.** New features follow the global TDD rule
+   (red→green→refactor, 80%+ on the new code). Existing untested code gets **characterization tests**
+   that pin current behaviour first, then we refactor under green.
+3. **Real dependencies for integration tests, not mocks.** Integration tests hit a real Postgres
+   (`scripts/init_test_db.py`), real Redis, and a stubbed-but-faithful Mem0/S3 — mocked infra hides
+   the migration/transaction bugs that bite in prod (this is why the idle-in-tx leak survived).
+   Reserve mocking for external paid APIs (LLM, Composio) via recorded fixtures.
+4. **Every gap fix ships with its test.** No `BRAIN §8` item is "done" without a regression test that
+   would have caught it (e.g. a connection-leak test for G1, a restart-recovery test for G4).
+5. **Coverage targets are per-tier, not global.** 80% on touched/critical-path code; the long tail of
+   103 routers reaches coverage opportunistically, not in one sprint.
+
+---
+
+## 4. The pyramid (per primitive)
+
+For each primitive: **unit** (pure logic), **integration** (real DB/Redis, cross-module), **contract**
+(stable interface shape), **e2e** (in §5).
+
+### 4.1 Chat / reasoning entry  *(biggest hole)*
+- **Unit:** `AutoBrain.assess()` verdict table (ATOM→ORGANISM × RESPOND/DELEGATE/MISSION); cache→regex→LLM tier selection.
+- **Unit:** `UniversalRouter.route()` each tier in isolation (0 override, 1 cache hit, 2a rule, 2b trigger, 2.5 semantic, 2c keyword, 3 LLM fallback) — assert the *right tier fires* for crafted inputs.
+- **Unit:** `IntentClassifier` vs `SmartIntentClassifier` — distinct expectations, no cross-contamination.
+- **Integration:** one tool loop turn — message → router → runtime → `UnifiedToolExecutor` → result fed back → streamed. Assert tool events aren't dropped. **Run against both loops** (chat `_run_tool_loop` and AgentFactory `execute_with_prompt`) until they're unified (G6).
+- **Contract:** SSE chunk shape stays AI-SDK compatible.
+
+### 4.2 Memory
+- **Unit:** Ebbinghaus decay math; L1 summary roll; ContextRouter layer selection.
+- **Integration:** write-after-turn writes exactly once per layer (catches the dual-write G12); read-before-turn respects the budget cap; Mem0-down path uses the circuit breaker and degrades (already covered — keep).
+- **Contract:** `ContextBundle` shape.
+
+### 4.3 RAG  *(no functional test today)*
+- **Unit:** semantic chunker boundaries; RRF/rerank ordering; knapsack budget.
+- **Integration:** ingest a doc → Postgres row + S3 object + S3 Vectors entry all created; retrieve returns it; **delete the doc → vector removed** (no orphan, RAG DoD).
+- **Contract:** `external_file_id == documents.id` linkage holds.
+
+### 4.4 NL2SQL
+- **Unit:** validator rewrite/read-only enforcement (keep existing).
+- **Integration:** question → generate → validate → execute against a seeded test DB → self-correct loop on a deliberately bad gen (≤2 retries) → training example saved. Assert **no unvalidated SQL ever executes** and creds never logged.
+
+### 4.5 Knowledge graph (the moat — test it like it matters)
+- **Unit:** `map_shopify_catalog` / `map_orders_to_fbt` edge generation from fixture orders.
+- **Integration:** build from sources → persist to S3 JSON → `load_graph()` round-trips; **rebuild is idempotent**; FBT/collection/vendor edges queryable; graph survives a reload (G11 — single source of truth).
+
+### 4.6 Missions
+- **Unit:** planner DAG validation/retry; `AgentMatcher` role→agent; `deterministic_checks`.
+- **Integration:** full tick lifecycle on a real DB: create → plan → approve → dispatch → complete → reconcile → verify → deliverable. **Restart durability test:** kill and re-create the coordinator mid-run; assert it resumes from DB state (this is the proof Mission Zero P1 is closed). **Stall test:** ASSIGNED>60s / RUNNING>300s → re-dispatch. **Retry-with-critique test** once G5 is fixed.
+- **Contract:** board bridge mirrors `OrchestrationTask` ↔ `BoardTask` correctly (`verified`→`done`).
+
+### 4.7 Playbooks  *(durability hole — G4)*
+- **Integration:** schedule → run → complete (keep `test_recipe_scheduler`). **New, gating: restart-recovery** — start a recipe, kill the process, restart; assert a stuck `running`/`pending` `RecipeExecution` is recovered or failed-cleanly, not orphaned. This test must exist *before* G4 is called fixed.
+
+### 4.8 Channels
+- **Contract (parametrized over all 11 adapters):** each implements `_to_envelope()` → `handle_message()` → `send_message()`; inbound builds a valid `RequestEnvelope`; activity counters update.
+- **Integration:** one adapter (slack) full round-trip against a stub transport.
+
+### 4.9 Cross-cutting (infra)
+- **DB:** connection-leak/pool test — assert `get_db()` leaves no idle-in-transaction connection after a request that hydrates an `Agent` across an `await` (regression for G1).
+- **Migrations:** `alembic upgrade head` then `downgrade base` on a scratch DB in CI; assert `lock_timeout`/`statement_timeout` set (regression for G2).
+- **Config:** CI grep gate — zero `os.getenv` outside `config.py` (regression for G7).
+- **Authz:** unit tests proving `_check_agent_permission` / `validate_composio_action` **deny** on error (regression for G3).
+- **Bare-except gate:** count must not increase (PRD-141 Phase 0 sets this up).
+
+---
+
+## 5. Golden-journey backbone (the e2e suite)
+
+These are the user-visible flows that must never break. Each is one e2e test (backend API-level +
+frontend Playwright where there's UI). This list *is* the "is it working" definition.
+
+| # | Journey | Spans |
+|---|---|---|
+| J1 | **Signup → onboarding wizard → configured workspace** | Clerk → provisioning → VOYAGER/BLUEPRINT/SCRIBE/FORGE → Mission Zero |
+| J2 | **Chat → agent → tool call → response** | router → runtime → UnifiedToolExecutor → SSE |
+| J3 | **Widget message → vertical plugin → response** | widget auth → PLUGIN_REGISTRY → generic core → SSE (run for both `generic` and `shopify`) |
+| J4 | **Mission: create → plan → approve → execute → verify → deliverable** | coordinator full lifecycle + restart durability |
+| J5 | **Doc upload → RAG index → retrieval surfaces in chat** | ingest → S3 Vectors → retrieve-in-turn |
+| J6 | **Marketplace install → cascade dependencies → agent usable** | install → `cascade_agent_dependencies` → runtime |
+| J7 | **Playbook: schedule → run → complete (and recover after restart)** | scheduler → executor → durability |
+| J8 | **NL2SQL: connect DB → ask question → validated SQL → answer** | source → generate → validate → execute |
+| J9 | **Shopify sync → knowledge graph built → FBT proactive opener** | catalog sync → graph → widget opener (the moat, end-to-end) |
+| J10 | **Cross-workspace isolation** | two workspaces, prove no data bleed across J2–J9 |
+
+J9 and J10 are the two that most directly protect the strategy: J9 proves the moat works end-to-end;
+J10 proves the multi-tenant promise.
+
+---
+
+## 6. Frontend strategy (from 1 test to a real net)
+
+- **Tooling:** Vitest (already configured, unused) for unit/component; **Playwright** for e2e (J1–J7
+  have UI). React Testing Library for components.
+- **First targets (highest leverage):**
+  1. `lib/api-client.ts` — it carries auth + `X-Workspace-ID` on every call; a bug here is platform-wide. Unit-test header injection, error envelope handling, retry.
+  2. The ~5 most-used `use-*-api.ts` hooks (chat, missions, deliverables, marketplace, workspace).
+  3. The onboarding wizard (J1) — multi-step, SSE, the first thing every user sees.
+  4. Marketplace install flow (J6).
+- **Contract tests** against the backend OpenAPI so frontend types can't silently drift from the API.
+- **Target:** every valued surface (Command Center, Activity, kanban, analytics, widgets) has at least
+  a smoke test that it renders and its primary action fires.
+
+---
+
+## 7. Test infrastructure
+
+- **DB:** `scripts/init_test_db.py` → ephemeral Postgres per CI run; transactional rollback per test
+  for speed; a small seed (`seed_onboarding_agents` + fixture workspace/agents).
+- **External APIs:** recorded fixtures for LLM and Composio (deterministic, no spend). A nightly job
+  may run a small live-smoke subset.
+- **Layout:** keep `orchestrator/tests/` (backend) and add `frontend/**/__tests__` + `e2e/`
+  (Playwright). Mirror the primitive structure so coverage gaps are obvious.
+- **CI gates (blocking):** golden-journey suite green; no new bare excepts; no `os.getenv` outside
+  config; alembic up/down passes; coverage on touched files ≥ 80%; the Shopify-in-generic gate
+  (existing).
+- **Coverage reporting:** publish per-primitive coverage so the dashboard (§9) can show it.
+
+---
+
+## 8. Sequencing
+
+Implementation is **gated on both PRD-141s merging**. Then, in Rock-Solid Wave order:
+
+1. **Wave 0 (parallel, safe now):** finish this plan + the dashboard spec; stand up the e2e harness
+   skeleton (no assertions yet) so journeys can be filled in fast.
+2. **Wave 2 — Test net (the missing thing):** write J1–J10 golden journeys + the §4 integration tests
+   for the untested primitives (router/assess/tool-loop, RAG, reconciler, playbook durability). This
+   is where the bulk of the work is.
+3. **Per-primitive (Wave 3):** fill unit + contract tests to the DoD as each primitive is hardened;
+   each `BRAIN §8` gap fix lands with its regression test.
+4. **Frontend:** §6, sequenced with the surfaces being hardened.
+
+Order within Wave 2: do the tests that double as gap regressions first (G1 leak, G4 durability,
+G3 fail-closed) — they protect data and reliability, and they're cheap relative to their blast radius.
+
+---
+
+## 9. Tie to "Is it working?"
+
+Wave 0 of the Rock-Solid plan builds one dashboard answering the founding question. This test plan
+feeds it: every golden journey (§5) emits a pass/fail signal, and per-primitive coverage (§7) becomes
+a tile. The dashboard's "mission success rate," "per-primitive health," and "error rate by subsystem"
+are the production mirror of this suite. Tests prove it works in CI; the dashboard proves it works in
+prod. Same contracts, two surfaces.
+
+---
+
+## 10. What this plan is NOT
+
+- Not a mandate to hit 80% on all ~919 backend + 721 frontend files immediately — that's the long
+  tail, reached opportunistically.
+- Not a license to write tests against soon-to-change surfaces before the 141s merge (the gate).
+- Not a replacement for the dashboard — tests are pre-prod proof; the dashboard is live proof.

--- a/scripts/ralph/prd-142-wave0.json
+++ b/scripts/ralph/prd-142-wave0.json
@@ -1,0 +1,145 @@
+{
+  "project": "Automatos AI Platform",
+  "branchName": "ralph/prd-142-wave0-measurement",
+  "description": "PRD-142 Wave 0 — Measurement First (\"Is it working?\" dashboard). Source PRD: docs/PRDS/PRD-142-WAVE0-MEASUREMENT.md. Extension + instrumentation only: surface ONE dashboard section answering the founding question with five real numbers (error rate by subsystem, mission success rate, widget engagement, activation, per-primitive health). REUSE-FIRST (CLAUDE.md §2): record_error (core/utils/exception_telemetry.py) gets a queryable sink; widget_event_log + heartbeat_results + the existing GET /api/analytics/dashboard/success-rate union are reused; the fake successRate:85.0 placeholder in analytics_engine.py is DELETED. NO new frontend page/route — extend frontend/components/dashboard/dashboard.tsx only. NO migrate-and-drop of WorkflowExecution (that is Wave 3 per PLAYBOOK-ENGINE-DESIGN.md §4.2; Wave 0 only reads via the existing union and adds NO new WorkflowExecution reads). NO HARNESS/learning-loop work (Wave 4). NO Grafana board, NO full Playwright net (Wave 2). Phases: A error sink (US-001/002), B reuse+de-fake (US-003/004), C fill gaps (US-005/006), D assemble (US-007), Gate live-verify (US-008). Canonical noun is Mission, never Workflow, in user-facing labels. Every new endpoint is workspace-scoped via get_request_context_hybrid and has a tenant-isolation test.",
+  "userStories": [
+    {
+      "id": "US-001",
+      "title": "Persist record_error to a queryable error_events sink (Phase A)",
+      "description": "As the platform, I need structured errors stored in a queryable table so the dashboard can show error rate by subsystem instead of scraping the automatos.errors logger.",
+      "acceptanceCriteria": [
+        "Create an Alembic migration for table error_events: id BIGSERIAL PK, subsystem VARCHAR(64) NOT NULL, operation VARCHAR(128) NOT NULL, error_type VARCHAR(128), error_message VARCHAR(500), workspace_id UUID NULL, agent_id INT NULL, action_name VARCHAR(128) NULL, event_data JSONB NOT NULL DEFAULT '{}', created_at TIMESTAMP NOT NULL DEFAULT now()",
+        "Add indexes idx_error_events_subsystem_created (subsystem, created_at) and idx_error_events_workspace_created (workspace_id, created_at)",
+        "Add a core/models/error_event.py ORM model following the widget_event_log.py / ToolExecutionLog single-table-JSONB pattern (extend_existing=True)",
+        "Add a best-effort persistence path so record_error rows also land in error_events WITHOUT changing record_error's keyword-only signature or its never-raises contract (mirror modules/widgets/telemetry.py log_widget_event: try/except catch-all, rollback, swallow). The existing automatos.errors logger emit MUST remain unchanged",
+        "If the error_events sink is unavailable, record_error logs and returns — it NEVER raises (telemetry must not mask the original failure)",
+        "Create orchestrator/tests/test_error_events_sink.py: test_record_error_persists_row, test_record_error_sink_failure_is_swallowed, test_record_error_truncates_message_in_db, test_none_workspace_persists",
+        "Type checks pass (mypy/pyright)",
+        "pytest orchestrator/tests/test_error_events_sink.py green"
+      ],
+      "priority": 2,
+      "passes": false,
+      "notes": "Reuse-checked 2026-05-29: no existing error-event table exists; closest is the automatos.errors logger (core/utils/exception_telemetry.py:22). A focused append-only table is justified and follows the established widget_event_log pattern. Do NOT change record_error's signature — handlers already call it with keyword args. Do NOT mass-adopt record_error across handlers here (that was out of scope in PRD-141 US-001 and stays out). The migration must be online-safe (new table, no backfill, no NOT NULL on an existing large table)."
+    },
+    {
+      "id": "US-002",
+      "title": "Error-rate-by-subsystem aggregation endpoint (Phase A)",
+      "description": "As an operator, I need one endpoint that returns error counts grouped by subsystem over a window so the dashboard can render the error-rate tile.",
+      "acceptanceCriteria": [
+        "Add GET /api/analytics/errors/by-subsystem?window=24h to an existing analytics router (api/analytics_real.py or api/analytics.py — do NOT create a new router file)",
+        "Workspace-scoped via ctx = Depends(get_request_context_hybrid); filter error_events by ctx.workspace_id",
+        "Returns {window, total, by_subsystem: [{subsystem, count, rate}], generated_at}; rate = count/total over the window, 0 when total is 0 (no divide-by-zero)",
+        "Query uses idx_error_events_subsystem_created and the created_at window — no full-table scan",
+        "Create orchestrator/tests/test_errors_by_subsystem_endpoint.py: test_groups_by_subsystem, test_window_filtering, test_empty_window_returns_zero, test_workspace_isolation",
+        "Type checks pass",
+        "pytest orchestrator/tests/test_errors_by_subsystem_endpoint.py green"
+      ],
+      "priority": 3,
+      "passes": false,
+      "notes": "BLOCKED by US-001 (needs the error_events table). Reuse the existing analytics router prefix /api/analytics (api/analytics_real.py:32) — do not add a new router. workspace_id NULL rows (system-level errors) are excluded from the workspace-scoped view by design; that is correct, not a bug."
+    },
+    {
+      "id": "US-003",
+      "title": "Delete the fake agent-metrics placeholders (Phase B)",
+      "description": "As a user, I need the dashboard to show real numbers, not a hardcoded 85% success rate.",
+      "acceptanceCriteria": [
+        "In orchestrator/core/services/analytics_engine.py _get_agent_metrics (line ~107) remove the hardcoded successRate: 85.0, avgExecutionTime: 2.5, totalTokensUsed: 0, recentExecutions: 0 placeholder values",
+        "Replace with real values where a real source exists — mission success via the same OrchestrationRun union used by api/analytics_real.py:53; OMIT any field that has no real source rather than fake it",
+        "grep -n '85.0' orchestrator/core/services/analytics_engine.py returns ZERO matches",
+        "grep -n '# Placeholder' orchestrator/core/services/analytics_engine.py returns ZERO matches",
+        "Before removing any key, verify it is not consumed by frontend/components/dashboard/metric-cards.tsx — keep the return-shape stable for fields the UI reads",
+        "Create orchestrator/tests/test_analytics_engine_real_metrics.py: test_agent_metrics_no_placeholders, test_success_rate_matches_orchestration_runs",
+        "Type checks pass",
+        "pytest green; existing analytics tests green"
+      ],
+      "priority": 1,
+      "passes": false,
+      "notes": "Cheapest honesty win — land it first. The fake 85.0 is the literal symptom Wave 0 exists to kill (analytics_engine.py:118). This also satisfies the no-hardcoded-values rule (CLAUDE.md §4). Do NOT touch _get_workflow_metrics (line 144-174) — its mission success math is already real and correct; only _get_agent_metrics is faked."
+    },
+    {
+      "id": "US-004",
+      "title": "Widget-engagement aggregation endpoint (Phase B)",
+      "description": "As an operator, I need widget engagement counts so I can see whether the widgets we ship are actually used.",
+      "acceptanceCriteria": [
+        "Add GET /api/analytics/widget-engagement?window=7d to an existing analytics router (no new router file)",
+        "Workspace-scoped: resolve the sites belonging to ctx.workspace_id, then aggregate widget_event_log for those sites",
+        "Returns {window, by_event_type: [{event_type, count}], sessions, generated_at} grouped over WIDGET_EVENT_TYPES (core/models/widget_event_log.py)",
+        "Query uses idx_widget_event_log_type_created and is read-only — ZERO writes to widget_event_log",
+        "grep -rn 'WidgetEventLog(' orchestrator/api/ in the new endpoint's file returns ZERO matches (read-only; no row construction)",
+        "Create orchestrator/tests/test_widget_engagement_endpoint.py: test_groups_by_event_type, test_window_filtering, test_workspace_site_scoping, test_empty_returns_zero",
+        "Type checks pass",
+        "pytest orchestrator/tests/test_widget_engagement_endpoint.py green"
+      ],
+      "priority": 4,
+      "passes": false,
+      "notes": "Reuse-checked: widget_event_log table + idx_widget_event_log_type_created + writer log_widget_event all exist (PRD-008-A); only the read/aggregation side is missing. Do NOT add new event types or touch the writer modules/widgets/telemetry.py."
+    },
+    {
+      "id": "US-005",
+      "title": "Activation metric — define + compute (Phase C)",
+      "description": "As a founder, I need an activation number so I know whether new workspaces reach first value.",
+      "acceptanceCriteria": [
+        "Add GET /api/analytics/activation to an existing analytics router (no new router file)",
+        "Definition (documented in the endpoint docstring): a workspace is activated when it has >=1 OrchestrationRun with state == 'completed'. Activation rate = activated workspaces / provisioned workspaces",
+        "Returns {activated, total_workspaces, rate, generated_at}; rate is 0 when total_workspaces is 0 (no divide-by-zero); NO fake fallback value",
+        "Computed from OrchestrationRun only — NO new table, NO new WorkflowExecution reads",
+        "Create orchestrator/tests/test_activation_endpoint.py: test_activation_counts_completed_missions, test_rate_zero_when_no_workspaces, test_workspace_with_no_completed_run_not_activated",
+        "Type checks pass",
+        "pytest orchestrator/tests/test_activation_endpoint.py green"
+      ],
+      "priority": 5,
+      "passes": false,
+      "notes": "Use the canonical RunState.COMPLETED.value (core/models/orchestration_enums.py) for the completed check, matching api/analytics_real.py:69 — do not hardcode the string 'completed' if the enum is available. This is a platform-level rate across workspaces; it is the one tile that is intentionally NOT filtered to a single workspace_id."
+    },
+    {
+      "id": "US-006",
+      "title": "Per-primitive health rollup endpoint (Phase C)",
+      "description": "As an operator, I need each of the 8 primitives shown green/degraded/down from the heartbeats we already run.",
+      "acceptanceCriteria": [
+        "Add GET /api/analytics/primitive-health to an existing analytics router (no new router file)",
+        "Roll the latest heartbeat_results findings (api/heartbeat.py) into per-primitive status for: chat, memory, RAG, NL2SQL, graph, missions, playbooks, channels",
+        "Returns {primitives: [{name, status, last_checked}], generated_at}; status in {green, degraded, down, unknown}",
+        "Primitives with no heartbeat coverage report 'unknown' — NOT faked green",
+        "Read-only rollup: NO change to the heartbeat writer, schedule, or heartbeat_results schema",
+        "Create orchestrator/tests/test_primitive_health_endpoint.py: test_maps_findings_to_primitives, test_missing_coverage_is_unknown, test_latest_result_wins",
+        "Type checks pass",
+        "pytest orchestrator/tests/test_primitive_health_endpoint.py green"
+      ],
+      "priority": 6,
+      "passes": false,
+      "notes": "Reuse-checked: heartbeat_results table + GET /api/heartbeat/analytics (api/heartbeat.py:284) exist. If the heartbeat findings do not cleanly map to all 8 primitive names, report the unmapped ones as 'unknown' rather than inventing coverage — honest gaps over fake greens. Keep the primitive name list aligned with PRD-142 §12 Wave 3 (chat/memory/RAG/NL2SQL/graph/missions/playbooks/channels)."
+    },
+    {
+      "id": "US-007",
+      "title": "Assemble the \"Is it working?\" dashboard section (Phase D)",
+      "description": "As a user, I need the five metrics on one screen, on the dashboard I already use — not a new page.",
+      "acceptanceCriteria": [
+        "Add ONE section to frontend/components/dashboard/dashboard.tsx (or a new child component it renders) titled 'Is it working?' with five tiles: Activation, Mission success rate, Per-primitive health, Error rate by subsystem, Widget engagement",
+        "NO new route and NO new page: no new page.tsx is added anywhere under frontend/app/ (verify: git status shows zero new files matching frontend/app/**/page.tsx)",
+        "Add hooks to frontend/hooks/use-analytics-api.ts (or use-unified-analytics.ts) calling the four new endpoints plus the existing /api/analytics/dashboard/success-rate",
+        "Reuse existing Card / MetricCards / recharts patterns and the ApiResponse<T> envelope; tile labels use the canonical noun Mission (never Workflow)",
+        "Loading and empty states handled (no crash on zero data); NO console.log; NO hardcoded metric values in the component",
+        "tsc type checks pass for the frontend",
+        "The section renders without runtime error against the live API (verified in US-008)"
+      ],
+      "priority": 7,
+      "passes": false,
+      "notes": "BLOCKED by US-002, US-003, US-004, US-005, US-006 (renders all five). Extend the existing dashboard — do NOT rewrite the working UI (feedback-ui-changes). Full Playwright E2E for this section is Wave 2 (TEST-PLAN J-series), NOT here. The Dashboard component already wires recharts + react-query hooks (frontend/components/dashboard/dashboard.tsx:65) — follow that exact pattern."
+    },
+    {
+      "id": "US-008",
+      "title": "Live verification gate (operational — not code)",
+      "description": "As Gerard, I need to see five real numbers on a live workspace before Wave 0 is declared done.",
+      "acceptanceCriteria": [
+        "On the deployed Railway frontend, the dashboard 'Is it working?' section renders five REAL values for a workspace with real data (push -> Railway -> verify live URL; never localhost)",
+        "grep -n '85.0' orchestrator/core/services/analytics_engine.py returns ZERO matches (the fake placeholder is gone)",
+        "All four new endpoints return 200 with the documented shapes for that workspace",
+        "Tenant isolation spot-checked live: a second workspace sees its own numbers, not the first's",
+        "passes flips to true ONLY after the live screen is confirmed by Gerard"
+      ],
+      "priority": 8,
+      "passes": false,
+      "notes": "This is an operational gate, not a code story (mirrors PRD-141 US-008/016/026). Do NOT auto-flip passes — it requires Gerard's live confirmation on the Railway URL. This enforces the no-local-builds rule (prod verification only)."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Design-phase only — **no platform code**. Lands the PRD-142 core design review and its companion architecture specs, plus the first wave's build spec. Reviewable as a doc set; nothing here changes runtime behaviour.

**Verdict of the review:** fix-not-rewrite — **0 rewrites**, strangler-fig hardening across the platform.

### Design review + companions
- `docs/PRDS/PRD-142-CORE-DESIGN-REVIEW.md` — rewrite-vs-fix decision per subsystem, 6-wave roadmap, §11 cut list
- `docs/architecture/PLAYBOOK-ENGINE-DESIGN.md` — Playbook consolidate+harden; **C-lite** shared `DurableRunner`; `recipe_executions` + `workflow_executions` **migrate-and-drop** into one `playbook_executions`
- `docs/architecture/KNOWLEDGE-GRAPH-CANONICAL.md` — `workspace_graphs` is the canonical moat store; `knowledge_nodes/edges` **fix-not-cut** (wired in Wave 4); `neural_field` cut with the dead `AgentExecutionManager`
- `docs/architecture/{BRAIN-BLUEPRINT,GUARDRAILS,DIAGRAMS,TEST-PLAN}.md`

### Wave 0 build spec — Measurement first
- `docs/PRDS/PRD-142-WAVE0-MEASUREMENT.md` — one **"Is it working?"** dashboard section answering the founding question with five real numbers (error rate by subsystem, mission success rate, widget engagement, activation, per-primitive health). Reuse-first: `record_error` sink, `widget_event_log`, `heartbeat_results`, the existing `/api/analytics/dashboard/success-rate` union. **Deletes** the fake `successRate: 85.0` placeholder in `analytics_engine.py`. **No new frontend page** — extends the existing dashboard.
- `scripts/ralph/prd-142-wave0.json` — 8 user stories (US-001..008) matching the `prd-141-reliability.json` structure.

## Scope guardrails baked into the Wave 0 spec
- No new frontend page/route; no `WorkflowExecution` migrate-and-drop (that is Wave 3); no HARNESS/learning-loop work (Wave 4); no Grafana board; no full Playwright net (Wave 2).
- Every new endpoint is workspace-scoped with a tenant-isolation test.

## Review checklist
- [ ] Design verdict (fix-not-rewrite) and the 4 locked decisions read correctly
- [ ] Wave 0 scope is the right first slice and the reuse map is accurate
- [ ] No build code should land until the wave is green-lit

## Test plan
- [ ] Docs only — no tests to run. Wave 0 code (with its pytest suite) lands in a separate PR once green-lit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive architecture foundation documents defining platform design principles, invariants, and system boundaries.
  * Introduced strategic planning roadmap with Wave 0 focused on system health visibility through a new "Is it working?" dashboard section measuring error rates, mission success, widget engagement, and platform health.
  * Established development guardrails and testing strategy for platform stability and reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AutomatosAI/automatos-ai/pull/398?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->