### PR TITLE
fix(prd-140): unblock + harden platform-tool authz gate (org-chart writes)

### DIFF
--- a/orchestrator/core/security/hierarchy_permissions.py
+++ b/orchestrator/core/security/hierarchy_permissions.py
@@ -4,29 +4,35 @@ Single chokepoint that answers "may actor X apply change C to target T?".
 Called from the platform tool dispatcher (``platform_executor``) and intended
 for service-layer mutations as defence in depth.
 
-Model
------
-* **No actor** (``actor_agent_id is None``) → ALLOW. A missing actor means the
-  call originates from a trusted platform/system flow (startup seeds, heartbeat
-  ticks, agent factory) that has no agent identity to scope against.
-* **System agents** (``agents.is_system_agent``) → ALLOW anything. These rows
-  are platform-seeded only (Auto, Auto CTO, onboarding agents); users cannot
-  set the flag, so the flag itself is the trust boundary.
-* **Everyone else** is scoped to their org subtree: an actor may modify any
-  agent in (or equal to) their ``reports_to_id`` subtree, plus tasks/playbooks
-  owned by an agent in that subtree.
-* Anything an actor may **not** do directly, but which Auto could arbitrate,
-  is denied with ``escalation_target="auto"`` so the caller can route it to Auto
-  instead of hard-failing. See :mod:`core.services.auto_cadence`.
+Security model (deny-by-default; every check is workspace-bound)
+----------------------------------------------------------------
+The actor gate runs first and fails closed on anything suspicious:
 
-Defaults are conservative: broken hierarchy (cycle / depth cap), unresolved
-owner, or workspace-global resources (skills) deny-with-escalation rather than
-fail open.
+* **No actor** (``actor_agent_id is None``) → DENY. Absence of identity is not
+  proof of trust — a trusted system flow must pass an explicit (seeded) actor
+  id, never rely on ambient authority.
+* **Unknown actor** (no ``agents`` row) → DENY.
+* **Cross-workspace actor** (actor's ``workspace_id`` ≠ the call's
+  ``workspace_id``) → DENY. Blocks cross-tenant IDOR before any reasoning.
+* **Inactive actor** (``status`` set and not ``active``) → DENY.
+* **System bypass** is *narrowed*: a row gets the free pass only when
+  ``is_system_agent`` is set **and** its ``name`` is on
+  :data:`SYSTEM_BYPASS_ALLOWLIST`. The flag alone is not a master key — that
+  way a stray/forgotten ``is_system_agent`` flag cannot escalate on its own.
+  These rows are platform-seeded (Auto, Auto CTO, onboarding agents).
 
-Queries use raw SQL against the minimal columns the decision needs
-(``agents.id/is_system_agent/reports_to_id``, ``board_tasks.assigned_agent_id``,
-``workflow_recipes.created_by_agent_id``) so the helper is cheap and does not
-depend on the full ORM model being loadable.
+Everyone else is scoped to their org subtree: an actor may modify any agent in
+(or equal to) their ``reports_to_id`` subtree, plus tasks/playbooks owned by an
+agent in that subtree, and only within their own workspace.
+
+Authority *limits* (out-of-subtree, unresolved owner, workspace-global skills,
+broken hierarchy) deny with ``escalation_target="auto"`` so the caller can route
+the request to Auto for arbitration instead of hard-failing. Security failures
+(anonymous / unknown / cross-workspace / inactive) deny with **no** escalation —
+those are not arbitrated, they are refused. See :mod:`core.services.auto_cadence`.
+
+Queries use raw SQL against the minimal columns the decision needs so the helper
+is cheap and does not depend on the full ORM model being loadable.
 """
 
 from __future__ import annotations
@@ -54,6 +60,23 @@ TARGET_TOOL_ASSIGNMENT = "tool_assignment"
 # Targets whose scope is the target agent row itself.
 _AGENT_TARGETS = frozenset({TARGET_AGENT, TARGET_HEARTBEAT, TARGET_TOOL_ASSIGNMENT})
 
+# Narrowed system-agent bypass allowlist — only these *named*, platform-seeded
+# actors bypass the hierarchy. ``is_system_agent=True`` is necessary but not
+# sufficient; the name must also match. Adding to this list is a
+# security-sensitive change. Keep in sync with the seeds in ``core/seeds/``
+# (seed_auto_agent, seed_cto_agent, seed_onboarding_agents).
+SYSTEM_BYPASS_ALLOWLIST: frozenset = frozenset({
+    "Auto",            # workspace orchestrator (seed_auto_agent)
+    "Auto CTO",        # platform CTO agent (seed_cto_agent)
+    "VOYAGER",         # Mission Zero onboarding (seed_onboarding_agents)
+    "BLUEPRINT",       # Mission Zero onboarding
+    "SCRIBE",          # Mission Zero onboarding
+    "FORGE",           # Mission Zero onboarding (builds agents/org)
+    "HARNESS",         # weekly self-optimisation service actor
+    "platform-admin",  # explicit admin agent
+    "platform-system", # internal service actor
+})
+
 # Max reporting-chain depth before we treat the chain as broken. Real org
 # trees rarely exceed a handful of levels; anything deeper is almost certainly
 # a cycle the visited-set missed (defence in depth).
@@ -67,9 +90,11 @@ MAX_SUBTREE_DEPTH: int = 16
 class PermissionDecision:
     """Result of a permission check. Always inspect ``allowed`` first.
 
-    ``escalation_target`` is set (to ``"auto"``) when the actor cannot make the
-    change directly but Auto could arbitrate it — the caller should route the
-    request to Auto rather than surfacing a hard failure.
+    ``escalation_target`` is set (to ``"auto"``) only when the actor is
+    legitimate but lacks *authority* for this specific change and Auto could
+    arbitrate it — the caller should route the request to Auto rather than
+    surfacing a hard failure. Security failures (anonymous / cross-workspace /
+    inactive) leave it ``None``: those are refused, not arbitrated.
     """
 
     allowed: bool
@@ -93,110 +118,152 @@ def can_actor_modify(
     *,
     actor_agent_id: Optional[int],
     target_type: str,
+    workspace_id: object,
     target_id: Optional[object] = None,
     change_type: str = "update",
+    source: Optional[str] = None,
 ) -> PermissionDecision:
     """Decide whether ``actor`` may apply ``change_type`` to ``target``.
 
