### PR TITLE
fix(prd-142-wave1): WS-D W1-S8 — get_db() rolls back before close (idle-in-tx)

### DIFF
--- a/orchestrator/core/database/database.py
+++ b/orchestrator/core/database/database.py
@@ -108,6 +108,11 @@ def get_db() -> Session:
     try:
         yield db
     finally:
+        # Roll back any transaction the handler left open before returning the
+        # connection to the pool, so it is never 'idle in transaction' (holds
+        # row locks, blocks DDL). After a handler that committed, this is a
+        # no-op. Aligns with the get_db_session() pattern below.
+        db.rollback()
         db.close()
 
 @contextmanager

--- a/orchestrator/tests/test_w1s8_get_db_lifecycle.py
+++ b/orchestrator/tests/test_w1s8_get_db_lifecycle.py
@@ -1,0 +1,106 @@
+"""PRD-142 Wave 1 · WS-D · W1-S8 — get_db() must not linger idle-in-transaction.
+
+The FastAPI ``get_db()`` dependency previously only ``close()``d the session in
+its ``finally``. A read-only handler opens an implicit transaction on its first
+SELECT; if it never commits, returning the connection to the pool *without*
+rolling back can leave it 'idle in transaction' — holding row locks and blocking
+DDL (a 9 hr idle SELECT on ``agents`` was observed in production, PRD-135).
+
+The fix aligns ``get_db()`` with the safe ``get_db_session()`` pattern: roll back
+before close so no transaction lingers. After a handler that already committed,
+the rollback is a harmless no-op (no active transaction to undo).
+
+These tests drive the generator with a recording fake session — no real DB.
+"""
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+ORCH_ROOT = Path(__file__).resolve().parent.parent
+if str(ORCH_ROOT) not in sys.path:
+    sys.path.insert(0, str(ORCH_ROOT))
+
+# Importing database.py builds the SQLAlchemy engine, which refuses to construct
+# without POSTGRES_* creds. These tests never touch a real DB (SessionLocal is
+# replaced with a fake); setdefault means a real .env still wins.
+for _k, _v in {
+    "POSTGRES_USER": "test",
+    "POSTGRES_PASSWORD": "test",
+    "POSTGRES_HOST": "localhost",
+    "POSTGRES_PORT": "5432",
+    "POSTGRES_DB": "test",
+}.items():
+    os.environ.setdefault(_k, _v)
+
+import core.database.database as dbmod  # noqa: E402
+
+
+class _RecordingSession:
+    """Records the lifecycle calls get_db() makes, in order."""
+
+    def __init__(self):
+        self.calls = []
+
+    def commit(self):
+        self.calls.append("commit")
+
+    def rollback(self):
+        self.calls.append("rollback")
+
+    def close(self):
+        self.calls.append("close")
+
+
+def _patch_session_local(rec):
+    """Swap SessionLocal for a factory returning ``rec``; return a restore fn."""
+    original = dbmod.SessionLocal
+    dbmod.SessionLocal = lambda: rec
+    return lambda: setattr(dbmod, "SessionLocal", original)
+
+
+def test_get_db_rolls_back_before_close_on_normal_exit():
+    """A read-only handler (no commit) must roll back, then close."""
+    rec = _RecordingSession()
+    restore = _patch_session_local(rec)
+    try:
+        gen = dbmod.get_db()
+        db = next(gen)
+        assert db is rec
+        # Exhaust the generator → runs the finally block.
+        with pytest.raises(StopIteration):
+            next(gen)
+    finally:
+        restore()
+    assert rec.calls == ["rollback", "close"]
+
+
+def test_get_db_rolls_back_before_close_on_exception():
+    """If the handler raises, the finally must still roll back, then close."""
+    rec = _RecordingSession()
+    restore = _patch_session_local(rec)
+    try:
+        gen = dbmod.get_db()
+        next(gen)
+        with pytest.raises(ValueError):
+            gen.throw(ValueError("handler boom"))
+    finally:
+        restore()
+    assert rec.calls == ["rollback", "close"]
+
+
+def test_get_db_rollback_after_commit_is_harmless():
+    """A handler that commits is unaffected — rollback runs but is a no-op."""
+    rec = _RecordingSession()
+    restore = _patch_session_local(rec)
+    try:
+        gen = dbmod.get_db()
+        db = next(gen)
+        db.commit()  # handler persisted its work
+        with pytest.raises(StopIteration):
+            next(gen)
+    finally:
+        restore()
+    # close always follows rollback; the committed work is already durable.
+    assert rec.calls == ["commit", "rollback", "close"]


### PR DESCRIPTION
## Summary

PRD-142 Wave 1 · **WS-D · W1-S8** — stop the FastAPI `get_db()` dependency from
leaving connections **idle in transaction**.

`get_db()` (`orchestrator/core/database/database.py`) only `close()`d its session
in the `finally`. A read-only handler opens an implicit transaction on its first
SELECT; if it never commits, returning the connection to the pool **without a
rollback** can leave it `idle in transaction` — holding row locks and blocking
DDL. (A 9 hr idle `SELECT … FROM agents` was observed during PRD-135 cleanup.)

Fix: roll back before close, aligning `get_db()` with the safe `get_db_session()`
pattern already in the same file. After a handler that already committed, the
rollback is a harmless no-op (no active transaction to undo).

```diff
 finally:
+    db.rollback()
     db.close()
```

This one change covers **every request handler** across the platform.

## Scope — what is and isn't here

- ✅ **W1-S8** — `get_db()` rollback-before-close (this PR).
- ✅ **`pool_pre_ping`** (part of W1-S9) — **already enabled** (`database.py:87`,
  with `pool_recycle=3600`). No change needed.
- ⏭️ **W1-S9 background holders — deferred to a separate, carefully-reviewed PR.**
  The audit found the real idle-in-tx leaks are **not** simple close-without-rollback;
  they're **one DB session held across long LLM awaits** on live, valued surfaces:
  - `services/coordinator_service.py` (~line 1086) holds `db` across the
    `asyncio.gather` agent I/O **and** `MissionReconciler.reconcile`, whose
    `_get_executor_model` runs a wide `agents` SELECT immediately before the
    verify LLM call — **the exact 9 hr `agents` leak.** Live, every mission tick.
  - `services/heartbeat_service.py::_orchestrator_tick_llm` (~line 563) holds `db`
    across its `generate_response` iteration loop. Live, frequent.
  - `services/harness_service.py::_harness_tick` (~line 264) holds `db` across a
    5-phase awaited pipeline. Flag-gated, weekly.

  These change **mission/heartbeat transaction atomicity**, so they're split out
  for isolated review with per-surface tests + a `pg_stat_activity` reproduce-then-verify
  (the W1-S9 AC), rather than riding alongside this trivial dependency fix.

## Test plan

- [x] `tests/test_w1s8_get_db_lifecycle.py` — 3 tests, all green:
  - read-only handler (no commit) → `rollback` then `close`
  - handler raises → `finally` still `rollback` then `close`
  - handler that committed → `commit, rollback, close` (rollback is a no-op)
- [x] `py_compile` on touched files
- [ ] Full endpoint suite requires a live DB (verified locally via unit tests; no
      behavioural change for handlers that already commit)
- [ ] Post-deploy: `pg_stat_activity` shows no `idle in transaction > 60s` from a
      read-only request after return

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced database connection management to ensure proper cleanup and return of connections to the pool in all operational scenarios, including normal completion, error conditions, and pre-existing transactions.

* **Tests**
  * Added comprehensive test coverage for database connection lifecycle behavior across multiple transaction handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->