### PR TITLE
fix(memory): distil durable facts before feeding L3 (Mem0)

### DIFF
--- a/orchestrator/consumers/chatbot/smart_memory.py
+++ b/orchestrator/consumers/chatbot/smart_memory.py
@@ -13,6 +13,7 @@ Features:
 """
 
 import asyncio
+import json
 import logging
 import re
 import time
@@ -438,25 +439,56 @@ class SmartMemoryManager:
             logger.info("[SmartMemory] Memory classified as: %s", tier)
 
             max_chars = self._get_store_max_chars()
-            messages = [
-                {"role": "user", "content": user_message[:max_chars]},
-                {"role": "assistant", "content": assistant_response[:max_chars]}
-            ]
+
+            # L3 input curation: distil durable facts from this exchange BEFORE
+            # feeding Mem0. Sending the raw transcript made Mem0's server-side
+            # extraction emit thin, episodic facts ("User requested…"). Curating
+            # here yields durable knowledge instead. The verbatim transcript is
+            # still dual-written to L2 below, so nothing is lost.
+            facts = await self._distill_durable_facts(
+                user_message,
+                assistant_response,
+                workspace_id=workspace_id,
+                agent_id=agent_id,
+            )
+
+            if facts is None:
+                # Distillation failed (LLM/parse error) — fall back to the raw
+                # exchange so a transient outage never drops the memory.
+                l3_messages = [
+                    {"role": "user", "content": user_message[:max_chars]},
+                    {"role": "assistant", "content": assistant_response[:max_chars]},
+                ]
+                distilled = False
+            elif facts:
+                # Durable facts found → store those, not the raw turns.
+                l3_messages = [
+                    {"role": "user", "content": fact[:max_chars]} for fact in facts
+                ]
+                distilled = True
+            else:
+                # facts == [] → nothing durable in this exchange. Skip L3 so we
+                # don't store episodic noise; L2 still keeps the transcript.
+                l3_messages = None
+                distilled = True
 
             base_metadata = {
                 "chat_id": chat_id,
                 "timestamp": datetime.utcnow().isoformat(),
                 "workspace_id": workspace_id,
                 "agent_id": agent_id,
+                "distilled": distilled,
             }
 
-            results = await self.unified_service.store_two_tier(
-                workspace_id=workspace_id,
-                messages=messages,
-                agent_id=agent_id,
-                tier=tier,
-                metadata=base_metadata,
-            )
+            results = []
+            if l3_messages is not None:
+                results = await self.unified_service.store_two_tier(
+                    workspace_id=workspace_id,
+                    messages=l3_messages,
+                    agent_id=agent_id,
+                    tier=tier,
+                    metadata=base_metadata,
+                )
 
             # PRD-131d Phase 3: also preserve the raw transcript in L2 so the
             # Memory Explorer can surface full convos, not just Mem0's distilled
@@ -478,23 +510,124 @@ class SmartMemoryManager:
                     "[SmartMemory] Transcript storage skipped", exc_info=True,
                 )
 
-            # Check if any storage succeeded
-            success = any(r[1] and not r[1].get("error") for r in results)
+            # L3 stored OK, or was deliberately skipped (nothing durable) — both
+            # count as success; the L2 transcript above preserves the raw
+            # exchange regardless.
+            l3_ok = any(r[1] and not r[1].get("error") for r in results)
+            success = l3_ok or l3_messages is None
 
             if success:
-                tiers_stored = [r[0] for r in results if r[1] and not r[1].get("error")]
-                logger.info("[SmartMemory] Stored in tiers: %s", tiers_stored)
+                if l3_ok:
+                    tiers_stored = [r[0] for r in results if r[1] and not r[1].get("error")]
+                    logger.info("[SmartMemory] Stored distilled facts in tiers: %s", tiers_stored)
+                else:
+                    logger.info("[SmartMemory] No durable facts — L3 skipped; transcript kept in L2")
                 # Invalidate cache
                 self._invalidate_cache(workspace_id, agent_id)
                 return True
             else:
                 errors = [f"{r[0]}: {r[1].get('error') if r[1] else 'None'}" for r in results]
-                logger.warning("[SmartMemory] Storage failed: %s", errors)
+                logger.warning("[SmartMemory] L3 storage failed: %s", errors)
                 return False
 
         except Exception as e:
             logger.error("[SmartMemory] Storage failed: %s", e, exc_info=True)
             return False
+
+    # ---------------------------------------------------------------
+    # L3 input curation — distil durable facts before feeding Mem0
+    # ---------------------------------------------------------------
+
+    async def _distill_durable_facts(
+        self,
+        user_message: str,
+        assistant_response: str,
+        *,
+        workspace_id: str,
+        agent_id: Optional[int],
+    ) -> Optional[List[str]]:
+        """Distil 0..N durable facts from a chat exchange for the L3 (Mem0) feed.
+
+        Returns:
+            - ``list[str]`` of durable facts (possibly empty → nothing worth
+              keeping; caller should skip L3),
+            - ``None`` on LLM/parse failure so the caller can fall back to the
+              raw exchange rather than silently dropping the memory.
+        """
+        prompt = self._build_distill_prompt(user_message, assistant_response)
+        try:
+            # Imported here (not at module top) so tests can monkeypatch
+            # ``core.llm.create_llm_manager`` and have it take effect per call.
+            from core.llm import create_llm_manager
+
+            llm = create_llm_manager(
+                service_name="memory_integration",
+                workspace_id=workspace_id,
+                agent_id=agent_id,
+                request_type="memory_distill",
+            )
+            response = await llm.generate_response(
+                messages=[{"role": "user", "content": prompt}]
+            )
+            content = response.content if hasattr(response, "content") else str(response)
+        except Exception:
+            logger.warning(
+                "[SmartMemory] Fact distillation LLM call failed", exc_info=True
+            )
+            return None
+
+        return self._parse_distilled_facts(content)
+
+    @staticmethod
+    def _build_distill_prompt(user_message: str, assistant_response: str) -> str:
+        """Prompt that asks the LLM for durable knowledge, not interaction logs."""
+        return (
+            "You are curating long-term memory for an AI assistant. From the "
+            "single chat exchange below, extract only DURABLE facts worth "
+            "remembering for future conversations — stable knowledge about the "
+            "user, their business, their domain, their preferences, or decisions "
+            "and constraints that will still matter weeks from now.\n\n"
+            "Do NOT record transient interaction events (e.g. 'user asked to run "
+            "a mission', 'assistant said it would do X', 'user was informed "
+            "that…'). Those are conversation logs, not knowledge.\n\n"
+            "Write each fact as a standalone, third-person statement that makes "
+            "sense without the surrounding conversation. Preserve specifics "
+            "(names, standards, numbers, spellings).\n\n"
+            "Return ONLY a JSON array of strings. If nothing durable is worth "
+            "keeping, return an empty array [].\n\n"
+            f"User: {user_message}\n"
+            f"Assistant: {assistant_response}\n\n"
+            "Durable facts (JSON array):"
+        )
+
+    @staticmethod
+    def _parse_distilled_facts(content: str) -> Optional[List[str]]:
+        """Parse the LLM output into a list of facts.
+
+        Tolerates prose and ```json code fences around the array. Returns the
+        parsed list (possibly empty), or ``None`` if no JSON array can be found.
+        """
+        if not content:
+            return None
+        text = content.strip()
+        # Strip a ```json … ``` (or bare ```) code fence if present.
+        fence = re.search(r"```(?:json)?\s*(.*?)```", text, re.DOTALL)
+        if fence:
+            text = fence.group(1).strip()
+        # Prefer a clean parse; otherwise grab the first […] array in the text.
+        candidate = text
+        if not (candidate.startswith("[") and candidate.endswith("]")):
+            match = re.search(r"\[.*\]", text, re.DOTALL)
+            if not match:
+                return None
+            candidate = match.group(0)
+        try:
+            parsed = json.loads(candidate)
+        except (ValueError, TypeError):
+            return None
+        if not isinstance(parsed, list):
+            return None
+        return [str(f).strip() for f in parsed if str(f).strip()]
 
     # ---------------------------------------------------------------
     # Daily Log Summary (US-011 / US-012)