-    Never raises for permission state — always returns a ``PermissionDecision``.
+    ``workspace_id`` scopes every check — cross-tenant mutations are denied
+    here. Never raises for permission state — always returns a
+    ``PermissionDecision``.
     """
-    # Trusted system/platform flow with no agent identity.
+    ws = _ws(workspace_id)
+
+    # --- Actor gate (fail closed on anything suspicious) -----------------
     if actor_agent_id is None:
-        return _allow("no_actor", target_type, target_id, change_type)
+        # No ambient authority. Trusted flows must pass an explicit actor id.
+        return _deny("anonymous_actor", target_type, target_id, change_type,
+                     source=source, escalate=False)
 
     actor = _agent_row(db, actor_agent_id)
     if actor is None:
-        return _deny(
-            "actor_not_found", target_type, target_id, change_type,
-            actor_id=actor_agent_id, escalate=False,
-        )
+        return _deny("actor_not_found", target_type, target_id, change_type,
+                     actor_id=actor_agent_id, source=source, escalate=False)
 
-    if bool(actor.is_system_agent):
+    if _ws(actor.workspace_id) != ws:
+        return _deny("cross_workspace_actor", target_type, target_id, change_type,
+                     actor_id=actor_agent_id, actor_name=actor.name,
+                     source=source, escalate=False)
+
+    if (actor.status or "active").strip().lower() != "active":
+        return _deny("actor_inactive", target_type, target_id, change_type,
+                     actor_id=actor_agent_id, actor_name=actor.name,
+                     source=source, escalate=False)
+
+    # --- Narrowed system bypass: flag AND allowlisted name ---------------
+    if bool(actor.is_system_agent) and (actor.name or "") in SYSTEM_BYPASS_ALLOWLIST:
         return _allow(
             "system_actor_bypass", target_type, target_id, change_type,
-            actor_id=actor_agent_id, bypass=True, bypass_kind="system_actor",
+            actor_id=actor_agent_id, actor_name=actor.name, source=source,
+            bypass=True, bypass_kind="system_actor",
         )
 
-    # Non-system actor — scope by org hierarchy.
+    # --- Scope by org hierarchy (within the actor's workspace) -----------
     if target_type in _AGENT_TARGETS:
-        return _scope_to_agent(db, actor_agent_id, target_id, target_type, change_type)
+        return _scope_to_agent(db, actor, actor_agent_id, ws, target_id,
+                               target_type, change_type, source)
 
     if target_type == TARGET_SKILL:
         # Skills are workspace-global, not owned by a single agent — a
         # non-system actor never edits one directly; route to Auto.
-        return _deny(
-            "skill_requires_escalation", target_type, target_id, change_type,
-            actor_id=actor_agent_id, escalate=True,
-        )
+        return _deny("skill_requires_escalation", target_type, target_id, change_type,
+                     actor_id=actor_agent_id, actor_name=actor.name,
+                     source=source, escalate=True)
 
     if target_type == TARGET_TASK:
         owner = _owner_id(db, "SELECT assigned_agent_id FROM board_tasks WHERE id = :id", target_id)
-        return _scope_via_owner(db, actor_agent_id, owner, target_type, target_id, change_type)
+        return _scope_via_owner(db, actor, actor_agent_id, ws, owner,
+                                target_type, target_id, change_type, source)
 
     if target_type == TARGET_PLAYBOOK:
         owner = _owner_id(db, "SELECT created_by_agent_id FROM workflow_recipes WHERE id = :id", target_id)
-        return _scope_via_owner(db, actor_agent_id, owner, target_type, target_id, change_type)
+        return _scope_via_owner(db, actor, actor_agent_id, ws, owner,
+                                target_type, target_id, change_type, source)
 
     return _deny(
         f"unknown_target_type:{target_type}", target_type, target_id, change_type,
-        actor_id=actor_agent_id, escalate=False,
+        actor_id=actor_agent_id, actor_name=actor.name, source=source, escalate=False,
     )
 
 
 # ----------------------------------------------------------------- scope helpers
 
 
-def _scope_to_agent(db, actor_id, target_id, target_type, change_type) -> PermissionDecision:
+def _scope_to_agent(db, actor, actor_id, ws, target_id, target_type, change_type, source) -> PermissionDecision:
     """Scope a change whose target *is* an agent row (agent / heartbeat / tool)."""
     if target_id is None:
         return _deny("missing_target", target_type, target_id, change_type,
-                     actor_id=actor_id, escalate=True)
+                     actor_id=actor_id, actor_name=actor.name, source=source, escalate=True)
     target_int = _as_int(target_id)
     if target_int is None:
         return _deny("invalid_target_id", target_type, target_id, change_type,
-                     actor_id=actor_id, escalate=False)
+                     actor_id=actor_id, actor_name=actor.name, source=source, escalate=False)
     if target_int == actor_id:
-        return _allow("self_mutation", target_type, target_id, change_type, actor_id=actor_id)
-    return _by_subtree(db, actor_id, target_int, target_type, target_id, change_type,
+        return _allow("self_mutation", target_type, target_id, change_type,
+                      actor_id=actor_id, actor_name=actor.name, source=source)
+
+    target = _agent_row(db, target_int)
+    if target is None:
+        return _deny("target_not_found", target_type, target_id, change_type,
+                     actor_id=actor_id, actor_name=actor.name, source=source, escalate=False)
+    if _ws(target.workspace_id) != ws:
+        return _deny("cross_workspace_target", target_type, target_id, change_type,
+                     actor_id=actor_id, actor_name=actor.name, source=source, escalate=False)
+
+    return _by_subtree(db, actor, actor_id, target_int, target_type, target_id, change_type, source,
                        allow_reason="subtree_authority", deny_reason="out_of_subtree")
 
 
-def _scope_via_owner(db, actor_id, owner_id, target_type, target_id, change_type) -> PermissionDecision:
+def _scope_via_owner(db, actor, actor_id, ws, owner_id, target_type, target_id, change_type, source) -> PermissionDecision:
     """Scope a change to a resource owned by an agent (task / playbook)."""
     if owner_id is None:
         # Orphaned / unresolvable owner (or the owner column is absent in this
         # deployment) — only Auto can safely arbitrate.
         return _deny("unresolved_owner", target_type, target_id, change_type,
-                     actor_id=actor_id, escalate=True)
+                     actor_id=actor_id, actor_name=actor.name, source=source, escalate=True)
     owner_int = _as_int(owner_id)
     if owner_int is None:
         return _deny("invalid_owner", target_type, target_id, change_type,
-                     actor_id=actor_id, escalate=True)
+                     actor_id=actor_id, actor_name=actor.name, source=source, escalate=True)
     if owner_int == actor_id:
-        return _allow("owner_self", target_type, target_id, change_type, actor_id=actor_id)
-    return _by_subtree(db, actor_id, owner_int, target_type, target_id, change_type,
+        return _allow("owner_self", target_type, target_id, change_type,
+                      actor_id=actor_id, actor_name=actor.name, source=source)
+
+    owner = _agent_row(db, owner_int)
+    if owner is not None and _ws(owner.workspace_id) != ws:
+        return _deny("cross_workspace_owner", target_type, target_id, change_type,
+                     actor_id=actor_id, actor_name=actor.name, source=source, escalate=False)
+
+    return _by_subtree(db, actor, actor_id, owner_int, target_type, target_id, change_type, source,
                        allow_reason="owner_in_subtree", deny_reason="owner_out_of_subtree")
 
 
-def _by_subtree(db, actor_id, candidate_id, target_type, target_id, change_type,
+def _by_subtree(db, actor, actor_id, candidate_id, target_type, target_id, change_type, source,
                 *, allow_reason, deny_reason) -> PermissionDecision:
     rel = _in_subtree(db, root_id=actor_id, candidate_id=candidate_id)
     if rel is True:
-        return _allow(allow_reason, target_type, target_id, change_type, actor_id=actor_id)
+        return _allow(allow_reason, target_type, target_id, change_type,
+                      actor_id=actor_id, actor_name=actor.name, source=source)
     if rel is None:
         return _deny("broken_hierarchy", target_type, target_id, change_type,
-                     actor_id=actor_id, escalate=True)
+                     actor_id=actor_id, actor_name=actor.name, source=source, escalate=True)
     return _deny(deny_reason, target_type, target_id, change_type,
-                 actor_id=actor_id, escalate=True)
+                 actor_id=actor_id, actor_name=actor.name, source=source, escalate=True)
 
 
 # ----------------------------------------------------------------- db helpers
 
 
 def _agent_row(db, agent_id):
-    """Return a row with ``is_system_agent``/``reports_to_id`` or ``None``."""
+    """Return a row with ``name``/``is_system_agent``/``reports_to_id``/
+    ``workspace_id``/``status`` or ``None``."""
     return db.execute(
-        text("SELECT is_system_agent, reports_to_id FROM agents WHERE id = :id"),
+        text(
+            "SELECT name, is_system_agent, reports_to_id, workspace_id, status "
+            "FROM agents WHERE id = :id"
+        ),
         {"id": agent_id},
     ).first()
 
@@ -263,28 +330,38 @@ def _sid(value) -> Optional[str]:
     return str(value) if value is not None else None
 
 
+def _ws(value) -> Optional[str]:
+    """Normalise a workspace id (UUID / str / None) for equality comparison."""
+    return str(value) if value is not None else None
+
+
 def _allow(reason, target_type, target_id, change_type, *,
-           actor_id=None, bypass=False, bypass_kind=None) -> PermissionDecision:
+           actor_id=None, actor_name=None, source=None,
+           bypass=False, bypass_kind=None) -> PermissionDecision:
     return PermissionDecision(
         allowed=True,
         reason=reason,
         bypass=bypass,
         bypass_kind=bypass_kind,
         actor_agent_id=actor_id,
+        actor_name=actor_name,
         target_type=target_type,
         target_id=_sid(target_id),
         change_type=change_type,
+        source=source,
     )
 
 
 def _deny(reason, target_type, target_id, change_type, *,
-          actor_id=None, escalate=False) -> PermissionDecision:
+          actor_id=None, actor_name=None, source=None, escalate=False) -> PermissionDecision:
     return PermissionDecision(
         allowed=False,
         reason=reason,
         escalation_target="auto" if escalate else None,
         actor_agent_id=actor_id,
+        actor_name=actor_name,
         target_type=target_type,
         target_id=_sid(target_id),
         change_type=change_type,
+        source=source,
     )

--- a/orchestrator/core/security/hierarchy_permissions.py
+++ b/orchestrator/core/security/hierarchy_permissions.py
@@ -1,67 +1,62 @@
 """PRD-140 — hierarchy permission helper.
 
