### PR TITLE
feat(prd-142-wave1): WS-C — durable execution + boot reaper

### DIFF
--- a/orchestrator/api/board_tasks.py
+++ b/orchestrator/api/board_tasks.py
@@ -6,7 +6,6 @@ CRUD + planning endpoints for the lightweight task board (PRD-72).
 Tasks follow a Kanban lifecycle: inbox -> assigned -> in_progress -> review -> blocked -> done.
 """
 
-import asyncio
 import json
 import logging
 from datetime import datetime, timedelta, timezone
@@ -22,6 +21,7 @@ from core.database.database import get_db
 from core.models.core import BoardTask
 from core.models import Agent
 from core.utils.exception_telemetry import record_error
+from core.utils.background_tasks import launch_guarded
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/v1/tasks", tags=["board-tasks"])
@@ -794,7 +794,17 @@ def _launch_task_execution(
         finally:
             db.close()
 
-    asyncio.create_task(_run())
+    # Guarded launch: a strong ref prevents GC-cancellation mid-run and an
+    # uncaught crash is recorded. _run() already records its own caught
+    # failures; the boot reaper (W1-S6) recovers any row stranded by a restart.
+    launch_guarded(
+        _run(),
+        subsystem="board",
+        operation="execute_task",
+        workspace_id=workspace_id,
+        agent_id=agent_id,
+        extra={"task_id": task_id},
+    )
 
 
 # ── Planning mode ────────────────────────────────────────────────────

--- a/orchestrator/api/wizard.py
+++ b/orchestrator/api/wizard.py
@@ -19,7 +19,6 @@ background so Railway's edge proxy cannot kill long-running intake jobs
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import os
 import tempfile
@@ -39,6 +38,7 @@ from core.database.database import get_db, get_db_session
 from core.models.business_profiles import BusinessProfile
 from core.models.core import Agent
 from core.utils.exception_telemetry import record_error
+from core.utils.background_tasks import launch_guarded
 
 from modules.intake.archetypes import (
     ARCHETYPES,
@@ -336,8 +336,10 @@ async def scrape_selected(
         meta={"total": len(selected)},
     )
 
-    # Fire-and-forget; the task handles all its own errors and progress emits
-    asyncio.create_task(
+    # Fire-and-forget; the pipeline handles its own errors and progress emits.
+    # Guarded so a GC'd loop can't silently cancel it and an uncaught crash is
+    # recorded; the boot reaper (W1-S6) fails any profile stranded by a restart.
+    launch_guarded(
         _run_scrape_pipeline(
             profile_id=profile_id,
             workspace_id=workspace_id,
@@ -345,7 +347,11 @@ async def scrape_selected(
             archetype_slug=archetype,
             selected_urls=selected,
             user_goals=user_goals,
-        )
+        ),
+        subsystem="wizard",
+        operation="scrape_pipeline",
+        workspace_id=workspace_id,
+        extra={"profile_id": profile_id, "domain": domain},
     )
 
     logger.info(

--- a/orchestrator/api/workflows.py
+++ b/orchestrator/api/workflows.py
@@ -12,12 +12,12 @@ from fastapi.responses import StreamingResponse
 from sqlalchemy.orm import Session, joinedload, attributes
 from sqlalchemy import and_, or_, func, desc, String
 from datetime import datetime, timedelta
-import asyncio
 import logging
 import json
 
 from config import config
 from core.database.database import get_db
+from core.utils.background_tasks import launch_guarded
 from core.models import (
     Workflow, WorkflowExecution, Agent, workflow_agents,
     WorkflowCreate, WorkflowUpdate, WorkflowResponse,
@@ -1015,12 +1015,17 @@ async def execute_workflow_advanced(
             handle = await runner.submit_task(task)
             logger.info(f"Workflow {workflow_id} execution {execution.id} queued (task={handle.task_id[:8]})")
         else:
-            # Phase 1 / Local: Run in-process (existing behavior)
-            asyncio.create_task(
+            # Phase 1 / Local: Run in-process (existing behavior), guarded so a
+            # GC'd loop can't silently cancel it and an uncaught crash is recorded.
+            launch_guarded(
                 execute_workflow_with_progress(
                     execution.id,
                     execution_data.get('options', {})
-                )
+                ),
+                subsystem="workflow",
+                operation="execute",
+                workspace_id=ctx.workspace_id,
+                extra={"execution_id": execution.id, "workflow_id": workflow_id},
             )
 
         return {
@@ -1122,19 +1127,18 @@ async def execute_workflow(
             handle = await runner.submit_task(task)
             logger.info(f"Workflow {workflow_id} execution {execution.id} queued (task={handle.task_id[:8]})")
         else:
-            # Phase 1 / Local: Run in-process (existing behavior)
-            import asyncio
-
-            async def _run_with_error_handling():
-                try:
-                    await execute_workflow_with_progress(
-                        execution.id,
-                        execution_data.get('options', {})
-                    )
-                except Exception as e:
-                    logger.error(f"❌ FATAL: Workflow execution task crashed: {e}", exc_info=True)
-
-            asyncio.create_task(_run_with_error_handling())
+            # Phase 1 / Local: Run in-process (existing behavior), guarded so a
+            # GC'd loop can't silently cancel it and an uncaught crash is recorded.
+            launch_guarded(
+                execute_workflow_with_progress(
+                    execution.id,
+                    execution_data.get('options', {})
+                ),
+                subsystem="workflow",
+                operation="execute",
+                workspace_id=ctx.workspace_id,
+                extra={"execution_id": execution.id, "workflow_id": workflow_id},
+            )
 
         logger.info(f"Workflow {workflow_id} execution {execution.id} started")
         

--- a/orchestrator/config.py
+++ b/orchestrator/config.py
@@ -128,6 +128,19 @@ class Config:
     MEMORY_ARCHIVAL_BATCH_SIZE: int = int(os.getenv("MEMORY_ARCHIVAL_BATCH_SIZE", "500"))
 
     # =============================================================================
+    # BOOT REAPER — orphaned in-flight runs (PRD-142 Wave 1 · WS-C · W1-S6)
+    # =============================================================================
+    # On restart, in-flight rows whose background executor died with the old
+    # process are stranded forever (a board task stuck 'in_progress', a wizard
+    # profile stuck 'scraping', a workflow execution stuck 'running'). The reaper
+    # sweeps them once per deploy under the boot leader lock.
+    BOOT_REAPER_ENABLED: bool = os.getenv("BOOT_REAPER_ENABLED", "true").lower() in ("true", "1", "yes")
+    # A row counts as orphaned only after it has been in-flight this long. Must
+    # exceed the slowest legitimate job (the wizard scrape runs ~10–20 min) so a
+    # live run is never reaped out from under itself.
+    BOOT_REAPER_STALE_MINUTES: int = int(os.getenv("BOOT_REAPER_STALE_MINUTES", "30"))
+
+    # =============================================================================
     # API SECURITY
     # =============================================================================
     ORCHESTRATOR_API_KEY: str = os.getenv("ORCHESTRATOR_API_KEY") or os.getenv("AUTOMATOS_API_KEY") or os.getenv("API_KEY")

--- a/orchestrator/core/boot/__init__.py
+++ b/orchestrator/core/boot/__init__.py
@@ -1,0 +1,6 @@
+"""Boot-time tasks (PRD-142 Wave 1 · WS-C).
+
+Houses startup seeds and the orphaned-run reaper so that boot work is
+importable, unit-testable, and observable rather than buried in ``main.py`` as
+fire-and-forget closures.
+"""

--- a/orchestrator/core/boot/reaper.py
+++ b/orchestrator/core/boot/reaper.py
@@ -1,0 +1,190 @@
+"""Boot-time orphaned-run reaper (PRD-142 Wave 1 · WS-C · W1-S6).
+
+On restart, an in-flight row whose background ``asyncio`` executor died with the
+old process is stranded forever — nothing remains to move it to a terminal
+state. ``reap_orphaned_runs`` runs once per deploy (under the boot leader lock)
+and sweeps the three durable-launch surfaces:
+
+  - **board task** stuck ``in_progress`` → ``done`` + ``error_message``
+    (the board has no 'failed' Kanban column; this mirrors its own failure path);
+  - **wizard profile** stuck ``scraping``/``scanning`` → ``failed`` +
+    ``quality_findings`` (the wizard's own failure convention);
+  - **workflow execution** stuck ``pending``/``running`` → ``failed`` +
+    ``error_message`` + ``completed_at``.
+
+A row is reaped only once it has been in-flight longer than
+``BOOT_REAPER_STALE_MINUTES`` — long enough that no legitimately running job
+(the wizard scrape, ~10–20 min, is the slowest) could still own it. Staleness is
+filtered in Python: the row volume is tiny pre-launch and the cutoff logic stays
+unit-testable. Each reaped surface fires
+``record_error(subsystem=<surface>, operation="boot_reap")`` so the sweep
+surfaces on the ERRORS-by-subsystem dashboard tile (the WS-A sink).
+
+Missions are deliberately EXCLUDED: ``OrchestrationRun`` rows are owned by the
+coordinator's reconcile loop, which already resumes/cleans RUNNING runs. Reaping
+them here would race that state machine.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Callable, Optional
+
+from config import config
+from core.models.business_profiles import BusinessProfile
+from core.models.core import BoardTask, WorkflowExecution
+from core.utils.exception_telemetry import record_error
+
+logger = logging.getLogger(__name__)
+
+_ORPHAN_REASON = "orphaned_on_restart"
+
+
+class OrphanedRunError(RuntimeError):
+    """Synthetic error recorded when the reaper marks an orphaned run terminal.
+
+    The reaper is proactive (it isn't catching a live exception), but
+    ``record_error`` takes an ``Exception`` — this gives the ``error_events`` row
+    a meaningful ``error_type`` instead of a generic ``RuntimeError``.
+    """
+
+
+def _coerce_aware(ts: datetime) -> datetime:
+    """Treat a tz-naive timestamp as UTC so it compares against an aware cutoff.
+
+    ``WorkflowExecution.started_at`` is tz-NAIVE; ``BoardTask`` and
+    ``BusinessProfile`` timestamps are tz-AWARE. Normalising to aware-UTC lets a
+    single cutoff serve all three surfaces.
+    """
+    return ts.replace(tzinfo=timezone.utc) if ts.tzinfo is None else ts
+
+
+def _is_stale(ts: Optional[datetime], cutoff: datetime) -> bool:
+    """True iff ``ts`` is older than ``cutoff``.
+
+    A ``None`` timestamp can't be proven stale, so it is left alone — a later
+    deploy will catch the row once it carries a real timestamp.
+    """
+    if ts is None:
+        return False
+    return _coerce_aware(ts) < cutoff
+
+
+def _reap_board_tasks(db, cutoff: datetime, now: datetime) -> int:
+    rows = db.query(BoardTask).filter(BoardTask.status == "in_progress").all()
+    stale = [r for r in rows if _is_stale(r.started_at or r.updated_at, cutoff)]
+    for r in stale:
+        # The board has no 'failed' column; its own failure path marks 'done'
+        # + error_message, so we mirror that exactly.
+        r.status = "done"
+        r.error_message = f"{_ORPHAN_REASON}: executor lost on restart"
+        r.completed_at = now
+    if stale:
+        record_error(
+            subsystem="board",
+            operation="boot_reap",
+            error=OrphanedRunError(f"reaped {len(stale)} orphaned board task(s)"),
+            extra={"reaped_ids": [r.id for r in stale], "reason": _ORPHAN_REASON},
+        )
+    return len(stale)
+
+
+def _reap_business_profiles(db, cutoff: datetime, now: datetime) -> int:
+    rows = (
+        db.query(BusinessProfile)
+        .filter(BusinessProfile.status.in_(["scraping", "scanning"]))
+        .all()
+    )
+    # updated_at is bumped on each status transition, so it marks when the row
+    # entered the in-flight state.
+    stale = [r for r in rows if _is_stale(r.updated_at, cutoff)]
+    for r in stale:
+        r.status = "failed"  # wizard's own failure convention
+        findings = dict(r.quality_findings or {})
+        errors = list(findings.get("errors") or [])
+        errors.append(f"{_ORPHAN_REASON}: scrape executor lost on restart")
+        findings["errors"] = errors
+        r.quality_findings = findings
+    if stale:
+        record_error(
+            subsystem="wizard",
+            operation="boot_reap",
+            error=OrphanedRunError(f"reaped {len(stale)} orphaned wizard profile(s)"),
+            extra={"reaped_ids": [str(r.id) for r in stale], "reason": _ORPHAN_REASON},
+        )
+    return len(stale)
+
+
+def _reap_workflow_executions(db, cutoff: datetime, now: datetime) -> int:
+    rows = (
+        db.query(WorkflowExecution)
+        .filter(WorkflowExecution.status.in_(["pending", "running"]))
+        .all()
+    )
+    stale = [r for r in rows if _is_stale(r.started_at, cutoff)]
+    # completed_at is a tz-NAIVE column here, unlike the aware board column.
+    naive_now = now.replace(tzinfo=None) if now.tzinfo is not None else now
+    for r in stale:
+        r.status = "failed"
+        r.error_message = f"{_ORPHAN_REASON}: executor lost on restart"
+        r.completed_at = naive_now
+    if stale:
+        record_error(
+            subsystem="workflow",
+            operation="boot_reap",
+            error=OrphanedRunError(
+                f"reaped {len(stale)} orphaned workflow execution(s)"
+            ),
+            extra={"reaped_ids": [r.id for r in stale], "reason": _ORPHAN_REASON},
+        )
+    return len(stale)
+
+
+def _run_surface(
+    db,
+    cutoff: datetime,
+    now: datetime,
+    subsystem: str,
+    fn: Callable[[object, datetime, datetime], int],
+) -> int:
+    """Run one surface reaper in isolation — a failure is recorded, not raised.
+
+    One broken surface must not stop the others from being swept.
+    """
+    try:
+        return fn(db, cutoff, now)
+    except Exception as exc:  # noqa: BLE001 — surface isolation by design
+        logger.exception("Boot reaper: %s surface failed", subsystem)
+        record_error(subsystem=subsystem, operation="boot_reap", error=exc)
+        return 0
+
+
+def reap_orphaned_runs(db, *, now: Optional[datetime] = None) -> int:
+    """Sweep orphaned in-flight rows across board / wizard / workflow surfaces.
+
+    Returns the number of rows marked terminal. Mutations are committed once at
+    the end (tiny row volume pre-launch). Never raises out of a surface — each is
+    isolated so one failure can't abort the rest.
+    """
+    if not config.BOOT_REAPER_ENABLED:
+        logger.info("Boot reaper disabled (BOOT_REAPER_ENABLED=false) — skipping")
+        return 0
+
+    now = now or datetime.now(timezone.utc)
+    cutoff = now - timedelta(minutes=config.BOOT_REAPER_STALE_MINUTES)
+
+    reaped = 0
+    reaped += _run_surface(db, cutoff, now, "board", _reap_board_tasks)
+    reaped += _run_surface(db, cutoff, now, "wizard", _reap_business_profiles)
+    reaped += _run_surface(db, cutoff, now, "workflow", _reap_workflow_executions)
+
+    if reaped:
+        try:
+            db.commit()
+        except Exception:  # noqa: BLE001 — don't let a commit failure crash boot
+            logger.exception("Boot reaper: commit failed; rolling back")
+            db.rollback()
+            return 0
+        logger.warning("Boot reaper: marked %d orphaned run(s) terminal", reaped)
+
+    return reaped

--- a/orchestrator/core/boot/startup_tasks.py
+++ b/orchestrator/core/boot/startup_tasks.py
@@ -1,0 +1,83 @@
+"""Observable boot-time background seeds (PRD-142 Wave 1 · WS-C · W1-S7).
+
+These two coroutines were previously nested closures launched fire-and-forget
+from ``main.py`` whose failures were only ``logger.warning``-ed. Extracted here
+they are importable + unit-testable, and on failure they now also fire
+``record_error(subsystem="startup")`` so a failed boot seed surfaces on the
+ERRORS-by-subsystem dashboard tile instead of dying silently.
+
+Both functions are *self-guarding*: they never raise, so launching them with a
+bare ``create_task`` cannot leave an unretrieved task exception.
+"""
+from __future__ import annotations
+
+import logging
+
+from core.utils.exception_telemetry import record_error
+
+logger = logging.getLogger(__name__)
+
+
+async def embed_all_agents_on_startup() -> None:
+    """Seed semantic embeddings for agents across all workspaces (PRD-64).
+
+    Non-fatal: any failure is logged + recorded and boot continues.
+    """
+    try:
+        from core.database.database import SessionLocal
+        from core.llm.embedding_manager import get_embedding_manager
+        from core.models.core import Agent
+        from core.models.workspaces import Workspace
+        from core.routing.semantic_indexer import embed_workspace_agents
+
+        db = SessionLocal()
+        try:
+            emgr = get_embedding_manager()
+            emgr._ensure_provider()
+            logger.info("PRD-64: Embedding provider: %s", emgr.get_provider_info())
+
+            ws_ids = [w.id for w in db.query(Workspace.id).all()]
+            total = 0
+            for ws_id in ws_ids:
+                try:
+                    total += await embed_workspace_agents(ws_id, db)
+                except Exception:
+                    logger.warning("PRD-64: Failed to embed workspace %s", ws_id, exc_info=True)
+
+            all_agents = db.query(Agent).filter(Agent.status == "active").count()
+            with_embeddings = (
+                db.query(Agent)
+                .filter(Agent.status == "active", Agent.semantic_embedding.isnot(None))
+                .count()
+            )
+            logger.info(
+                "PRD-64: Semantic embeddings seeded — %d new, %d/%d agents have embeddings",
+                total,
+                with_embeddings,
+                all_agents,
+            )
+        finally:
+            db.close()
+    except Exception as exc:
+        logger.warning("PRD-64: Startup embedding seed failed (non-fatal): %s", exc, exc_info=True)
+        record_error(subsystem="startup", operation="embed_all_agents", error=exc)
+
+
+async def ensure_field_memory_collection() -> None:
+    """Ensure the shared ``field_memory`` collection + indexes exist (PRD-108).
+
+    Must run before the coordinator boots. Non-fatal: any failure is logged +
+    recorded and boot continues.
+    """
+    try:
+        from modules.context.adapters.vector_field import VectorFieldSharedContext
+        from modules.context.factory import get_shared_context
+
+        ctx = get_shared_context()
+        inner = getattr(ctx, "_inner", ctx)
+        if isinstance(inner, VectorFieldSharedContext):
+            await inner.ensure_shared_collection()
+            logger.info("PRD-108: shared field_memory collection ready")
+    except Exception as exc:
+        logger.warning("PRD-108: shared field_memory bootstrap failed (non-fatal)", exc_info=True)
+        record_error(subsystem="startup", operation="ensure_field_memory_collection", error=exc)

--- a/orchestrator/core/utils/background_tasks.py
+++ b/orchestrator/core/utils/background_tasks.py
@@ -1,0 +1,85 @@
+"""Guarded fire-and-forget task launcher (PRD-142 Wave 1 · WS-C · W1-S5).
+
+``asyncio.create_task`` is a footgun for fire-and-forget work. The event loop
+keeps only a *weak* reference to the task, so if the caller doesn't hold a
+strong reference the task can be garbage-collected — and silently cancelled —
+mid-flight (see the asyncio docs' "Important" note on ``create_task``). And if
+the coroutine raises, the exception surfaces only as a "Task exception was never
+retrieved" warning at GC time, invisible to our telemetry.
+
+``launch_guarded`` replaces bare ``create_task`` at every fire-and-forget site:
+
+  - it keeps a strong reference in a module-level set until the task finishes,
+    so the task can never be GC-cancelled;
+  - it attaches a done-callback that retrieves the result and, on an *uncaught*
+    exception, fires ``record_error`` so the crash lands on the
+    ERRORS-by-subsystem dashboard tile instead of vanishing. Cancellation
+    (graceful shutdown) is not reported as a failure.
+
+This is the lightweight half of WS-C. It deliberately does NOT try to make
+request-scoped closures (board task runs, wizard scrape pipelines) serializable
+onto the Redis ``queued`` backend — that backend runs structured ``AgentTask``
+descriptors, not arbitrary coroutines, and inventing a queue for them is the
+risk the PRD warns against. Restart-survival for those surfaces is delivered by
+the W1-S6 boot reaper, which marks any row stranded by a crash/restart terminal.
+Where a true durable executor already exists (the workflow ``queued`` backend),
+callers still prefer it; this launcher only replaces the in-process fallback.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Coroutine, Dict, Optional, Set
+from uuid import UUID
+
+from core.utils.exception_telemetry import record_error
+
+logger = logging.getLogger(__name__)
+
+# Strong references to in-flight fire-and-forget tasks. Without this, the event
+# loop holds only a weak reference and the GC can cancel a task mid-flight.
+_BACKGROUND_TASKS: Set[asyncio.Task] = set()
+
+
+def launch_guarded(
+    coro: Coroutine[Any, Any, Any],
+    *,
+    subsystem: str,
+    operation: str,
+    workspace_id: Optional[UUID] = None,
+    agent_id: Optional[int] = None,
+    extra: Optional[Dict[str, Any]] = None,
+) -> asyncio.Task:
+    """Launch ``coro`` as a guarded background task and return the Task.
+
+    The task is strongly referenced until it completes (no GC-cancellation), and
+    any *uncaught* exception is reported via ``record_error`` with the caller's
+    ``subsystem``/``operation``. Cancellation is not reported as a failure.
+
+    Must be called from within a running event loop — like ``create_task``.
+    """
+    task = asyncio.create_task(coro)
+    _BACKGROUND_TASKS.add(task)
+
+    def _on_done(t: asyncio.Task) -> None:
+        _BACKGROUND_TASKS.discard(t)
+        try:
+            exc = t.exception()
+        except asyncio.CancelledError:
+            return  # graceful cancellation is not a recordable failure
+        if exc is None:
+            return
+        logger.error(
+            "Guarded task %s.%s crashed: %s", subsystem, operation, exc, exc_info=exc
+        )
+        record_error(
+            subsystem=subsystem,
+            operation=operation,
+            error=exc,
+            workspace_id=workspace_id,
+            agent_id=agent_id,
+            extra=extra,
+        )
+
+    task.add_done_callback(_on_done)
+    return task

--- a/orchestrator/main.py
+++ b/orchestrator/main.py
@@ -354,66 +354,22 @@ async def _boot_phase_1_core():
 
 
 async def _seed_semantic_embeddings():
-    """Phase 1 continued: Background embedding seed (non-blocking)."""
+    """Phase 1 continued: launch the non-blocking boot seeds.
+
+    The seed bodies live in ``core.boot.startup_tasks`` — importable, tested,
+    and observable: on failure they report into ``error_events`` via
+    ``record_error(subsystem="startup")`` (WS-A sink) instead of dying with
+    only a log line. Both are self-guarding (never raise), so a bare
+    ``create_task`` cannot leak an unretrieved exception.
+    """
     import asyncio as _asyncio
-    from core.routing.semantic_indexer import embed_workspace_agents as _embed_ws
-    from core.models.workspaces import Workspace as _Workspace
+    from core.boot.startup_tasks import (
+        embed_all_agents_on_startup,
+        ensure_field_memory_collection,
+    )
 
-    async def _embed_all_agents_on_startup():
-        """Background task: embed agents in all workspaces."""
-        try:
-            from core.database.database import SessionLocal as _SL
-            from core.llm.embedding_manager import get_embedding_manager
-            from core.models.core import Agent as _Agent
-
-            _db = _SL()
-            try:
-                emgr = get_embedding_manager()
-                emgr._ensure_provider()
-                logger.info(f"PRD-64: Embedding provider: {emgr.get_provider_info()}")
-
-                ws_ids = [w.id for w in _db.query(_Workspace.id).all()]
-                total = 0
-                for ws_id in ws_ids:
-                    try:
-                        total += await _embed_ws(ws_id, _db)
-                    except Exception:
-                        logger.warning("PRD-64: Failed to embed workspace %s", ws_id, exc_info=True)
-
-                all_agents = _db.query(_Agent).filter(_Agent.status == "active").count()
-                with_embeddings = _db.query(_Agent).filter(
-                    _Agent.status == "active",
-                    _Agent.semantic_embedding.isnot(None),
-                ).count()
-                logger.info(
-                    f"PRD-64: Semantic embeddings seeded — "
-                    f"{total} new, {with_embeddings}/{all_agents} agents have embeddings"
-                )
-            finally:
-                _db.close()
-        except Exception as e:
-            logger.warning(f"PRD-64: Startup embedding seed failed (non-fatal): {e}", exc_info=True)
-
-    _asyncio.create_task(_embed_all_agents_on_startup())
-
-    # PRD-108 single-collection refactor: ensure the shared field_memory
-    # collection + payload indexes exist before the coordinator boots.
-    async def _ensure_field_memory_collection() -> None:
-        try:
-            from modules.context.factory import get_shared_context
-            from modules.context.adapters.vector_field import VectorFieldSharedContext
-            ctx = get_shared_context()
-            inner = getattr(ctx, "_inner", ctx)
-            if isinstance(inner, VectorFieldSharedContext):
-                await inner.ensure_shared_collection()
-                logger.info("PRD-108: shared field_memory collection ready")
-        except Exception:
-            logger.warning(
-                "PRD-108: shared field_memory bootstrap failed (non-fatal)",
-                exc_info=True,
-            )
-
-    _asyncio.create_task(_ensure_field_memory_collection())
+    _asyncio.create_task(embed_all_agents_on_startup())
+    _asyncio.create_task(ensure_field_memory_collection())
 
 
 class TrustGateError(RuntimeError):

--- a/orchestrator/main.py
+++ b/orchestrator/main.py
@@ -352,6 +352,21 @@ async def _boot_phase_1_core():
 
         logger.info("Boot seeds completed (leader worker)")
 
+        # ── Orphaned-run reaper (PRD-142 Wave 1 · WS-C · W1-S6) ──
+        # Runs under the leader lock so exactly one worker reaps per deploy.
+        # In-flight rows whose background executor died with the previous
+        # process (board 'in_progress', wizard 'scraping', workflow 'running')
+        # are marked terminal here. Guarded: a reaper failure must never abort
+        # boot — it surfaces on the ERRORS-by-subsystem tile instead.
+        try:
+            from core.boot.reaper import reap_orphaned_runs
+            with get_db_session() as db:
+                reap_orphaned_runs(db)
+        except Exception as reap_err:
+            logger.warning("Boot reaper failed (non-fatal): %s", reap_err, exc_info=True)
+            from core.utils.exception_telemetry import record_error
+            record_error(subsystem="startup", operation="boot_reaper", error=reap_err)
+
 
 async def _seed_semantic_embeddings():
     """Phase 1 continued: launch the non-blocking boot seeds.

--- a/orchestrator/tests/test_w1s5_guarded_launcher.py
+++ b/orchestrator/tests/test_w1s5_guarded_launcher.py
@@ -1,0 +1,154 @@
+"""PRD-142 Wave 1 · WS-C · W1-S5 — guarded fire-and-forget launcher.
+
+``asyncio.create_task`` is a footgun for fire-and-forget work: the loop keeps
+only a *weak* reference, so an un-referenced task can be GC-cancelled mid-flight,
+and an uncaught exception surfaces only as a GC-time "never retrieved" warning —
+invisible to telemetry.
+
+``launch_guarded`` replaces every bare ``create_task`` site (board task run,
+wizard scrape pipeline, workflow local fallback). These tests prove the
+contract:
+
+  - the task is strongly referenced while in flight (no GC-cancellation);
+  - an *uncaught* exception fires ``record_error`` with the caller's
+    subsystem/operation and is then cleaned up;
+  - a clean completion records nothing;
+  - cancellation is NOT treated as a recordable error.
+"""
+import asyncio
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+ORCH_ROOT = Path(__file__).resolve().parent.parent
+if str(ORCH_ROOT) not in sys.path:
+    sys.path.insert(0, str(ORCH_ROOT))
+
+# Importing the launcher pulls in core.utils.exception_telemetry → SessionLocal,
+# which builds the SQLAlchemy engine and refuses to without POSTGRES_* creds.
+# These tests never touch a real DB; setdefault means a real .env still wins.
+for _k, _v in {
+    "POSTGRES_USER": "test",
+    "POSTGRES_PASSWORD": "test",
+    "POSTGRES_HOST": "localhost",
+    "POSTGRES_PORT": "5432",
+    "POSTGRES_DB": "test",
+}.items():
+    os.environ.setdefault(_k, _v)
+
+import core.utils.background_tasks as bg  # noqa: E402
+
+
+async def _settle():
+    """Let scheduled done-callbacks (loop.call_soon) run."""
+    for _ in range(3):
+        await asyncio.sleep(0)
+
+
+def test_holds_strong_ref_while_in_flight(monkeypatch):
+    monkeypatch.setattr(bg, "record_error", MagicMock())
+
+    async def _drive():
+        started = asyncio.Event()
+
+        async def _work():
+            started.set()
+            await asyncio.sleep(0.05)
+
+        task = bg.launch_guarded(_work(), subsystem="x", operation="y")
+        await started.wait()
+        # Strongly referenced while pending — this is the GC-cancellation guard.
+        assert task in bg._BACKGROUND_TASKS
+        await asyncio.gather(task, return_exceptions=True)
+        await _settle()
+        return task
+
+    task = asyncio.run(_drive())
+    assert task not in bg._BACKGROUND_TASKS  # cleaned up on completion
+
+
+def test_records_uncaught_exception(monkeypatch):
+    rec = MagicMock()
+    monkeypatch.setattr(bg, "record_error", rec)
+
+    async def _boom():
+        raise RuntimeError("kaboom")
+
+    async def _drive():
+        task = bg.launch_guarded(_boom(), subsystem="board", operation="execute_task")
+        await asyncio.gather(task, return_exceptions=True)
+        await _settle()
+        return task
+
+    task = asyncio.run(_drive())
+    assert task not in bg._BACKGROUND_TASKS
+    rec.assert_called_once()
+    kw = rec.call_args.kwargs
+    assert kw["subsystem"] == "board"
+    assert kw["operation"] == "execute_task"
+    assert "kaboom" in str(kw["error"])
+
+
+def test_clean_completion_records_nothing(monkeypatch):
+    rec = MagicMock()
+    monkeypatch.setattr(bg, "record_error", rec)
+
+    async def _ok():
+        return "fine"
+
+    async def _drive():
+        task = bg.launch_guarded(_ok(), subsystem="wizard", operation="scrape_pipeline")
+        await asyncio.gather(task, return_exceptions=True)
+        await _settle()
+        return task
+
+    task = asyncio.run(_drive())
+    rec.assert_not_called()
+    assert task not in bg._BACKGROUND_TASKS
+
+
+def test_cancellation_is_not_recorded(monkeypatch):
+    rec = MagicMock()
+    monkeypatch.setattr(bg, "record_error", rec)
+
+    async def _drive():
+        async def _hang():
+            await asyncio.sleep(10)
+
+        task = bg.launch_guarded(_hang(), subsystem="x", operation="y")
+        await asyncio.sleep(0)      # let it start
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+        await _settle()
+        return task
+
+    task = asyncio.run(_drive())
+    rec.assert_not_called()         # cancellation != failure
+    assert task not in bg._BACKGROUND_TASKS
+
+
+def test_workspace_and_extra_are_plumbed(monkeypatch):
+    rec = MagicMock()
+    monkeypatch.setattr(bg, "record_error", rec)
+
+    async def _boom():
+        raise ValueError("nope")
+
+    async def _drive():
+        task = bg.launch_guarded(
+            _boom(),
+            subsystem="workflow",
+            operation="execute",
+            workspace_id="ws-123",
+            agent_id=7,
+            extra={"execution_id": 42},
+        )
+        await asyncio.gather(task, return_exceptions=True)
+        await _settle()
+
+    asyncio.run(_drive())
+    kw = rec.call_args.kwargs
+    assert kw["workspace_id"] == "ws-123"
+    assert kw["agent_id"] == 7
+    assert kw["extra"] == {"execution_id": 42}

--- a/orchestrator/tests/test_w1s6_boot_reaper.py
+++ b/orchestrator/tests/test_w1s6_boot_reaper.py
@@ -1,0 +1,257 @@
+"""PRD-142 Wave 1 · WS-C · W1-S6 — boot reaper for orphaned runs.
+
+When the orchestrator restarts, any in-flight row whose background ``asyncio``
+executor died with the old process is stranded forever: a board task stuck in
+``in_progress``, a wizard profile stuck in ``scraping``/``scanning``, a workflow
+execution stuck in ``running``/``pending``. Nothing remains to move it to a
+terminal state.
+
+``reap_orphaned_runs`` runs once per deploy (under the boot leader lock) and
+sweeps those three surfaces. A row is reaped only if it has been in-flight
+longer than ``BOOT_REAPER_STALE_MINUTES`` — long enough that no legitimately
+running job (the wizard scrape, ~10–20 min, is the slowest) could still own it.
+Each surface is marked terminal using its OWN failure convention:
+
+  - board task  → ``status="done"`` + ``error_message`` (the board has no
+    'failed' Kanban column; its own failure path uses 'done' + error_message);
+  - wizard profile → ``status="failed"`` + ``quality_findings``;
+  - workflow execution → ``status="failed"`` + ``error_message`` + ``completed_at``.
+
+Each reap fires ``record_error(subsystem=<surface>, operation="boot_reap")`` so
+the sweep surfaces on the ERRORS-by-subsystem dashboard tile (the WS-A sink).
+
+These tests prove the contract with no real DB: a fake Session returns seeded
+rows and staleness is filtered in Python (the row volume is tiny pre-launch).
+"""
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+ORCH_ROOT = Path(__file__).resolve().parent.parent
+if str(ORCH_ROOT) not in sys.path:
+    sys.path.insert(0, str(ORCH_ROOT))
+
+# Importing the reaper pulls in core.utils.exception_telemetry → SessionLocal →
+# the SQLAlchemy engine, which refuses to build without POSTGRES_* creds. These
+# tests never touch a real DB; setdefault means a real .env still wins.
+for _k, _v in {
+    "POSTGRES_USER": "test",
+    "POSTGRES_PASSWORD": "test",
+    "POSTGRES_HOST": "localhost",
+    "POSTGRES_PORT": "5432",
+    "POSTGRES_DB": "test",
+}.items():
+    os.environ.setdefault(_k, _v)
+
+import core.boot.reaper as reaper  # noqa: E402
+from core.models.business_profiles import BusinessProfile  # noqa: E402
+from core.models.core import BoardTask, WorkflowExecution  # noqa: E402
+
+NOW = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+OLD = NOW - timedelta(minutes=90)          # well past the 30-min default
+FRESH = NOW - timedelta(minutes=1)         # comfortably inside the window
+OLD_NAIVE = (NOW - timedelta(minutes=90)).replace(tzinfo=None)  # workflow tz-naive
+
+
+# ---------------------------------------------------------------------------
+# Fake DB — query(Model) returns seeded rows; staleness is filtered in Python.
+# ---------------------------------------------------------------------------
+
+class _FakeQuery:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def filter(self, *args, **kwargs):  # SQLAlchemy expressions are ignored
+        return self
+
+    def all(self):
+        return list(self._rows)
+
+
+class _FakeSession:
+    def __init__(self, rows_by_model=None, raise_for=None):
+        self._rows_by_model = rows_by_model or {}
+        self._raise_for = raise_for or set()
+        self.query_calls = 0
+        self.commits = 0
+        self.rollbacks = 0
+
+    def query(self, model):
+        self.query_calls += 1
+        if model in self._raise_for:
+            raise RuntimeError(f"query({model.__name__}) blew up")
+        return _FakeQuery(self._rows_by_model.get(model, []))
+
+    def commit(self):
+        self.commits += 1
+
+    def rollback(self):
+        self.rollbacks += 1
+
+
+def _board(id_, status, started_at, updated_at=None):
+    return SimpleNamespace(
+        id=id_, status=status, started_at=started_at,
+        updated_at=updated_at, completed_at=None, error_message=None,
+        workspace_id=None,
+    )
+
+
+def _profile(id_, status, updated_at):
+    return SimpleNamespace(
+        id=id_, status=status, updated_at=updated_at,
+        quality_findings=None, workspace_id=None,
+    )
+
+
+def _wfe(id_, status, started_at):
+    return SimpleNamespace(
+        id=id_, status=status, started_at=started_at,
+        completed_at=None, error_message=None, workspace_id=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _is_stale — naive/aware coercion + the None guard
+# ---------------------------------------------------------------------------
+
+def test_is_stale_aware_old_is_stale():
+    cutoff = NOW - timedelta(minutes=30)
+    assert reaper._is_stale(OLD, cutoff) is True
+
+
+def test_is_stale_naive_old_is_stale():
+    """A tz-naive timestamp (WorkflowExecution.started_at) is assumed UTC."""
+    cutoff = NOW - timedelta(minutes=30)
+    assert reaper._is_stale(OLD_NAIVE, cutoff) is True
+
+
+def test_is_stale_recent_is_not_stale():
+    cutoff = NOW - timedelta(minutes=30)
+    assert reaper._is_stale(FRESH, cutoff) is False
+
+
+def test_is_stale_none_is_not_stale():
+    """No timestamp → cannot prove staleness → never reaped."""
+    cutoff = NOW - timedelta(minutes=30)
+    assert reaper._is_stale(None, cutoff) is False
+
+
+# ---------------------------------------------------------------------------
+# Per-surface terminal conventions
+# ---------------------------------------------------------------------------
+
+def test_reaps_stale_board_task_as_done(monkeypatch):
+    rec = MagicMock()
+    monkeypatch.setattr(reaper, "record_error", rec)
+    row = _board(7, "in_progress", OLD)
+    db = _FakeSession({BoardTask: [row]})
+
+    n = reaper.reap_orphaned_runs(db, now=NOW)
+
+    assert n == 1
+    assert row.status == "done"                 # board's own failure convention
+    assert row.completed_at is not None
+    assert "orphan" in (row.error_message or "").lower()
+    assert db.commits >= 1
+    rec.assert_called_once()
+    kw = rec.call_args.kwargs
+    assert kw["subsystem"] == "board"
+    assert kw["operation"] == "boot_reap"
+
+
+def test_reaps_stale_wizard_profile_as_failed(monkeypatch):
+    rec = MagicMock()
+    monkeypatch.setattr(reaper, "record_error", rec)
+    row = _profile("p1", "scraping", OLD)
+    db = _FakeSession({BusinessProfile: [row]})
+
+    n = reaper.reap_orphaned_runs(db, now=NOW)
+
+    assert n == 1
+    assert row.status == "failed"
+    assert row.quality_findings  # an error note was recorded
+    kw = rec.call_args.kwargs
+    assert kw["subsystem"] == "wizard"
+    assert kw["operation"] == "boot_reap"
+
+
+def test_reaps_stale_workflow_execution_as_failed(monkeypatch):
+    rec = MagicMock()
+    monkeypatch.setattr(reaper, "record_error", rec)
+    row = _wfe(42, "running", OLD_NAIVE)
+    db = _FakeSession({WorkflowExecution: [row]})
+
+    n = reaper.reap_orphaned_runs(db, now=NOW)
+
+    assert n == 1
+    assert row.status == "failed"
+    assert row.completed_at is not None
+    assert "orphan" in (row.error_message or "").lower()
+    kw = rec.call_args.kwargs
+    assert kw["subsystem"] == "workflow"
+    assert kw["operation"] == "boot_reap"
+
+
+# ---------------------------------------------------------------------------
+# Staleness gate — fresh rows survive
+# ---------------------------------------------------------------------------
+
+def test_fresh_rows_are_not_reaped(monkeypatch):
+    rec = MagicMock()
+    monkeypatch.setattr(reaper, "record_error", rec)
+    db = _FakeSession({
+        BoardTask: [_board(1, "in_progress", FRESH)],
+        BusinessProfile: [_profile("p", "scraping", FRESH)],
+        WorkflowExecution: [_wfe(2, "running", FRESH.replace(tzinfo=None))],
+    })
+
+    n = reaper.reap_orphaned_runs(db, now=NOW)
+
+    assert n == 0
+    rec.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Aggregate behaviour
+# ---------------------------------------------------------------------------
+
+def test_reap_returns_total_count_across_surfaces(monkeypatch):
+    monkeypatch.setattr(reaper, "record_error", MagicMock())
+    db = _FakeSession({
+        BoardTask: [_board(1, "in_progress", OLD)],
+        BusinessProfile: [_profile("p", "scraping", OLD)],
+        WorkflowExecution: [_wfe(2, "running", OLD_NAIVE)],
+    })
+
+    assert reaper.reap_orphaned_runs(db, now=NOW) == 3
+    assert db.commits >= 1
+
+
+def test_disabled_flag_short_circuits(monkeypatch):
+    monkeypatch.setattr(reaper.config, "BOOT_REAPER_ENABLED", False)
+    rec = MagicMock()
+    monkeypatch.setattr(reaper, "record_error", rec)
+    db = _FakeSession({BoardTask: [_board(1, "in_progress", OLD)]})
+
+    assert reaper.reap_orphaned_runs(db, now=NOW) == 0
+    assert db.query_calls == 0          # short-circuit before any query
+    rec.assert_not_called()
+
+
+def test_one_surface_failure_does_not_abort_others(monkeypatch):
+    """A surface that blows up is recorded but the others still get reaped."""
+    monkeypatch.setattr(reaper, "record_error", MagicMock())
+    db = _FakeSession(
+        rows_by_model={
+            BusinessProfile: [_profile("p", "scraping", OLD)],
+            WorkflowExecution: [_wfe(2, "running", OLD_NAIVE)],
+        },
+        raise_for={BoardTask},
+    )
+
+    # board raises, wizard + workflow still reaped → 2
+    assert reaper.reap_orphaned_runs(db, now=NOW) == 2

--- a/orchestrator/tests/test_w1s7_startup_observability.py
+++ b/orchestrator/tests/test_w1s7_startup_observability.py
@@ -1,0 +1,110 @@
+"""PRD-142 Wave 1 · WS-C · W1-S7 — observable startup tasks.
+
+The two boot-time background seeds — agent semantic embedding (PRD-64) and the
+shared ``field_memory`` collection bootstrap (PRD-108) — used to swallow their
+failures with only a ``logger.warning``. They were launched fire-and-forget
+from ``main.py`` and reached their handler only when a real dependency blew up,
+so a failed boot seed died silently and never showed up anywhere.
+
+They now also fire ``record_error(subsystem="startup")`` so a failed seed lights
+up the ERRORS-by-subsystem dashboard tile (the WS-A sink). These tests prove the
+contract:
+
+  - on failure, ``record_error`` fires with ``subsystem="startup"`` and the
+    right ``operation`` — and the task itself never raises (boot proceeds);
+  - on success, ``record_error`` does NOT fire.
+"""
+import asyncio
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+ORCH_ROOT = Path(__file__).resolve().parent.parent
+if str(ORCH_ROOT) not in sys.path:
+    sys.path.insert(0, str(ORCH_ROOT))
+
+# Importing core.boot.startup_tasks pulls in core.utils.exception_telemetry,
+# which imports SessionLocal and thus builds the SQLAlchemy engine — it refuses
+# to build without POSTGRES_* creds. These tests never touch a real DB; the
+# setdefault means a real .env (when present) still wins.
+for _k, _v in {
+    "POSTGRES_USER": "test",
+    "POSTGRES_PASSWORD": "test",
+    "POSTGRES_HOST": "localhost",
+    "POSTGRES_PORT": "5432",
+    "POSTGRES_DB": "test",
+}.items():
+    os.environ.setdefault(_k, _v)
+
+
+# ---------------------------------------------------------------------------
+# embed_all_agents_on_startup (subsystem="startup", operation="embed_all_agents")
+# ---------------------------------------------------------------------------
+
+def test_embed_startup_failure_emits_startup_error(monkeypatch):
+    import core.boot.startup_tasks as st
+    import core.database.database as db_mod
+
+    rec = MagicMock()
+    monkeypatch.setattr(st, "record_error", rec, raising=False)
+
+    # SessionLocal() is the first call inside the try → make it raise to drive
+    # straight to the terminal except. A distinctive message proves it was THIS
+    # failure that was recorded (not an incidental import error).
+    def _boom():
+        raise RuntimeError("db unavailable")
+
+    monkeypatch.setattr(db_mod, "SessionLocal", _boom)
+
+    # Must NOT raise — boot proceeds even when the seed blows up.
+    asyncio.run(st.embed_all_agents_on_startup())
+
+    rec.assert_called_once()
+    kw = rec.call_args.kwargs
+    assert kw["subsystem"] == "startup"
+    assert kw["operation"] == "embed_all_agents"
+    assert "db unavailable" in str(kw["error"])
+
+
+# ---------------------------------------------------------------------------
+# ensure_field_memory_collection (subsystem="startup",
+#                                 operation="ensure_field_memory_collection")
+# ---------------------------------------------------------------------------
+
+def test_field_memory_startup_failure_emits_startup_error(monkeypatch):
+    import core.boot.startup_tasks as st
+    import modules.context.factory as factory_mod
+
+    rec = MagicMock()
+    monkeypatch.setattr(st, "record_error", rec, raising=False)
+
+    def _boom():
+        raise RuntimeError("context factory down")
+
+    monkeypatch.setattr(factory_mod, "get_shared_context", _boom)
+
+    asyncio.run(st.ensure_field_memory_collection())
+
+    rec.assert_called_once()
+    kw = rec.call_args.kwargs
+    assert kw["subsystem"] == "startup"
+    assert kw["operation"] == "ensure_field_memory_collection"
+    assert "context factory down" in str(kw["error"])
+
+
+def test_field_memory_success_does_not_emit(monkeypatch):
+    """Guardrail: a clean bootstrap must NOT record an error."""
+    import core.boot.startup_tasks as st
+    import modules.context.factory as factory_mod
+
+    rec = MagicMock()
+    monkeypatch.setattr(st, "record_error", rec, raising=False)
+
+    # ctx._inner is a plain MagicMock → the isinstance(VectorFieldSharedContext)
+    # guard is False → the body is a clean no-op, no error path taken.
+    monkeypatch.setattr(factory_mod, "get_shared_context", lambda: MagicMock())
+
+    asyncio.run(st.ensure_field_memory_collection())
+
+    rec.assert_not_called()


### PR DESCRIPTION
## Summary

PRD-142 Wave 1 **WS-C** — make in-flight work survive process restarts and stop fire-and-forget launches from silently dying. Backend-only, no new features/UI. Pairs with the already-merged WS-A error sink (PR #404).

Three commits, four stories:

- **W1-S7 — observable startup seeds.** The two boot seeds (PRD-64 agent embeddings, PRD-108 `field_memory` collection) were nested fire-and-forget closures in `main.py` whose failures were only `logger.warning`-ed. Extracted to `core/boot/startup_tasks.py` (importable, unit-tested); on failure they now also fire `record_error(subsystem="startup")` so a failed boot seed lights up the ERRORS-by-subsystem tile instead of dying silently.
- **W1-S4 — durable launch record before dispatch.** *Already satisfied by existing code* — board (`status='in_progress'`), wizard (`status='scraping'`) and workflow (`WorkflowExecution` row) all commit a durable in-flight row **before** dispatch. No new code; locked in by the W1-S6 reaper tests, which recover exactly those rows.
- **W1-S6 — boot reaper for orphaned runs.** New `core/boot/reaper.py`, leader-gated so exactly one worker reaps per deploy. Sweeps the three durable-launch surfaces and marks anything stranded by a crash/restart terminal using each surface's **own** failure convention (board → `done`+`error_message`, wizard → `failed`+`quality_findings`, workflow → `failed`+`completed_at`). Staleness is filtered in Python against a configurable threshold (default 30 min > the slowest legit job) and tolerates the naive/aware datetime split across the three tables. Each surface fires `record_error(operation="boot_reap")`. **Missions are excluded** — `OrchestrationRun` is owned by the coordinator's reconcile loop; reaping here would race it.
- **W1-S5 — guarded launcher replaces fire-and-forget.** New `core/utils/background_tasks.launch_guarded`: holds a strong ref (a bare `create_task` can be GC-cancelled mid-flight) and reports any uncaught crash via `record_error` (cancellation is not a failure). Replaces **all four** bare `asyncio.create_task` sites (board run, wizard scrape, two workflow local fallbacks); deletes the redundant `_run_with_error_handling` wrapper + now-unused `asyncio` imports (no dual path).

## Design notes / why no Redis queue

W1-S5 deliberately does **not** route board/wizard/workflow closures onto the `queued` backend — that backend runs structured `AgentTask` descriptors, not arbitrary request-scoped coroutines, and inventing a queue for them is the risk the PRD explicitly warns against. Where a true durable executor already exists (the workflow `queued` backend) callers still prefer it. Restart-survival for board/wizard is delivered by the W1-S6 reaper. `execute_workflow_with_progress` is a PRD-125-disabled stub, so its local-fallback rows are exactly what the reaper now cleans.

## Config

- `BOOT_REAPER_ENABLED` (default `true`)
- `BOOT_REAPER_STALE_MINUTES` (default `30`)

## Test plan

- [x] `tests/test_w1s7_startup_observability.py` — failure fires `record_error(subsystem="startup")`, success does not, task never raises (3 tests)
- [x] `tests/test_w1s6_boot_reaper.py` — naive/aware staleness, per-surface terminal conventions, fresh rows survive, aggregate count, disabled-flag short-circuit, surface isolation (11 tests)
- [x] `tests/test_w1s5_guarded_launcher.py` — strong-ref held in flight, uncaught crash recorded, clean completion silent, cancellation not recorded, kwargs plumbed (5 tests)
- [x] All 19 WS-C tests green; `py_compile` clean across `main.py` + the three touched API modules
- [ ] Canary soak on Railway before relying on the reaper in anger (per PRD risk note)