--- a/orchestrator/tests/test_l3_distill_input.py
+++ b/orchestrator/tests/test_l3_distill_input.py
@@ -1,0 +1,265 @@
+"""L3 input curation — distill durable facts before feeding Mem0.
+
+The chat path used to send the raw user+assistant exchange to L3 (Mem0). Mem0's
+default *server-side* extraction then produced thin, episodic facts like
+"User requested to fire a mission…" / "User was informed that…" — interaction
+logs, not durable knowledge.
+
+The fix curates the L3 input *in the orchestrator*: distil 0..N durable facts
+from the exchange first, and:
+  - non-empty facts → store those to L3,
+  - ``[]`` (nothing durable) → skip L3 entirely,
+  - ``None`` (LLM/parse failure) → fall back to the raw exchange so a transient
+    outage never drops the memory.
+
+In every case the verbatim transcript is still dual-written to L2 (Postgres),
+so the literal conversation is preserved for the Memory Explorer.
+
+These tests use a fake LLM manager (no network) and a recording fake of the
+UnifiedMemoryService (no Mem0, no DB).
+"""
+import os
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+ORCH_ROOT = Path(__file__).resolve().parent.parent
+if str(ORCH_ROOT) not in sys.path:
+    sys.path.insert(0, str(ORCH_ROOT))
+
+# Some imports down-chain build config; never touches a real DB in these tests.
+for _k, _v in {
+    "POSTGRES_USER": "test",
+    "POSTGRES_PASSWORD": "test",
+    "POSTGRES_HOST": "localhost",
+    "POSTGRES_PORT": "5432",
+    "POSTGRES_DB": "test",
+}.items():
+    os.environ.setdefault(_k, _v)
+
+import core.llm as core_llm  # noqa: E402  (patch target for create_llm_manager)
+
+# consumers/__init__.py eagerly imports the chatbot stack → RAG → camelot, an
+# optional PDF dep that isn't installed in the test env. Stub it so the import
+# chain resolves without the real package.
+sys.modules.setdefault("camelot", types.ModuleType("camelot"))
+
+from consumers.chatbot.smart_memory import SmartMemoryManager  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+class _FakeResp:
+    def __init__(self, content: str):
+        self.content = content
+
+
+class _FakeLLM:
+    """Returns a canned ``.content`` (or raises) from generate_response."""
+
+    def __init__(self, content_or_exc):
+        self._content_or_exc = content_or_exc
+        self.calls = []
+
+    async def generate_response(self, messages, tools=None):
+        self.calls.append(messages)
+        if isinstance(self._content_or_exc, Exception):
+            raise self._content_or_exc
+        return _FakeResp(self._content_or_exc)
+
+
+def _patch_llm(monkeypatch, content_or_exc) -> _FakeLLM:
+    """Swap create_llm_manager so the distiller talks to a fake LLM."""
+    fake = _FakeLLM(content_or_exc)
+    monkeypatch.setattr(core_llm, "create_llm_manager", lambda **kwargs: fake)
+    return fake
+
+
+class _FakeUnified:
+    """Records store_two_tier (L3) and store_transcript (L2) calls."""
+
+    def __init__(self):
+        self.two_tier_calls = []
+        self.transcript_calls = []
+
+    async def store_two_tier(self, **kwargs):
+        self.two_tier_calls.append(kwargs)
+        return [("global", {"success": True})]
+
+    async def store_transcript(self, **kwargs):
+        self.transcript_calls.append(kwargs)
+        return "row-id"
+
+
+# ---------------------------------------------------------------------------
+# _distill_durable_facts
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_distill_parses_json_array_of_facts(monkeypatch):
+    fake = _patch_llm(
+        monkeypatch,
+        '["InBuildUK is a UK smoke-ventilation contractor.", '
+        '"Blog posts should cite EN 12101-2, EN 12101-6 and EN 12101-10."]',
+    )
+    mgr = SmartMemoryManager()
+    facts = await mgr._distill_durable_facts(
+        "We do smoke ventilation for UK contractors",
+        "Noted — I'll cite EN 12101-2/-6/-10 in posts.",
+        workspace_id="ws1",
+        agent_id=3,
+    )
+    assert facts == [
+        "InBuildUK is a UK smoke-ventilation contractor.",
+        "Blog posts should cite EN 12101-2, EN 12101-6 and EN 12101-10.",
+    ]
+    # The distiller actually invoked the LLM once.
+    assert len(fake.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_distill_returns_empty_list_when_nothing_durable(monkeypatch):
+    _patch_llm(monkeypatch, "[]")
+    mgr = SmartMemoryManager()
+    facts = await mgr._distill_durable_facts(
+        "fire a mission to write the blog post",
+        "OK, firing the mission now.",
+        workspace_id="ws1",
+        agent_id=None,
+    )
+    assert facts == []
+
+
+@pytest.mark.asyncio
+async def test_distill_tolerates_prose_around_the_json(monkeypatch):
+    # Models sometimes wrap the array in prose / code fences.
+    _patch_llm(
+        monkeypatch,
+        'Here are the durable facts:\n```json\n["User prefers British English."]\n```',
+    )
+    mgr = SmartMemoryManager()
+    facts = await mgr._distill_durable_facts(
+        "Please always use British spelling.",
+        "Will do.",
+        workspace_id="ws1",
+        agent_id=None,
+    )
+    assert facts == ["User prefers British English."]
+
+
+@pytest.mark.asyncio
+async def test_distill_returns_none_on_llm_error(monkeypatch):
+    _patch_llm(monkeypatch, RuntimeError("llm provider down"))
+    mgr = SmartMemoryManager()
+    facts = await mgr._distill_durable_facts(
+        "anything", "anything", workspace_id="ws1", agent_id=None
+    )
+    assert facts is None
+
+
+@pytest.mark.asyncio
+async def test_distill_returns_none_on_unparseable_output(monkeypatch):
+    _patch_llm(monkeypatch, "I could not find any facts, sorry.")
+    mgr = SmartMemoryManager()
+    facts = await mgr._distill_durable_facts(
+        "anything", "anything", workspace_id="ws1", agent_id=None
+    )
+    assert facts is None
+
+
+# ---------------------------------------------------------------------------
+# store_conversation routing
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_store_conversation_feeds_distilled_facts_to_l3(monkeypatch):
+    _patch_llm(monkeypatch, '["User prefers concise blog posts."]')
+    mgr = SmartMemoryManager()
+    fake = _FakeUnified()
+    mgr._unified_service = fake
+
+    ok = await mgr.store_conversation(
+        workspace_id="ws1",
+        agent_id=3,
+        user_message="I like my blog posts kept concise and skimmable",
+        assistant_response="Understood, I'll keep them concise from now on.",
+    )
+
+    assert ok is True
+    # L3 received exactly one store, and its content is the distilled fact —
+    # NOT the raw assistant response.
+    assert len(fake.two_tier_calls) == 1
+    l3_text = " ".join(m["content"] for m in fake.two_tier_calls[0]["messages"])
+    assert "User prefers concise blog posts." in l3_text
+    assert "Understood, I'll keep them concise" not in l3_text
+    # L2 transcript still preserved verbatim.
+    assert len(fake.transcript_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_store_conversation_skips_l3_when_nothing_durable(monkeypatch):
+    _patch_llm(monkeypatch, "[]")
+    mgr = SmartMemoryManager()
+    fake = _FakeUnified()
+    mgr._unified_service = fake
+
+    ok = await mgr.store_conversation(
+        workspace_id="ws1",
+        agent_id=3,
+        user_message="fire a mission to create the EN 12101 blog post",
+        assistant_response="OK, firing the mission now.",
+    )
+
+    # Nothing durable → L3 is skipped entirely (no episodic noise stored).
+    assert len(fake.two_tier_calls) == 0
+    # But the raw transcript is still preserved in L2.
+    assert len(fake.transcript_calls) == 1
+    assert ok is True
+
+
+@pytest.mark.asyncio
+async def test_store_conversation_falls_back_to_raw_on_distill_error(monkeypatch):
+    _patch_llm(monkeypatch, RuntimeError("llm provider down"))
+    mgr = SmartMemoryManager()
+    fake = _FakeUnified()
+    mgr._unified_service = fake
+
+    ok = await mgr.store_conversation(
+        workspace_id="ws1",
+        agent_id=3,
+        user_message="Some substantive message about the project",
+        assistant_response="A substantive assistant reply worth keeping.",
+    )
+
+    # On distill failure we fall back to the raw exchange so memory isn't lost.
+    assert ok is True
+    assert len(fake.two_tier_calls) == 1
+    l3_text = " ".join(m["content"] for m in fake.two_tier_calls[0]["messages"])
+    assert "A substantive assistant reply worth keeping." in l3_text
+    # L2 transcript still written.
+    assert len(fake.transcript_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_store_conversation_still_skips_trivial_before_distilling(monkeypatch):
+    # Trivial greetings must short-circuit BEFORE any LLM call.
+    fake_llm = _patch_llm(monkeypatch, '["should not be reached"]')
+    mgr = SmartMemoryManager()
+    fake = _FakeUnified()
+    mgr._unified_service = fake
+
+    ok = await mgr.store_conversation(
+        workspace_id="ws1",
+        agent_id=3,
+        user_message="hi",
+        assistant_response="Hello! How can I help?",
+    )
+
+    assert ok is False
+    assert len(fake_llm.calls) == 0
+    assert len(fake.two_tier_calls) == 0
+    assert len(fake.transcript_calls) == 0


### PR DESCRIPTION
## Summary

Platform L3 (Mem0) memories were coming out short, episodic, and third-person — e.g. *"User requested to fire a mission…"*, *"User was informed that…"*. Those are interaction logs, not durable knowledge, and they're useless for future retrieval (surfaced during the **InBuildUK pilot**).

**Root cause:** `store_conversation` fed the **raw user+assistant exchange** straight to L3. Mem0 runs its *own* server-side extraction with its **default** prompt (the orchestrator passes none), so it distils the literal turns into thin "what just happened" facts.

**Fix (orchestrator-only, lowest blast radius):** curate the L3 input *before* the Mem0 feed. Distil 0..N durable facts from the exchange in `SmartMemoryManager`, then route:

| Distill result | L3 (Mem0) | L2 (Postgres transcript) |
|---|---|---|
| facts present | store the **distilled facts** | verbatim ✅ |
| `[]` (nothing durable) | **skip** (no episodic noise) | verbatim ✅ |
| `None` (LLM/parse error) | **fall back** to raw exchange | verbatim ✅ |

The verbatim transcript is still dual-written to **L2** (PRD-131d Phase 3) in every case, so the Memory Explorer keeps the literal conversation — only the L3 *distilled* layer changes.

## Why this approach

- **Reuse over build:** `create_llm_manager(service_name="memory_integration")` is the existing `system_llm` (cheap/fast) tier; model + temperature come from DB `system_settings`. No new config, no new service, **no hardcoded values**, no Mem0-fork change.
- **No memory loss:** distill failure falls back to the old raw-feed behaviour; nothing durable is ever silently dropped.
- **No backward-compat shim:** the raw-feed path is replaced, not kept alongside.

## Changes

- `orchestrator/consumers/chatbot/smart_memory.py`
  - New `_distill_durable_facts()` (LLM call, returns `list[str] | None`), `_build_distill_prompt()`, `_parse_distilled_facts()` (tolerates prose / ```json code fences).
  - `store_conversation()` rewired to distil → route → dual-write; `distilled` flag added to L3 metadata; success = L3 stored **or** deliberately skipped.

## Test plan

- [x] `tests/test_l3_distill_input.py` — 9 tests (TDD RED→GREEN), fake LLM + fake UnifiedMemoryService, no network/DB:
  - distill: parses JSON array · `[]` when nothing durable · tolerates prose/code-fences · `None` on LLM error · `None` on unparseable output
  - routing: feeds distilled facts to L3 (raw assistant text absent) · skips L3 when nothing durable (transcript still written) · falls back to raw on distill error · still skips trivial "hi" before any LLM call
- [x] Full memory suite: **71 passed**. The 2 failures in `test_memory_fixes.py` (Mem0 `search_query` param, `PlatformActionExecutor._get_memory_stats`) are **pre-existing on `main`** and unrelated — they load `mem0_client.py`/`platform_executor.py` directly and never touch `smart_memory.py`.
- [ ] Post-merge: verify on Railway that new InBuildUK exchanges produce durable L3 facts (not "User requested…").