### PR TITLE
fix(widgets): match request origin against allow-list regardless of s…

### DIFF
--- a/orchestrator/api/shopify.py
+++ b/orchestrator/api/shopify.py
@@ -48,6 +48,28 @@ def _verify_internal_key(authorization: str = Header(...)) -> None:
         raise HTTPException(status_code=401, detail="Invalid internal API key")
 
 
+def _build_allowed_domains(shop: str, metadata: Dict[str, Any]) -> List[str]:
+    """Origins permitted to use the minted widget key.
+
+    Always allows the shop's ``*.myshopify.com`` domains. When the shop has a
+    custom primary domain (e.g. ``www.inbuilduk.com``) the storefront serves
+    the widget from there, so the browser ``Origin`` is the custom domain —
+    not ``*.myshopify.com``. Allow that host plus its apex and sibling
+    subdomains, otherwise the blog/chat widgets 403 on custom-domain stores.
+    """
+    domains = [f"https://{shop}", f"https://*.{shop}", "https://*.myshopify.com"]
+
+    primary = metadata.get("domain")
+    if primary:
+        host = primary.split("://", 1)[-1].strip("/").split("/", 1)[0]
+        if host and "myshopify.com" not in host:
+            apex = host[4:] if host.startswith("www.") else host
+            domains += [f"https://{host}", f"https://{apex}", f"https://*.{apex}"]
+
+    seen: set[str] = set()
+    return [d for d in domains if not (d in seen or seen.add(d))]
+
+
 # ── Pydantic models ─────────────────────────────────────────────────
 
 class ProvisionRequest(BaseModel):
@@ -204,7 +226,7 @@ async def provision_workspace(
         name=f"Shopify Widget Key ({shop})",
         key_type="public",
         permissions=["chat", "documents:read", "agents:read", "agents:execute"],
-        allowed_domains=[f"https://{shop}", f"https://*.{shop}", "https://*.myshopify.com"],
+        allowed_domains=_build_allowed_domains(shop, request.metadata),
     )
 
     db.commit()

--- a/orchestrator/core/services/api_key_service.py
+++ b/orchestrator/core/services/api_key_service.py
@@ -25,6 +25,20 @@ def _hash_key(raw_key: str) -> str:
     return hashlib.sha256(raw_key.encode()).hexdigest()
 
 
+def _host_only(value: str) -> str:
+    """Reduce an origin or allow-list pattern to its host[:port] form.
+
+    Request origins arrive as bare hosts (``_extract_origin`` returns
+    ``parsed.hostname``) while allow-list entries are commonly stored with a
+    scheme (``https://*.myshopify.com``) and sometimes a trailing slash. A
+    scheme-prefixed pattern can never ``fnmatch`` a bare host, so we strip the
+    scheme and trailing slash from both sides before comparing.
+    """
+    if "://" in value:
+        value = value.split("://", 1)[1]
+    return value.rstrip("/")
+
+
 class ApiKeyService:
     """Manages SDK API keys with SHA-256 hashing."""
 
@@ -206,8 +220,9 @@ class ApiKeyService:
         if not api_key.allowed_domains:
             return True
 
+        candidate = _host_only(origin)
         for pattern in api_key.allowed_domains:
-            if fnmatch(origin, pattern):
+            if fnmatch(candidate, _host_only(pattern)):
                 return True
 
         return False

