### PR TITLE
feat(prd-142): Wave 0 measurement backend (real dashboard metrics)

### DIFF
--- a/orchestrator/alembic/versions/prd142_wave0_error_events.py
+++ b/orchestrator/alembic/versions/prd142_wave0_error_events.py
@@ -1,0 +1,69 @@
+"""PRD-142 Wave 0 US-001: error_events queryable sink
+
+Append-only table backing the dashboard's "error rate by subsystem" tile.
+Mirrors the PRD-008-A widget_event_log pattern: single table, JSONB
+payload, two indexes that match the dashboard rollup queries.
+
+Online-safe: creates a brand-new table only. No backfill, no NOT NULL
+added to an existing large table, no data migration.
+
+Standalone migration (down_revision = None) — the orchestrator alembic
+config has many heads and this matches the established convention for
+add-a-table changes (see add_job_title_to_agents.py).
+
+Revision ID: prd142_wave0_error_events
+Create Date: 2026-05-29
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB, UUID as PGUUID
+
+
+revision = "prd142_wave0_error_events"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "error_events",
+        sa.Column("id", sa.BigInteger, primary_key=True, autoincrement=True),
+        sa.Column("subsystem", sa.String(64), nullable=False),
+        sa.Column("operation", sa.String(128), nullable=False),
+        sa.Column("error_type", sa.String(128), nullable=True),
+        sa.Column("error_message", sa.String(500), nullable=True),
+        sa.Column("workspace_id", PGUUID(as_uuid=True), nullable=True),
+        sa.Column("agent_id", sa.Integer, nullable=True),
+        sa.Column("action_name", sa.String(128), nullable=True),
+        sa.Column(
+            "event_data",
+            JSONB,
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime,
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    op.create_index(
+        "idx_error_events_subsystem_created",
+        "error_events",
+        ["subsystem", "created_at"],
+    )
+    op.create_index(
+        "idx_error_events_workspace_created",
+        "error_events",
+        ["workspace_id", "created_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_error_events_workspace_created", table_name="error_events")
+    op.drop_index("idx_error_events_subsystem_created", table_name="error_events")
+    op.drop_table("error_events")

--- a/orchestrator/api/analytics_real.py
+++ b/orchestrator/api/analytics_real.py
@@ -21,6 +21,8 @@ from core.models.core import LLMUsage
 from core.models.error_event import ErrorEvent
 from core.models.orchestration import OrchestrationRun, OrchestrationTask
 from core.models.orchestration_enums import RunState, TaskState, TERMINAL_RUN_STATES
+from core.models.sites import Site
+from core.models.widget_event_log import WIDGET_EVENT_TYPES, WidgetEventLog
 import logging
 import psutil
 import time
@@ -182,6 +184,85 @@ async def get_errors_by_subsystem(
         "window": window,
         "total": total,
         "by_subsystem": by_subsystem,
+        "generated_at": datetime.utcnow().isoformat(),
+    }
+
+
+@router.get("/widget-engagement")
+async def get_widget_engagement(
+    window: str = "7d",
+    ctx: RequestContext = Depends(get_request_context_hybrid),
+    db: Session = Depends(get_db),
+) -> Dict[str, Any]:
+    """Widget engagement counts by event_type + distinct sessions (PRD-142 Wave 0 US-004).
+
+    Backs the dashboard "Widget engagement" tile. Read-only aggregation
+    over ``widget_event_log`` (writer: ``modules/widgets/telemetry.py``;
+    schema: ``core/models/widget_event_log.py``). This endpoint does NOT
+    construct ``WidgetEventLog`` rows — telemetry's writer remains the
+    single source of truth.
+
+    Tenant isolation: ``widget_event_log`` has no ``workspace_id``
+    column, so we resolve the caller's ``sites`` first (one workspace,
+    many sites — PRD-008-A) and restrict the aggregation to that set.
+    A workspace with zero sites short-circuits to an empty payload.
+
+    Index path: the aggregation filters
+    ``event_type IN WIDGET_EVENT_TYPES`` so
+    ``idx_widget_event_log_type_created`` is eligible alongside the
+    ``created_at >= cutoff`` window — no full-table scan.
+
+    Returns ``{window, by_event_type: [{event_type, count}], sessions,
+    generated_at}``.
+    """
+    window_start = datetime.utcnow() - _parse_window(window)
+
+    site_rows = (
+        db.query(Site.id).filter(Site.workspace_id == ctx.workspace_id).all()
+    )
+    site_ids = [row[0] for row in site_rows]
+
+    if not site_ids:
+        return {
+            "window": window,
+            "by_event_type": [],
+            "sessions": 0,
+            "generated_at": datetime.utcnow().isoformat(),
+        }
+
+    agg_rows = (
+        db.query(
+            WidgetEventLog.event_type,
+            func.count(WidgetEventLog.id).label("count"),
+        )
+        .filter(
+            WidgetEventLog.site_id.in_(site_ids),
+            WidgetEventLog.event_type.in_(WIDGET_EVENT_TYPES),
+            WidgetEventLog.created_at >= window_start,
+        )
+        .group_by(WidgetEventLog.event_type)
+        .all()
+    )
+
+    by_event_type = [
+        {"event_type": r.event_type, "count": int(r.count or 0)}
+        for r in agg_rows
+    ]
+
+    sessions = (
+        db.query(func.count(func.distinct(WidgetEventLog.session_id)))
+        .filter(
+            WidgetEventLog.site_id.in_(site_ids),
+            WidgetEventLog.event_type.in_(WIDGET_EVENT_TYPES),
+            WidgetEventLog.created_at >= window_start,
+        )
+        .scalar()
+    ) or 0
+
+    return {
+        "window": window,
+        "by_event_type": by_event_type,
+        "sessions": int(sessions),
         "generated_at": datetime.utcnow().isoformat(),
     }
 

--- a/orchestrator/api/analytics_real.py
+++ b/orchestrator/api/analytics_real.py
@@ -18,6 +18,7 @@ from core.models import (
     AgentStatistics, SystemMetrics
 )
 from core.models.core import LLMUsage
+from core.models.error_event import ErrorEvent
 from core.models.orchestration import OrchestrationRun, OrchestrationTask
 from core.models.orchestration_enums import RunState, TaskState, TERMINAL_RUN_STATES
 import logging
@@ -107,6 +108,83 @@ async def get_agent_success_rate(ctx: RequestContext = Depends(get_request_conte
     except Exception as e:
         logger.error(f"Error calculating success rate: {e}")
         return {"value": 0, "trend": 0, "total_executions": 0, "successful_executions": 0, "error": str(e)}
+
+def _parse_window(window: str) -> timedelta:
+    """Parse a window string like '24h' or '7d' into a timedelta.
+
+    Supports ``h`` (hours) and ``d`` (days). Falls back to 24h on malformed
+    input — dashboard queries should not 400 because a UI sent a stale param.
+    """
+    try:
+        if not window:
+            return timedelta(hours=24)
+        unit = window[-1].lower()
+        value = int(window[:-1])
+        if value <= 0:
+            return timedelta(hours=24)
+        if unit == "h":
+            return timedelta(hours=value)
+        if unit == "d":
+            return timedelta(days=value)
+    except (ValueError, IndexError):
+        pass
+    return timedelta(hours=24)
+
+
+@router.get("/errors/by-subsystem")
+async def get_errors_by_subsystem(
+    window: str = "24h",
+    ctx: RequestContext = Depends(get_request_context_hybrid),
+    db: Session = Depends(get_db),
+) -> Dict[str, Any]:
+    """Error count by subsystem over a rolling window (PRD-142 Wave 0 US-002).
+
+    Backs the dashboard "Error rate by subsystem" tile. Reads from the
+    ``error_events`` sink populated by ``record_error`` (US-001). Filters
+    by the caller's workspace; system-level rows (``workspace_id IS NULL``)
+    are excluded from this workspace-scoped view by design — the
+    dashboard tile shows per-tenant errors only.
+
+    Index path: ``idx_error_events_subsystem_created`` /
+    ``idx_error_events_workspace_created`` cover the ``(workspace_id,
+    created_at)`` filter + ``GROUP BY subsystem`` — no full-table scan.
+
+    Returns ``{window, total, by_subsystem: [{subsystem, count, rate}],
+    generated_at}``. ``rate = count / total`` over the window; 0 when
+    total is 0 (no divide-by-zero).
+    """
+    window_start = datetime.utcnow() - _parse_window(window)
+
+    rows = (
+        db.query(
+            ErrorEvent.subsystem,
+            func.count(ErrorEvent.id).label("count"),
+        )
+        .filter(
+            ErrorEvent.workspace_id == ctx.workspace_id,
+            ErrorEvent.created_at >= window_start,
+        )
+        .group_by(ErrorEvent.subsystem)
+        .all()
+    )
+
+    total = int(sum(int(r.count or 0) for r in rows))
+    by_subsystem = [
+        {
+            "subsystem": r.subsystem,
+            "count": int(r.count or 0),
+            "rate": (int(r.count or 0) / total) if total > 0 else 0,
+        }
+        for r in rows
+    ]
+
+    return {
+        "window": window,
+        "total": total,
+        "by_subsystem": by_subsystem,
+        "generated_at": datetime.utcnow().isoformat(),
+    }
+
 
 @router.get("/dashboard/task-completion-time")
 async def get_avg_task_completion_time(ctx: RequestContext = Depends(get_request_context_hybrid), db: Session = Depends(get_db)) -> Dict[str, Any]:

--- a/orchestrator/api/analytics_real.py
+++ b/orchestrator/api/analytics_real.py
@@ -23,6 +23,7 @@ from core.models.orchestration import OrchestrationRun, OrchestrationTask
 from core.models.orchestration_enums import RunState, TaskState, TERMINAL_RUN_STATES
 from core.models.sites import Site
 from core.models.widget_event_log import WIDGET_EVENT_TYPES, WidgetEventLog
+from core.models.workspaces import Workspace
 import logging
 import psutil
 import time
@@ -263,6 +264,51 @@ async def get_widget_engagement(
         "window": window,
         "by_event_type": by_event_type,
         "sessions": int(sessions),
+        "generated_at": datetime.utcnow().isoformat(),
+    }
+
+
+@router.get("/activation")
+async def get_activation(
+    ctx: RequestContext = Depends(get_request_context_hybrid),
+    db: Session = Depends(get_db),
+) -> Dict[str, Any]:
+    """Platform-wide activation rate (PRD-142 Wave 0 US-005).
+
+    Definition: a workspace is "activated" when it has >=1
+    ``OrchestrationRun`` with ``state == RunState.COMPLETED.value`` —
+    i.e. at least one mission has reached the canonical terminal success
+    state (``core/models/orchestration_enums.py``). The activation rate
+    is ``activated_workspaces / provisioned_workspaces``.
+
+    This is the one Wave 0 tile that is intentionally NOT filtered to a
+    single ``workspace_id`` — it answers a platform-level founder
+    question ("are new workspaces reaching first value?"), not a tenant
+    question. The endpoint still requires authentication via
+    ``get_request_context_hybrid`` to gate access to the aggregate.
+
+    Computed from ``OrchestrationRun`` only — NO new table, NO
+    ``WorkflowExecution`` reads (Wave 0 scope; the ``WorkflowExecution``
+    drop is owned by Wave 3 per PLAYBOOK-ENGINE-DESIGN.md §4.2).
+
+    Returns ``{activated, total_workspaces, rate, generated_at}``;
+    ``rate = activated / total_workspaces``, 0 when ``total_workspaces``
+    is 0 (no divide-by-zero, no fake fallback value).
+    """
+    activated = (
+        db.query(func.count(func.distinct(OrchestrationRun.workspace_id)))
+        .filter(OrchestrationRun.state == RunState.COMPLETED.value)
+        .scalar()
+    ) or 0
+
+    total_workspaces = db.query(func.count(Workspace.id)).scalar() or 0
+
+    rate = (activated / total_workspaces) if total_workspaces > 0 else 0
+
+    return {
+        "activated": int(activated),
+        "total_workspaces": int(total_workspaces),
+        "rate": rate,
         "generated_at": datetime.utcnow().isoformat(),
     }
 

--- a/orchestrator/core/models/error_event.py
+++ b/orchestrator/core/models/error_event.py
@@ -1,0 +1,70 @@
+"""
+ErrorEvent ORM model (PRD-142 Wave 0 US-001).
+
+Append-only queryable sink for ``record_error`` records. The
+``automatos.errors`` logger emit is the source of truth for *log* sinks;
+this table is the source of truth for *dashboard* rollups — specifically
+the "error rate by subsystem" tile defined in PRD-142 Wave 0.
+
+Pattern follows PRD-008-A ``WidgetEventLog`` / PRD-139 ``ToolExecutionLog``:
+single table, JSONB payload, fire-and-forget writer that never propagates
+failures (see ``core/utils/exception_telemetry.py``).
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import BigInteger, Column, DateTime, Index, Integer, String
+from sqlalchemy.dialects.postgresql import JSONB, UUID as PGUUID
+from sqlalchemy.sql import func
+
+from core.database.base import Base
+
+
+class ErrorEvent(Base):
+    __tablename__ = "error_events"
+    __table_args__ = (
+        Index("idx_error_events_subsystem_created", "subsystem", "created_at"),
+        Index("idx_error_events_workspace_created", "workspace_id", "created_at"),
+        {"extend_existing": True},
+    )
+
+    id = Column(BigInteger, primary_key=True, autoincrement=True)
+
+    # Coarse origin of the failure (e.g. "memory", "tools", "harness").
+    # Dashboard groups by this column.
+    subsystem = Column(String(64), nullable=False)
+
+    # The specific operation that failed (e.g. "add_memory").
+    operation = Column(String(128), nullable=False)
+
+    # Python exception class name. Nullable because record_error tolerates
+    # arbitrary objects in `error` and we never want a sink write to be the
+    # thing that fails persistence.
+    error_type = Column(String(128), nullable=True)
+
+    # Truncated exception message — VARCHAR(500) to bound storage and
+    # protect downstream JSON parsers from pathological strings.
+    error_message = Column(String(500), nullable=True)
+
+    # Owning workspace, if known. NULL for system-level errors raised
+    # before workspace context is established (startup, cron, etc.).
+    workspace_id = Column(PGUUID(as_uuid=True), nullable=True)
+
+    # Owning agent, if known.
+    agent_id = Column(Integer, nullable=True)
+
+    # Platform action involved, if any.
+    action_name = Column(String(128), nullable=True)
+
+    # Caller-supplied extras (correlation IDs, tool/plumbing context, ...).
+    # Keep small (<2KB typical). Schema is per-subsystem and intentionally
+    # loose so this table can outlive any one PRD's metadata choices.
+    event_data = Column(JSONB, nullable=False, server_default="{}")
+
+    created_at = Column(DateTime, server_default=func.now(), nullable=False)
+
+    def __repr__(self) -> str:
+        return (
+            f"<ErrorEvent id={self.id} subsystem={self.subsystem!r} "
+            f"operation={self.operation!r} type={self.error_type!r}>"
+        )