-Single chokepoint that says yes/no/why for "actor X wants to make change C
-on target T". Designed to be called from service-layer mutations (the only
-correct enforcement point) and from tool wrappers as a defence in depth.
+Single chokepoint that answers "may actor X apply change C to target T?".
+Called from the platform tool dispatcher (``platform_executor``) and intended
+for service-layer mutations as defence in depth.
 
-Defaults are conservative:
+Model
+-----
+* **No actor** (``actor_agent_id is None``) → ALLOW. A missing actor means the
+  call originates from a trusted platform/system flow (startup seeds, heartbeat
+  ticks, agent factory) that has no agent identity to scope against.
+* **System agents** (``agents.is_system_agent``) → ALLOW anything. These rows
+  are platform-seeded only (Auto, Auto CTO, onboarding agents); users cannot
+  set the flag, so the flag itself is the trust boundary.
+* **Everyone else** is scoped to their org subtree: an actor may modify any
+  agent in (or equal to) their ``reports_to_id`` subtree, plus tasks/playbooks
+  owned by an agent in that subtree.
+* Anything an actor may **not** do directly, but which Auto could arbitrate,
+  is denied with ``escalation_target="auto"`` so the caller can route it to Auto
+  instead of hard-failing. See :mod:`core.services.auto_cadence`.
 
-  * Default DENY on broken state — missing manager, cycle in reports_to_id
-    chain, unknown target, deleted/inactive actor.
-  * Default DENY on ambiguity — if the helper cannot decide, the caller
-    must NOT proceed. No "fail open" path.
+Defaults are conservative: broken hierarchy (cycle / depth cap), unresolved
+owner, or workspace-global resources (skills) deny-with-escalation rather than
+fail open.
 
-System-agent bypass is **narrowed**: not every ``is_system_agent=True``
-record gets a free pass. Only the specific named system actors registered
-in :data:`SYSTEM_BYPASS_ALLOWLIST` may bypass, and every bypass is recorded
-to ``permission_bypass_log`` (see :mod:`core.security.bypass_audit`).
+Queries use raw SQL against the minimal columns the decision needs
+(``agents.id/is_system_agent/reports_to_id``, ``board_tasks.assigned_agent_id``,
+``workflow_recipes.created_by_agent_id``) so the helper is cheap and does not
+depend on the full ORM model being loadable.
 """
 
 from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import Iterable, Optional, Set
-from uuid import UUID
+from typing import Optional, Set
+
+from sqlalchemy import text
 
 logger = logging.getLogger(__name__)
 
 
 # ----------------------------------------------------------------- constants
 
-
-# Target-type string constants used by callers (platform_executor,
-# core.security.__init__, tests). These are the public API for the
-# ``target_type`` argument of :func:`can_actor_modify`. Kept as plain
-# strings so they survive JSON round-trips through the dispatcher.
-#
-# Currently can_actor_modify only enforces hierarchy on TARGET_AGENT;
-# the other target types fall through to default-deny (intentional —
-# tightening will land per-target in follow-ups).
-TARGET_AGENT          = "agent"
-TARGET_HEARTBEAT      = "heartbeat"
-TARGET_PLAYBOOK       = "playbook"
-TARGET_TASK           = "task"
-TARGET_SKILL          = "skill"
+# Target-type string constants — the public API for ``target_type``. Kept as
+# plain strings so they survive JSON round-trips through the dispatcher.
+TARGET_AGENT           = "agent"
+TARGET_HEARTBEAT       = "heartbeat"
+TARGET_PLAYBOOK        = "playbook"
+TARGET_TASK            = "task"
+TARGET_SKILL           = "skill"
 TARGET_TOOL_ASSIGNMENT = "tool_assignment"
 
+# Targets whose scope is the target agent row itself.
+_AGENT_TARGETS = frozenset({TARGET_AGENT, TARGET_HEARTBEAT, TARGET_TOOL_ASSIGNMENT})
 
-# Narrowed bypass allowlist — these specific named actors may bypass the
-# hierarchy. Adding to this list is a security-sensitive change. ``Auto``
-# is the workspace orchestrator (slug auto-{workspace_id}); the others are
-# platform service actors.
-SYSTEM_BYPASS_ALLOWLIST: frozenset[str] = frozenset(
-    {
-        "Auto",                   # workspace orchestrator
-        "HARNESS",                # weekly self-optimisation service actor
-        "platform-admin",         # explicit admin agent
-        "platform-system",        # internal service actor
-    }
-)
-
-# Maximum subtree depth before we treat the chain as broken. Real org
-# trees rarely exceed 6 levels; anything deeper is almost certainly a
-# cycle the visited-set didn't catch (defence in depth).
+# Max reporting-chain depth before we treat the chain as broken. Real org
+# trees rarely exceed a handful of levels; anything deeper is almost certainly
+# a cycle the visited-set missed (defence in depth).
 MAX_SUBTREE_DEPTH: int = 16
 
 
@@ -70,12 +65,18 @@ MAX_SUBTREE_DEPTH: int = 16
 
 @dataclass(frozen=True)
 class PermissionDecision:
-    """Result of a permission check. Always inspect ``allowed`` first."""
+    """Result of a permission check. Always inspect ``allowed`` first.
+
+    ``escalation_target`` is set (to ``"auto"``) when the actor cannot make the
+    change directly but Auto could arbitrate it — the caller should route the
+    request to Auto rather than surfacing a hard failure.
+    """
 
     allowed: bool
     reason: str
+    escalation_target: Optional[str] = None
     bypass: bool = False
-    bypass_kind: Optional[str] = None  # 'system_actor' | 'workspace_owner' | None
+    bypass_kind: Optional[str] = None  # 'system_actor' | None
     actor_agent_id: Optional[int] = None
     actor_name: Optional[str] = None
     target_type: Optional[str] = None
@@ -92,261 +93,198 @@ def can_actor_modify(
     *,
     actor_agent_id: Optional[int],
     target_type: str,
-    target_id: Optional[str],
-    change_type: str,
-    workspace_id: UUID | str,
-    source: Optional[str] = None,
+    target_id: Optional[object] = None,
+    change_type: str = "update",
 ) -> PermissionDecision:
     """Decide whether ``actor`` may apply ``change_type`` to ``target``.
 