--- a/orchestrator/tests/test_api_key_domain_check.py
+++ b/orchestrator/tests/test_api_key_domain_check.py
@@ -1,0 +1,92 @@
+"""Regression tests for widget API-key origin matching.
+
+Covers the scheme-mismatch bug where a request origin (bare host, as returned
+by ``_extract_origin``) could never match an allow-list entry stored with a
+scheme (``https://*.myshopify.com``), causing every Bearer-key blog/chat
+request from a real storefront to 403.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from api.shopify import _build_allowed_domains
+from core.services.api_key_service import ApiKeyService
+
+
+def _key(domains):
+    return SimpleNamespace(allowed_domains=domains)
+
+
+class TestCheckDomainSchemeInsensitive:
+    def test_bare_host_matches_scheme_prefixed_wildcard(self):
+        # The actual prod failure: bare host vs https://*.myshopify.com.
+        key = _key(["https://*.myshopify.com"])
+        assert ApiKeyService.check_domain(key, "besafe-ltd.myshopify.com") is True
+
+    def test_bare_host_matches_exact_scheme_prefixed_entry(self):
+        key = _key(["https://besafe-ltd.myshopify.com"])
+        assert ApiKeyService.check_domain(key, "besafe-ltd.myshopify.com") is True
+
+    def test_trailing_slash_in_pattern_is_ignored(self):
+        key = _key(["https://www.inbuilduk.com/"])
+        assert ApiKeyService.check_domain(key, "www.inbuilduk.com") is True
+
+    def test_scheme_prefixed_origin_also_matches(self):
+        key = _key(["https://*.myshopify.com"])
+        assert ApiKeyService.check_domain(key, "https://x.myshopify.com") is True
+
+    def test_non_matching_origin_is_rejected(self):
+        key = _key(["https://*.myshopify.com"])
+        assert ApiKeyService.check_domain(key, "evil.example.com") is False
+
+    def test_empty_allow_list_permits_all(self):
+        assert ApiKeyService.check_domain(_key([]), "anything.example.com") is True
+        assert ApiKeyService.check_domain(_key(None), "anything.example.com") is True
+
+
+class TestBuildAllowedDomains:
+    def test_myshopify_only_when_no_custom_domain(self):
+        domains = _build_allowed_domains("shop.myshopify.com", {})
+        assert domains == [
+            "https://shop.myshopify.com",
+            "https://*.shop.myshopify.com",
+            "https://*.myshopify.com",
+        ]
+
+    def test_custom_www_domain_adds_apex_and_wildcard(self):
+        domains = _build_allowed_domains(
+            "inbuild-uk.myshopify.com", {"domain": "https://www.inbuilduk.com"}
+        )
+        assert "https://www.inbuilduk.com" in domains
+        assert "https://inbuilduk.com" in domains
+        assert "https://*.inbuilduk.com" in domains
+
+    def test_custom_domain_origins_pass_check_domain(self):
+        domains = _build_allowed_domains(
+            "inbuild-uk.myshopify.com", {"domain": "https://www.inbuilduk.com"}
+        )
+        key = _key(domains)
+        for origin in ("www.inbuilduk.com", "inbuilduk.com", "shop.inbuilduk.com"):
+            assert ApiKeyService.check_domain(key, origin) is True
+
+    def test_no_duplicate_entries(self):
+        domains = _build_allowed_domains(
+            "inbuild-uk.myshopify.com", {"domain": "https://www.inbuilduk.com"}
+        )
+        assert len(domains) == len(set(domains))
+
+    def test_myshopify_primary_domain_does_not_duplicate(self):
+        # primaryDomain == the myshopify domain → no custom entries added.
+        domains = _build_allowed_domains(
+            "shop.myshopify.com", {"domain": "https://shop.myshopify.com"}
+        )
+        assert domains == [
+            "https://shop.myshopify.com",
+            "https://*.shop.myshopify.com",
+            "https://*.myshopify.com",
+        ]
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
…cheme

Request origins arrive as bare hosts (_extract_origin returns parsed.hostname) but key allowed_domains are stored with an https:// scheme, so fnmatch never matched and every Bearer-key blog/chat request from a real storefront 403'd. The chat widget masked this by using the JWT token-exchange path, which skips the origin check; the blog widget calls the API with the raw ak_pub_ key and hit the broken check directly. Normalize both sides to host-only before match.

Also include the shop's custom primary domain (+ apex/subdomain wildcards) in the provisioned allow-list so custom-domain storefronts (e.g. www.inbuilduk.com) are permitted, not just *.myshopify.com.