### PR TITLE
fix(blog): repair 500 crash on manual blog post create

### DIFF
--- a/orchestrator/api/blog.py
+++ b/orchestrator/api/blog.py
@@ -20,10 +20,23 @@ from config import config
 from core.auth.dependencies import RequestContext
 from core.auth.hybrid import get_request_context_hybrid
 from core.database.database import get_db
+from core.models.workspaces import Workspace
 from core.services.blog_service import BlogService
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/blog", tags=["Blog"])
+
+
+def _resolve_author_name(db: Session, workspace_id) -> str:
+    """Public byline for a post: the workspace/brand name.
+
+    ``author_name`` is exposed on public widget endpoints, so it must never be
+    user PII. We use the workspace name (e.g. "InBuildUK") and fall back to a
+    neutral label when it is missing or blank.
+    """
+    name = db.query(Workspace.name).filter(Workspace.id == workspace_id).scalar()
+    name = (name or "").strip()
+    return name or "Workspace Author"
 
 
 # ---------------------------------------------------------------------------
@@ -66,7 +79,7 @@ async def create_post(
 ):
     """Create a new blog post (draft by default)."""
     svc = BlogService(db, ctx.workspace_id)
-    author_name = ctx.user.display_name if ctx.user and ctx.user.display_name else "Workspace Author"
+    author_name = _resolve_author_name(db, ctx.workspace_id)
     post = await svc.create_post(
         title=body.title,
         content=body.content,

--- a/orchestrator/tests/test_blog_author_byline.py
+++ b/orchestrator/tests/test_blog_author_byline.py
@@ -1,0 +1,79 @@
+"""Blog author byline resolution.
+
+The authenticated create-post endpoint used to read ``ctx.user.display_name``,
+but ``UserContext`` has no such attribute (it carries ``id``/``email``/role only).
+Every authenticated create therefore raised ``AttributeError`` and returned 500 —
+manual blog posting was 100% broken in production.
+
+The byline is *public* (widget endpoints expose ``author_name`` on every post),
+so we deliberately do NOT fall back to the user's email (PII leak). Instead the
+public byline is the workspace/brand name (e.g. "InBuildUK"), falling back to a
+neutral "Workspace Author" when the name is missing or blank.
+
+These tests pin ``_resolve_author_name`` with a MagicMock DB session — no real
+Postgres, no network.
+"""
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+ORCH_ROOT = Path(__file__).resolve().parent.parent
+if str(ORCH_ROOT) not in sys.path:
+    sys.path.insert(0, str(ORCH_ROOT))
+
+# core.database.database resolves a DB URL at import time; never connects here.
+for _k, _v in {
+    "POSTGRES_USER": "test",
+    "POSTGRES_PASSWORD": "test",
+    "POSTGRES_HOST": "localhost",
+    "POSTGRES_PORT": "5432",
+    "POSTGRES_DB": "test",
+}.items():
+    os.environ.setdefault(_k, _v)
+
+from api.blog import _resolve_author_name  # noqa: E402
+
+
+def _db_returning(scalar_value):
+    """MagicMock session whose query(...).filter(...).scalar() yields a value."""
+    db = MagicMock()
+    db.query.return_value.filter.return_value.scalar.return_value = scalar_value
+    return db
+
+
+def test_resolve_author_name_uses_workspace_name():
+    db = _db_returning("InBuildUK")
+    assert _resolve_author_name(db, uuid4()) == "InBuildUK"
+
+
+def test_resolve_author_name_falls_back_when_missing():
+    # No workspace row / NULL name → neutral byline, never an empty string.
+    db = _db_returning(None)
+    assert _resolve_author_name(db, uuid4()) == "Workspace Author"
+
+
+def test_resolve_author_name_falls_back_on_blank():
+    # A blank/whitespace name must not become the public byline.
+    db = _db_returning("   ")
+    assert _resolve_author_name(db, uuid4()) == "Workspace Author"
+
+
+def test_resolve_author_name_strips_surrounding_whitespace():
+    db = _db_returning("  InBuildUK  ")
+    assert _resolve_author_name(db, uuid4()) == "InBuildUK"
+
+
+def test_resolve_author_name_never_leaks_pii():
+    # Guard the security intent: the resolver only ever touches the workspace
+    # name, so an email can never become the public byline.
+    db = _db_returning("user@example.com")
+    # (This only happens if a workspace is literally named after an email; the
+    # point is the resolver has no access path to ctx.user.email at all.)
+    result = _resolve_author_name(db, uuid4())
+    assert result == "user@example.com"  # returned verbatim — it's the ws name
+    # The function signature takes only (db, workspace_id) — no user object.
+    import inspect
+    params = list(inspect.signature(_resolve_author_name).parameters)
+    assert params == ["db", "workspace_id"]


### PR DESCRIPTION
## Summary
- Manual blog posting was **100% broken in production**: `create_post` read `ctx.user.display_name`, but `UserContext` has no `display_name` attribute (it carries `id`/`email`/`role` only), so every authenticated create raised `AttributeError` → 500. Surfaced trying to post a manual blog on the **InBuildUK** workspace.
- `author_name` is rendered **publicly** (the widget endpoints `GET /api/widgets/blog/posts` and `/posts/{slug}` expose it on every post), so the fix deliberately avoids `ctx.user.email` — that would leak PII.
- New `_resolve_author_name(db, workspace_id)` resolves the byline from the **workspace/brand name** (e.g. "InBuildUK"), with a neutral `"Workspace Author"` fallback when the name is missing or blank.

## Changes
- `orchestrator/api/blog.py` — add `_resolve_author_name` helper + `Workspace` import; replace the crashing line in `create_post`.
- `orchestrator/tests/test_blog_author_byline.py` — 5 unit tests (MagicMock session, no DB/network): name present, NULL → fallback, blank → fallback, whitespace-strip, and a guard pinning the `(db, workspace_id)` signature so the resolver can never reach user PII.

## Test plan
- [x] `pytest tests/test_blog_author_byline.py` — 5 passed
- [x] Grepped `api/`+`core/` for other `ctx.user.display_name` / `ctx.user.name` misuse — none
- [ ] Post a manual blog post on InBuildUK on the deployed branch → expect 201 and byline "InBuildUK"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved blog post creation errors that previously resulted in 500 errors.
  * Blog post author attribution now displays the workspace brand name instead of the authenticated user's name, with a fallback to "Workspace Author" when unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->