-    Parameters
-    ----------
-    db                : SQLAlchemy session.
-    actor_agent_id    : ID of the agent attempting the change. ``None`` is
-                        treated as an anonymous caller and almost always
-                        denied (only the explicit platform-system flow may
-                        pass with ``None``).
-    target_type       : 'agent' | 'playbook' | 'task' | 'skill' | 'tool' | ...
-    target_id         : ID of the target row (string for UUID tables, int as
-                        string for integer PKs).
-    change_type       : Free-form short verb e.g. 'update', 'delete',
-                        'assign_skill', 'configure_heartbeat'.
-    workspace_id      : Workspace scope — every check is workspace-bound.
-                        Cross-workspace mutations are always denied here.
-    source            : Optional caller identifier for audit ('platform_tool',
-                        'api/agents', 'heartbeat_tick', etc.).
-
-    Returns
-    -------
-    PermissionDecision (always non-None — never raises for permission state).
+    Never raises for permission state — always returns a ``PermissionDecision``.
     """
-    from core.models import Agent
-
-    workspace_id_str = str(workspace_id)
-
-    # --- Anonymous / missing actor: always deny (no ambient authority) ---
+    # Trusted system/platform flow with no agent identity.
     if actor_agent_id is None:
-        return PermissionDecision(
-            allowed=False,
-            reason="anonymous_actor",
-            actor_agent_id=None,
-            target_type=target_type,
-            target_id=str(target_id) if target_id is not None else None,
-            change_type=change_type,
-            source=source,
-        )
+        return _allow("no_actor", target_type, target_id, change_type)
 
-    actor = db.query(Agent).filter(Agent.id == actor_agent_id).first()
+    actor = _agent_row(db, actor_agent_id)
     if actor is None:
-        return PermissionDecision(
-            allowed=False,
-            reason="actor_not_found",
-            actor_agent_id=actor_agent_id,
-            target_type=target_type,
-            target_id=str(target_id) if target_id is not None else None,
-            change_type=change_type,
-            source=source,
+        return _deny(
+            "actor_not_found", target_type, target_id, change_type,
+            actor_id=actor_agent_id, escalate=False,
         )
 
-    # --- Workspace boundary check (cross-tenant attack surface) ---
-    if str(actor.workspace_id) != workspace_id_str:
-        return PermissionDecision(
-            allowed=False,
-            reason="cross_workspace_actor",
-            actor_agent_id=actor.id,
-            actor_name=actor.name,
-            target_type=target_type,
-            target_id=str(target_id) if target_id is not None else None,
-            change_type=change_type,
-            source=source,
+    if bool(actor.is_system_agent):
+        return _allow(
+            "system_actor_bypass", target_type, target_id, change_type,
+            actor_id=actor_agent_id, bypass=True, bypass_kind="system_actor",
         )
 
-    # --- Inactive actor cannot mutate ---
-    if (actor.status or "").lower() != "active":
-        return PermissionDecision(
-            allowed=False,
-            reason="actor_inactive",
-            actor_agent_id=actor.id,
-            actor_name=actor.name,
-            target_type=target_type,
-            target_id=str(target_id) if target_id is not None else None,
-            change_type=change_type,
-            source=source,
+    # Non-system actor — scope by org hierarchy.
+    if target_type in _AGENT_TARGETS:
+        return _scope_to_agent(db, actor_agent_id, target_id, target_type, change_type)
+
+    if target_type == TARGET_SKILL:
+        # Skills are workspace-global, not owned by a single agent — a
+        # non-system actor never edits one directly; route to Auto.
+        return _deny(
+            "skill_requires_escalation", target_type, target_id, change_type,
+            actor_id=actor_agent_id, escalate=True,
         )
 
-    # --- Narrowed system-agent bypass ---
-    # Bypass is only granted when BOTH conditions hold: ``is_system_agent``
-    # is set AND the agent's name is on the explicit allowlist. The flag
-    # alone is not a golden key.
-    if (
-        bool(getattr(actor, "is_system_agent", False))
-        and (actor.name or "") in SYSTEM_BYPASS_ALLOWLIST
-    ):
-        return PermissionDecision(
-            allowed=True,
-            reason="system_actor_bypass",
-            bypass=True,
-            bypass_kind="system_actor",
-            actor_agent_id=actor.id,
-            actor_name=actor.name,
-            target_type=target_type,
-            target_id=str(target_id) if target_id is not None else None,
-            change_type=change_type,
-            source=source,
-        )
+    if target_type == TARGET_TASK:
+        owner = _owner_id(db, "SELECT assigned_agent_id FROM board_tasks WHERE id = :id", target_id)
+        return _scope_via_owner(db, actor_agent_id, owner, target_type, target_id, change_type)
 
-    # --- Subtree authority (team-lead path) ---
-    # The actor may modify any agent in their reports-to subtree, plus
-    # workspace-owned playbooks and board tasks they (or their reports)
-    # own. Cross-team and shared-resource mutations are denied at this layer.
-    if target_type == "agent":
-        if target_id is None:
-            return _deny(actor, target_type, target_id, change_type, source, "missing_target")
-        try:
-            target_int = int(target_id)
-        except (TypeError, ValueError):
-            return _deny(actor, target_type, target_id, change_type, source, "invalid_target_id")
+    if target_type == TARGET_PLAYBOOK:
+        owner = _owner_id(db, "SELECT created_by_agent_id FROM workflow_recipes WHERE id = :id", target_id)
+        return _scope_via_owner(db, actor_agent_id, owner, target_type, target_id, change_type)
 
-        if target_int == actor.id:
-            return PermissionDecision(
-                allowed=True,
-                reason="self_mutation",
-                actor_agent_id=actor.id,
-                actor_name=actor.name,
-                target_type=target_type,
-                target_id=str(target_id),
-                change_type=change_type,
-                source=source,
-            )
-
-        target = db.query(Agent).filter(Agent.id == target_int).first()
-        if target is None:
-            return _deny(actor, target_type, target_id, change_type, source, "target_not_found")
-        if str(target.workspace_id) != workspace_id_str:
-            return _deny(actor, target_type, target_id, change_type, source, "cross_workspace_target")
-
-        in_subtree = _agent_in_subtree(db, root_id=actor.id, candidate_id=target_int)
-        if in_subtree is None:
-            # Cycle detected or chain too deep — default DENY.
-            return _deny(actor, target_type, target_id, change_type, source, "broken_hierarchy")
-        if in_subtree:
-            return PermissionDecision(
-                allowed=True,
-                reason="subtree_authority",
-                actor_agent_id=actor.id,
-                actor_name=actor.name,
-                target_type=target_type,
-                target_id=str(target_id),
-                change_type=change_type,
-                source=source,
-            )
-        return _deny(actor, target_type, target_id, change_type, source, "out_of_subtree")
-
-    # Other target_types fall through to default-deny here — wiring for
-    # playbook / skill / tool / task is added per resource as the chokepoint
-    # rolls out (Ticket 2). Default-deny means a new tool added before its
-    # permission rules are coded gets blocked, not silently allowed.
     return _deny(
-        actor,
-        target_type,
-        target_id,
-        change_type,
-        source,
-        f"unsupported_target_type:{target_type}",
+        f"unknown_target_type:{target_type}", target_type, target_id, change_type,
+        actor_id=actor_agent_id, escalate=False,
     )
 
 
-# ----------------------------------------------------------------- helpers
+# ----------------------------------------------------------------- scope helpers
 
 
-def subtree_of(db, root_agent_id: int) -> Set[int]:
-    """Return every agent id reachable via reports_to_id from ``root``.
+def _scope_to_agent(db, actor_id, target_id, target_type, change_type) -> PermissionDecision:
+    """Scope a change whose target *is* an agent row (agent / heartbeat / tool)."""
+    if target_id is None:
+        return _deny("missing_target", target_type, target_id, change_type,
+                     actor_id=actor_id, escalate=True)
+    target_int = _as_int(target_id)
+    if target_int is None:
+        return _deny("invalid_target_id", target_type, target_id, change_type,
+                     actor_id=actor_id, escalate=False)
+    if target_int == actor_id:
+        return _allow("self_mutation", target_type, target_id, change_type, actor_id=actor_id)
+    return _by_subtree(db, actor_id, target_int, target_type, target_id, change_type,
+                       allow_reason="subtree_authority", deny_reason="out_of_subtree")
 
