### PR TITLE
feat(prd-142-wave1): WS-A — adopt record_error at failure hot-paths

### DIFF
--- a/orchestrator/api/board_tasks.py
+++ b/orchestrator/api/board_tasks.py
@@ -21,6 +21,7 @@ from core.auth.dependencies import RequestContext
 from core.database.database import get_db
 from core.models.core import BoardTask
 from core.models import Agent
+from core.utils.exception_telemetry import record_error
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/v1/tasks", tags=["board-tasks"])
@@ -766,6 +767,14 @@ def _launch_task_execution(
         except Exception as e:
             logger.error(
                 "[BoardTasks] Task %d execution failed: %s", task_id, e, exc_info=True,
+            )
+            record_error(
+                subsystem="board",
+                operation="execute_task",
+                error=e,
+                workspace_id=workspace_id,
+                agent_id=agent_id,
+                extra={"task_id": task_id},
             )
             try:
                 task = db.query(BoardTask).get(task_id)

--- a/orchestrator/api/wizard.py
+++ b/orchestrator/api/wizard.py
@@ -38,6 +38,7 @@ from core.auth.hybrid import get_request_context_hybrid
 from core.database.database import get_db, get_db_session
 from core.models.business_profiles import BusinessProfile
 from core.models.core import Agent
+from core.utils.exception_telemetry import record_error
 
 from modules.intake.archetypes import (
     ARCHETYPES,
@@ -777,6 +778,13 @@ async def _run_scrape_pipeline(
 
     except Exception as exc:  # noqa: BLE001
         logger.exception("wizard pipeline failed profile=%s: %s", profile_id, exc)
+        record_error(
+            subsystem="wizard",
+            operation="scrape_pipeline",
+            error=exc,
+            workspace_id=workspace_id,
+            extra={"profile_id": profile_id, "domain": domain},
+        )
         # Mark the profile row failed so the UI can reflect it on reload
         try:
             with get_db_session() as db:

--- a/orchestrator/modules/coordination/planner.py
+++ b/orchestrator/modules/coordination/planner.py
@@ -25,6 +25,7 @@ from uuid import UUID, uuid4
 from config import COMPLEXITY_TOKEN_BUDGET, Config
 from core.llm import create_llm_manager
 from core.models.core import Agent
+from core.utils.exception_telemetry import record_error
 from core.models.orchestration_enums import ComplexityTier, TaskType
 from modules.coordination.templates import match_template, render_template
 from services.orchestration_deps import (
@@ -424,7 +425,15 @@ class MissionPlanner:
                 max_concurrent=max_concurrent,
             )
 
-        raise PlanValidationError(last_errors)
+        err = PlanValidationError(last_errors)
+        record_error(
+            subsystem="planner",
+            operation="replan",
+            error=err,
+            workspace_id=workspace_id,
+            extra={"goal": goal[:200], "failed_task_title": failed_task_title},
+        )
+        raise err
 
     @staticmethod
     async def decompose(
@@ -641,8 +650,17 @@ class MissionPlanner:
                 max_concurrent=max_concurrent,
             )
 
-        # All retries exhausted
-        raise PlanValidationError(last_errors)
+        # All retries exhausted — record the terminal planning failure so the
+        # ERRORS-by-subsystem tile reflects it, then surface to the caller.
+        err = PlanValidationError(last_errors)
+        record_error(
+            subsystem="planner",
+            operation="decompose",
+            error=err,
+            workspace_id=workspace_id,
+            extra={"goal": goal[:200]},
+        )
+        raise err
 
 
 # ---------------------------------------------------------------------------

--- a/orchestrator/modules/coordination/verification.py
+++ b/orchestrator/modules/coordination/verification.py
@@ -24,6 +24,7 @@ from uuid import UUID
 
 from config import Config
 from core.llm import create_llm_manager
+from core.utils.exception_telemetry import record_error
 from modules.coordination.deterministic_checks import DeterministicChecker, DeterministicResult
 
 logger = logging.getLogger(__name__)
@@ -467,6 +468,7 @@ class VerificationService:
         ]
 
         last_error: Optional[str] = None
+        last_exc: Optional[Exception] = None
 
         for attempt in range(1, max_retries + 1):
             try:
@@ -560,7 +562,8 @@ class VerificationService:
                     tokens_used=tokens_used,
                 )
 
-            except Exception:
+            except Exception as exc:
+                last_exc = exc
                 last_error = f"LLM judge call failed on attempt {attempt}"
                 logger.error(
                     "Verification LLM judge error (attempt %d/%d) for task '%s'",
@@ -568,10 +571,18 @@ class VerificationService:
                     exc_info=True,
                 )
 
-        # All retries exhausted — return partial (escalate to human)
+        # All retries exhausted — return partial (escalate to human). Record the
+        # terminal failure so the ERRORS-by-subsystem tile reflects it; the
+        # advisory degrade-to-PARTIAL behaviour is unchanged.
         logger.warning(
             "Verification LLM judge exhausted %d retries for task '%s': %s",
             max_retries, task_title, last_error,
+        )
+        record_error(
+            subsystem="verification",
+            operation="verify_task",
+            error=last_exc or RuntimeError(last_error or "LLM judge failed"),
+            extra={"task_title": task_title[:200], "max_retries": max_retries},
         )
         return VerificationResult(
             verdict=VERDICT_PARTIAL,
@@ -650,6 +661,7 @@ class VerificationService:
         ]
 
         last_error: Optional[str] = None
+        last_exc: Optional[Exception] = None
 
         for attempt in range(1, max_retries + 1):
             try:
@@ -718,7 +730,8 @@ class VerificationService:
                     tokens_used=tokens_used,
                 )
 
