### PR TITLE
PRD-142 Wave 2 WS-F: make the Test Net enforceable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,101 @@
+name: test
+
+# PRD-142 Wave 2 (W2-S3) — the Test Net's enforcement gate.
+#
+# Runs the orchestrator pytest suite on every PR against a real Postgres
+# service so DB-touching tests connect instead of hanging. (W2-S2 traced a
+# pre-existing hang in test_82c_wiring to psycopg2.connect blocking forever
+# when no Postgres is present — see that test's decompose path.) A per-test
+# timeout is the safety net: any future hang fails fast instead of burning
+# the whole job.
+#
+# Introduced NON-REQUIRED on purpose. The net is expected to surface
+# pre-existing gaps that Wave 2 (WS-G golden journeys, WS-H untested
+# primitives, WS-I regressions) will close. Flipping this to a required
+# check in branch protection is a deliberate follow-up, made once the suite
+# is green — that flip is the repo admin's call, not this workflow's.
+
+on:
+  push:
+    branches:
+      - main
+      - "ralph/**"
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  orchestrator-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: test_db
+        ports:
+          - 5432:5432
+        # Hold the job until Postgres can actually accept connections.
+        options: >-
+          --health-cmd "pg_isready -U test -d test_db"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      # Wire config.get_database_url() at the ephemeral service above. These
+      # are throwaway CI credentials for a container that lives only for the
+      # job — not secrets, and never reused.
+      DATABASE_URL: postgresql://test:test@127.0.0.1:5432/test_db
+      POSTGRES_USER: test
+      POSTGRES_PASSWORD: test
+      POSTGRES_HOST: 127.0.0.1
+      POSTGRES_PORT: "5432"
+      POSTGRES_DB: test_db
+      ENVIRONMENT: development
+
+    defaults:
+      run:
+        working-directory: orchestrator
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: orchestrator/requirements.txt
+
+      # weasyprint (libpango/libcairo) and python-magic (libmagic) crash on
+      # *import*, not at install, when their C libraries are missing — which
+      # would break pytest collection before a single test runs. Install the
+      # shared libs the dependency set needs at import time.
+      - name: Install system libraries
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libpango-1.0-0 libpangocairo-1.0-0 libgdk-pixbuf-2.0-0 \
+            libcairo2 libffi-dev libmagic1 ghostscript
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Initialise test database schema
+        run: python scripts/init_test_db.py
+
+      - name: Run test net
+        run: |
+          pytest \
+            --timeout=60 \
+            --timeout-method=thread \
+            -o faulthandler_timeout=90 \
+            -p no:cacheprovider \
+            -v

--- a/orchestrator/conftest.py
+++ b/orchestrator/conftest.py
@@ -1,0 +1,54 @@
+"""Root pytest fixtures for the orchestrator suite (PRD-142 Wave 2, W2-S4).
+
+This is the common ancestor of both ``tests/`` (the mock-based unit suite) and
+``modules/*/tests/`` (the real-DB module suites), so the shared real-DB
+transactional fixture lives here. The module conftests previously each carried
+their own copy of this fixture plus a hardcoded database URL; that duplication
+(and the in-source credential) is now centralised.
+
+Credentials are resolved through the central config resolver
+(``get_database_url``), never a literal in source. In CI the Postgres service
+env vars drive it; for local runs the developer's ``DATABASE_URL`` /
+``POSTGRES_*`` environment applies.
+"""
+
+from typing import Generator
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+
+@pytest.fixture(scope="session")
+def test_db_url() -> str:
+    """Resolve the test database URL from central config — no hardcoded creds."""
+    # Imported lazily so collecting the mock-only suite never forces a DB
+    # config resolution it doesn't need.
+    from core.database.database import get_database_url
+
+    return get_database_url()
+
+
+@pytest.fixture(scope="session")
+def test_engine(test_db_url):
+    """Session-scoped SQLAlchemy engine bound to the test database."""
+    engine = create_engine(test_db_url)
+    yield engine
+    engine.dispose()
+
+
+@pytest.fixture(scope="function")
+def db_session(test_engine) -> Generator[Session, None, None]:
+    """Transactional session: each test runs inside a transaction that is rolled
+    back on teardown, so tests never mutate the database for one another."""
+    connection = test_engine.connect()
+    transaction = connection.begin()
+
+    SessionLocal = sessionmaker(bind=connection)
+    session = SessionLocal()
+
+    yield session
+
+    session.close()
+    transaction.rollback()
+    connection.close()