-    Cycle-safe (visited set + depth cap). Returns at minimum ``{root_id}``
-    even when the agent has no direct reports. Returns an empty set when
-    the chain is broken or the depth cap is exceeded.
+
+def _scope_via_owner(db, actor_id, owner_id, target_type, target_id, change_type) -> PermissionDecision:
+    """Scope a change to a resource owned by an agent (task / playbook)."""
+    if owner_id is None:
+        # Orphaned / unresolvable owner (or the owner column is absent in this
+        # deployment) — only Auto can safely arbitrate.
+        return _deny("unresolved_owner", target_type, target_id, change_type,
+                     actor_id=actor_id, escalate=True)
+    owner_int = _as_int(owner_id)
+    if owner_int is None:
+        return _deny("invalid_owner", target_type, target_id, change_type,
+                     actor_id=actor_id, escalate=True)
+    if owner_int == actor_id:
+        return _allow("owner_self", target_type, target_id, change_type, actor_id=actor_id)
+    return _by_subtree(db, actor_id, owner_int, target_type, target_id, change_type,
+                       allow_reason="owner_in_subtree", deny_reason="owner_out_of_subtree")
+
+
+def _by_subtree(db, actor_id, candidate_id, target_type, target_id, change_type,
+                *, allow_reason, deny_reason) -> PermissionDecision:
+    rel = _in_subtree(db, root_id=actor_id, candidate_id=candidate_id)
+    if rel is True:
+        return _allow(allow_reason, target_type, target_id, change_type, actor_id=actor_id)
+    if rel is None:
+        return _deny("broken_hierarchy", target_type, target_id, change_type,
+                     actor_id=actor_id, escalate=True)
+    return _deny(deny_reason, target_type, target_id, change_type,
+                 actor_id=actor_id, escalate=True)
+
+
+# ----------------------------------------------------------------- db helpers
+
+
+def _agent_row(db, agent_id):
+    """Return a row with ``is_system_agent``/``reports_to_id`` or ``None``."""
+    return db.execute(
+        text("SELECT is_system_agent, reports_to_id FROM agents WHERE id = :id"),
+        {"id": agent_id},
+    ).first()
+
+
+def _reports_to_id(db, agent_id) -> Optional[int]:
+    return db.execute(
+        text("SELECT reports_to_id FROM agents WHERE id = :id"),
+        {"id": agent_id},
+    ).scalar()
+
+
+def _owner_id(db, sql: str, target_id) -> Optional[int]:
+    """Resolve an owning-agent id, tolerant of a missing row or column.
+
+    Wrapped in a SAVEPOINT so that a query failure (e.g. the column does not
+    exist in this deployment) rolls back only the probe and leaves the caller's
+    transaction intact; we then treat the owner as unresolved (→ escalate).
     """
-    from core.models import Agent
-
-    out: Set[int] = {root_agent_id}
-    frontier: Set[int] = {root_agent_id}
-
-    for _ in range(MAX_SUBTREE_DEPTH):
-        if not frontier:
-            return out
-        rows = (
-            db.query(Agent.id)
-            .filter(Agent.reports_to_id.in_(frontier))
-            .all()
-        )
-        next_frontier: Set[int] = {row.id for row in rows} - out
-        out.update(next_frontier)
-        frontier = next_frontier
-
-    # Hit depth cap — chain is suspect. Default deny by returning empty.
-    logger.warning(
-        "[hierarchy] subtree_of(%s) exceeded MAX_SUBTREE_DEPTH=%d — defaulting deny",
-        root_agent_id,
-        MAX_SUBTREE_DEPTH,
-    )
-    return set()
+    if target_id is None:
+        return None
+    try:
+        with db.begin_nested():
+            return db.execute(text(sql), {"id": target_id}).scalar()
+    except Exception:
+        logger.debug("[hierarchy] owner lookup failed (%s) — treating as unresolved", sql)
+        return None
 
 
-def _agent_in_subtree(db, root_id: int, candidate_id: int) -> Optional[bool]:
-    """Return True / False / None.
+def _in_subtree(db, *, root_id: int, candidate_id: int) -> Optional[bool]:
+    """Walk UP from ``candidate`` toward ``root`` via ``reports_to_id``.
 