-            except Exception:
+            except Exception as exc:
+                last_exc = exc
                 last_error = f"Consistency LLM call failed on attempt {attempt}"
                 logger.error(
                     "Consistency check error (attempt %d/%d) for run %s",
@@ -726,10 +739,18 @@ class VerificationService:
                     exc_info=True,
                 )
 
-        # All retries exhausted — assume passed (don't block human review)
+        # All retries exhausted — assume passed (don't block human review).
+        # Record the terminal failure so the ERRORS-by-subsystem tile reflects
+        # it; the fail-open behaviour is unchanged.
         logger.warning(
             "Consistency check exhausted %d retries for run %s: %s",
             max_retries, run_id, last_error,
+        )
+        record_error(
+            subsystem="verification",
+            operation="cross_task_consistency",
+            error=last_exc or RuntimeError(last_error or "consistency check failed"),
+            extra={"run_id": str(run_id), "max_retries": max_retries},
         )
         return ConsistencyResult(
             passed=True,

--- a/orchestrator/services/destinations/dispatcher.py
+++ b/orchestrator/services/destinations/dispatcher.py
@@ -28,6 +28,7 @@ from sqlalchemy.orm import Session
 
 from core.database.database import SessionLocal
 from core.models.sites import Site
+from core.utils.exception_telemetry import record_error
 from modules.widgets.telemetry import log_widget_event
 
 from services.destinations.base import CALLBACK_PLATFORMS, CallbackPayload, DispatchResult
@@ -216,9 +217,34 @@ async def dispatch_one_destination(
 
         # Permanent failure — bail without burning more attempts
         if not result.retryable:
+            record_error(
+                subsystem="widget",
+                operation="deliver_callback",
+                error=RuntimeError(result.error or "callback delivery failed"),
+                workspace_id=workspace_id,
+                extra={
+                    "destination_type": destination_type,
+                    "site_id": str(site_id),
+                    "attempt": attempt,
+                    "retryable": False,
+                },
+            )
             return result
 
-    # Exhausted attempts
+    # Exhausted attempts — every retry failed; record the terminal failure so
+    # the ERRORS-by-subsystem tile reflects undelivered callbacks.
+    record_error(
+        subsystem="widget",
+        operation="deliver_callback",
+        error=RuntimeError((last.error if last else None) or "callback delivery exhausted retries"),
+        workspace_id=workspace_id,
+        extra={
+            "destination_type": destination_type,
+            "site_id": str(site_id),
+            "attempts": MAX_ATTEMPTS,
+            "retryable": True,
+        },
+    )
     return last  # type: ignore[return-value]
 
 

--- a/orchestrator/tests/test_w1s1_hotpath_telemetry.py
+++ b/orchestrator/tests/test_w1s1_hotpath_telemetry.py
@@ -1,0 +1,257 @@
+"""PRD-142 Wave 1 · WS-A · W1-S1 — record_error adoption at failure hot-paths.
+
+Wave 0 shipped the ``error_events`` sink + ``record_error`` (persistence is
+covered by ``test_error_events_sink.py``). The ERRORS-by-subsystem dashboard
+tile was empty only because real failure paths never *called* ``record_error``.
+
+These tests prove the *adoption*: each test drives a subsystem's hot-path to
+its terminal failure and asserts ``record_error`` fires with the correct
+``subsystem``/``operation``. They patch the module-level ``record_error`` with
+a stub (so no DB is touched) and patch the one dependency whose failure the
+hot-path exists to handle.
+
+Subsystems covered here (Tier 1, clean seams): planner, verification, widget.
+board + wizard live in ``test_w1s1_hotpath_telemetry_io.py`` (heavier mocking).
+"""
+import asyncio
+import os
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+ORCH_ROOT = Path(__file__).resolve().parent.parent
+if str(ORCH_ROOT) not in sys.path:
+    sys.path.insert(0, str(ORCH_ROOT))
+
+# These unit tests mock the DB/session entirely (no query ever runs), but
+# importing the coordination/widget modules eagerly constructs the SQLAlchemy
+# engine, which refuses to build without POSTGRES_* creds. Provide inert
+# placeholders so the engine constructs lazily; we never connect. setdefault
+# means a real .env (when present) still wins.
+for _k, _v in {
+    "POSTGRES_USER": "test",
+    "POSTGRES_PASSWORD": "test",
+    "POSTGRES_HOST": "localhost",
+    "POSTGRES_PORT": "5432",
+    "POSTGRES_DB": "test",
+}.items():
+    os.environ.setdefault(_k, _v)
+
+
+def _raising_llm():
+    """An LLMManager whose generate_response always raises — drives the retry
+    loops in planner/verification straight to their terminal failure."""
+    llm = MagicMock()
+    llm.generate_response = AsyncMock(side_effect=RuntimeError("LLM unavailable"))
+    return llm
+
+
+def _active_agent(name: str = "Researcher"):
+    """A roster agent shaped for ``_render_agent_roster`` (needs a real str
+    name/description and status == 'active'; everything else is guarded)."""
+    a = MagicMock()
+    a.status = "active"
+    a.name = name
+    a.description = "Does research and analysis"
+    a.model_config = {}
+    a.tags = []
+    a.skills = []
+    return a
+
+
+# ---------------------------------------------------------------------------
+# planner (subsystem="planner")
+# ---------------------------------------------------------------------------
+
+def test_decompose_emits_planner_error(monkeypatch):
+    from modules.coordination import planner as planner_mod
+
+    rec = MagicMock()
+    monkeypatch.setattr(planner_mod, "record_error", rec, raising=False)
+    monkeypatch.setattr(planner_mod, "create_llm_manager", lambda **kw: _raising_llm())
+
+    ws = uuid4()
+    with pytest.raises(planner_mod.PlanValidationError):
+        asyncio.run(
+            planner_mod.MissionPlanner.decompose(
+                goal="Build a go-to-market plan",
+                workspace_id=ws,
+                agents=[_active_agent()],
+            )
+        )
+
+    assert rec.call_count >= 1, "record_error never called from decompose"
+    kw = rec.call_args.kwargs
+    assert kw["subsystem"] == "planner"
+    assert kw["operation"] == "decompose"
+    assert kw["workspace_id"] == ws
+
+
+def test_replan_emits_planner_error(monkeypatch):
+    from modules.coordination import planner as planner_mod
+
+    rec = MagicMock()
+    monkeypatch.setattr(planner_mod, "record_error", rec, raising=False)
+    monkeypatch.setattr(planner_mod, "create_llm_manager", lambda **kw: _raising_llm())
+
+    ws = uuid4()
+    with pytest.raises(planner_mod.PlanValidationError):
+        asyncio.run(
+            planner_mod.MissionPlanner.replan(
+                goal="Build a go-to-market plan",
+                workspace_id=ws,
+                agents=[_active_agent()],
+                completed_outputs=[],
+                failed_task_title="Draft positioning",
+                failed_task_reason="ran out of budget",
+            )
+        )
+
+    assert rec.call_count >= 1, "record_error never called from replan"
+    kw = rec.call_args.kwargs
+    assert kw["subsystem"] == "planner"
+    assert kw["operation"] == "replan"
+    assert kw["workspace_id"] == ws
+
+
+# ---------------------------------------------------------------------------
+# verification (subsystem="verification") — fails open, so no raise
+# ---------------------------------------------------------------------------
+
+def test_verify_task_emits_verification_error(monkeypatch):
+    from modules.coordination import verification as verif_mod
+
+    rec = MagicMock()
+    monkeypatch.setattr(verif_mod, "record_error", rec, raising=False)
+    monkeypatch.setattr(verif_mod, "create_llm_manager", lambda **kw: _raising_llm())
+
+    svc = verif_mod.VerificationService()
+    result = asyncio.run(
+        svc.verify_task(
+            task_title="Write the summary",
+            task_description="Summarize the quarterly report",
+            output=(
+                "This is a sufficiently long task output paragraph so the "
+                "deterministic checker does not short-circuit before the LLM "
+                "judge runs and exhausts its retries."
+            ),
+            verification_criteria=[],
+        )
+    )
+
+    # Verification is advisory: a judge failure degrades to PARTIAL, never raises.
+    assert result.verdict == verif_mod.VERDICT_PARTIAL
+    assert rec.call_count >= 1, "record_error never called from verify_task"
+    kw = rec.call_args.kwargs
+    assert kw["subsystem"] == "verification"
+    assert kw["operation"] == "verify_task"
+
+
+def test_cross_task_consistency_emits_verification_error(monkeypatch):
+    from modules.coordination import verification as verif_mod
+
+    rec = MagicMock()
+    monkeypatch.setattr(verif_mod, "record_error", rec, raising=False)
+    monkeypatch.setattr(verif_mod, "create_llm_manager", lambda **kw: _raising_llm())
+
+    svc = verif_mod.VerificationService()
+    run_id = uuid4()
+    result = asyncio.run(
+        svc.verify_cross_task_consistency(
+            run_id=run_id,
+            goal="Build a go-to-market plan",
+            task_outputs=[
+                {"task_id": "1", "title": "Positioning", "output": "Output A"},
+                {"task_id": "2", "title": "Pricing", "output": "Output B"},
+            ],
+        )
+    )
+
+    # Consistency also fails open (defaults to passed) — must still record.
+    assert result.passed is True
+    assert rec.call_count >= 1, "record_error never called from consistency check"
+    kw = rec.call_args.kwargs
+    assert kw["subsystem"] == "verification"
+    assert kw["operation"] == "cross_task_consistency"
+
+
+# ---------------------------------------------------------------------------
+# widget (subsystem="widget") — code-path failure, not an exception
+# ---------------------------------------------------------------------------
+
+def test_widget_permanent_failure_emits_widget_error(monkeypatch):
+    from services.destinations import dispatcher as disp_mod
+
+    rec = MagicMock()
+    monkeypatch.setattr(disp_mod, "record_error", rec, raising=False)
+    # log_widget_event is async + writes the DB — stub it out.
+    monkeypatch.setattr(disp_mod, "log_widget_event", AsyncMock())
+
+    fail = disp_mod.DispatchResult(
+        success=False,
+        destination_type="telegram",
+        latency_ms=5,
+        error="bot token invalid",
+        retryable=False,  # permanent → terminal on attempt 1
+    )
+    monkeypatch.setattr(disp_mod, "dispatch_via_channel", AsyncMock(return_value=fail))
+
+    ws = uuid4()
+    result = asyncio.run(
+        disp_mod.dispatch_one_destination(
+            db=MagicMock(),
+            site_id=uuid4(),
+            workspace_id=ws,
+            session_id="sess-1",
+            request_id="req-1",
+            destination={"platform": "telegram"},
+            payload=MagicMock(),
+        )
+    )
+
+    assert result.success is False
+    assert rec.call_count >= 1, "record_error never called on terminal widget failure"
+    kw = rec.call_args.kwargs
+    assert kw["subsystem"] == "widget"
+    assert kw["operation"] == "deliver_callback"
+    assert kw["workspace_id"] == ws
+
+
+def test_widget_success_does_not_emit(monkeypatch):
+    """Guardrail: a successful delivery must NOT record an error."""
+    from services.destinations import dispatcher as disp_mod
+
+    rec = MagicMock()
+    monkeypatch.setattr(disp_mod, "record_error", rec, raising=False)
+    monkeypatch.setattr(disp_mod, "log_widget_event", AsyncMock())
+
+    ok = disp_mod.DispatchResult(
+        success=True,
+        destination_type="telegram",
+        latency_ms=5,
+        error=None,
+        retryable=False,
+    )
+    monkeypatch.setattr(disp_mod, "dispatch_via_channel", AsyncMock(return_value=ok))
+
+    result = asyncio.run(
+        disp_mod.dispatch_one_destination(
+            db=MagicMock(),
+            site_id=uuid4(),
+            workspace_id=uuid4(),
+            session_id="sess-1",
+            request_id="req-1",
+            destination={"platform": "telegram"},
+            payload=MagicMock(),
+        )
+    )
+
+    assert result.success is True
+    rec.assert_not_called()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/orchestrator/tests/test_w1s1_hotpath_telemetry_io.py
+++ b/orchestrator/tests/test_w1s1_hotpath_telemetry_io.py
@@ -1,0 +1,178 @@
+"""PRD-142 Wave 1 · WS-A · W1-S1 — record_error adoption (Tier 2: board + wizard).
+
+Companion to ``test_w1s1_hotpath_telemetry.py`` (Tier 1: planner/verification/
+widget, clean seams). These two hot-paths need heavier mocking because both are
+fire-and-forget background coroutines that own their own DB session and reach
+their failure handler only after a real dependency blows up:
+
+- **board** (``api.board_tasks._launch_task_execution``): schedules an inner
+  ``_run()`` via ``asyncio.create_task``. We intercept ``create_task`` to capture
+  the coroutine, stub ``SessionLocal``, and make ``AgentFactory`` raise so ``_run``
+  falls into its terminal ``except``.
+- **wizard** (``api.wizard._run_scrape_pipeline``): an async pipeline whose first
+  step is ``_firecrawl_client()``. We make that raise to drive straight to the
+  top-level ``except`` and stub the DB/progress side-effects in that handler.
+
+Both subsystems fail open (the background task swallows the exception so the
+request that spawned it already returned). The proof here is purely that
+``record_error`` fires with the right ``subsystem``/``operation`` on the terminal
+failure — that is what lights up the ERRORS-by-subsystem dashboard tile.
+"""
+import asyncio
+import os
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+ORCH_ROOT = Path(__file__).resolve().parent.parent
+if str(ORCH_ROOT) not in sys.path:
+    sys.path.insert(0, str(ORCH_ROOT))
+
+# Importing api.board_tasks / api.wizard eagerly constructs the SQLAlchemy
+# engine, which refuses to build without POSTGRES_* creds. These tests mock the
+# DB entirely (no query ever runs), so provide inert placeholders; setdefault
+# means a real .env (when present) still wins.
+for _k, _v in {
+    "POSTGRES_USER": "test",
+    "POSTGRES_PASSWORD": "test",
+    "POSTGRES_HOST": "localhost",
+    "POSTGRES_PORT": "5432",
+    "POSTGRES_DB": "test",
+}.items():
+    os.environ.setdefault(_k, _v)
+
+
+# ---------------------------------------------------------------------------
+# board (subsystem="board") — fire-and-forget background coroutine
+# ---------------------------------------------------------------------------
+
+def test_board_task_failure_emits_board_error(monkeypatch):
+    from api import board_tasks as bt_mod
+    import core.database.database as db_mod
+    import modules.agents.factory.agent_factory as factory_mod
+
+    rec = MagicMock()
+    monkeypatch.setattr(bt_mod, "record_error", rec, raising=False)
+
+    # _launch_task_execution schedules its work via create_task; capture the
+    # coroutine instead of letting it loose on a loop, then drive it ourselves.
+    captured: dict = {}
+    monkeypatch.setattr(
+        bt_mod.asyncio,
+        "create_task",
+        lambda coro: captured.__setitem__("coro", coro) or MagicMock(),
+    )
+
+    # SessionLocal() is called OUTSIDE the try → must succeed (return a mock).
+    monkeypatch.setattr(db_mod, "SessionLocal", lambda: MagicMock())
+
+    # AgentFactory is constructed as the first statement inside the try; make it
+    # raise so _run() falls into its terminal except hot-path. (Local import in
+    # _run resolves the name off the already-loaded module, so this patch wins.)
+    monkeypatch.setattr(
+        factory_mod,
+        "AgentFactory",
+        MagicMock(side_effect=RuntimeError("agent unavailable")),
+    )
+
+    ws = str(uuid4())
+    bt_mod._launch_task_execution(
+        task_id=123,
+        agent_id=7,
+        workspace_id=ws,
+        prompt="do the thing",
+    )
+
+    assert "coro" in captured, "create_task was never invoked"
+    asyncio.run(captured["coro"])
+
+    assert rec.call_count >= 1, "record_error never called on terminal board failure"
+    kw = rec.call_args.kwargs
+    assert kw["subsystem"] == "board"
+    assert kw["operation"] == "execute_task"
+    assert kw["workspace_id"] == ws
+
+
+def test_board_task_success_does_not_emit(monkeypatch):
+    """Guardrail: a clean agent execution must NOT record an error."""
+    from api import board_tasks as bt_mod
+    import core.database.database as db_mod
+    import modules.agents.factory.agent_factory as factory_mod
+
+    rec = MagicMock()
+    monkeypatch.setattr(bt_mod, "record_error", rec, raising=False)
+
+    captured: dict = {}
+    monkeypatch.setattr(
+        bt_mod.asyncio,
+        "create_task",
+        lambda coro: captured.__setitem__("coro", coro) or MagicMock(),
+    )
+    monkeypatch.setattr(db_mod, "SessionLocal", lambda: MagicMock())
+
+    # Factory returns a normal result → no exception, no record_error. The
+    # completion block is guarded by task.status == "in_progress"; the mocked
+    # task's status won't match, so we never touch report/dispatch helpers.
+    factory = MagicMock()
+    factory.execute_with_prompt = AsyncMock(return_value={"result": "all good"})
+    monkeypatch.setattr(factory_mod, "AgentFactory", lambda **kw: factory)
+
+    bt_mod._launch_task_execution(
+        task_id=123,
+        agent_id=7,
+        workspace_id=str(uuid4()),
+        prompt="do the thing",
+    )
+    asyncio.run(captured["coro"])
+
+    rec.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# wizard (subsystem="wizard") — fire-and-forget intake pipeline
+# ---------------------------------------------------------------------------
+
+def test_wizard_pipeline_failure_emits_wizard_error(monkeypatch):
+    from api import wizard as wiz_mod
+
+    rec = MagicMock()
+    monkeypatch.setattr(wiz_mod, "record_error", rec, raising=False)
+
+    # _firecrawl_client() is the first call inside the pipeline's try; make it
+    # raise to drive straight to the top-level except.
+    monkeypatch.setattr(
+        wiz_mod,
+        "_firecrawl_client",
+        MagicMock(side_effect=RuntimeError("firecrawl unavailable")),
+    )
+
+    # The except marks the profile failed (DB) and emits a terminal progress
+    # event — stub both so no real session/SSE is touched.
+    monkeypatch.setattr(wiz_mod, "get_db_session", MagicMock())
+    monkeypatch.setattr(wiz_mod, "progress_emit", AsyncMock())
+
+    ws = str(uuid4())
+    pid = str(uuid4())
+    asyncio.run(
+        wiz_mod._run_scrape_pipeline(
+            profile_id=pid,
+            workspace_id=ws,
+            domain="example.com",
+            archetype_slug=None,
+            selected_urls=["https://example.com"],
+            user_goals=[],
+        )
+    )
+
+    assert rec.call_count >= 1, "record_error never called on wizard pipeline failure"
+    kw = rec.call_args.kwargs
+    assert kw["subsystem"] == "wizard"
+    assert kw["operation"] == "scrape_pipeline"
+    assert kw["workspace_id"] == ws
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

PRD-142 **Wave 1 · WS-A · W1-S1**. Wave 0 shipped the `error_events` sink, the `record_error()` helper, the aggregation endpoint, and the ERRORS-by-subsystem dashboard tile — but the tile read empty because **no real failure path ever called `record_error`**. This PR is pure *adoption*: it invokes the existing helper from five live terminal failure handlers. No new infra, no schema, no control-flow change.

`record_error` is best-effort and never raises (failed sink writes are swallowed), so every call is additive to the handler it sits in.

### Subsystems wired (`subsystem` / `operation`)
- **planner** — `decompose`, `replan` (post-retry-loop `PlanValidationError`)
- **verification** — `verify_task`, `cross_task_consistency` (LLM judge retries exhausted; both fail open)
- **widget** — `deliver_callback` (both terminal returns: permanent failure + retries exhausted)
- **board** — `execute_task` (`_launch_task_execution._run()` terminal `except`)
- **wizard** — `scrape_pipeline` (`_run_scrape_pipeline` top-level `except`)

### Deferred (documented, not dropped)
- **workflow** — `execute_workflow_with_progress` is a disabled PRD-125 stub; both `create_task` paths are dead code.
- **mission-run** — the real terminal failure lives in the coordinator/runner, not in `dispatcher.py` (which only logs non-fatal warnings).

Instrumenting dead or non-terminal code adds noise, not signal.

## Tests
- `test_w1s1_hotpath_telemetry.py` — 6 Tier 1 tests (clean seams: planner/verification/widget), incl. a widget success guardrail.
- `test_w1s1_hotpath_telemetry_io.py` — 3 Tier 2 tests (heavier mocking: board/wizard fire-and-forget coroutines), incl. a board success guardrail.
- Each drives a subsystem's hot-path to its terminal failure and asserts `record_error` fires with the correct `subsystem`/`operation`. DB is fully mocked.
- Full telemetry suite green (21 passed): new tests + Wave 0 `test_exception_telemetry.py` / `test_error_events_sink.py`, including the **signature-unchanged guardrail** and the **bare-except CI gate**.
- Existing `test_board_task_handlers.py` still green.

> W1-S2 (no-bare-`except` + `scripts/ci/check-no-bare-except.sh` gate) already landed in the base, so it is not part of this diff.

## Test plan
- [ ] CI / pytest green on the telemetry suite
- [ ] After deploy, trigger a real failure in each subsystem and confirm rows land in `error_events` and surface on the ERRORS-by-subsystem tile