--- a/orchestrator/modules/codegraph/tests/conftest.py
+++ b/orchestrator/modules/codegraph/tests/conftest.py
@@ -9,42 +9,14 @@ import pytest
 import tempfile
 import shutil
 from pathlib import Path
-from sqlalchemy import create_engine, text
-from sqlalchemy.orm import sessionmaker, Session
+from sqlalchemy import text
+from sqlalchemy.orm import Session
 from typing import Generator
 
 from modules.codegraph import CodeGraphService
 
-
-# Test database URL (use in-memory SQLite for fast tests)
-TEST_DB_URL = "postgresql://postgres:secure_password_123@127.0.0.1:5432/orchestrator_db"
-
-
-@pytest.fixture(scope="session")
-def test_engine():
-    """Create test database engine"""
-    engine = create_engine(TEST_DB_URL)
-    yield engine
-    engine.dispose()
-
-
-@pytest.fixture(scope="function")
-def db_session(test_engine) -> Generator[Session, None, None]:
-    """
-    Provide a transactional database session for each test.
-    Rolls back after test completes.
-    """
-    connection = test_engine.connect()
-    transaction = connection.begin()
-    
-    SessionLocal = sessionmaker(bind=connection)
-    session = SessionLocal()
-    
-    yield session
-    
-    session.close()
-    transaction.rollback()
-    connection.close()
+# ``test_engine`` and the transactional ``db_session`` fixture come from the
+# root orchestrator/conftest.py (PRD-142 W2-S4) — no per-module DB URL here.
 
 
 @pytest.fixture

--- a/orchestrator/modules/learning/tests/conftest.py
+++ b/orchestrator/modules/learning/tests/conftest.py
@@ -6,7 +6,6 @@ Uses centralized credential system for database access
 import pytest
 import os
 from uuid import uuid4
-from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, Session
 from typing import Generator
 
@@ -15,19 +14,12 @@ from core.models.workspaces import Workspace
 # Set test environment
 os.environ['ENVIRONMENT'] = 'development'
 
-# Use real database like CodeGraph/Memory
-TEST_DB_URL = "postgresql://postgres:secure_password_123@127.0.0.1:5432/orchestrator_db"
-
 # Shared test workspace ID
 TEST_WORKSPACE_ID = uuid4()
 
-
-@pytest.fixture(scope="session")
-def test_engine():
-    """Create test database engine"""
-    engine = create_engine(TEST_DB_URL)
-    yield engine
-    engine.dispose()
+# ``test_engine`` (and its DB URL) come from the root orchestrator/conftest.py
+# (PRD-142 W2-S4). This module overrides ``db_session`` only to seed a
+# Workspace row so the learning tables' FK constraints are satisfied.
 
 
 @pytest.fixture(scope="function")

--- a/orchestrator/modules/search/tests/conftest.py
+++ b/orchestrator/modules/search/tests/conftest.py
@@ -10,8 +10,6 @@ import pytest
 import numpy as np
 from datetime import datetime
 from typing import List
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker, Session
 
 TEST_EMBEDDING_DIM = int(os.getenv("VECTOR_STORE_DIMENSIONS", "2048"))
 
@@ -21,40 +19,15 @@ from modules.search import (
     EnhancedVectorStore, VectorDocument, SearchMode, RankingStrategy
 )
 
-
-# Test database URL
-TEST_DB_URL = "postgresql://postgres:secure_password_123@127.0.0.1:5432/orchestrator_db"
-
-
-@pytest.fixture(scope="session")
-def test_engine():
-    """Create test database engine"""
-    engine = create_engine(TEST_DB_URL)
-    yield engine
-    engine.dispose()
-
-
-@pytest.fixture(scope="function")
-def db_session(test_engine):
-    """Provide a transactional database session for each test"""
-    connection = test_engine.connect()
-    transaction = connection.begin()
-    
-    SessionLocal = sessionmaker(bind=connection)
-    session = SessionLocal()
-    
-    yield session
-    
-    session.close()
-    transaction.rollback()
-    connection.close()
+# ``test_db_url``, ``test_engine`` and the transactional ``db_session`` fixture
+# come from the root orchestrator/conftest.py (PRD-142 W2-S4).
 
 
 @pytest.fixture