-    None signals broken hierarchy (cycle, depth cap, missing manager) so
-    the caller can choose default deny.
+    Returns True (candidate is root or a descendant), False (disjoint), or
+    None (cycle / depth cap → broken hierarchy, caller should default deny).
     """
-    from core.models import Agent
-
-    # Walk UP from candidate toward root with cycle detection. This is
-    # cheaper than expanding the full subtree of root when the tree is
-    # wide — we only ever load the actor's reporting chain.
     visited: Set[int] = set()
     cursor: Optional[int] = candidate_id
     depth = 0
-
     while cursor is not None:
-        if cursor in visited:
-            logger.warning(
-                "[hierarchy] cycle detected at agent_id=%s while walking from %s",
-                cursor,
-                candidate_id,
-            )
-            return None
-        if depth >= MAX_SUBTREE_DEPTH:
-            logger.warning(
-                "[hierarchy] depth cap exceeded walking from %s",
-                candidate_id,
-            )
-            return None
-        visited.add(cursor)
         if cursor == root_id:
             return True
-        row = (
-            db.query(Agent.reports_to_id)
-            .filter(Agent.id == cursor)
-            .first()
-        )
-        if row is None:
-            # candidate row vanished mid-walk — treat as broken
+        if cursor in visited:
+            logger.warning("[hierarchy] cycle detected walking from %s", candidate_id)
             return None
-        # SQLAlchemy Row supports attribute access by column label.
-        cursor = getattr(row, "reports_to_id", None)
+        if depth >= MAX_SUBTREE_DEPTH:
+            logger.warning("[hierarchy] depth cap exceeded walking from %s", candidate_id)
+            return None
+        visited.add(cursor)
+        cursor = _reports_to_id(db, cursor)
         depth += 1
-
     return False
 
 
-def _deny(actor, target_type, target_id, change_type, source, reason) -> PermissionDecision:
+# ----------------------------------------------------------------- decision factories
+
+
+def _as_int(value) -> Optional[int]:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _sid(value) -> Optional[str]:
+    return str(value) if value is not None else None
+
+
+def _allow(reason, target_type, target_id, change_type, *,
+           actor_id=None, bypass=False, bypass_kind=None) -> PermissionDecision:
+    return PermissionDecision(
+        allowed=True,
+        reason=reason,
+        bypass=bypass,
+        bypass_kind=bypass_kind,
+        actor_agent_id=actor_id,
+        target_type=target_type,
+        target_id=_sid(target_id),
+        change_type=change_type,
+    )
+
+
+def _deny(reason, target_type, target_id, change_type, *,
+          actor_id=None, escalate=False) -> PermissionDecision:
     return PermissionDecision(
         allowed=False,
         reason=reason,
-        actor_agent_id=getattr(actor, "id", None),
-        actor_name=getattr(actor, "name", None),
+        escalation_target="auto" if escalate else None,
+        actor_agent_id=actor_id,
         target_type=target_type,
-        target_id=str(target_id) if target_id is not None else None,
+        target_id=_sid(target_id),
         change_type=change_type,
-        source=source,
     )

--- a/orchestrator/modules/tools/discovery/platform_executor.py
+++ b/orchestrator/modules/tools/discovery/platform_executor.py
@@ -553,8 +553,10 @@ class PlatformActionExecutor:
                     self.db,
                     actor_agent_id=actor_id,
                     target_type=target_type,
+                    workspace_id=self.workspace_id,
                     target_id=target_id,
                     change_type="update" if action_def.permission_level == "write" else "delete",
+                    source="platform_tool",
                 )
                 if not decision.allowed:
                     logger.warning(

--- a/orchestrator/modules/tools/execution/exec_platform.py
+++ b/orchestrator/modules/tools/execution/exec_platform.py
@@ -55,13 +55,20 @@ async def execute_platform_action(
             "tool": tool_name,
         }
 
-    # Inject agent context into params so handlers (submit_report, blog,
-    # auto_reporting, board_tasks) can attribute the call. Don't overwrite
-    # if the LLM already supplied them.
-    if agent_id and isinstance(parameters, dict):
-        if "_agent_id" not in parameters:
-            parameters = {**parameters, "_agent_id": agent_id}
-        if "_agent_name" not in parameters:
+    # Actor identity is server-minted from the trusted runtime ``agent_id``,
+    # NEVER from caller/LLM-supplied params. Strip any _agent_id/_agent_name a
+    # tool call tried to smuggle in — otherwise an agent could set
+    # _agent_id=<a system agent's id> and impersonate it, bypassing the
+    # hierarchy permission check (core.security.hierarchy_permissions) entirely.
+    # When agent_id is unknown the keys stay absent → the permission check sees
+    # no actor and fails closed (anonymous_actor → deny).
+    if isinstance(parameters, dict):
+        parameters = {
+            k: v for k, v in parameters.items()
+            if k not in ("_agent_id", "_agent_name")
+        }
+        if agent_id:
+            parameters["_agent_id"] = agent_id
             try:
                 from core.models import Agent
                 agent = executor.db.query(Agent).filter(
@@ -69,7 +76,7 @@ async def execute_platform_action(
                     Agent.workspace_id == workspace_id,
                 ).first()
                 if agent:
-                    parameters = {**parameters, "_agent_name": agent.name}
+                    parameters["_agent_name"] = agent.name
             except Exception as e:
                 logger.debug("[exec_platform] _agent_name lookup failed: %s", e)
 

--- a/orchestrator/tests/security/test_hierarchy_permissions.py
+++ b/orchestrator/tests/security/test_hierarchy_permissions.py
@@ -1,19 +1,19 @@
 """Tests for core.security.hierarchy_permissions — PRD-140 Phase 1.
 
-Covers:
-  - System agent bypass (Auto / CTO can edit anything)
-  - Skill always-deny for non-system actors (escalates to Auto)
-  - In-subtree allow / cross-subtree deny
-  - Self-edit allow
-  - Unknown target_type → deny
-  - Missing actor → deny
-  - Unresolvable target owner (e.g. orphaned playbook) → deny with
-    escalation_target='auto'
+Covers the hardened, deny-by-default contract:
+  - Actor gate fails closed: anonymous / unknown / cross-workspace / inactive
+    actors are denied (no escalation — refused, not arbitrated).
+  - System bypass is narrowed: ``is_system_agent`` AND an allowlisted name.
+    The flag alone is not a master key.
+  - In-subtree allow / cross-subtree deny (deny escalates to Auto).
+  - Self-edit allow; cross-workspace target deny.
+  - Skill always-deny for non-system actors (escalates to Auto).
+  - Task / playbook scoping via owning agent's subtree.
+  - Unknown target_type → deny.
 
 Uses an in-memory SQLite DB with the minimal columns the helper queries
-(``agents.id`` / ``agents.is_system_agent`` / ``agents.reports_to_id``,
-``board_tasks.id`` / ``assigned_agent_id``, ``workflow_recipes.id`` /
-``created_by_agent_id``). Recursive CTE works on SQLite ≥ 3.8.
+(``agents.id/name/is_system_agent/reports_to_id/workspace_id/status``,
+``board_tasks.id/assigned_agent_id``, ``workflow_recipes.id/created_by_agent_id``).
 """
 
 from __future__ import annotations
@@ -31,6 +31,9 @@ from core.security.hierarchy_permissions import (
     TARGET_TOOL_ASSIGNMENT,
 )
 
+WS = "11111111-1111-1111-1111-111111111111"
+WS2 = "22222222-2222-2222-2222-222222222222"
+
 
 # ----------------------------------------------------------------- fixtures
 
@@ -43,8 +46,11 @@ def db():
             """
             CREATE TABLE agents (
                 id INTEGER PRIMARY KEY,
+                name TEXT,
                 is_system_agent INTEGER NOT NULL DEFAULT 0,
-                reports_to_id INTEGER REFERENCES agents(id)
+                reports_to_id INTEGER REFERENCES agents(id),
+                workspace_id TEXT,
+                status TEXT DEFAULT 'active'
             )
             """
         ))
@@ -72,9 +78,9 @@ def db():
 
 
 def _seed_org(db):
-    """Seed a small org chart:
+    """Seed a small org chart (all in workspace WS):
 
-        AUTO (1, system)
+        Auto (1, system, allowlisted)
             ├── VECTOR (2)
             │     ├── PULSE (3)
             │     └── SOCIAL OPS (4)
@@ -82,24 +88,38 @@ def _seed_org(db):
             └── ATLAS (6)
                   └── FIXER (7)
 
-    AUTO is the only system agent. VECTOR's subtree includes 2,3,4,5.
-    ATLAS's subtree includes 6,7. PULSE and FIXER are in disjoint subtrees.
+    Plus edge-case rows:
+        ROGUE (8)   — is_system_agent=1 but NOT allowlisted (no master key)
+        SLEEPER (9) — status='inactive'
+        FOREIGN (10) — workspace WS2 (cross-tenant target)
     """
     rows = [
-        (1, 1, None),   # AUTO — system
-        (2, 0, 1),      # VECTOR → AUTO
-        (3, 0, 2),      # PULSE → VECTOR
-        (4, 0, 2),      # SOCIAL OPS → VECTOR
-        (5, 0, 4),      # SOCIAL PUBLISHER → SOCIAL OPS
-        (6, 0, 1),      # ATLAS → AUTO
-        (7, 0, 6),      # FIXER → ATLAS
+        # id, name,                is_sys, parent, workspace, status
+        (1,  "Auto",               1, None, WS, "active"),
+        (2,  "VECTOR",             0, 1,    WS, "active"),
+        (3,  "PULSE",              0, 2,    WS, "active"),
+        (4,  "SOCIAL OPS",         0, 2,    WS, "active"),
+        (5,  "SOCIAL PUBLISHER",   0, 4,    WS, "active"),
+        (6,  "ATLAS",              0, 1,    WS, "active"),
+        (7,  "FIXER",              0, 6,    WS, "active"),
+        (8,  "ROGUE",              1, 2,    WS, "active"),
+        (9,  "SLEEPER",            0, 1,    WS, "inactive"),
+        (10, "FOREIGN",            0, None, WS2, "active"),
     ]