--- a/orchestrator/core/services/analytics_engine.py
+++ b/orchestrator/core/services/analytics_engine.py
@@ -111,14 +111,10 @@ class AnalyticsEngine:
             active_agents = self.db.query(Agent).filter(Agent.status == 'active').count()
             total_agents = self.db.query(Agent).count()
             
-            # Basic metrics
+            # Real counts only — agent success/exec/tokens are omitted until a real source exists (mission success rate lives in _get_workflow_metrics), not faked
             return {
                 "activeAgents": active_agents,
                 "totalAgents": total_agents,
-                "successRate": 85.0,  # Placeholder
-                "avgExecutionTime": 2.5,  # Placeholder
-                "totalTokensUsed": 0,  # Placeholder
-                "recentExecutions": 0  # Placeholder
             }
             
         except Exception as e:
@@ -407,19 +403,19 @@ class AnalyticsEngine:
             return "Unknown"
     
     async def get_agent_analytics(self, agent_id: int, period: str = "7d") -> Dict[str, Any]:
-        """Get detailed analytics for a specific agent"""
+        """Get detailed analytics for a specific agent.
+
+        Per-agent execution metrics (success rate, avg time, tokens) have no
+        persisted source yet — track_agent_execution only logs/publishes to
+        Redis — so they are omitted rather than faked. Mission-level success
+        rate lives in _get_workflow_metrics.
+        """
         try:
-            # Placeholder implementation
             return {
                 "agentId": agent_id,
                 "period": period,
-                "successRate": 85.0,
-                "avgExecutionTime": 2.5,
-                "totalTokensUsed": 0,
-                "totalExecutions": 0,
-                "performanceTrend": []
             }
-            
+
         except Exception as e:
             logger.error(f"Error getting agent analytics: {e}", exc_info=True)
             return {"error": str(e)}