-async def vector_store():
+async def vector_store(test_db_url):
     """Provide EnhancedVectorStore instance"""
     store = EnhancedVectorStore(
-        database_url=TEST_DB_URL,
+        database_url=test_db_url,
         embedding_dimension=TEST_EMBEDDING_DIM,
         similarity_function="cosine",
         table_name="test_vector_documents"
@@ -71,10 +44,10 @@ def context_optimizer():
 
 
 @pytest.fixture
-def search_config():
+def search_config(test_db_url):
     """Provide SearchConfig for testing"""
     return SearchConfig(
-        database_url=TEST_DB_URL,
+        database_url=test_db_url,
         embedding_dimension=TEST_EMBEDDING_DIM,
         default_max_results=10,
         mmr_lambda=0.7

--- a/orchestrator/pytest.ini
+++ b/orchestrator/pytest.ini
@@ -1,0 +1,21 @@
+[pytest]
+# PRD-142 Wave 2 (W2-S1): first pytest config for the orchestrator suite.
+# Until this landed there was no config at all, so async mode, marker
+# registration and import resolution were all implicit. This pins them.
+
+# rootdir is orchestrator/ so `core.*` / `modules.*` absolute imports resolve.
+pythonpath = .
+
+# Default collection = the main orchestrator suite. The real-DB module suites
+# (modules/*/tests) need live services and are run explicitly in CI / WS-G.
+testpaths = tests
+
+# pytest-asyncio 1.x already defaults to strict; pin it so a future default
+# flip can't silently change collection of @pytest.mark.asyncio tests.
+asyncio_mode = strict
+
+# Registered markers (not --strict-markers, so existing ad-hoc marks still run).
+markers =
+    golden: end-to-end golden-journey backbone (J1-J10); select with `-m golden`
+    integration: hits real infrastructure (Postgres/S3/vectors); needs services
+    slow: long-running; deselect with `-m "not slow"` for fast inner-loop runs

--- a/orchestrator/requirements.txt
+++ b/orchestrator/requirements.txt
@@ -51,6 +51,7 @@ cachetools>=5.3.0
 # Development/Testing
 pytest==7.4.3
 pytest-asyncio==0.21.1
+pytest-timeout==2.3.1  # per-test timeout net for CI (PRD-142 W2-S3); kills hangs fast
 black==23.11.0
 isort==5.12.0
 

--- a/orchestrator/tests/test_82c_wiring.py
+++ b/orchestrator/tests/test_82c_wiring.py
@@ -637,7 +637,20 @@ class TestWiringCoordinatorTick:
     async def test_process_run_calls_dispatch_ready(self):
         """E2E: coordinator tick calls dispatch_ready, executes both tasks."""
         svc = CoordinatorService.__new__(CoordinatorService)
-        svc._execute_task = AsyncMock()
+
+        # Tick phases: _prepare_task (serial DB) -> _run_agent_io (concurrent)
+        # -> _record_task_result (serial). _prepare_task threads the real task
+        # through in its prep dict.
+        async def _prep(db, run, task, agent_id):
+            return {
+                "task": task, "agent_id": agent_id, "agent_runtime": None,
+                "prompt": f"prompt-{task.id}", "factory": MagicMock(),
+                "attachment_ids": [], "mode_caps": {},
+            }
+
+        svc._prepare_task = AsyncMock(side_effect=_prep)
+        svc._run_agent_io = AsyncMock(return_value={"status": "success"})
+        svc._record_task_result = AsyncMock()
         svc._create_mission_field = AsyncMock(return_value="field-1")
         svc._get_field = MagicMock(return_value=None)
 
@@ -676,7 +689,7 @@ class TestWiringCoordinatorTick:
             await svc._process_run(db, run)
 
             mock_ready.assert_called_once()
-            assert svc._execute_task.call_count == 2
+            assert svc._run_agent_io.call_count == 2
             mock_reconcile.assert_called_once()
 
     @pytest.mark.asyncio
@@ -690,12 +703,25 @@ class TestWiringCoordinatorTick:
         task_1 = _mock_task(seq=1)
         task_2 = _mock_task(seq=2)
 
-        async def _exec_side_effect(db, run, task, agent_id):
+        async def _prep(db, run, task, agent_id):
+            return {
+                "task": task, "agent_id": agent_id, "agent_runtime": None,
+                "prompt": f"prompt-{task.id}", "factory": MagicMock(),
+                "attachment_ids": [], "mode_caps": {},
+            }
+
+        async def _io_side_effect(factory, agent_id, prompt, task,
+                                  attachment_ids, *, mode_caps=None,
+                                  agent_runtime=None):
             call_count["n"] += 1
             if task.id == task_1.id:
                 raise RuntimeError("LLM timeout")
 
-        svc._execute_task = AsyncMock(side_effect=_exec_side_effect)
+        # gather(return_exceptions=True) captures the raise; the tick records
+        # an error result and still reconciles.
+        svc._prepare_task = AsyncMock(side_effect=_prep)
+        svc._run_agent_io = AsyncMock(side_effect=_io_side_effect)
+        svc._record_task_result = AsyncMock()
 
         run = _mock_run(max_concurrent=2)
         run.state = "running"

--- a/orchestrator/tests/test_coordinator_parallel.py
+++ b/orchestrator/tests/test_coordinator_parallel.py
@@ -4,7 +4,7 @@ Wiring tests for US-003: Parallel dispatch wired into coordinator tick.
 
 Proves:
 1. _process_run() calls dispatch_ready() (not dispatch_next())
-2. When 2 tasks are dispatched, both _execute_task calls happen concurrently
+2. When 2 tasks are dispatched, both agent-I/O calls happen concurrently
 3. Sequential missions (max_concurrent=1) still work unchanged
 4. An exception in one task does not crash the tick or prevent reconciliation
 """
@@ -69,7 +69,25 @@ def _make_dispatch_result(*, task_id, agent_id=1, dispatched=True):
 def coordinator():
     """Create a CoordinatorService instance with heavy deps mocked out."""
     svc = CoordinatorService.__new__(CoordinatorService)
-    svc._execute_task = AsyncMock()
+
+    # The tick splits each task into three phases: _prepare_task (serial DB
+    # prep) -> _run_agent_io (concurrent, no DB) -> _record_task_result
+    # (serial). Mock all three. _prepare_task returns a prep dict embedding the
+    # real task so the gather/record phases thread it through unchanged.
+    async def _prep(db, run, task, agent_id):
+        return {
+            "task": task,
+            "agent_id": agent_id,
+            "agent_runtime": None,
+            "prompt": f"prompt-{task.id}",
+            "factory": MagicMock(),
+            "attachment_ids": [],
+            "mode_caps": {},
+        }
+
+    svc._prepare_task = AsyncMock(side_effect=_prep)
+    svc._run_agent_io = AsyncMock(return_value={"status": "success"})
+    svc._record_task_result = AsyncMock()
     svc._create_mission_field = AsyncMock(return_value="field-1")
     svc._get_field = MagicMock(return_value=None)
     return svc
@@ -99,7 +117,7 @@ class TestProcessRunParallelDispatch:
     @pytest.mark.asyncio
     async def test_two_tasks_both_execute(self, coordinator, mock_db):
         """
-        US-003 AC: dispatch 2 tasks, verify both _execute_task calls happen.
+        US-003 AC: dispatch 2 tasks, verify both agent-I/O calls happen.
         """
         run = _make_run(max_concurrent=2)
         task_1 = _make_task(seq=1)
@@ -140,11 +158,12 @@ class TestProcessRunParallelDispatch:
             await coordinator._process_run(mock_db, run)
 
             # Both tasks should have been executed
-            assert coordinator._execute_task.call_count == 2
+            assert coordinator._run_agent_io.call_count == 2
 
-            # Verify correct task/agent pairs
-            calls = coordinator._execute_task.call_args_list
-            call_task_ids = {c.args[2].id for c in calls}
+            # Verify correct task/agent pairs (task is positional arg 3 of
+            # _run_agent_io: factory, agent_id, prompt, task, attachment_ids)
+            calls = coordinator._run_agent_io.call_args_list
+            call_task_ids = {c.args[3].id for c in calls}
             assert task_1.id in call_task_ids
             assert task_2.id in call_task_ids
 
@@ -185,7 +204,7 @@ class TestProcessRunParallelDispatch:
 
             await coordinator._process_run(mock_db, run)
 
-            assert coordinator._execute_task.call_count == 1
+            assert coordinator._run_agent_io.call_count == 1
 
     @pytest.mark.asyncio
     async def test_no_dispatch_still_reconciles(self, coordinator, mock_db):
@@ -216,7 +235,7 @@ class TestProcessRunParallelDispatch:
 
             await coordinator._process_run(mock_db, run)
 
-            assert coordinator._execute_task.call_count == 0
+            assert coordinator._run_agent_io.call_count == 0
             mock_reconcile.assert_called_once()
 
     @pytest.mark.asyncio
@@ -234,12 +253,16 @@ class TestProcessRunParallelDispatch:
 
         call_counter = {"n": 0}
 
-        async def _execute_side_effect(db, run, task, agent_id):
+        async def _io_side_effect(factory, agent_id, prompt, task,
+                                  attachment_ids, *, mode_caps=None,
+                                  agent_runtime=None):
             call_counter["n"] += 1
             if task.id == task_1.id:
                 raise RuntimeError("LLM timeout")
 
-        coordinator._execute_task = AsyncMock(side_effect=_execute_side_effect)
+        # asyncio.gather(return_exceptions=True) captures the raise; Phase 3
+        # converts it to an error dict and still records + reconciles.
+        coordinator._run_agent_io = AsyncMock(side_effect=_io_side_effect)
 
         _task_list = [task_1, task_2]
 

--- a/orchestrator/tests/test_synthesis_executor.py
+++ b/orchestrator/tests/test_synthesis_executor.py
@@ -6,7 +6,7 @@ Proves:
 1. _collect_upstream_outputs fetches dependency task outputs
 2. _build_synthesis_prompt includes all upstream outputs
 3. _auto_synthesis_verification_criteria generates required_sections + min_length
-4. _execute_task detects TaskType.SYNTHESIS and uses synthesis prompt
+4. _prepare_task detects TaskType.SYNTHESIS and uses synthesis prompt
 """
 import sys
 from pathlib import Path
@@ -219,23 +219,17 @@ class TestAutoSynthesisVerificationCriteria:
 
 
 # ---------------------------------------------------------------------------
-# Test: _execute_task uses synthesis prompt for SYNTHESIS tasks
+# Test: _prepare_task uses synthesis prompt for SYNTHESIS tasks
 # ---------------------------------------------------------------------------
 
-class TestExecuteTaskSynthesisWiring:
+class TestPrepareTaskSynthesisWiring:
     @pytest.mark.asyncio
     async def test_synthesis_task_uses_synthesis_prompt(self):
-        """Verify that _execute_task builds synthesis prompt for SYNTHESIS tasks."""
-        # Mock AgentFactory before it gets imported inside _execute_task
+        """Verify that _prepare_task builds synthesis prompt for SYNTHESIS tasks."""
+        # Mock AgentFactory before it gets imported inside _prepare_task
         mock_agent_factory_cls = MagicMock()
         mock_factory_instance = MagicMock()
         mock_factory_instance.active_agents = {}
-
-        captured_prompt = {}
-
-        async def mock_execute(*, agent, prompt, max_retries, max_tool_iterations):
-            captured_prompt["value"] = prompt
-            return {"status": "success", "execution": {"tokens_used": 500}}
 
         async def mock_activate(agent_id, workspace_dir):
             runtime = MagicMock()
@@ -243,7 +237,6 @@ class TestExecuteTaskSynthesisWiring:
             return runtime
 
         mock_factory_instance.activate_agent = mock_activate
-        mock_factory_instance.execute_with_prompt = mock_execute
         mock_agent_factory_cls.return_value = mock_factory_instance
 
         # Create a mock module for the lazy import
@@ -287,23 +280,25 @@ class TestExecuteTaskSynthesisWiring:
             mock_dispatcher.record_task_running.return_value = None
             mock_dispatcher.record_task_completion.return_value = None
 
-            await service._execute_task(db, run, synthesis_task, agent_id=1)
+            prep = await service._prepare_task(db, run, synthesis_task, agent_id=1)
 
-        # Verify synthesis prompt was used (not standard build_task_prompt)
-        assert "value" in captured_prompt
-        prompt = captured_prompt["value"]
+        # Verify synthesis prompt was built (not standard build_task_prompt)
+        prompt = prep["prompt"]
         assert "Synthesis Task: Merge Research" in prompt
         assert "AI findings" in prompt
         assert "ML findings" in prompt
 
-        # Verify verification criteria were auto-set
+        # Verify verification criteria were auto-set. Synthesis deliberately
+        # emits only a min_length floor — no required_sections, because the
+        # planner can't predict the agent's headings (see
+        # _auto_synthesis_verification_criteria).
         assert synthesis_task.verification_criteria is not None
-        section_check = next(
+        length_check = next(
             c for c in synthesis_task.verification_criteria
-            if c["type"] == "required_sections"
+            if c["type"] == "min_length"
         )
-        assert "Research AI" in section_check["value"]
-        assert "Research ML" in section_check["value"]
+        # Two upstream outputs of 11 chars each -> 22; floored at 200.
+        assert length_check["value"] == 200
 
     @pytest.mark.asyncio
     async def test_non_synthesis_task_uses_standard_prompt(self):
@@ -360,7 +355,7 @@ class TestExecuteTaskSynthesisWiring:
             mock_dispatcher.record_task_completion.return_value = None
             mock_dispatcher.build_task_prompt.return_value = "Standard prompt"
 
-            await service._execute_task(db, run, task, agent_id=1)
+            await service._prepare_task(db, run, task, agent_id=1)
 
         # Verify standard build_task_prompt was called
         mock_dispatcher.build_task_prompt.assert_called_once_with(task)


### PR DESCRIPTION
## Summary

WS-F of PRD-142 Wave 2 ("Test Net") — the four sub-tasks that make the
orchestrator test suite *enforceable* on every PR. Backend-first, no
frontend. Ships as its own PR, mirroring how Wave 1 shipped.

- **W2-S1 — pin pytest config.** First-ever `pytest.ini` for the suite.
  Pins async mode (`strict`), registers markers (`golden`/`integration`/
  `slow`), fixes import resolution (`pythonpath=.`), and scopes default
  collection to the unit suite (`tests/`).
- **W2-S2 — repoint coordinator tests.** The coordinator refactor split
  `_execute_task` into `_prepare_task` (serial DB prep) → `_run_agent_io`
  (concurrent, no DB) → `_record_task_result` (serial). The stale tests
  still drove the removed method; repointed at the new phases. **Zero
  `_execute_task` references remain in `tests/`.**
- **W2-S4 — centralize the real-DB fixture.** Three module conftests each
  hardcoded the *same* Postgres URL (with a live password) and duplicated
  a connect/begin/rollback session fixture. Lifted `test_db_url` /
  `test_engine` / `db_session` into the root `orchestrator/conftest.py`
  (the common ancestor of `tests/` and `modules/*/tests/`), resolving the
  URL through central config instead of a literal. Learning keeps a thin
  `db_session` override only to seed its `Workspace` FK row.
- **W2-S3 — the CI gate.** `.github/workflows/test.yml` runs the suite on
  every PR against a real Postgres service container, plus `pytest-timeout`
  as a per-test safety net.

## Why a real Postgres service + a timeout net

W2-S2 surfaced a pre-existing hang: `test_82c_wiring`'s decompose path
calls `config.PLANNER_MODEL` → `get_system_setting` → `db.query().first()`
→ `psycopg2.connect()`, which **blocks forever** when no Postgres is
present. The gate fixes the cause (provide a DB so the connect succeeds)
*and* adds a belt: `--timeout=60 --timeout-method=thread` so any future
hang fails one test fast instead of burning the whole job.

## Deliberately scoped out

- **Introduced NON-REQUIRED.** The net is expected to surface pre-existing
  gaps that Wave 2 WS-G (golden journeys), WS-H (untested primitives) and
  WS-I (regressions) will close. Flipping this to a *required* check in
  branch protection is your call, made once the suite is green — this PR
  doesn't touch branch protection.
- **No lint gates folded in.** An `os.getenv`-outside-`config.py` gate
  would be perma-red on day one (51 pre-existing violations), and a
  bare-except gate (0 violations today) is a different concern from the
  *test* net. Both can be a follow-up; the `os.getenv` one needs the 51
  cleaned first.
- **`test_byok_isolation.py` is intentionally NOT in this PR.** It's an
  unrelated cross-tenant credential-isolation workstream that was sitting
  untracked in the tree; left for its own PR.

## Test plan

- [x] W2-S2 edited tests pass locally (9/9) against the env shim:
      `test_coordinator_parallel`, `test_82c_wiring::TestWiringCoordinatorTick`,
      `test_synthesis_executor::TestPrepareTaskSynthesisWiring`.
- [x] Root + module conftests carry zero hardcoded credentials; no
      orphaned imports left behind.
- [x] `test.yml` YAML validated (parses; 6 steps, Postgres service,
      30-min job cap).
- [ ] **First CI run on this PR** — confirm install + `init_test_db.py` +
      collection succeed against the Postgres service (the run itself is
      the acceptance check for W2-S3).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Automated test suite now runs on all pushes to `main` and pull requests with Postgres service container
  * Per-test timeout enforcement added to prevent hanging tests
  * Consolidated shared test database fixtures across modules
  * Added custom pytest markers for selective test execution

* **Chores**
  * Added GitHub Actions CI workflow for continuous testing
  * Updated test timeout dependency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->