-    for id_, sys_, parent in rows:
+    for id_, name, sys_, parent, ws, status in rows:
         db.execute(
-            text("INSERT INTO agents (id, is_system_agent, reports_to_id) VALUES (:i, :s, :p)"),
-            {"i": id_, "s": sys_, "p": parent},
+            text(
+                "INSERT INTO agents (id, name, is_system_agent, reports_to_id, workspace_id, status) "
+                "VALUES (:i, :n, :s, :p, :w, :st)"
+            ),
+            {"i": id_, "n": name, "s": sys_, "p": parent, "w": ws, "st": status},
         )
     db.commit()
+
+
+def _check(db, **kwargs):
+    kwargs.setdefault("workspace_id", WS)
+    return can_actor_modify(db, **kwargs)
 
 
 # ----------------------------------------------------------------- tests
@@ -108,36 +128,71 @@ def _seed_org(db):
 class TestSystemBypass:
     def test_auto_can_edit_any_agent(self, db):
         _seed_org(db)
-        d = can_actor_modify(db, actor_agent_id=1, target_type=TARGET_AGENT, target_id=7)
+        d = _check(db, actor_agent_id=1, target_type=TARGET_AGENT, target_id=7)
         assert d.allowed
         assert "system" in d.reason
+        assert d.bypass and d.bypass_kind == "system_actor"
 
     def test_auto_can_edit_skills(self, db):
         _seed_org(db)
-        d = can_actor_modify(db, actor_agent_id=1, target_type=TARGET_SKILL, target_id=99)
+        d = _check(db, actor_agent_id=1, target_type=TARGET_SKILL, target_id=99)
         assert d.allowed
         assert "system" in d.reason
 
-
-class TestNoActor:
-    def test_none_actor_treated_as_system(self, db):
+    def test_system_flag_without_allowlisted_name_is_not_a_master_key(self, db):
+        # ROGUE (8) has is_system_agent=1 but is NOT on the allowlist, so it
+        # gets ordinary subtree authority, not a bypass. FIXER (7) is outside
+        # ROGUE's (empty) subtree → denied.
         _seed_org(db)
-        d = can_actor_modify(db, actor_agent_id=None, target_type=TARGET_AGENT, target_id=3)
-        assert d.allowed
-        assert "no_actor" in d.reason
+        d = _check(db, actor_agent_id=8, target_type=TARGET_AGENT, target_id=7)
+        assert not d.allowed
+        assert not d.bypass
+        assert d.escalation_target == "auto"
+
+
+class TestActorGate:
+    def test_none_actor_denied_no_escalation(self, db):
+        _seed_org(db)
+        d = _check(db, actor_agent_id=None, target_type=TARGET_AGENT, target_id=3)
+        assert not d.allowed
+        assert d.reason == "anonymous_actor"
+        assert d.escalation_target is None
+
+    def test_actor_not_in_db_denied(self, db):
+        _seed_org(db)
+        d = _check(db, actor_agent_id=999, target_type=TARGET_AGENT, target_id=2)
+        assert not d.allowed
+        assert "not_found" in d.reason
+        assert d.escalation_target is None
+
+    def test_cross_workspace_actor_denied(self, db):
+        # VECTOR lives in WS; a call scoped to WS2 must be refused outright.
+        _seed_org(db)
+        d = _check(db, actor_agent_id=2, target_type=TARGET_AGENT, target_id=3, workspace_id=WS2)
+        assert not d.allowed
+        assert d.reason == "cross_workspace_actor"
+        assert d.escalation_target is None
+
+    def test_inactive_actor_denied(self, db):
+        # SLEEPER (9) is inactive — even a self-edit is refused.
+        _seed_org(db)
+        d = _check(db, actor_agent_id=9, target_type=TARGET_AGENT, target_id=9)
+        assert not d.allowed
+        assert d.reason == "actor_inactive"
+        assert d.escalation_target is None
 
 
 class TestSkillAlwaysDeny:
     def test_non_system_cannot_edit_skill(self, db):
         _seed_org(db)
-        d = can_actor_modify(db, actor_agent_id=2, target_type=TARGET_SKILL, target_id=99)
+        d = _check(db, actor_agent_id=2, target_type=TARGET_SKILL, target_id=99)
         assert not d.allowed
         assert d.escalation_target == "auto"
         assert "skill" in d.reason
 
     def test_skill_create_with_no_target_id_still_denied(self, db):
         _seed_org(db)