--- a/orchestrator/core/utils/exception_telemetry.py
+++ b/orchestrator/core/utils/exception_telemetry.py
@@ -6,6 +6,13 @@
 subsystem error rates (e.g. Phase 1's "Mem0 error rate < 0.1%") are counted by
 filtering the ``automatos.errors`` logger on ``structured_error.subsystem``.
 
+PRD-142 Wave 0 US-001 added a best-effort persistence path so the same
+records also land in the queryable ``error_events`` table, which backs the
+dashboard "error rate by subsystem" tile. The persistence path is purely
+additive: the logger emit is unchanged, the signature is unchanged, and a
+failed sink write (DB outage, missing table, anything) is swallowed because
+telemetry must not mask the original failure.
+
 This module is pure-additive. It does not replace existing handlers; callers
 opt in by invoking ``record_error`` from within their ``except`` block.
 """
@@ -15,11 +22,22 @@ import logging
 from typing import Any, Dict, Optional
 from uuid import UUID
 
+# Imported at module scope so tests can monkey-patch SessionLocal. The
+# import is wrapped to tolerate environments where the DB layer can't be
+# initialised (alembic offline mode, lightweight smoke tests, ...) — we
+# fall back to None and the sink path becomes a no-op, preserving the
+# never-raises contract.
+try:  # pragma: no cover — import-time guard
+    from core.database.database import SessionLocal
+except Exception:  # noqa: BLE001 — telemetry must never crash at import
+    SessionLocal = None  # type: ignore[assignment]
+
 # Dedicated channel so log processors can route/aggregate errors without
 # scraping the message text. The existing ContextFilter (see
 # core/utils/logging_adapter.py) still enriches these records with ambient
 # request/workspace context when installed.
 _ERROR_LOGGER = logging.getLogger("automatos.errors")
+_SINK_LOGGER = logging.getLogger(__name__)
 
 # Bound the message so a pathological exception string cannot blow up log
 # storage or downstream JSON parsers.
@@ -50,6 +68,11 @@ def record_error(
     The record carries a ``structured_error`` ``extra`` dict and ``exc_info=True``
     so handlers within an ``except`` block also capture the traceback. This
     function never raises — telemetry must not mask the original failure.
+
+    PRD-142 Wave 0 US-001: the record is also persisted to ``error_events``
+    on a best-effort basis. A failed sink write is logged at WARNING and
+    swallowed; the ``automatos.errors`` emit above always happens first so
+    we never blind-spot a failure when the DB is down.
     """
     error_message = str(error)[:_MAX_MESSAGE_LEN]
 
@@ -73,3 +96,70 @@ def record_error(
         exc_info=True,
         extra={"structured_error": structured_error},
     )
+
+    _persist_error_event(
+        subsystem=subsystem,
+        operation=operation,
+        error=error,
+        error_message=error_message,
+        workspace_id=workspace_id,
+        agent_id=agent_id,
+        action_name=action_name,
+        extra=extra,
+    )
+
+
+def _persist_error_event(
+    *,
+    subsystem: str,
+    operation: str,
+    error: Exception,
+    error_message: str,
+    workspace_id: Optional[UUID],
+    agent_id: Optional[int],
+    action_name: Optional[str],
+    extra: Optional[Dict[str, Any]],
+) -> None:
+    """Best-effort write to ``error_events``.
+
+    Mirrors ``modules/widgets/telemetry.log_widget_event``: catch-all,
+    rollback, swallow. Telemetry MUST NEVER fail the calling business path.
+    """
+    if SessionLocal is None:  # pragma: no cover — defensive
+        return
+
+    db = None
+    try:
+        from core.models.error_event import ErrorEvent  # local import
+
+        db = SessionLocal()
+        row = ErrorEvent(
+            subsystem=subsystem[:64],
+            operation=operation[:128],
+            error_type=type(error).__name__[:128],
+            error_message=error_message,  # already truncated to _MAX_MESSAGE_LEN
+            workspace_id=workspace_id,
+            agent_id=agent_id,
+            action_name=action_name[:128] if action_name else None,
+            event_data=extra or {},
+        )
+        db.add(row)
+        db.commit()
+    except Exception as exc:  # noqa: BLE001 — best-effort by contract
+        _SINK_LOGGER.warning(
+            "error_events sink write failed (subsystem=%r operation=%r): %s",
+            subsystem,
+            operation,
+            exc,
+        )
+        if db is not None:
+            try:
+                db.rollback()
+            except Exception:  # noqa: BLE001 — give up; never propagate
+                pass
+    finally:
+        if db is not None:
+            try:
+                db.close()
+            except Exception:  # noqa: BLE001 — never propagate
+                pass

--- a/orchestrator/tests/test_activation_endpoint.py
+++ b/orchestrator/tests/test_activation_endpoint.py
@@ -1,0 +1,273 @@
+"""PRD-142 Wave 0 US-005 — GET /api/analytics/activation.
+
+Platform-level activation rate (the one Wave 0 tile that is intentionally
+NOT filtered to a single ``workspace_id`` — see US-005 notes). A workspace
+is "activated" when it has >=1 ``OrchestrationRun`` with
+``state == RunState.COMPLETED.value``; the rate is
+``activated / total_workspaces``.
+
+Computed from ``OrchestrationRun`` only — no new table, no
+``WorkflowExecution`` reads (Wave 0 scope; Wave 3 owns the
+``WorkflowExecution`` drop).
+
+The endpoint MUST:
+
+* Count DISTINCT ``OrchestrationRun.workspace_id`` filtered to
+  ``state == 'completed'`` — workspaces whose runs are all in non-completed
+  states do NOT contribute.
+* Count ``Workspace`` rows for the denominator.
+* Return ``rate = 0`` when ``total_workspaces == 0`` (no divide-by-zero),
+  with NO fake fallback value.
+* Return shape ``{activated, total_workspaces, rate, generated_at}``.
+"""
+from __future__ import annotations
+
+import operator
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, List, Optional, Tuple
+from unittest.mock import MagicMock
+from uuid import UUID, uuid4
+
+import pytest
+
+ORCH_ROOT = Path(__file__).resolve().parent.parent
+if str(ORCH_ROOT) not in sys.path:
+    sys.path.insert(0, str(ORCH_ROOT))
+
+import config  # noqa: E402,F401
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _filter_on(args: Iterable, column_name: str):
+    """Return the SQLAlchemy expression in ``args`` whose left side is the
+    column named ``column_name``, or ``None`` if absent.
+    """
+    for expr in args:
+        left = getattr(expr, "left", None)
+        if left is not None and getattr(left, "name", None) == column_name:
+            return expr
+    return None
+
+
+def _make_client(
+    *,
+    workspace_id: UUID,
+    activated_count: int,
+    total_workspaces: int,
+    captured_filters: Optional[List[Tuple]] = None,
+):
+    """Build a TestClient bound to the analytics_real router with the
+    workspace ctx and DB dependencies overridden.
+
+    The endpoint issues queries in this order:
+
+    1. ``db.query(func.count(func.distinct(OrchestrationRun.workspace_id)))
+        .filter(OrchestrationRun.state == RunState.COMPLETED.value).scalar()``
+        → number of activated workspaces.
+    2. ``db.query(func.count(Workspace.id)).scalar()`` → total
+        provisioned workspaces (denominator).
+
+    ``captured_filters`` collects ``(tag, args, kwargs)`` for every
+    ``.filter(...)`` call so tests can assert which state filter was
+    applied to the activation count query.
+    """
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from api.analytics_real import router as analytics_router
+    from core.auth.dependencies import RequestContext, UserContext
+    from core.auth.hybrid import get_request_context_hybrid
+    from core.database.database import get_db
+
+    fake_db = MagicMock()
+    captured_filters = (
+        captured_filters if captured_filters is not None else []
+    )
+
+    activated_q = MagicMock()
+    activated_q.filter.side_effect = lambda *a, **k: (
+        captured_filters.append(("activated", a, k)) or activated_q
+    )
+    activated_q.scalar.return_value = activated_count
+
+    total_q = MagicMock()
+    total_q.filter.side_effect = lambda *a, **k: (
+        captured_filters.append(("total", a, k)) or total_q
+    )
+    total_q.scalar.return_value = total_workspaces
+
+    mocks_in_order = [activated_q, total_q]
+    call_index = {"i": 0}
+
+    def _router(*_args, **_kwargs):
+        i = call_index["i"]
+        call_index["i"] += 1
+        return mocks_in_order[i] if i < len(mocks_in_order) else MagicMock()
+
+    fake_db.query.side_effect = _router
+
+    app = FastAPI()
+    app.include_router(analytics_router)
+
+    def _override_ctx():
+        return RequestContext(
+            workspace_id=workspace_id,
+            user=UserContext(id="test-user", email="test@example.com", role="owner"),
+            auth_type="clerk",
+        )
+
+    def _override_db():
+        yield fake_db
+
+    app.dependency_overrides[get_request_context_hybrid] = _override_ctx
+    app.dependency_overrides[get_db] = _override_db
+
+    return TestClient(app), fake_db, captured_filters
+
+
+# ---------------------------------------------------------------------------
+# Tests (named exactly as US-005 AC requires)
+# ---------------------------------------------------------------------------
+
+
+def test_activation_counts_completed_missions():
+    """Endpoint returns activated/total/rate computed from OrchestrationRun.
+
+    The activation count query MUST filter on
+    ``state == RunState.COMPLETED.value`` (canonical enum, not a hardcoded
+    string). The rate is the float ratio activated / total_workspaces.
+    """
+    from core.models.orchestration_enums import RunState
+
+    ws = uuid4()
+    captured: List[Tuple] = []
+    client, _db, _ = _make_client(
+        workspace_id=ws,
+        activated_count=3,
+        total_workspaces=10,
+        captured_filters=captured,
+    )
+
+    resp = client.get("/api/analytics/activation")
+    assert resp.status_code == 200, resp.text
+
+    body = resp.json()
+    assert body["activated"] == 3
+    assert body["total_workspaces"] == 10
+    assert body["rate"] == pytest.approx(0.3)
+    assert "generated_at" in body
+    datetime.fromisoformat(body["generated_at"])
+
+    # The activation count query MUST filter on state == 'completed'.
+    activated_filters = [c for c in captured if c[0] == "activated"]
+    assert activated_filters, (
+        "endpoint must call .filter(...) on the activation count query "
+        "to restrict to completed missions"
+    )
+    _tag, args, _kwargs = activated_filters[0]
+
+    state_expr = _filter_on(args, "state")
+    assert state_expr is not None, (
+        f"OrchestrationRun.state filter must be present (defines what "
+        f"'activated' means); got {args}"
+    )
+    assert state_expr.operator is operator.eq, (
+        f"state filter must use ==; got {state_expr.operator!r}"
+    )
+    # Canonical enum value — never the bare string literal.
+    assert state_expr.right.value == RunState.COMPLETED.value, (
+        f"state filter must bind to RunState.COMPLETED.value "
+        f"({RunState.COMPLETED.value!r}); got {state_expr.right.value!r}"
+    )
+
+
+def test_rate_zero_when_no_workspaces():
+    """No provisioned workspaces → rate = 0 (no divide-by-zero, no fake fallback)."""
+    ws = uuid4()
+    client, _db, _ = _make_client(
+        workspace_id=ws,
+        activated_count=0,
+        total_workspaces=0,
+    )
+
+    resp = client.get("/api/analytics/activation")
+    assert resp.status_code == 200, resp.text
+
+    body = resp.json()
+    assert body["activated"] == 0
+    assert body["total_workspaces"] == 0
+    # The honest zero — NOT a fabricated default like 85.0 (US-003 deleted that).
+    assert body["rate"] == 0
+    assert "generated_at" in body
+
+
+def test_workspace_with_no_completed_run_not_activated():
+    """A workspace with zero completed runs does not contribute to ``activated``.
+
+    Enforced by the ``state == RunState.COMPLETED.value`` filter on the
+    activation count query: workspaces whose runs are all in pending /
+    planning / running / failed / cancelled states are excluded by the
+    DB engine, never reaching the COUNT(DISTINCT workspace_id).
+
+    Concretely we mock the DB to return ``activated=2`` for a tenant
+    population of ``total_workspaces=5`` — the 3 workspaces "with no
+    completed run" are the gap (5 - 2 = 3 not activated) — and assert
+    both the response math and that the filter that produced this is
+    bound to the COMPLETED state, not e.g. RUNNING.
+    """
+    from core.models.orchestration_enums import RunState
+
+    ws = uuid4()
+    captured: List[Tuple] = []
+    client, _db, _ = _make_client(
+        workspace_id=ws,
+        activated_count=2,
+        total_workspaces=5,
+        captured_filters=captured,
+    )
+
+    resp = client.get("/api/analytics/activation")
+    assert resp.status_code == 200, resp.text
+
+    body = resp.json()
+    assert body["activated"] == 2
+    assert body["total_workspaces"] == 5
+    # 3 workspaces have no completed run; rate reflects only the 2 that do.
+    assert body["rate"] == pytest.approx(0.4)
+
+    # And the filter that produced "2" is COMPLETED — not any other state.
+    activated_filters = [c for c in captured if c[0] == "activated"]
+    assert activated_filters, (
+        "activation count query must apply a state filter to exclude "
+        "non-completed runs"
+    )
+    _tag, args, _kwargs = activated_filters[0]
+    state_expr = _filter_on(args, "state")
+    assert state_expr is not None, (
+        f"state filter is required to exclude non-completed runs; got {args}"
+    )
+    assert state_expr.right.value == RunState.COMPLETED.value, (
+        f"only state == 'completed' rows define activation; "
+        f"got filter on {state_expr.right.value!r}"
+    )
+    # Sanity: it is NOT RUNNING / PENDING / FAILED / etc.
+    for non_activated in (
+        RunState.RUNNING.value,
+        RunState.PENDING.value,
+        RunState.FAILED.value,
+        RunState.CANCELLED.value,
+    ):
+        assert state_expr.right.value != non_activated, (
+            f"activation filter must not be {non_activated!r}; that would "
+            f"miscount workspaces with no completed mission as activated"
+        )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/orchestrator/tests/test_analytics_engine_real_metrics.py
+++ b/orchestrator/tests/test_analytics_engine_real_metrics.py
@@ -1,0 +1,78 @@
+"""PRD-142 Wave 0 US-003 — analytics_engine must report real numbers, not placeholders.
+
+These tests bypass ``AnalyticsEngine.__init__`` (which opens a DB session + Redis)
+via ``__new__`` and inject a mock session, so they exercise the metric methods in
+isolation without external services.
+"""
+from unittest.mock import MagicMock
+
+import pytest
+
+from core.services.analytics_engine import AnalyticsEngine
+
+
+def _engine_with_db(db) -> AnalyticsEngine:
+    """Construct an AnalyticsEngine without running __init__ (no DB/Redis)."""
+    engine = AnalyticsEngine.__new__(AnalyticsEngine)
+    engine.db = db
+    return engine
+
+
+@pytest.mark.asyncio
+async def test_agent_metrics_no_placeholders():
+    """_get_agent_metrics returns only real, DB-derived counts — no fake fields."""
+    db = MagicMock()
+    q = MagicMock()
+    q.filter.return_value = q
+    q.count.return_value = 4
+    db.query.return_value = q
+
+    metrics = await _engine_with_db(db)._get_agent_metrics()
+
+    # Real values survive
+    assert metrics["activeAgents"] == 4
+    assert metrics["totalAgents"] == 4
+
+    # The PRD-142 §Wave0 fake placeholders are gone
+    assert "successRate" not in metrics
+    assert "avgExecutionTime" not in metrics
+    assert "totalTokensUsed" not in metrics
+    assert "recentExecutions" not in metrics
+
+    # Belt-and-suspenders: the literal fakes never appear as a value
+    assert 85.0 not in metrics.values()
+    assert 2.5 not in metrics.values()
+
+
+@pytest.mark.asyncio
+async def test_success_rate_matches_orchestration_runs():
+    """Mission success rate is computed from orchestration data, never hardcoded.
+
+    With 0 legacy workflow executions and 10 orchestration tasks of which 8 are
+    verified, the combined success rate must be 80.0 — derived, not the old 85.0.
+    """
+    # (bare .count(), filtered .filter()....count()) per model
+    specs = {
+        "Workflow": (0, 0),
+        "WorkflowExecution": (0, 0),
+        "OrchestrationRun": (0, 0),
+        "OrchestrationTask": (10, 8),
+    }
+
+    def query_side_effect(model):
+        total, subset = specs.get(getattr(model, "__name__", ""), (0, 0))
+        q = MagicMock()
+        filtered = MagicMock()
+        filtered.filter.return_value = filtered
+        filtered.count.return_value = subset
+        q.filter.return_value = filtered
+        q.count.return_value = total
+        return q
+
+    db = MagicMock()
+    db.query.side_effect = query_side_effect
+
+    metrics = await _engine_with_db(db)._get_workflow_metrics()
+
+    assert metrics["successRate"] == 80.0
+    assert metrics["successRate"] != 85.0

--- a/orchestrator/tests/test_error_events_sink.py
+++ b/orchestrator/tests/test_error_events_sink.py
@@ -1,0 +1,226 @@
+"""PRD-142 Wave 0 US-001 — error_events sink + record_error persistence.
+
+The ``record_error`` function (``core/utils/exception_telemetry.py``) MUST
+persist its records to the ``error_events`` table in addition to emitting on
+the ``automatos.errors`` logger, so the dashboard can query subsystem error
+rates without scraping log files.
+
+Fire-and-forget contract (mirrors ``modules/widgets/telemetry.py``):
+
+* The signature stays keyword-only and unchanged.
+* The sink write is best-effort: a DB outage, a missing table, or a
+  serialisation failure MUST NOT propagate. ``record_error`` never raises.
+* If persistence fails, the original ``automatos.errors`` log line still
+  goes out, so we never blind-spot a failure.
+"""
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+ORCH_ROOT = Path(__file__).resolve().parent.parent
+if str(ORCH_ROOT) not in sys.path:
+    sys.path.insert(0, str(ORCH_ROOT))
+
+# Ensure .env is loaded so core.database.database can resolve creds at
+# import time (matches PRD-008-A test pattern).
+import config  # noqa: E402,F401
+
+
+# ---------------------------------------------------------------------------
+# Model
+# ---------------------------------------------------------------------------
+
+def test_error_event_table_name_and_indexes():
+    """The model is named ``error_events`` and carries the two indexes the
+    aggregation endpoint (US-002) needs."""
+    from core.models.error_event import ErrorEvent
+
+    assert ErrorEvent.__tablename__ == "error_events"
+
+    indexed = {idx.name for idx in ErrorEvent.__table__.indexes}
+    assert "idx_error_events_subsystem_created" in indexed
+    assert "idx_error_events_workspace_created" in indexed
+
+
+def test_error_event_event_data_defaults_to_empty_jsonb():
+    from core.models.error_event import ErrorEvent
+
+    server_default = ErrorEvent.__table__.c.event_data.server_default
+    assert server_default is not None
+    assert "{}" in str(server_default.arg)
+
+
+# ---------------------------------------------------------------------------
+# record_error — persistence
+# ---------------------------------------------------------------------------
+
+def test_record_error_persists_row(caplog):
+    """Happy path: record_error opens a session, builds an ErrorEvent row,
+    and commits it. The logger emit still happens."""
+    from core.utils import exception_telemetry
+
+    fake_session = MagicMock()
+    session_factory = MagicMock(return_value=fake_session)
+
+    ws = uuid4()
+    with patch.object(exception_telemetry, "SessionLocal", session_factory, create=True):
+        with caplog.at_level(logging.ERROR, logger="automatos.errors"):
+            try:
+                raise ValueError("boom")
+            except ValueError as exc:
+                exception_telemetry.record_error(
+                    subsystem="memory",
+                    operation="add_memory",
+                    error=exc,
+                    workspace_id=ws,
+                    agent_id=42,
+                    action_name="platform_add_memory",
+                    extra={"correlation_id": "abc"},
+                )
+
+    # Logger emit must still happen (never replaced).
+    assert any(r.name == "automatos.errors" for r in caplog.records)
+
+    # Sink got a row added and committed.
+    fake_session.add.assert_called_once()
+    fake_session.commit.assert_called_once()
+    row = fake_session.add.call_args[0][0]
+    assert row.subsystem == "memory"
+    assert row.operation == "add_memory"
+    assert row.error_type == "ValueError"
+    assert row.error_message == "boom"
+    assert row.workspace_id == ws
+    assert row.agent_id == 42
+    assert row.action_name == "platform_add_memory"
+    assert row.event_data == {"correlation_id": "abc"}
+
+
+def test_record_error_sink_failure_is_swallowed(caplog):
+    """If commit() raises (DB outage, missing table, anything), record_error
+    must still return cleanly and the logger emit must still happen."""
+    from core.utils import exception_telemetry
+
+    fake_session = MagicMock()
+    fake_session.commit.side_effect = RuntimeError("simulated DB outage")
+    session_factory = MagicMock(return_value=fake_session)
+
+    with patch.object(exception_telemetry, "SessionLocal", session_factory, create=True):
+        with caplog.at_level(logging.ERROR, logger="automatos.errors"):
+            try:
+                raise RuntimeError("real failure")
+            except RuntimeError as exc:
+                # MUST NOT raise — telemetry must not mask the original failure.
+                exception_telemetry.record_error(
+                    subsystem="tools",
+                    operation="dispatch",
+                    error=exc,
+                )
+
+    # Logger emit still happened.
+    assert any(r.name == "automatos.errors" for r in caplog.records)
+    # Sink attempted rollback.
+    fake_session.rollback.assert_called_once()
+
+
+def test_record_error_truncates_message_in_db():
+    """The DB column is VARCHAR(500). A pathological long exception message
+    must be truncated before persistence so the INSERT doesn't fail."""
+    from core.utils import exception_telemetry
+
+    fake_session = MagicMock()
+    session_factory = MagicMock(return_value=fake_session)
+
+    long_message = "x" * 1000
+    with patch.object(exception_telemetry, "SessionLocal", session_factory, create=True):
+        try:
+            raise RuntimeError(long_message)
+        except RuntimeError as exc:
+            exception_telemetry.record_error(
+                subsystem="memory",
+                operation="add_memory",
+                error=exc,
+            )
+
+    row = fake_session.add.call_args[0][0]
+    assert len(row.error_message) == 500
+    assert row.error_message == "x" * 500
+
+
+def test_none_workspace_persists():
+    """System-level errors have workspace_id=None. They must still persist —
+    the column is nullable. The aggregation endpoint excludes NULL workspace
+    rows from per-workspace views by design (US-002 notes)."""
+    from core.utils import exception_telemetry
+
+    fake_session = MagicMock()
+    session_factory = MagicMock(return_value=fake_session)
+
+    with patch.object(exception_telemetry, "SessionLocal", session_factory, create=True):
+        try:
+            raise KeyError("missing")
+        except KeyError as exc:
+            exception_telemetry.record_error(
+                subsystem="harness",
+                operation="apply_prescription",
+                error=exc,
+                workspace_id=None,
+            )
+
+    fake_session.add.assert_called_once()
+    fake_session.commit.assert_called_once()
+    row = fake_session.add.call_args[0][0]
+    assert row.workspace_id is None
+    assert row.subsystem == "harness"
+    assert row.error_type == "KeyError"
+
+
+def test_record_error_rollback_failure_is_also_swallowed():
+    """Even a rollback() that itself raises must not propagate — defensive
+    parity with log_widget_event."""
+    from core.utils import exception_telemetry
+
+    fake_session = MagicMock()
+    fake_session.commit.side_effect = RuntimeError("commit broke")
+    fake_session.rollback.side_effect = RuntimeError("rollback also broke")
+    session_factory = MagicMock(return_value=fake_session)
+
+    with patch.object(exception_telemetry, "SessionLocal", session_factory, create=True):
+        try:
+            raise ValueError("boom")
+        except ValueError as exc:
+            # MUST NOT raise.
+            exception_telemetry.record_error(
+                subsystem="memory",
+                operation="add_memory",
+                error=exc,
+            )
+
+
+def test_record_error_signature_unchanged():
+    """Guardrail: record_error keeps its keyword-only signature. Adding a
+    positional ``db`` parameter would break every existing caller."""
+    import inspect
+
+    from core.utils.exception_telemetry import record_error
+
+    sig = inspect.signature(record_error)
+    expected = {
+        "subsystem", "operation", "error", "workspace_id",
+        "agent_id", "action_name", "extra",
+    }
+    assert set(sig.parameters.keys()) == expected
+    # All keyword-only.
+    for name, param in sig.parameters.items():
+        assert param.kind == inspect.Parameter.KEYWORD_ONLY, (
+            f"{name} must remain keyword-only"
+        )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/orchestrator/tests/test_errors_by_subsystem_endpoint.py
+++ b/orchestrator/tests/test_errors_by_subsystem_endpoint.py
@@ -1,0 +1,232 @@
+"""PRD-142 Wave 0 US-002 — GET /api/analytics/errors/by-subsystem.
+
+This endpoint backs the dashboard "Error rate by subsystem" tile. It:
+
+* Aggregates ``error_events`` rows by ``subsystem`` over a configurable
+  rolling window (default 24h).
+* Filters by the caller's ``ctx.workspace_id`` — system-level rows
+  (``workspace_id IS NULL``) are intentionally excluded from the
+  workspace-scoped view (US-002 notes).
+* Computes ``rate = count / total`` per subsystem; ``rate`` is 0 when
+  ``total`` is 0 (no divide-by-zero).
+* Uses the ``idx_error_events_subsystem_created`` index path via a filter
+  on ``created_at >= window_start`` and a ``GROUP BY subsystem`` — no
+  full-table scan.
+
+Tests cover the contract: aggregation shape, window math, empty-window
+safety, and workspace isolation.
+"""
+from __future__ import annotations
+
+import operator
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Iterable, List, Optional, Tuple
+from unittest.mock import MagicMock
+from uuid import UUID, uuid4
+
+import pytest
+
+ORCH_ROOT = Path(__file__).resolve().parent.parent
+if str(ORCH_ROOT) not in sys.path:
+    sys.path.insert(0, str(ORCH_ROOT))
+
+import config  # noqa: E402,F401
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _row(subsystem: str, count: int) -> SimpleNamespace:
+    """Row shape returned by the aggregation query: (subsystem, count)."""
+    return SimpleNamespace(subsystem=subsystem, count=count)
+
+
+def _filter_on(args: Iterable, column_name: str):
+    """Return the SQLAlchemy ``BinaryExpression`` in ``args`` whose left
+    side is the column named ``column_name``, or ``None`` if absent."""
+    for expr in args:
+        left = getattr(expr, "left", None)
+        if left is not None and getattr(left, "name", None) == column_name:
+            return expr
+    return None
+
+
+def _make_client(
+    *,
+    workspace_id: UUID,
+    agg_rows: Optional[List[SimpleNamespace]] = None,
+    captured_filters: Optional[List[Tuple]] = None,
+):
+    """Build a TestClient bound to the analytics_real router with the
+    workspace ctx and DB dependencies overridden.
+
+    Returns ``(client, fake_db, captured_filters)``. ``captured_filters``
+    accumulates ``(args, kwargs)`` for each ``q.filter(...)`` call so tests
+    can introspect the SQL expressions the endpoint applies.
+    """
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from api.analytics_real import router as analytics_router
+    from core.auth.dependencies import RequestContext, UserContext
+    from core.auth.hybrid import get_request_context_hybrid
+    from core.database.database import get_db
+
+    fake_db = MagicMock()
+    captured_filters = captured_filters if captured_filters is not None else []
+
+    q = MagicMock()
+
+    def _capture_filter(*args, **kwargs):
+        captured_filters.append((args, kwargs))
+        return q
+
+    q.filter.side_effect = _capture_filter
+    q.group_by.return_value = q
+    q.all.return_value = agg_rows or []
+    fake_db.query.return_value = q
+
+    app = FastAPI()
+    app.include_router(analytics_router)
+
+    def _override_ctx():
+        return RequestContext(
+            workspace_id=workspace_id,
+            user=UserContext(id="test-user", email="test@example.com", role="owner"),
+            auth_type="clerk",
+        )
+
+    def _override_db():
+        yield fake_db
+
+    app.dependency_overrides[get_request_context_hybrid] = _override_ctx
+    app.dependency_overrides[get_db] = _override_db
+
+    return TestClient(app), fake_db, captured_filters
+
+
+# ---------------------------------------------------------------------------
+# Tests (named exactly as US-002 AC requires)
+# ---------------------------------------------------------------------------
+
+
+def test_groups_by_subsystem():
+    """Endpoint groups error_events by subsystem and computes rate = count/total."""
+    ws = uuid4()
+    rows = [_row("memory", 6), _row("tools", 3), _row("harness", 1)]
+    client, _db, _captured = _make_client(workspace_id=ws, agg_rows=rows)
+
+    resp = client.get("/api/analytics/errors/by-subsystem?window=24h")
+    assert resp.status_code == 200, resp.text
+
+    body = resp.json()
+    assert body["window"] == "24h"
+    assert body["total"] == 10
+
+    by_sub = {entry["subsystem"]: entry for entry in body["by_subsystem"]}
+    assert set(by_sub) == {"memory", "tools", "harness"}
+
+    assert by_sub["memory"]["count"] == 6
+    assert by_sub["tools"]["count"] == 3
+    assert by_sub["harness"]["count"] == 1
+
+    # rate = count / total (over the window)
+    assert by_sub["memory"]["rate"] == pytest.approx(0.6)
+    assert by_sub["tools"]["rate"] == pytest.approx(0.3)
+    assert by_sub["harness"]["rate"] == pytest.approx(0.1)
+
+    assert "generated_at" in body
+    # generated_at is ISO 8601 parseable
+    datetime.fromisoformat(body["generated_at"])
+
+
+def test_window_filtering():
+    """The endpoint applies a >= filter on created_at sized to the window arg.
+
+    Verifies (a) the index-eligible filter is present and (b) the cutoff
+    is roughly ``now - window`` so we cannot accidentally return all-time
+    error counts when the dashboard asks for the last 24h.
+    """
+    ws = uuid4()
+    captured: List[Tuple] = []
+
+    client, _db, _ = _make_client(
+        workspace_id=ws, agg_rows=[_row("memory", 1)], captured_filters=captured
+    )
+
+    before = datetime.utcnow()
+    resp = client.get("/api/analytics/errors/by-subsystem?window=24h")
+    after = datetime.utcnow()
+    assert resp.status_code == 200, resp.text
+
+    assert captured, "endpoint must call .filter(...) on the query"
+    args, _kwargs = captured[0]
+
+    created_expr = _filter_on(args, "created_at")
+    assert created_expr is not None, (
+        f"created_at window filter must be present in filter args; got {args}"
+    )
+    # It must be a >= comparator (rolling window, not equality).
+    assert created_expr.operator is operator.ge, (
+        f"created_at filter must use >= for the window; got {created_expr.operator!r}"
+    )
+
+    cutoff = created_expr.right.value
+    expected_low = before - timedelta(hours=24, seconds=5)
+    expected_high = after - timedelta(hours=24) + timedelta(seconds=5)
+    assert expected_low <= cutoff <= expected_high, (
+        f"window=24h cutoff must be ~now-24h; got {cutoff}, expected in "
+        f"[{expected_low}, {expected_high}]"
+    )
+
+
+def test_empty_window_returns_zero():
+    """No rows in the window → total=0, by_subsystem=[], and NO divide-by-zero."""
+    ws = uuid4()
+    client, _db, _ = _make_client(workspace_id=ws, agg_rows=[])
+
+    resp = client.get("/api/analytics/errors/by-subsystem?window=24h")
+    assert resp.status_code == 200, resp.text
+
+    body = resp.json()
+    assert body["total"] == 0
+    assert body["by_subsystem"] == []
+    # Window echoed back so the UI can label the tile.
+    assert body["window"] == "24h"
+
+
+def test_workspace_isolation():
+    """The query filters by the caller's workspace_id — another tenant cannot leak."""
+    my_ws = uuid4()
+    captured: List[Tuple] = []
+    client, _db, _ = _make_client(
+        workspace_id=my_ws, agg_rows=[], captured_filters=captured
+    )
+
+    resp = client.get("/api/analytics/errors/by-subsystem?window=24h")
+    assert resp.status_code == 200, resp.text
+
+    assert captured, "endpoint must call .filter(...) on the query"
+    args, _kwargs = captured[0]
+
+    ws_expr = _filter_on(args, "workspace_id")
+    assert ws_expr is not None, (
+        f"workspace_id filter must be present (tenant isolation); got {args}"
+    )
+    # Equality, not IN/IS NULL — we want the caller's workspace exactly.
+    assert ws_expr.operator is operator.eq, (
+        f"workspace_id filter must use ==; got {ws_expr.operator!r}"
+    )
+    # The bind value on the right side must be the caller's workspace_id.
+    assert ws_expr.right.value == my_ws, (
+        f"workspace_id filter must bind to caller's workspace; got {ws_expr.right.value}"
+    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/orchestrator/tests/test_widget_engagement_endpoint.py
+++ b/orchestrator/tests/test_widget_engagement_endpoint.py
@@ -1,0 +1,308 @@
+"""PRD-142 Wave 0 US-004 — GET /api/analytics/widget-engagement.
+
+Read-only aggregation over the existing ``widget_event_log`` sink
+(``core/models/widget_event_log.py``; writer in
+``modules/widgets/telemetry.py``).
+
+The endpoint backs the dashboard "Widget engagement" tile:
+
+* Resolves the sites belonging to the caller's ``ctx.workspace_id`` and
+  aggregates ``widget_event_log`` rows for ONLY those sites — tenant
+  isolation, since ``widget_event_log`` itself has no ``workspace_id``.
+* Counts grouped by ``event_type`` over a rolling window (default 7d),
+  restricted to the ``WIDGET_EVENT_TYPES`` allow-list so the
+  ``idx_widget_event_log_type_created`` index path is eligible.
+* Returns the number of distinct sessions in the window.
+* Is READ-ONLY — no ``WidgetEventLog(...)`` row construction in the
+  endpoint module (the writer remains the single source of truth).
+"""
+from __future__ import annotations
+
+import operator
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Iterable, List, Optional, Tuple
+from unittest.mock import MagicMock
+from uuid import UUID, uuid4
+
+import pytest
+
+ORCH_ROOT = Path(__file__).resolve().parent.parent
+if str(ORCH_ROOT) not in sys.path:
+    sys.path.insert(0, str(ORCH_ROOT))
+
+import config  # noqa: E402,F401
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _row(event_type: str, count: int) -> SimpleNamespace:
+    """Row shape returned by the aggregation query: (event_type, count)."""
+    return SimpleNamespace(event_type=event_type, count=count)
+
+
+def _filter_on(args: Iterable, column_name: str):
+    """Return the SQLAlchemy expression in ``args`` whose left side is the
+    column named ``column_name``, or ``None`` if absent.
+    """
+    for expr in args:
+        left = getattr(expr, "left", None)
+        if left is not None and getattr(left, "name", None) == column_name:
+            return expr
+    return None
+
+
+def _make_client(
+    *,
+    workspace_id: UUID,
+    site_ids: Optional[List[UUID]] = None,
+    agg_rows: Optional[List[SimpleNamespace]] = None,
+    distinct_sessions: int = 0,
+    captured_filters: Optional[List[Tuple]] = None,
+):
+    """Build a TestClient bound to the analytics_real router with the
+    workspace ctx and DB dependencies overridden.
+
+    The endpoint issues queries in this order:
+
+    1. ``db.query(Site.id).filter(Site.workspace_id == ws).all()``
+    2. ``db.query(WidgetEventLog.event_type, count).filter(...).group_by(...).all()``
+    3. ``db.query(func.count(func.distinct(WidgetEventLog.session_id))).filter(...).scalar()``
+
+    When ``site_ids`` is empty the endpoint short-circuits and queries
+    2/3 are not invoked.
+
+    ``captured_filters`` collects ``(tag, args, kwargs)`` for every
+    ``.filter(...)`` call where ``tag`` identifies which query the filter
+    came from ("sites", "agg", or "sessions"). Tests use this to make
+    tenant-isolation and window-math assertions.
+    """
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from api.analytics_real import router as analytics_router
+    from core.auth.dependencies import RequestContext, UserContext
+    from core.auth.hybrid import get_request_context_hybrid
+    from core.database.database import get_db
+
+    fake_db = MagicMock()
+    captured_filters = (
+        captured_filters if captured_filters is not None else []
+    )
+
+    site_q = MagicMock()
+    site_q.filter.side_effect = lambda *a, **k: (
+        captured_filters.append(("sites", a, k)) or site_q
+    )
+    # Site query result rows look like (Site.id,) — emulate that shape.
+    site_q.all.return_value = [(sid,) for sid in (site_ids or [])]
+
+    agg_q = MagicMock()
+    agg_q.filter.side_effect = lambda *a, **k: (
+        captured_filters.append(("agg", a, k)) or agg_q
+    )
+    agg_q.group_by.return_value = agg_q
+    agg_q.all.return_value = agg_rows or []
+
+    sess_q = MagicMock()
+    sess_q.filter.side_effect = lambda *a, **k: (
+        captured_filters.append(("sessions", a, k)) or sess_q
+    )
+    sess_q.scalar.return_value = distinct_sessions
+
+    mocks_in_order = [site_q, agg_q, sess_q]
+    call_index = {"i": 0}
+
+    def _router(*_args, **_kwargs):
+        i = call_index["i"]
+        call_index["i"] += 1
+        return mocks_in_order[i] if i < len(mocks_in_order) else MagicMock()
+
+    fake_db.query.side_effect = _router
+
+    app = FastAPI()
+    app.include_router(analytics_router)
+
+    def _override_ctx():
+        return RequestContext(
+            workspace_id=workspace_id,
+            user=UserContext(id="test-user", email="test@example.com", role="owner"),
+            auth_type="clerk",
+        )
+
+    def _override_db():
+        yield fake_db
+
+    app.dependency_overrides[get_request_context_hybrid] = _override_ctx
+    app.dependency_overrides[get_db] = _override_db
+
+    return TestClient(app), fake_db, captured_filters
+
+
+# ---------------------------------------------------------------------------
+# Tests (named exactly as US-004 AC requires)
+# ---------------------------------------------------------------------------
+
+
+def test_groups_by_event_type():
+    """Endpoint groups widget_event_log rows by event_type with counts."""
+    ws = uuid4()
+    site_id = uuid4()
+    rows = [
+        _row("proactive_fired", 12),
+        _row("callback_requested", 3),
+        _row("cart_idle_fired", 5),
+    ]
+    client, _db, _captured = _make_client(
+        workspace_id=ws,
+        site_ids=[site_id],
+        agg_rows=rows,
+        distinct_sessions=7,
+    )
+
+    resp = client.get("/api/analytics/widget-engagement?window=7d")
+    assert resp.status_code == 200, resp.text
+
+    body = resp.json()
+    assert body["window"] == "7d"
+
+    by_evt = {entry["event_type"]: entry for entry in body["by_event_type"]}
+    assert set(by_evt) == {"proactive_fired", "callback_requested", "cart_idle_fired"}
+    assert by_evt["proactive_fired"]["count"] == 12
+    assert by_evt["callback_requested"]["count"] == 3
+    assert by_evt["cart_idle_fired"]["count"] == 5
+
+    assert body["sessions"] == 7
+
+    assert "generated_at" in body
+    datetime.fromisoformat(body["generated_at"])
+
+
+def test_window_filtering():
+    """The endpoint applies a >= filter on created_at sized to the window arg.
+
+    Catches a regression where ``widget-engagement?window=7d`` would
+    return all-time counts.
+    """
+    ws = uuid4()
+    site_id = uuid4()
+    captured: List[Tuple] = []
+
+    client, _db, _ = _make_client(
+        workspace_id=ws,
+        site_ids=[site_id],
+        agg_rows=[_row("proactive_fired", 1)],
+        distinct_sessions=1,
+        captured_filters=captured,
+    )
+
+    before = datetime.utcnow()
+    resp = client.get("/api/analytics/widget-engagement?window=7d")
+    after = datetime.utcnow()
+    assert resp.status_code == 200, resp.text
+
+    agg_filters = [c for c in captured if c[0] == "agg"]
+    assert agg_filters, "endpoint must call .filter(...) on the aggregation query"
+    _tag, args, _kwargs = agg_filters[0]
+
+    created_expr = _filter_on(args, "created_at")
+    assert created_expr is not None, (
+        f"created_at window filter must be present on the aggregation query; "
+        f"got {args}"
+    )
+    assert created_expr.operator is operator.ge, (
+        f"created_at filter must use >= for the rolling window; "
+        f"got {created_expr.operator!r}"
+    )
+
+    cutoff = created_expr.right.value
+    expected_low = before - timedelta(days=7, seconds=5)
+    expected_high = after - timedelta(days=7) + timedelta(seconds=5)
+    assert expected_low <= cutoff <= expected_high, (
+        f"window=7d cutoff must be ~now-7d; got {cutoff}, expected in "
+        f"[{expected_low}, {expected_high}]"
+    )
+
+
+def test_workspace_site_scoping():
+    """The endpoint scopes events to the caller's sites — not all sites globally.
+
+    Two checks: (1) the site query filters by ``Site.workspace_id == ws``
+    and (2) the aggregation query restricts ``WidgetEventLog.site_id`` to
+    the resolved set, so another workspace's events cannot leak in.
+    """
+    my_ws = uuid4()
+    my_site_a = uuid4()
+    my_site_b = uuid4()
+    captured: List[Tuple] = []
+
+    client, _db, _ = _make_client(
+        workspace_id=my_ws,
+        site_ids=[my_site_a, my_site_b],
+        agg_rows=[_row("proactive_fired", 1)],
+        distinct_sessions=1,
+        captured_filters=captured,
+    )
+
+    resp = client.get("/api/analytics/widget-engagement?window=7d")
+    assert resp.status_code == 200, resp.text
+
+    # (1) Sites query filtered by workspace_id == my_ws
+    site_filters = [c for c in captured if c[0] == "sites"]
+    assert site_filters, "endpoint must filter sites by workspace_id"
+    _tag, sargs, _ = site_filters[0]
+    ws_expr = _filter_on(sargs, "workspace_id")
+    assert ws_expr is not None, (
+        f"Site.workspace_id filter is required for tenant isolation; got {sargs}"
+    )
+    assert ws_expr.operator is operator.eq, (
+        f"Site.workspace_id filter must be ==; got {ws_expr.operator!r}"
+    )
+    assert ws_expr.right.value == my_ws
+
+    # (2) Aggregation query restricts to the caller's sites
+    agg_filters = [c for c in captured if c[0] == "agg"]
+    assert agg_filters, "endpoint must filter widget_event_log by site_id"
+    _tag, aargs, _ = agg_filters[0]
+    site_id_expr = _filter_on(aargs, "site_id")
+    assert site_id_expr is not None, (
+        f"WidgetEventLog.site_id IN (caller's sites) filter must be present; "
+        f"got {aargs}"
+    )
+    # Expect an IN-clause: ``site_id.in_([...])``
+    op_name = getattr(site_id_expr.operator, "__name__", "") or repr(
+        site_id_expr.operator
+    )
+    assert "in_op" in op_name or "in" in op_name.lower(), (
+        f"WidgetEventLog.site_id filter must be IN(...); got {op_name}"
+    )
+
+
+def test_empty_returns_zero():
+    """No matching events in the window → empty list + sessions=0, no crash."""
+    ws = uuid4()
+    site_id = uuid4()
+    client, _db, _ = _make_client(
+        workspace_id=ws,
+        site_ids=[site_id],
+        agg_rows=[],
+        distinct_sessions=0,
+    )
+
+    resp = client.get("/api/analytics/widget-engagement?window=7d")
+    assert resp.status_code == 200, resp.text
+
+    body = resp.json()
+    assert body["window"] == "7d"
+    assert body["by_event_type"] == []
+    assert body["sessions"] == 0
+    assert "generated_at" in body
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/scripts/ralph/PROMPT_build_prd142.md
+++ b/scripts/ralph/PROMPT_build_prd142.md
@@ -1,0 +1,140 @@
+# Ralph Build Prompt — PRD-142 Wave 0 (Measurement First)
+
+You are an autonomous build agent. Each invocation, you implement **ONE** unchecked user story from the plan, then exit. The loop runs you again on the next story.
+
+## Hard lock
+
+Your working directory is **`/Users/gkavanagh/Development/Automatos-AI-Platform/automatos-ai`** on branch **`ralph/prd-142-wave0-measurement`**.
+
+- NEVER `cd` to another worktree or clone.
+- NEVER check out a different branch.
+- NEVER `git push`, NEVER open or merge a PR. You commit to this local branch ONLY. A human reviews before anything merges.
+- All file edits, all reads, all commits happen inside this checkout.
+- If you accidentally drift, abort with `RALPH_ABORT: drifted out of checkout`.
+
+## The PRD
+
+- `scripts/ralph/prd-142-wave0.json` — the user stories. **The `passes` field is the single source of truth for progress.** There is no separate checkbox file.
+- `docs/PRDS/PRD-142-WAVE0-MEASUREMENT.md` — full Wave 0 context: 5-metric source table, reuse map (file:line cited), out-of-scope list.
+- `CLAUDE.md` at repo root — reuse-first mandate, canonical terms, clean-coding rules.
+
+## What this PRD is
+
+**PRD-142 Wave 0 is EXTENSION + INSTRUMENTATION, not new product.** It surfaces five real numbers answering "is the platform working?": error rate by subsystem, mission success rate, widget engagement, activation, per-primitive health. Every metric reuses an existing sink/table/endpoint. Read the reuse map in the PRD before writing anything — the burden is on you to justify why an existing surface is not enough (CLAUDE.md §2).
+
+## Scope of THIS run — backend stories only
+
+You MAY execute, in priority order:
+
+- **US-001** — persist record_error to a queryable `error_events` sink (Alembic migration + ORM model + best-effort write path)
+- **US-002** — `GET /api/analytics/errors/by-subsystem` aggregation endpoint (BLOCKED until US-001 lands the table)
+- **US-004** — `GET /api/analytics/widget-engagement` read-only aggregation endpoint
+- **US-005** — `GET /api/analytics/activation` endpoint
+- **US-006** — `GET /api/analytics/primitive-health` rollup endpoint
+
+OUT OF SCOPE — do NOT start these; a human drives them:
+
+- **US-003** — already DONE (`passes: true`). Skip it.
+- **US-007** — frontend dashboard assembly. Needs browser verification; a human supervises it. Do NOT touch `frontend/`.
+- **US-008** — operational live-verification gate. Human-only.
+
+**Completion condition:** when US-001, US-002, US-004, US-005, US-006 all have `passes: true`, write the completion commit and emit `RALPH_COMPLETE`. Do NOT attempt US-007 or US-008.
+
+## Canonical terminology (CLAUDE.md §10)
+
+- **Mission** (never "Workflow"/"Job") in all user-facing labels and metric names.
+- **Playbook** (never "Recipe"). **Deliverable** (never "Output"/"Artifact"). **Knowledge Graph** (never "Business Graph").
+
+## TDD is mandatory (testing.md)
+
+For every story: **write the test FIRST (RED), watch it fail, then implement (GREEN).** The story's acceptance criteria name the exact test file and test functions — create that file, make those tests real, and do not weaken an assertion to make it pass.
+
+## 4-phase loop
+
+### Phase 1 — Orient
+
+1. Read `scripts/ralph/prd-142-wave0.json`. Among {US-001, US-002, US-004, US-005, US-006}, find the **first** (lowest `priority`) story with `passes: false`.
+2. If all five are `passes: true`, write the completion commit (Phase 4) and emit `RALPH_COMPLETE`.
+3. Read that story's `acceptanceCriteria` AND `notes`. The notes carry the reuse decision and the "do NOT touch X" boundaries — obey them literally.
+4. Run `git status` and `git log --oneline -10` to confirm a clean tree and recent history. If the tree is dirty with work that is not yours, STOP and emit `RALPH_ABORT: dirty tree`.
+
+### Phase 2 — Implement ONE story
+
+- Read existing code first. Use Grep/Glob aggressively. The PRD reuse map cites exact files — `core/utils/exception_telemetry.py` (record_error), `core/models/widget_event_log.py` + `modules/widgets/telemetry.py` (widget pattern), `api/analytics_real.py` (the OrchestrationRun union + RunState enum), `api/heartbeat.py` (heartbeat_results). Reuse them.
+- Make the smallest change that satisfies the acceptance criteria. Do not add fields, endpoints, or tables the story does not ask for.
+- **Every new endpoint is workspace-scoped** via `ctx = Depends(get_request_context_hybrid)` and filtered by `ctx.workspace_id`, EXCEPT US-005 activation, which is an intentional platform-level cross-workspace rate. Each endpoint story must add a tenant-isolation test.
+- **US-001 migration must be online-safe:** new table only, no backfill, no `NOT NULL` added to an existing large table, no data migration. Follow the `widget_event_log` / single-table-JSONB ORM pattern with `extend_existing=True`. Do NOT change `record_error`'s keyword-only signature or its never-raises contract — the sink write is best-effort (try/except, rollback, swallow); the `automatos.errors` logger emit stays unchanged.
+- Add new endpoints to an EXISTING analytics router (`api/analytics_real.py` or `api/analytics.py`). Do NOT create a new router file.
+- If you delete a surface the story replaces, delete it cleanly — no `_legacy_` shims (CLAUDE.md §4).
+
+### Phase 3 — Validate
+
+```bash
+# 1. Syntax + import health
+python3 -m py_compile $(git diff --name-only --diff-filter=AM HEAD | grep '\.py$')
+cd orchestrator && python -c "from main import app; print('import OK')"
+
+# 2. The story's own tests (named in its acceptanceCriteria) must pass
+cd orchestrator && python -m pytest tests/<the story's test file> -v
+
+# 3. The grep gates in the acceptanceCriteria must return what the AC says (usually ZERO)
+```
+
+All must pass. For US-001 also confirm the Alembic migration is syntactically valid and has a non-empty `downgrade()` (`python3 -m py_compile orchestrator/alembic/versions/<new>.py`). Do NOT run the migration against a live DB — a human applies migrations.
+
+If validation fails:
+- If a quick honest fix is obvious, apply it.
+- Otherwise revert your changes (`git checkout -- .`) and exit with a commit message starting `BLOCKED:`. Don't half-ship, and never weaken a test to go green.
+
+### Phase 4 — Flip passes + Commit + Exit
+
+1. In `scripts/ralph/prd-142-wave0.json`, set the finished story's `"passes": false` to `"passes": true` and append a one-line completion note to its `notes` (what landed, commit-worthy facts). Keep the JSON valid.
+2. Stage the relevant files **by name** (never `git add .`). Skip `.env`, anything in `archive/`, anything you did not touch.
+3. Commit with this format:
+
+   ```
+   feat(prd-142): US-XXX — <one-line description>
+
+   <2-4 line body: what was added/reused and why; cite the reused surface>
+
+   Story: scripts/ralph/prd-142-wave0.json US-XXX
+   PRD: docs/PRDS/PRD-142-WAVE0-MEASUREMENT.md
+   ```
+
+4. If this was the **last** of the five backend stories (all now `passes: true`), instead end the body with:
+
+   ```
+   PRD-142 Wave 0 backend complete (US-001/002/004/005/006). US-007 frontend + US-008 live gate remain for human.
+
+   RALPH_COMPLETE
+   ```
+
+5. Exit. Do not loop into the next story yourself — the outer loop re-invokes you.
+
+## Project conventions (do not violate)
+
+- NO `os.getenv()` outside `orchestrator/config.py`.
+- NO hardcoded URLs / API keys / tokens / magic metric values.
+- SQLAlchemy: use `text()` with bind params, never f-string SQL. No divide-by-zero (rate is 0 when denominator is 0).
+- Pydantic response schemas live in `orchestrator/api/schemas/`.
+- Use the canonical `RunState.COMPLETED.value` enum (core/models/orchestration_enums.py), not the literal string, where it exists.
+- Reuse the `ApiResponse`/envelope pattern the existing analytics endpoints already use.
+
+## Anti-patterns (will be reverted on review)
+
+- Faking a metric value (a hardcoded number with no DB source) — Wave 0 exists to DELETE fakes, not add them. Omit a field rather than fake it.
+- Creating a new router file, a new frontend page, or touching `frontend/` in this run.
+- Adding a second event-writer or changing `modules/widgets/telemetry.py` / the heartbeat writer (US-004/US-006 are READ-only).
+- Changing `record_error`'s signature or making it raise (US-001).
+- `# type: ignore` / weakening an assertion to make checks pass.
+- Adding emoji to source files; writing a feature README unless the story requires it.
+- `git push`, opening a PR, or merging. Branch-local commits ONLY.
+
+## When in doubt
+
+- Re-read the story's `notes` field and the PRD reuse map.
+- Read `CLAUDE.md` at repo root.
+- Search before you build. Smaller diff > bigger diff. Reuse > build.
+- If a metric has no real source, report the honest gap (`unknown`/omit) — never invent coverage.
+
+Begin Phase 1.

--- a/scripts/ralph/loop-prd142.sh
+++ b/scripts/ralph/loop-prd142.sh
@@ -1,0 +1,242 @@
+#!/bin/bash
+
+# Ralph Wiggum Build Loop (Claude) — PRD-142 Wave 0 (Measurement First)
+# Usage:
+#   ./loop-prd142.sh           # Build mode (default, runs until RALPH_COMPLETE)
+#   ./loop-prd142.sh 8         # Max 8 iterations (safety cap)
+
+set -e
+
+# Allow nested Claude Code sessions (Ralph spawns child claude processes)
+unset CLAUDECODE
+
+MODE="build"
+MAX_ITERATIONS=0
+ITERATION=0
+CONSECUTIVE_FAILURES=0
+
+# Colors
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+GREEN='\033[0;32m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+for arg in "$@"; do
+  if [[ "$arg" =~ ^[0-9]+$ ]]; then
+    MAX_ITERATIONS=$arg
+  fi
+done
+
+PROMPT_FILE="scripts/ralph/PROMPT_build_prd142.md"
+
+if [[ ! -f "$PROMPT_FILE" ]]; then
+  echo -e "${RED}Error: $PROMPT_FILE not found${NC}"
+  exit 1
+fi
+
+seconds_until_next_hour() {
+  local now=$(date +%s)
+  local current_minute=$(date +%M)
+  local current_second=$(date +%S)
+  local seconds_past_hour=$((10#$current_minute * 60 + 10#$current_second))
+  local seconds_until=$((3600 - seconds_past_hour))
+  echo $seconds_until
+}
+
+seconds_until_daily_reset() {
+  local reset_hour=5
+  local now=$(date +%s)
+  local today_reset=$(date -v${reset_hour}H -v0M -v0S +%s 2>/dev/null || date -d "today ${reset_hour}:00:00" +%s)
+
+  if [[ $now -ge $today_reset ]]; then
+    local tomorrow_reset=$((today_reset + 86400))
+    echo $((tomorrow_reset - now))
+  else
+    echo $((today_reset - now))
+  fi
+}
+
+countdown() {
+  local seconds=$1
+  local message=$2
+
+  while [[ $seconds -gt 0 ]]; do
+    local hours=$((seconds / 3600))
+    local minutes=$(((seconds % 3600) / 60))
+    local secs=$((seconds % 60))
+    printf "\r${CYAN}%s${NC} Time remaining: %02d:%02d:%02d " "$message" $hours $minutes $secs
+    sleep 1
+    ((seconds--))
+  done
+  printf "\r%-80s\r" " "
+}
+
+is_usage_limit_error() {
+  local output="$1"
+  local exit_code="$2"
+
+  [[ "$exit_code" -eq 0 ]] && return 1
+
+  if echo "$output" | grep '^{' | jq -e 'select(.type == "result") | select(.subtype | test("error.*limit|rate_limit"))' &>/dev/null; then
+    return 0
+  fi
+
+  local error_text
+  error_text=$(echo "$output" | grep -v '^{' || true)
+  error_text+=$(echo "$output" | grep '^{' | jq -r 'select(.type == "result" and .is_error == true) | .result // empty' 2>/dev/null || true)
+
+  if [[ "$error_text" =~ "You've hit your limit" ]] || [[ "$error_text" =~ "You have hit your limit" ]]; then
+    return 0
+  fi
+  if [[ "$error_text" =~ Error:\ 429 ]] || [[ "$error_text" =~ Error:\ 529 ]]; then
+    return 0
+  fi
+  if [[ "$error_text" =~ rate.?limit ]] || [[ "$error_text" =~ usage.?limit ]]; then
+    return 0
+  fi
+  return 1
+}
+
+get_sleep_duration() {
+  local output="$1"
+
+  if [[ "$output" =~ "try again in "([0-9]+)" minute" ]]; then
+    echo $(( ${BASH_REMATCH[1]} * 60 + 60 ))
+    return
+  fi
+
+  if [[ "$output" =~ "try again in "([0-9]+)" hour" ]]; then
+    echo $(( ${BASH_REMATCH[1]} * 3600 + 60 ))
+    return
+  fi
+
+  if [[ "$output" =~ (daily|day|24.?hour) ]]; then
+    seconds_until_daily_reset
+    return
+  fi
+
+  local wait_time=$(seconds_until_next_hour)
+  [[ $wait_time -lt 300 ]] && wait_time=300
+  echo $wait_time
+}
+
+handle_usage_limit() {
+  local output="$1"
+  local sleep_duration=$(get_sleep_duration "$output")
+
+  echo ""
+  echo -e "${YELLOW}=== Usage Limit Detected ===${NC}"
+  echo -e "${YELLOW}Waiting for reset...${NC}"
+  echo ""
+
+  local resume_time=$(date -v+${sleep_duration}S "+%Y-%m-%d %H:%M:%S" 2>/dev/null || date -d "+${sleep_duration} seconds" "+%Y-%m-%d %H:%M:%S")
+  echo -e "Expected resume: ${CYAN}${resume_time}${NC}"
+  echo ""
+
+  countdown $sleep_duration "Waiting..."
+
+  echo ""
+  echo -e "${GREEN}Resuming...${NC}"
+  echo ""
+
+  CONSECUTIVE_FAILURES=0
+}
+
+echo -e "${GREEN}Ralph loop: BUILD mode — PRD-142 Wave 0 Measurement (5 backend stories: US-001/002/004/005/006)${NC}"
+[[ $MAX_ITERATIONS -gt 0 ]] && echo "Max iterations: $MAX_ITERATIONS"
+echo "Press Ctrl+C to stop"
+echo "---"
+
+while true; do
+  ITERATION=$((ITERATION + 1))
+  echo ""
+  echo -e "${GREEN}=== Build Iteration $ITERATION ===${NC}"
+  echo ""
+
+  TEMP_OUTPUT=$(mktemp)
+  set +e
+
+  claude --print \
+    --verbose \
+    --output-format stream-json \
+    --dangerously-skip-permissions \
+    < "$PROMPT_FILE" 2>&1 | tee "$TEMP_OUTPUT" | sed 's/\x1b\[[0-9;]*m//g' | grep --line-buffered '^{' | jq --unbuffered -r '
+      def tool_info:
+        if .name == "Edit" or .name == "Write" or .name == "Read" then
+          (.input.file_path // .input.path | split("/") | last | .[0:60])
+        elif .name == "Bash" then
+          (.input.command // .input.cmd | if contains("\n") then split("\n") | first | .[0:50] else .[0:80] end)
+        elif .name == "Grep" then
+          (.input.pattern | .[0:40])
+        elif .name == "Glob" then
+          (.input.pattern // .input.filePattern | .[0:40])
+        else null end;
+      if .type == "assistant" then
+        .message.content[] |
+        if .type == "text" then
+          if (.text | split("\n") | length) <= 3 then .text else empty end
+        elif .type == "tool_use" then
+          "    [" + .name + "]" + (tool_info | if . then " " + . else "" end)
+        else empty end
+      elif .type == "result" then
+        "--- " + ((.duration_ms / 1000 * 10 | floor / 10) | tostring) + "s, " + (.num_turns | tostring) + " turns ---"
+      else empty end
+    ' 2>/dev/null
+
+  EXIT_CODE=${PIPESTATUS[0]}
+  OUTPUT=$(cat "$TEMP_OUTPUT")
+  RESULT_MSG=$(sed 's/\x1b\[[0-9;]*m//g' "$TEMP_OUTPUT" | grep '^{' | jq -r 'select(.type == "result") | .result // empty' 2>/dev/null | tail -1)
+  rm -f "$TEMP_OUTPUT"
+  set -e
+
+  if is_usage_limit_error "$OUTPUT" "$EXIT_CODE"; then
+    handle_usage_limit "$OUTPUT"
+    ITERATION=$((ITERATION - 1))
+    continue
+  fi
+
+  if [[ $EXIT_CODE -ne 0 ]]; then
+    CONSECUTIVE_FAILURES=$((CONSECUTIVE_FAILURES + 1))
+    echo ""
+    echo -e "${RED}=== Error (exit code: $EXIT_CODE) ===${NC}"
+    echo -e "${RED}Output:${NC}"
+    echo "$OUTPUT" | tail -20
+    echo ""
+
+    BACKOFF=$((30 * (2 ** (CONSECUTIVE_FAILURES - 1))))
+    [[ $BACKOFF -gt 300 ]] && BACKOFF=300
+
+    echo -e "${YELLOW}Retrying in ${BACKOFF}s... (consecutive failures: $CONSECUTIVE_FAILURES)${NC}"
+    countdown $BACKOFF "Waiting..."
+    ITERATION=$((ITERATION - 1))
+    continue
+  fi
+
+  CONSECUTIVE_FAILURES=0
+
+  if [[ "$RESULT_MSG" =~ RALPH_COMPLETE ]]; then
+    echo ""
+    echo -e "${GREEN}=== Ralph Complete ===${NC}"
+    echo -e "${GREEN}PRD-142 Wave 0 backend done (US-001/002/004/005/006). US-007 frontend + US-008 live gate remain for human review.${NC}"
+    break
+  fi
+
+  if [[ "$RESULT_MSG" =~ RALPH_BLOCKED ]] || [[ "$RESULT_MSG" =~ RALPH_ABORT ]]; then
+    echo ""
+    echo -e "${YELLOW}=== Ralph Halted (BLOCKED/ABORT) ===${NC}"
+    echo -e "${YELLOW}A story could not proceed safely. Loop halted — see commit log / last output for the reason.${NC}"
+    break
+  fi
+
+  if [[ $MAX_ITERATIONS -gt 0 && $ITERATION -ge $MAX_ITERATIONS ]]; then
+    echo ""
+    echo -e "${GREEN}Reached max iterations ($MAX_ITERATIONS).${NC}"
+    break
+  fi
+
+  sleep 2
+done
+
+echo ""
+echo -e "${GREEN}Ralph loop complete. Iterations: $ITERATION${NC}"

--- a/scripts/ralph/prd-142-wave0.json
+++ b/scripts/ralph/prd-142-wave0.json
@@ -35,8 +35,8 @@
         "pytest orchestrator/tests/test_errors_by_subsystem_endpoint.py green"
       ],
       "priority": 3,
-      "passes": false,
-      "notes": "BLOCKED by US-001 (needs the error_events table). Reuse the existing analytics router prefix /api/analytics (api/analytics_real.py:32) — do not add a new router. workspace_id NULL rows (system-level errors) are excluded from the workspace-scoped view by design; that is correct, not a bug."
+      "passes": true,
+      "notes": "BLOCKED by US-001 (needs the error_events table). Reuse the existing analytics router prefix /api/analytics (api/analytics_real.py:32) — do not add a new router. workspace_id NULL rows (system-level errors) are excluded from the workspace-scoped view by design; that is correct, not a bug. DONE 2026-05-29: GET /api/analytics/errors/by-subsystem added to api/analytics_real.py (existing router, no new file). Workspace-scoped via ctx.workspace_id; window arg parsed by new _parse_window helper (h/d units, 24h default on malformed input). Returns {window, total, by_subsystem:[{subsystem,count,rate}], generated_at}; rate=count/total over the window with no divide-by-zero. Query groups by ErrorEvent.subsystem with (workspace_id, created_at >= cutoff) filter — index-eligible via idx_error_events_subsystem_created / idx_error_events_workspace_created. 4 new tests green in tests/test_errors_by_subsystem_endpoint.py incl. tenant isolation + window math; US-001 (8) and US-003 (2) tests still green (no regression)."
     },
     {
       "id": "US-003",

--- a/scripts/ralph/prd-142-wave0.json
+++ b/scripts/ralph/prd-142-wave0.json
@@ -88,8 +88,8 @@
         "pytest orchestrator/tests/test_activation_endpoint.py green"
       ],
       "priority": 5,
-      "passes": false,
-      "notes": "Use the canonical RunState.COMPLETED.value (core/models/orchestration_enums.py) for the completed check, matching api/analytics_real.py:69 — do not hardcode the string 'completed' if the enum is available. This is a platform-level rate across workspaces; it is the one tile that is intentionally NOT filtered to a single workspace_id."
+      "passes": true,
+      "notes": "Use the canonical RunState.COMPLETED.value (core/models/orchestration_enums.py) for the completed check, matching api/analytics_real.py:69 — do not hardcode the string 'completed' if the enum is available. This is a platform-level rate across workspaces; it is the one tile that is intentionally NOT filtered to a single workspace_id. DONE 2026-05-29: GET /api/analytics/activation added to api/analytics_real.py (existing router, no new file). Activation count = COUNT(DISTINCT OrchestrationRun.workspace_id) filtered to state == RunState.COMPLETED.value (canonical enum, never the literal 'completed'); denominator = COUNT(Workspace.id). Returns {activated, total_workspaces, rate, generated_at}; rate=activated/total_workspaces with no divide-by-zero and no fake fallback when zero workspaces. Intentionally platform-level — auth via ctx.Depends(get_request_context_hybrid) but NO workspace_id filter on the data (per US-005 notes). 3 new tests green in tests/test_activation_endpoint.py incl. completed-state-filter guardrail; US-001 (8), US-002 (4), US-003 (2), US-004 (4), exception_telemetry (4) all still green (25 total)."
     },
     {
       "id": "US-006",

--- a/scripts/ralph/prd-142-wave0.json
+++ b/scripts/ralph/prd-142-wave0.json
@@ -18,8 +18,8 @@
         "pytest orchestrator/tests/test_error_events_sink.py green"
       ],
       "priority": 2,
-      "passes": false,
-      "notes": "Reuse-checked 2026-05-29: no existing error-event table exists; closest is the automatos.errors logger (core/utils/exception_telemetry.py:22). A focused append-only table is justified and follows the established widget_event_log pattern. Do NOT change record_error's signature — handlers already call it with keyword args. Do NOT mass-adopt record_error across handlers here (that was out of scope in PRD-141 US-001 and stays out). The migration must be online-safe (new table, no backfill, no NOT NULL on an existing large table)."
+      "passes": true,
+      "notes": "Reuse-checked 2026-05-29: no existing error-event table exists; closest is the automatos.errors logger (core/utils/exception_telemetry.py:22). A focused append-only table is justified and follows the established widget_event_log pattern. Do NOT change record_error's signature — handlers already call it with keyword args. Do NOT mass-adopt record_error across handlers here (that was out of scope in PRD-141 US-001 and stays out). The migration must be online-safe (new table, no backfill, no NOT NULL on an existing large table). DONE 2026-05-29: error_events table + 2 indexes via alembic/versions/prd142_wave0_error_events.py (down_revision=None standalone, online-safe new-table-only). ORM core/models/error_event.py mirrors widget_event_log (extend_existing=True, JSONB event_data). record_error gets a best-effort sink via _persist_error_event (lazy SessionLocal import, catch-all/rollback/close, never raises) — signature + automatos.errors emit unchanged. 8 new tests green in tests/test_error_events_sink.py incl. signature guardrail; 4 existing test_exception_telemetry.py tests still green (no regression)."
     },
     {
       "id": "US-002",

--- a/scripts/ralph/prd-142-wave0.json
+++ b/scripts/ralph/prd-142-wave0.json
@@ -53,8 +53,8 @@
         "pytest green; existing analytics tests green"
       ],
       "priority": 1,
-      "passes": false,
-      "notes": "Cheapest honesty win — land it first. The fake 85.0 is the literal symptom Wave 0 exists to kill (analytics_engine.py:118). This also satisfies the no-hardcoded-values rule (CLAUDE.md §4). Do NOT touch _get_workflow_metrics (line 144-174) — its mission success math is already real and correct; only _get_agent_metrics is faked."
+      "passes": true,
+      "notes": "DONE 2026-05-29 (commit 756cbf4b8). Removed BOTH fake blocks: _get_agent_metrics (4 placeholders) and get_agent_analytics (5 placeholders) — the second block was not in the original AC but carried the same 85.0/2.5 fakes. grep '85.0'/'2.5'/'# Placeholder' all return 0. Verified no consumer: GET /api/analytics/agents/{id} has zero frontend callers; frontend performanceTrend at agent-performance.tsx:128 is a local stub reading snake_case agentStats, not this endpoint. _get_workflow_metrics left untouched (real). 2 tests green. Cheapest honesty win — landed first as proof-of-life."
     },
     {
       "id": "US-004",

--- a/scripts/ralph/prd-142-wave0.json
+++ b/scripts/ralph/prd-142-wave0.json
@@ -71,8 +71,8 @@
         "pytest orchestrator/tests/test_widget_engagement_endpoint.py green"
       ],
       "priority": 4,
-      "passes": false,
-      "notes": "Reuse-checked: widget_event_log table + idx_widget_event_log_type_created + writer log_widget_event all exist (PRD-008-A); only the read/aggregation side is missing. Do NOT add new event types or touch the writer modules/widgets/telemetry.py."
+      "passes": true,
+      "notes": "Reuse-checked: widget_event_log table + idx_widget_event_log_type_created + writer log_widget_event all exist (PRD-008-A); only the read/aggregation side is missing. Do NOT add new event types or touch the writer modules/widgets/telemetry.py. DONE 2026-05-29: GET /api/analytics/widget-engagement added to api/analytics_real.py (existing router, no new file). Workspace-scoped via Site.workspace_id resolution → site_id.in_(...) on widget_event_log (the log itself has no workspace_id; one workspace = many sites per PRD-008-A); empty-sites short-circuit returns zero. Aggregation filters event_type IN WIDGET_EVENT_TYPES so idx_widget_event_log_type_created is eligible alongside the created_at window; sessions = COUNT(DISTINCT session_id) over the same filter. Returns {window, by_event_type:[{event_type,count}], sessions, generated_at}; window parsing reuses _parse_window. Pure read — grep 'WidgetEventLog(' on analytics_real.py = 0 (no row construction). 4 new tests green in tests/test_widget_engagement_endpoint.py incl. tenant site-scoping + window math; US-001 (6+1 sig+1 rollback), US-002 (4), US-003 (2), and exception_telemetry (4) all still green (22 total)."
     },
     {
       "id": "US-005",


### PR DESCRIPTION
## Summary

PRD-142 **Wave 0** — the "Is it working?" measurement backend. Replaces fake/placeholder analytics with real, workspace-scoped metrics feeding the **existing** dashboard. Backend + instrumentation only — no new page, no new route, no frontend in this PR.

- **US-001** — persist `record_error()` to a queryable `error_events` sink (new table + model + best-effort write path that never raises and rolls back cleanly).
- **US-002** — `GET /api/analytics/errors/by-subsystem`: real error-rate-by-subsystem, workspace-scoped, windowed (`?window=24h`), backed by an index on `(workspace_id, created_at)`.
- **US-003** — removed fake agent-metrics placeholders from `analytics_engine.py`.
- **US-004** — `GET /api/analytics/widget-engagement`: real widget engagement, tenant-isolated via Site→workspace resolution.
- **US-005** — `GET /api/analytics/activation`: platform-level activation (distinct workspaces with ≥1 completed run / total workspaces).
- Wave 0 Ralph harness (`scripts/ralph/`) — prompt, loop script, story spec.

## Scope / deferrals

- **US-006** (per-primitive health tile) — **deferred to Wave 3.** No honest per-primitive data source exists yet: the heartbeat writer emits only operational findings (`agent_health`, `checklist`, …), none mapped to the 8 product primitives. Building now would ship a hollow all-"unknown" tile. Contract + sourcing options recorded for Wave 3.
- **US-007** (frontend tiles) and **US-008** (live Railway gate) — not in this PR; hands-on, separate.

## Test plan

- [x] 21/21 Wave 0 unit tests green (mocked DB + FastAPI TestClient, dependency-overridden ctx/db).
- [x] Endpoints reviewed for tenant isolation (workspace_id scoping) and divide-by-zero safety.
- [x] Migration reviewed — downgrade present, drops table + index cleanly.
- [x] Rebased onto main (PR #399 / PRD-140) — zero file overlap, clean merge.
- [ ] Post-merge: Railway applies migration (`alembic upgrade heads`); confirm `error_events` table created.
- [ ] Post-merge: hit the 3 endpoints on a deployed env; confirm real (non-placeholder) data renders.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Error rate analytics by subsystem with rolling-window filtering
  * Widget engagement metrics with distinct session counting
  * Platform activation rate measurement for compliance tracking
  * Persistent error event logging system supporting dashboard visibility

* **Tests**
  * Added comprehensive test coverage for new analytics endpoints and error logging functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AutomatosAI/automatos-ai/pull/400?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->