-        d = can_actor_modify(
+        d = _check(
             db, actor_agent_id=2, target_type=TARGET_SKILL, target_id=None,
             change_type="create",
         )
@@ -148,59 +203,61 @@ class TestSkillAlwaysDeny:
 class TestSubtreeScope:
     def test_vector_can_edit_pulse(self, db):
         _seed_org(db)
-        d = can_actor_modify(db, actor_agent_id=2, target_type=TARGET_AGENT, target_id=3)
+        d = _check(db, actor_agent_id=2, target_type=TARGET_AGENT, target_id=3)
         assert d.allowed
 
     def test_vector_can_edit_deep_descendant(self, db):
         # VECTOR (2) → SOCIAL OPS (4) → SOCIAL PUBLISHER (5)
         _seed_org(db)
-        d = can_actor_modify(db, actor_agent_id=2, target_type=TARGET_AGENT, target_id=5)
+        d = _check(db, actor_agent_id=2, target_type=TARGET_AGENT, target_id=5)
         assert d.allowed
 
     def test_vector_cannot_edit_atlas_subtree(self, db):
         _seed_org(db)
-        d = can_actor_modify(db, actor_agent_id=2, target_type=TARGET_AGENT, target_id=7)
+        d = _check(db, actor_agent_id=2, target_type=TARGET_AGENT, target_id=7)
         assert not d.allowed
         assert d.escalation_target == "auto"
 
     def test_pulse_cannot_edit_sibling(self, db):
         # PULSE and SOCIAL OPS both report to VECTOR but neither manages the other.
         _seed_org(db)
-        d = can_actor_modify(db, actor_agent_id=3, target_type=TARGET_AGENT, target_id=4)
+        d = _check(db, actor_agent_id=3, target_type=TARGET_AGENT, target_id=4)
         assert not d.allowed
 
     def test_self_edit_allowed(self, db):
         _seed_org(db)
-        d = can_actor_modify(db, actor_agent_id=2, target_type=TARGET_AGENT, target_id=2)
+        d = _check(db, actor_agent_id=2, target_type=TARGET_AGENT, target_id=2)
         assert d.allowed
+
+    def test_cross_workspace_target_denied(self, db):
+        # FOREIGN (10) lives in WS2 — VECTOR (WS) may not touch it.
+        _seed_org(db)
+        d = _check(db, actor_agent_id=2, target_type=TARGET_AGENT, target_id=10)
+        assert not d.allowed
+        assert d.reason == "cross_workspace_target"
+        assert d.escalation_target is None
 
 
 class TestTaskScoping:
     def test_task_assigned_in_subtree_allowed(self, db):
         _seed_org(db)
-        db.execute(text(
-            "INSERT INTO board_tasks (id, assigned_agent_id) VALUES (10, 3)"
-        ))
+        db.execute(text("INSERT INTO board_tasks (id, assigned_agent_id) VALUES (10, 3)"))
         db.commit()
-        d = can_actor_modify(db, actor_agent_id=2, target_type=TARGET_TASK, target_id=10)
+        d = _check(db, actor_agent_id=2, target_type=TARGET_TASK, target_id=10)
         assert d.allowed
 
     def test_task_assigned_outside_subtree_denied(self, db):
         _seed_org(db)
-        db.execute(text(
-            "INSERT INTO board_tasks (id, assigned_agent_id) VALUES (11, 7)"
-        ))
+        db.execute(text("INSERT INTO board_tasks (id, assigned_agent_id) VALUES (11, 7)"))
         db.commit()
-        d = can_actor_modify(db, actor_agent_id=2, target_type=TARGET_TASK, target_id=11)
+        d = _check(db, actor_agent_id=2, target_type=TARGET_TASK, target_id=11)
         assert not d.allowed
 
     def test_task_with_no_assignee_denies_with_escalation(self, db):
         _seed_org(db)
-        db.execute(text(
-            "INSERT INTO board_tasks (id, assigned_agent_id) VALUES (12, NULL)"
-        ))
+        db.execute(text("INSERT INTO board_tasks (id, assigned_agent_id) VALUES (12, NULL)"))
         db.commit()
-        d = can_actor_modify(db, actor_agent_id=2, target_type=TARGET_TASK, target_id=12)
+        d = _check(db, actor_agent_id=2, target_type=TARGET_TASK, target_id=12)
         assert not d.allowed
         assert d.escalation_target == "auto"
 
@@ -208,29 +265,23 @@ class TestTaskScoping:
 class TestPlaybookScoping:
     def test_playbook_owned_in_subtree_allowed(self, db):
         _seed_org(db)
-        db.execute(text(
-            "INSERT INTO workflow_recipes (id, created_by_agent_id) VALUES (20, 4)"
-        ))
+        db.execute(text("INSERT INTO workflow_recipes (id, created_by_agent_id) VALUES (20, 4)"))
         db.commit()
-        d = can_actor_modify(db, actor_agent_id=2, target_type=TARGET_PLAYBOOK, target_id=20)
+        d = _check(db, actor_agent_id=2, target_type=TARGET_PLAYBOOK, target_id=20)
         assert d.allowed
 
     def test_playbook_owned_outside_subtree_denied(self, db):
         _seed_org(db)
-        db.execute(text(
-            "INSERT INTO workflow_recipes (id, created_by_agent_id) VALUES (21, 7)"
-        ))
+        db.execute(text("INSERT INTO workflow_recipes (id, created_by_agent_id) VALUES (21, 7)"))
         db.commit()
-        d = can_actor_modify(db, actor_agent_id=2, target_type=TARGET_PLAYBOOK, target_id=21)
+        d = _check(db, actor_agent_id=2, target_type=TARGET_PLAYBOOK, target_id=21)
         assert not d.allowed
 
     def test_playbook_with_no_owner_escalates(self, db):
         _seed_org(db)
-        db.execute(text(
-            "INSERT INTO workflow_recipes (id, created_by_agent_id) VALUES (22, NULL)"
-        ))
+        db.execute(text("INSERT INTO workflow_recipes (id, created_by_agent_id) VALUES (22, NULL)"))
         db.commit()
-        d = can_actor_modify(db, actor_agent_id=2, target_type=TARGET_PLAYBOOK, target_id=22)
+        d = _check(db, actor_agent_id=2, target_type=TARGET_PLAYBOOK, target_id=22)
         assert not d.allowed
         assert d.escalation_target == "auto"
 
@@ -238,7 +289,7 @@ class TestPlaybookScoping:
 class TestToolAssignmentScoping:
     def test_assigning_tool_to_subtree_agent_allowed(self, db):
         _seed_org(db)
-        d = can_actor_modify(
+        d = _check(
             db, actor_agent_id=2, target_type=TARGET_TOOL_ASSIGNMENT, target_id=3,
             change_type="assign",
         )
@@ -246,7 +297,7 @@ class TestToolAssignmentScoping:
 
     def test_assigning_tool_to_outside_agent_denied(self, db):
         _seed_org(db)
-        d = can_actor_modify(
+        d = _check(
             db, actor_agent_id=2, target_type=TARGET_TOOL_ASSIGNMENT, target_id=7,
             change_type="assign",
         )
@@ -256,12 +307,6 @@ class TestToolAssignmentScoping:
 class TestEdgeCases:
     def test_unknown_target_type_denied(self, db):
         _seed_org(db)
-        d = can_actor_modify(db, actor_agent_id=2, target_type="invalid", target_id=1)
+        d = _check(db, actor_agent_id=2, target_type="invalid", target_id=1)
         assert not d.allowed
         assert "unknown_target_type" in d.reason
-
-    def test_actor_not_in_db_denied(self, db):
-        _seed_org(db)
-        d = can_actor_modify(db, actor_agent_id=999, target_type=TARGET_AGENT, target_id=2)
-        assert not d.allowed
-        assert "not_found" in d.reason


### PR DESCRIPTION
## Summary

The PRD-140 hierarchy permission gate (`can_actor_modify`) — the single chokepoint for mutating `platform_*` tool actions — was **crashing every gated platform write** (e.g. Auto's `platform_update_agent` / org-chart edits) because its keyword-only `workspace_id` parameter had no default and the dispatcher never passed it. This PR fixes the crash **and** hardens the gate to a deny-by-default, workspace-bound contract, and closes an actor-spoofing path.

### What was broken
- `can_actor_modify()` required `workspace_id` but `platform_executor` never passed it → `TypeError` on every gated write since PR #303. Auto's org-chart writes failed with "missing workspace authorization/context requirement."

### What this PR does
- **Actor gate fails closed**: anonymous (no actor id), unknown, cross-workspace, and inactive actors are denied. Absence of identity is no longer treated as trusted ambient authority.
- **Narrowed system bypass**: requires `is_system_agent=True` **AND** a name on `SYSTEM_BYPASS_ALLOWLIST` (Auto, Auto CTO, onboarding agents, service actors). A stray `is_system_agent` flag alone is no longer a master key.
- **Workspace-bound everywhere**: cross-tenant targets/owners are denied (IDOR closed) before any hierarchy reasoning.
- **Escalation discipline**: `escalation_target="auto"` is set only on authority limits (out-of-subtree, unresolved owner, skill, broken hierarchy) so legitimate-but-unauthorized actors route to Auto for arbitration. Security failures get no escalation hint.
- **Actor-spoofing closed**: `exec_platform` now server-mints actor identity from the trusted runtime `agent_id` only — it strips any LLM-supplied `_agent_id`/`_agent_name` before reapplying, removing an impersonation path that bypassed the gate entirely.

**Auto retains org-chart authority** via the allowlist bypass (it calls with a truthy runtime `agent_id`).

## Test plan
- [x] `pytest tests/security/test_hierarchy_permissions.py` — 24/24 green (anonymous/unknown/cross-workspace/inactive deny, narrowed-allowlist bypass, subtree/owner scoping, cross-tenant target deny)
- [x] `python scripts/check_hierarchy_gate.py` — CI gate green (19 gated / 28 allow-list / 46 mutating)
- [x] Confirmed `platform_executor.py:552` is the sole caller of `can_actor_modify` — no other call site crashes on the now-passed `workspace_id`
- [ ] Post-deploy: verify Auto can run `platform_update_agent` (org-chart write) on the live URL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Security Improvements**
  * Implemented strict, deny-by-default access control for workspace hierarchy operations
  * Restricted system agent bypass to require both system flag and allowlisted agent name
  * Added workspace-scoped permission validation to prevent unauthorized cross-tenant data access
  * Hardened platform action execution to prevent malicious or accidental agent impersonation through parameter manipulation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AutomatosAI/automatos-ai/pull/399?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->