### PR TITLE
test(prd-142-wave2): W2-S2b de-pollute test sys.modules for clean col…

### DIFF
--- a/orchestrator/tests/api/test_deliverables_api.py
+++ b/orchestrator/tests/api/test_deliverables_api.py
@@ -26,60 +26,89 @@ import pytest
 # Stub out transitive imports that need jwt/clerk before importing the router
 # (mirrors orchestrator/tests/test_agents_api_plugins.py).
 # ---------------------------------------------------------------------------
-for mod_name in [
-    "jwt", "jwt.algorithms", "jwt.exceptions",
-    "core.auth.clerk",
-]:
-    if mod_name not in sys.modules:
-        stub = ModuleType(mod_name)
-        stub.get_clerk_auth = MagicMock()
-        stub.decode = MagicMock()
-        stub.DecodeError = Exception
-        stub.ExpiredSignatureError = Exception
-        sys.modules[mod_name] = stub
-
 def _fake_dep():  # pragma: no cover — replaced via dependency_overrides
     raise RuntimeError("dependency not overridden")
 
 
-# core.auth.hybrid must be a real (stub) module exposing the dependency name
-if "core.auth.hybrid" not in sys.modules or not hasattr(
-    sys.modules["core.auth.hybrid"], "get_request_context_hybrid"
-):
-    hybrid_stub = ModuleType("core.auth.hybrid")
-    hybrid_stub.get_request_context_hybrid = _fake_dep
-    sys.modules["core.auth.hybrid"] = hybrid_stub
-
-# core.auth.dependencies exposes RequestContext — stub as MagicMock class alias.
-if "core.auth.dependencies" not in sys.modules:
-    deps_stub = ModuleType("core.auth.dependencies")
-    deps_stub.RequestContext = MagicMock
-    sys.modules["core.auth.dependencies"] = deps_stub
-
-# core.database.database imports fail without cryptography / DB env. Stub it.
-if "core.database" not in sys.modules:
-    sys.modules["core.database"] = ModuleType("core.database")
-if "core.database.database" not in sys.modules or not hasattr(
-    sys.modules["core.database.database"], "get_db"
-):
-    db_stub = ModuleType("core.database.database")
-    db_stub.get_db = _fake_dep
-    sys.modules["core.database.database"] = db_stub
-
-# services.deliverable_service imports core.workspace_client which pulls config.
-# Patch DeliverableService as a MagicMock so the router import succeeds.
-if "services" not in sys.modules:
-    sys.modules["services"] = ModuleType("services")
-svc_stub = ModuleType("services.deliverable_service")
-svc_stub.DeliverableService = MagicMock()
-sys.modules["services.deliverable_service"] = svc_stub
-
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from api.deliverables import router as deliverables_router
-from core.auth.hybrid import get_request_context_hybrid
-from core.database.database import get_db
+
+def _import_router_isolated():
+    """Import the deliverables router under stubbed transitive deps, then
+    restore sys.modules.
+
+    The router binds its dependencies (``get_db``, ``get_request_context_hybrid``,
+    ``DeliverableService``) at its own import time; the tests then swap them via
+    FastAPI ``dependency_overrides`` / ``patch``. So the stubs only need to exist
+    during this import — restoring sys.modules afterwards stops them leaking into
+    sibling modules' collection. (PRD-142 W2-S2b.)
+    """
+    _keys = (
+        "jwt", "jwt.algorithms", "jwt.exceptions", "core.auth.clerk",
+        "core.auth.hybrid", "core.auth.dependencies",
+        "core.database", "core.database.database",
+        "services", "services.deliverable_service",
+    )
+    _saved = {k: sys.modules.get(k) for k in _keys}
+    try:
+        for mod_name in [
+            "jwt", "jwt.algorithms", "jwt.exceptions",
+            "core.auth.clerk",
+        ]:
+            if mod_name not in sys.modules:
+                stub = ModuleType(mod_name)
+                stub.get_clerk_auth = MagicMock()
+                stub.decode = MagicMock()
+                stub.DecodeError = Exception
+                stub.ExpiredSignatureError = Exception
+                sys.modules[mod_name] = stub
+
+        # core.auth.hybrid must be a real (stub) module exposing the dependency name
+        if "core.auth.hybrid" not in sys.modules or not hasattr(
+            sys.modules["core.auth.hybrid"], "get_request_context_hybrid"
+        ):
+            hybrid_stub = ModuleType("core.auth.hybrid")
+            hybrid_stub.get_request_context_hybrid = _fake_dep
+            sys.modules["core.auth.hybrid"] = hybrid_stub
+
+        # core.auth.dependencies exposes RequestContext — stub as MagicMock class alias.
+        if "core.auth.dependencies" not in sys.modules:
+            deps_stub = ModuleType("core.auth.dependencies")
+            deps_stub.RequestContext = MagicMock
+            sys.modules["core.auth.dependencies"] = deps_stub
+
+        # core.database.database imports fail without cryptography / DB env. Stub it.
+        if "core.database" not in sys.modules:
+            sys.modules["core.database"] = ModuleType("core.database")
+        if "core.database.database" not in sys.modules or not hasattr(
+            sys.modules["core.database.database"], "get_db"
+        ):
+            db_stub = ModuleType("core.database.database")
+            db_stub.get_db = _fake_dep
+            sys.modules["core.database.database"] = db_stub
+
+        # services.deliverable_service imports core.workspace_client which pulls config.
+        # Patch DeliverableService as a MagicMock so the router import succeeds.
+        if "services" not in sys.modules:
+            sys.modules["services"] = ModuleType("services")
+        svc_stub = ModuleType("services.deliverable_service")
+        svc_stub.DeliverableService = MagicMock()
+        sys.modules["services.deliverable_service"] = svc_stub
+
+        from api.deliverables import router as deliverables_router
+        from core.auth.hybrid import get_request_context_hybrid
+        from core.database.database import get_db
+        return deliverables_router, get_request_context_hybrid, get_db
+    finally:
+        for _k, _v in _saved.items():
+            if _v is None:
+                sys.modules.pop(_k, None)
+            else:
+                sys.modules[_k] = _v
+
+
+deliverables_router, get_request_context_hybrid, get_db = _import_router_isolated()
 
 
 WORKSPACE_ID = uuid4()

--- a/orchestrator/tests/conftest.py
+++ b/orchestrator/tests/conftest.py
@@ -131,45 +131,45 @@ def mock_agent():
     return agent
 
 
-# ---- Recipe mocks ----
+# ---- Playbook mocks ----
 
 @pytest.fixture
-def mock_recipe():
-    """A WorkflowRecipe-like mock with cron schedule_config."""
-    recipe = MagicMock()
-    recipe.id = 42
-    recipe.template_id = "test-cron-recipe"
-    recipe.name = "Test Cron Recipe"
-    recipe.workspace_id = uuid4()
-    recipe.steps = [
+def mock_playbook():
+    """A WorkflowTemplate (Playbook)-like mock with cron schedule_config."""
+    playbook = MagicMock()
+    playbook.id = 42
+    playbook.template_id = "test-cron-playbook"
+    playbook.name = "Test Cron Playbook"
+    playbook.workspace_id = uuid4()
+    playbook.steps = [
         {"step_id": "s1", "order": 1, "agent_id": 101, "prompt_template": "Do the thing"},
     ]
-    recipe.schedule_config = {
+    playbook.schedule_config = {
         "type": "cron",
         "cron_expression": "0 9 * * *",
     }
-    recipe.owner_type = "workspace"
-    recipe.is_system = False
-    return recipe
+    playbook.owner_type = "workspace"
+    playbook.is_system = False
+    return playbook
 
 
 @pytest.fixture
-def mock_recipe_manual():
-    """A WorkflowRecipe-like mock with manual schedule (no cron)."""
-    recipe = MagicMock()
-    recipe.id = 99
-    recipe.template_id = "test-manual-recipe"
-    recipe.name = "Test Manual Recipe"
-    recipe.workspace_id = uuid4()
-    recipe.steps = [
+def mock_playbook_manual():
+    """A WorkflowTemplate (Playbook)-like mock with manual schedule (no cron)."""
+    playbook = MagicMock()
+    playbook.id = 99
+    playbook.template_id = "test-manual-playbook"
+    playbook.name = "Test Manual Playbook"
+    playbook.workspace_id = uuid4()
+    playbook.steps = [
         {"step_id": "s1", "order": 1, "agent_id": 101, "prompt_template": "Manual task"},
     ]
-    recipe.schedule_config = {
+    playbook.schedule_config = {
         "type": "manual",
     }
-    recipe.owner_type = "workspace"
-    recipe.is_system = False
-    return recipe
+    playbook.owner_type = "workspace"
+    playbook.is_system = False
+    return playbook
 
 
 # ---- Request context mock ----

--- a/orchestrator/tests/modules/tools/execution/test_exec_workspace_deliverable.py
+++ b/orchestrator/tests/modules/tools/execution/test_exec_workspace_deliverable.py
@@ -28,31 +28,60 @@ def _make_stub_module(name: str, **attrs) -> types.ModuleType:
     mod = types.ModuleType(name)
     for k, v in attrs.items():
         setattr(mod, k, v)
-    sys.modules[name] = mod
     return mod
 
 
-# core.workspace_client
-_make_stub_module("core", __path__=[])
-_make_stub_module("core.workspace_client", WorkspaceClient=_STUB_WORKSPACE_CLIENT)
-_make_stub_module("core.database", __path__=[])
-_make_stub_module("core.database.database", SessionLocal=_STUB_SESSION_LOCAL)
-_make_stub_module("core.models", __path__=[])
-_make_stub_module("core.models.core", Agent=MagicMock(name="AgentStub"))
-_make_stub_module("services", __path__=[])
-_make_stub_module(
-    "services.deliverable_service",
-    DeliverableService=_STUB_DELIVERABLE_SERVICE,
-    AGENT_REGISTERABLE_ARTIFACT_TYPES=frozenset({
-        "report", "image", "document", "slide", "spreadsheet", "code",
-    }),
-    _infer_artifact_type=lambda fp: (
-        "report" if fp.endswith(".md")
-        else "archive" if fp.endswith(".zip")
-        else "document"
+# Build the stub modules now, but DON'T install them into sys.modules at import
+# time — that would leak a pathless ``core`` / ``core.models`` / ``services``
+# into the collection of every sibling test module, breaking their real
+# ``core.*`` / ``services.*`` imports. exec_workspace imports these LAZILY inside
+# _auto_register_deliverable, so installing in setup_module and restoring in
+# teardown_module keeps the fakes live for THIS file's tests only and out of
+# collection. (PRD-142 W2-S2b.)
+_STUB_MODULES = {
+    "core": _make_stub_module("core", __path__=[]),
+    "core.workspace_client": _make_stub_module(
+        "core.workspace_client", WorkspaceClient=_STUB_WORKSPACE_CLIENT
     ),
-    _humanize_basename=lambda fp: fp.split("/")[-1],
-)
+    "core.database": _make_stub_module("core.database", __path__=[]),
+    "core.database.database": _make_stub_module(
+        "core.database.database", SessionLocal=_STUB_SESSION_LOCAL
+    ),
+    "core.models": _make_stub_module("core.models", __path__=[]),
+    "core.models.core": _make_stub_module(
+        "core.models.core", Agent=MagicMock(name="AgentStub")
+    ),
+    "services": _make_stub_module("services", __path__=[]),
+    "services.deliverable_service": _make_stub_module(
+        "services.deliverable_service",
+        DeliverableService=_STUB_DELIVERABLE_SERVICE,
+        AGENT_REGISTERABLE_ARTIFACT_TYPES=frozenset({
+            "report", "image", "document", "slide", "spreadsheet", "code",
+        }),
+        _infer_artifact_type=lambda fp: (
+            "report" if fp.endswith(".md")
+            else "archive" if fp.endswith(".zip")
+            else "document"
+        ),
+        _humanize_basename=lambda fp: fp.split("/")[-1],
+    ),
+}
+
+_saved_stub_modules = {}
+
+
+def setup_module(module):
+    for _name, _mod in _STUB_MODULES.items():
+        _saved_stub_modules[_name] = sys.modules.get(_name)
+        sys.modules[_name] = _mod
+
+
+def teardown_module(module):
+    for _name, _prior in _saved_stub_modules.items():
+        if _prior is None:
+            sys.modules.pop(_name, None)
+        else:
+            sys.modules[_name] = _prior
 
 # Load exec_workspace directly to avoid pulling the entire modules.tools package.
 _THIS = Path(__file__).resolve()

--- a/orchestrator/tests/test_action_semantic_index.py
+++ b/orchestrator/tests/test_action_semantic_index.py
@@ -100,10 +100,32 @@ _fake_em = _FakeEmbeddingManager()
 _fake_cache = _FakeCache()
 _fake_em_module.create_embedding_manager = lambda: _fake_em  # type: ignore[attr-defined]
 _fake_cache_module.get_cache_service = lambda: _fake_cache  # type: ignore[attr-defined]
-sys.modules.setdefault("core", type(sys)("core"))
-sys.modules["core.llm"] = _fake_em_module
-sys.modules["core.cache"] = type(sys)("core.cache")
-sys.modules["core.cache.service"] = _fake_cache_module
+
+# ActionSemanticIndex.__init__ imports core.cache.service / core.llm LAZILY, so
+# the fakes must be live while THIS module's tests run. Installing them at import
+# time, however, leaks a *pathless* fake ``core`` into the collection of sibling
+# test modules — breaking every ``core.*`` import they make. Install in
+# setup_module and restore in teardown_module so the fakes stay scoped to this
+# file's test phase and never touch collection. (PRD-142 W2-S2b.)
+_CORE_FAKE_KEYS = ("core", "core.llm", "core.cache", "core.cache.service")
+_saved_core_modules: Dict[str, object] = {}
+
+
+def setup_module(module):
+    for _k in _CORE_FAKE_KEYS:
+        _saved_core_modules[_k] = sys.modules.get(_k)
+    sys.modules.setdefault("core", type(sys)("core"))
+    sys.modules["core.llm"] = _fake_em_module
+    sys.modules["core.cache"] = type(sys)("core.cache")
+    sys.modules["core.cache.service"] = _fake_cache_module
+
+
+def teardown_module(module):
+    for _k, _v in _saved_core_modules.items():
+        if _v is None:
+            sys.modules.pop(_k, None)
+        else:
+            sys.modules[_k] = _v
 
 # Patch the import the index uses for ActionDefinition + get_action_registry
 # so we control the registry per-test. We rebuild a fresh registry per test.

--- a/orchestrator/tests/test_agents_api_plugins.py
+++ b/orchestrator/tests/test_agents_api_plugins.py
@@ -15,8 +15,9 @@ from uuid import uuid4
 import pytest
 
 # ---------------------------------------------------------------------------
-# Stub out transitive imports that need jwt/clerk
+# Stub out transitive imports that need jwt/clerk, then import the API module.
 # ---------------------------------------------------------------------------
+_stubs = {}
 for mod_name in [
     "jwt", "jwt.algorithms", "jwt.exceptions",
     "core.auth.clerk", "core.auth.hybrid",
@@ -29,8 +30,16 @@ for mod_name in [
         stub.DecodeError = Exception
         stub.ExpiredSignatureError = Exception
         sys.modules[mod_name] = stub
+        _stubs[mod_name] = stub
 
 from api.agents import _build_agent_response
+
+# Collection-safe (PRD-142 W2-S2b): drop the auth/jwt stubs we installed so a
+# pathless ``core.auth.*`` stub doesn't shadow the real submodule when sibling
+# test modules are collected afterwards. api.agents has already bound the
+# symbols it needs at its own import time, so removing the stubs is safe.
+for _k in _stubs:
+    sys.modules.pop(_k, None)
 
 
 # ---------------------------------------------------------------------------

--- a/orchestrator/tests/test_eval_graph_mode.py
+++ b/orchestrator/tests/test_eval_graph_mode.py
@@ -77,21 +77,8 @@ def _fake_actions() -> List[_FakeAction]:
     ]
 
 
-# Stub the modules.tools.discovery package hierarchy so prompt_builder
-# can be imported without the full orchestrator dependency chain.
-def _ensure_stub(name: str) -> None:
-    if name in sys.modules:
-        return
-    mod = types.ModuleType(name)
-    mod.__path__ = []
-    sys.modules[name] = mod
-
-
-for _pkg in ("modules", "modules.tools", "modules.tools.discovery"):
-    _ensure_stub(_pkg)
-
-
-# Stub ActionSemanticIndex
+# Build the fake discovery modules (just objects — NOT installed into
+# sys.modules at import time; see setup_module below).
 _fake_asi = MagicMock()
 _fake_asi.rank_actions = AsyncMock(return_value=[
     ("platform_list_agents", 0.95),
@@ -100,27 +87,58 @@ _fake_asi.rank_actions = AsyncMock(return_value=[
 ])
 _fake_asi_mod = types.ModuleType("modules.tools.discovery.action_semantic_index")
 _fake_asi_mod.get_action_semantic_index = lambda: _fake_asi
-sys.modules["modules.tools.discovery.action_semantic_index"] = _fake_asi_mod
 
-
-# Stub ActionRegistry
 _fake_registry = MagicMock()
 _fake_registry.build_filtered_prompt_summary.return_value = (
     "\n## Available Platform Actions\n\n- `platform_list_agents`: List all agents\n"
 )
 _fake_reg_mod = types.ModuleType("modules.tools.discovery.action_registry")
 _fake_reg_mod.get_action_registry = lambda: _fake_registry
-sys.modules["modules.tools.discovery.action_registry"] = _fake_reg_mod
 
-
-# Stub GraphRouter
 _fake_graph_router = MagicMock()
 _fake_graph_router_mod = types.ModuleType("modules.tools.discovery.graph_router")
 _fake_graph_router_mod.get_graph_router = lambda: _fake_graph_router
-sys.modules["modules.tools.discovery.graph_router"] = _fake_graph_router_mod
 
 
-# Now import prompt_builder
+# prompt_builder imports modules.tools.discovery.* LAZILY (inside methods), so
+# the fakes must be live during THIS file's test phase — but installing them at
+# import time leaks pathless ``modules`` / ``modules.tools`` / ``modules.tools.discovery``
+# into the collection of every sibling test that imports the real tree (turning
+# their real imports into ModuleNotFoundError). Install in setup_module and
+# restore in teardown_module so the fakes stay scoped to this file's tests and
+# never reach collection. (PRD-142 W2-S2b.)
+_PARENT_PKGS = ("modules", "modules.tools", "modules.tools.discovery")
+_STUB_SUBMODULES = {
+    "modules.tools.discovery.action_semantic_index": _fake_asi_mod,
+    "modules.tools.discovery.action_registry": _fake_reg_mod,
+    "modules.tools.discovery.graph_router": _fake_graph_router_mod,
+}
+_saved_eval_modules: Dict[str, Any] = {}
+
+
+def setup_module(module):
+    for _k in (*_PARENT_PKGS, *_STUB_SUBMODULES):
+        _saved_eval_modules[_k] = sys.modules.get(_k)
+    for _pkg in _PARENT_PKGS:
+        if _pkg not in sys.modules:
+            _m = types.ModuleType(_pkg)
+            _m.__path__ = []
+            sys.modules[_pkg] = _m
+    for _name, _mod in _STUB_SUBMODULES.items():
+        sys.modules[_name] = _mod
+
+
+def teardown_module(module):
+    for _k, _prior in _saved_eval_modules.items():
+        if _prior is None:
+            sys.modules.pop(_k, None)
+        else:
+            sys.modules[_k] = _prior
+
+
+# Import prompt_builder (top-level imports are stdlib-only; the
+# modules.tools.discovery.* imports are lazy inside methods, satisfied by the
+# stubs installed in setup_module).
 from scripts.eval.tool_routing.prompt_builder import PromptBuilder, _PREAMBLE, _CHAIN_HINT_HEADER
 
 

--- a/orchestrator/tests/test_identity_section.py
+++ b/orchestrator/tests/test_identity_section.py
@@ -47,12 +47,6 @@ class _FakePersonality:
 _personality_stub.AutomatosPersonality = _FakePersonality
 _personality_stub.load_orchestrator_settings = lambda ws_id: {}
 
-sys.modules.setdefault("consumers", types.ModuleType("consumers"))
-sys.modules["consumers"].__path__ = []
-sys.modules.setdefault("consumers.chatbot", types.ModuleType("consumers.chatbot"))
-sys.modules["consumers.chatbot"].__path__ = []
-sys.modules["consumers.chatbot.personality"] = _personality_stub
-
 # Stub context estimator
 _estimator_stub = types.ModuleType("modules.context.estimator")
 
@@ -63,34 +57,94 @@ class _FakeEstimator:
 
 
 _estimator_stub.TokenEstimator = _FakeEstimator
-sys.modules.setdefault("modules", types.ModuleType("modules"))
-sys.modules["modules"].__path__ = []
-sys.modules.setdefault("modules.context", types.ModuleType("modules.context"))
-sys.modules["modules.context"].__path__ = []
-sys.modules["modules.context.estimator"] = _estimator_stub
-sys.modules.setdefault("modules.context.sections", types.ModuleType("modules.context.sections"))
-sys.modules["modules.context.sections"].__path__ = []
 
-# Now load base and identity
-_base_mod = importlib.util.module_from_spec(
-    importlib.util.spec_from_file_location(
+
+def _load_sections_isolated():
+    """Load base.py + identity.py under a fake module graph, then restore.
+
+    The fakes only need to exist while the target files execute — the loaded
+    classes capture their dependencies at exec time. Restoring sys.modules
+    afterwards stops the fake ``consumers`` / ``modules`` packages (with
+    emptied ``__path__``) from leaking into the collection of sibling test
+    modules. (PRD-142 W2-S2b.)
+    """
+    _keys = (
+        "consumers",
+        "consumers.chatbot",
+        "consumers.chatbot.personality",
+        "modules",
+        "modules.context",
+        "modules.context.estimator",
+        "modules.context.sections",
         "modules.context.sections.base",
-        _ROOT / "modules" / "context" / "sections" / "base.py",
     )
-)
-sys.modules["modules.context.sections.base"] = _base_mod
-_base_mod.__spec__.loader.exec_module(_base_mod)
+    _saved = {k: sys.modules.get(k) for k in _keys}
+    try:
+        # Assign fresh fake packages — never mutate a real cached package's
+        # __path__ in place (setdefault + __path__=[] would corrupt the real
+        # ``consumers`` / ``modules`` packages if already imported).
+        for _name in (
+            "consumers",
+            "consumers.chatbot",
+            "modules",
+            "modules.context",
+            "modules.context.sections",
+        ):
+            _pkg = types.ModuleType(_name)
+            _pkg.__path__ = []
+            sys.modules[_name] = _pkg
+        sys.modules["consumers.chatbot.personality"] = _personality_stub
+        sys.modules["modules.context.estimator"] = _estimator_stub
 
-_identity_mod = importlib.util.module_from_spec(
-    importlib.util.spec_from_file_location(
-        "modules.context.sections.identity",
-        _ROOT / "modules" / "context" / "sections" / "identity.py",
-    )
-)
-_identity_mod.__spec__.loader.exec_module(_identity_mod)
+        # Now load base and identity
+        _base_mod = importlib.util.module_from_spec(
+            importlib.util.spec_from_file_location(
+                "modules.context.sections.base",
+                _ROOT / "modules" / "context" / "sections" / "base.py",
+            )
+        )
+        sys.modules["modules.context.sections.base"] = _base_mod
+        _base_mod.__spec__.loader.exec_module(_base_mod)
 
-IdentitySection = _identity_mod.IdentitySection
-SectionContext = _base_mod.SectionContext
+        _identity_mod = importlib.util.module_from_spec(
+            importlib.util.spec_from_file_location(
+                "modules.context.sections.identity",
+                _ROOT / "modules" / "context" / "sections" / "identity.py",
+            )
+        )
+        _identity_mod.__spec__.loader.exec_module(_identity_mod)
+
+        return _identity_mod.IdentitySection, _base_mod.SectionContext
+    finally:
+        for _k, _v in _saved.items():
+            if _v is None:
+                sys.modules.pop(_k, None)
+            else:
+                sys.modules[_k] = _v
+
+
+IdentitySection, SectionContext = _load_sections_isolated()
+
+
+@pytest.fixture(autouse=True)
+def _runtime_personality_stub():
+    """identity.py imports ``consumers.chatbot.personality`` LAZILY inside its
+    chatbot render path (render() and _get_personality_block), so the stub must
+    be live during this file's test phase — not just at import time. Installing
+    it here (after collection) keeps the fake out of sibling modules' collection,
+    and restoring per-test keeps it from bleeding into their test phase. The
+    leaf key alone resolves ``from consumers.chatbot.personality import X``
+    without needing pathless parent packages. (PRD-142 W2-S2b.)"""
+    _key = "consumers.chatbot.personality"
+    _saved = sys.modules.get(_key)
+    sys.modules[_key] = _personality_stub
+    try:
+        yield
+    finally:
+        if _saved is None:
+            sys.modules.pop(_key, None)
+        else:
+            sys.modules[_key] = _saved
 
 
 def _make_agent(name="TestAgent", description=None, persona_prompt=None, use_custom=False):
@@ -120,7 +174,7 @@ def test_basic_identity_includes_name_and_role():
     agent = _make_agent(name="Scout")
     ctx = _make_ctx(agent)
     section = IdentitySection()
-    result = asyncio.get_event_loop().run_until_complete(section.render(ctx))
+    result = asyncio.run(section.render(ctx))
     assert "Scout" in result
     assert "assistant" in result
     assert "Test Workspace" in result
@@ -130,7 +184,7 @@ def test_basic_identity_includes_description():
     agent = _make_agent(description="I find leads for the sales team.")
     ctx = _make_ctx(agent)
     section = IdentitySection()
-    result = asyncio.get_event_loop().run_until_complete(section.render(ctx))
+    result = asyncio.run(section.render(ctx))
     assert "I find leads for the sales team." in result
 
 
@@ -138,7 +192,7 @@ def test_basic_identity_includes_persona():
     agent = _make_agent(use_custom=True, persona_prompt="Speak like a pirate.")
     ctx = _make_ctx(agent)
     section = IdentitySection()
-    result = asyncio.get_event_loop().run_until_complete(section.render(ctx))
+    result = asyncio.run(section.render(ctx))
     assert "Speak like a pirate." in result
     assert "Persona & Communication Style" in result
 
@@ -147,7 +201,7 @@ def test_basic_identity_no_duplicate_description():
     agent = _make_agent(description="Welcome! I'm your helper.")
     ctx = _make_ctx(agent)
     section = IdentitySection()
-    result = asyncio.get_event_loop().run_until_complete(section.render(ctx))
+    result = asyncio.run(section.render(ctx))
     assert result.count("Welcome! I'm your helper.") == 1
 
 
@@ -158,7 +212,7 @@ def test_chatbot_identity_includes_description():
     agent = _make_agent(description="Hello! Welcome to our store.")
     ctx = _make_ctx(agent, personality=True)
     section = IdentitySection()
-    result = asyncio.get_event_loop().run_until_complete(section.render(ctx))
+    result = asyncio.run(section.render(ctx))
     assert "Hello! Welcome to our store." in result
     assert result.count("Hello! Welcome to our store.") == 1
 
@@ -167,7 +221,7 @@ def test_chatbot_identity_includes_persona():
     agent = _make_agent(use_custom=True, persona_prompt="Be concise and formal.")
     ctx = _make_ctx(agent, personality=True)
     section = IdentitySection()
-    result = asyncio.get_event_loop().run_until_complete(section.render(ctx))
+    result = asyncio.run(section.render(ctx))
     assert "Be concise and formal." in result
     assert "Persona & Communication Style" in result
     assert result.count("Be concise and formal.") == 1
@@ -177,7 +231,7 @@ def test_chatbot_identity_includes_personality_parts():
     agent = _make_agent()
     ctx = _make_ctx(agent, personality=True)
     section = IdentitySection()
-    result = asyncio.get_event_loop().run_until_complete(section.render(ctx))
+    result = asyncio.run(section.render(ctx))
     assert "BASE_PROMPT" in result
     assert "PLATFORM_SKILL" in result
     assert "TOOL_GUIDANCE" in result
@@ -188,7 +242,7 @@ def test_chatbot_identity_no_description_when_empty():
     agent = _make_agent(description="")
     ctx = _make_ctx(agent, personality=True)
     section = IdentitySection()
-    result = asyncio.get_event_loop().run_until_complete(section.render(ctx))
+    result = asyncio.run(section.render(ctx))
     assert "Agent Description" not in result
 
 
@@ -196,7 +250,7 @@ def test_chatbot_identity_no_persona_when_not_set():
     agent = _make_agent()
     ctx = _make_ctx(agent, personality=True)
     section = IdentitySection()
-    result = asyncio.get_event_loop().run_until_complete(section.render(ctx))
+    result = asyncio.run(section.render(ctx))
     assert "Persona & Communication Style" not in result
 
 
@@ -212,7 +266,7 @@ def test_render_failure_returns_minimal_identity():
         _FakePersonality, "get_base_system_prompt",
         side_effect=RuntimeError("boom"),
     ):
-        result = asyncio.get_event_loop().run_until_complete(section.render(ctx))
+        result = asyncio.run(section.render(ctx))
 
     assert "BrokenBot" in result
     assert "Automatos platform" in result

--- a/orchestrator/tests/test_platform_actions_section.py
+++ b/orchestrator/tests/test_platform_actions_section.py
@@ -10,6 +10,15 @@ registrars. Each scenario exercises one branch of the decision tree:
 - no ``query`` key in kwargs    → full dump
 - empty ``query`` string        → full dump
 - filtered output is shorter    → token-count surrogate for the prod-index AC
+
+Collection-pollution discipline (PRD-142 W2-S2b): pytest imports every test
+module during collection, before any test runs, so import-time ``sys.modules``
+fakes leak into sibling collection. We therefore install import-time stubs
+(estimator / base / section) only long enough to bind the classes and then
+restore sys.modules; the runtime stubs (config / action_registry /
+action_semantic_index) that the section imports lazily inside ``render()`` are
+(re)installed by an autouse fixture during the test phase and torn down after
+each test. Importing this module leaves sys.modules exactly as it found it.
 """
 from __future__ import annotations
 
@@ -23,19 +32,56 @@ from unittest.mock import MagicMock
 
 import pytest
 
-# ---------------------------------------------------------------------------
-# Boot the section module under a fake package tree so its lazy imports
-# resolve to in-test stubs instead of the real config / registry / index.
-# ---------------------------------------------------------------------------
-
 _THIS = Path(__file__).resolve()
 _ORCH = _THIS.parents[1]
 _SECTIONS = _ORCH / "modules" / "context" / "sections"
 _DISCOVERY = _ORCH / "modules" / "tools" / "discovery"
 
 
-# Pre-load the real ActionRegistry so we get a working build_*_prompt_summary
-# without triggering the live `register_all_actions` lazy-init.
+# ---------------------------------------------------------------------------
+# Watched sys.modules keys. Snapshot BEFORE we touch anything, restore after
+# the import-time block so collection of sibling modules sees no fakes.
+# ---------------------------------------------------------------------------
+_IMPORT_KEYS = (
+    "modules.context.estimator",
+    "modules.context.sections",
+    "modules.context.sections.base",
+    "modules.context.sections.platform_actions",
+)
+# Read by the section's LAZY imports at render() time — must be live during the
+# test phase, installed per-test by the autouse fixture (never at collection).
+_RUNTIME_KEYS = (
+    "config",
+    "modules.tools.discovery.action_registry",
+    "modules.tools.discovery.action_semantic_index",
+)
+# Parent packages we never intend to create; snapshot+restore as a guard so a
+# stray real/fake parent can't survive import either.
+_GUARD_KEYS = (
+    "modules",
+    "modules.context",
+    "modules.tools",
+    "modules.tools.discovery",
+)
+_PRE_IMPORT_SNAPSHOT = {
+    k: sys.modules.get(k) for k in (_IMPORT_KEYS + _RUNTIME_KEYS + _GUARD_KEYS)
+}
+
+
+def _restore(snapshot: dict) -> None:
+    """Restore sys.modules to a captured snapshot (None ⇒ delete the key)."""
+    for key, original in snapshot.items():
+        if original is None:
+            sys.modules.pop(key, None)
+        else:
+            sys.modules[key] = original
+
+
+# ---------------------------------------------------------------------------
+# Pre-load the real ActionRegistry under a private name (does not pollute the
+# watched ``modules.*`` namespace) so build_*_prompt_summary works without the
+# live ``register_all_actions`` lazy-init.
+# ---------------------------------------------------------------------------
 _ar_spec = importlib.util.spec_from_file_location(
     "action_registry_under_test", _DISCOVERY / "action_registry.py"
 )
@@ -47,12 +93,10 @@ ActionRegistry = _ar_mod.ActionRegistry
 
 
 # ---------------------------------------------------------------------------
-# Stub modules: config, base, action_registry, action_semantic_index
-# Section's lazy imports look up these dotted paths at call time, so we only
-# need to populate sys.modules; we can mutate stubs per-test.
+# Build stub module objects. Kept as module-level references; installed into
+# sys.modules only transiently for the import below, then per-test by the
+# autouse fixture.
 # ---------------------------------------------------------------------------
-
-
 class _StubConfig:
     """Mutable config stand-in for the canonical ``config.config`` singleton."""
 
@@ -61,32 +105,8 @@ class _StubConfig:
     PLATFORM_ACTIONS_MAX_TOKENS: int = 4000
 
 
-if "config" not in sys.modules:
-    _stub_config_module = ModuleType("config")
-    _stub_config_module.config = _StubConfig()
-    sys.modules["config"] = _stub_config_module
-else:
-    # Ensure required attrs exist on whatever config is already loaded
-    _existing_cfg = sys.modules["config"].config
-    if not hasattr(_existing_cfg, "SEMANTIC_TOOL_ROUTING"):
-        _existing_cfg.SEMANTIC_TOOL_ROUTING = True
-    if not hasattr(_existing_cfg, "SEMANTIC_TOOL_ROUTING_TOP_K"):
-        _existing_cfg.SEMANTIC_TOOL_ROUTING_TOP_K = 3
-    if not hasattr(_existing_cfg, "PLATFORM_ACTIONS_MAX_TOKENS"):
-        _existing_cfg.PLATFORM_ACTIONS_MAX_TOKENS = 4000
-
-
-# Provide a minimal ``modules.context.estimator.TokenEstimator`` so base.py
-# imports cleanly without the broader package.
-_estimator_pkg_modules: dict[str, ModuleType] = {}
-for pkg_name in ("modules", "modules.context", "modules.tools", "modules.tools.discovery"):
-    if pkg_name not in sys.modules:
-        mod = ModuleType(pkg_name)
-        mod.__path__ = []  # mark as namespace pkg
-        sys.modules[pkg_name] = mod
-        _estimator_pkg_modules[pkg_name] = mod
-
-_estimator_mod = ModuleType("modules.context.estimator")
+_stub_config_module = ModuleType("config")
+_stub_config_module.config = _StubConfig()
 
 
 class _NoopEstimator:
@@ -95,46 +115,15 @@ class _NoopEstimator:
         return len(content) // 4 + 1
 
 
+_estimator_mod = ModuleType("modules.context.estimator")
 _estimator_mod.TokenEstimator = _NoopEstimator
-sys.modules["modules.context.estimator"] = _estimator_mod
 
 
-# Now load the real BaseSection / SectionContext from disk so type checks
-# against `BaseSection` still work.
-_base_spec = importlib.util.spec_from_file_location(
-    "modules.context.sections.base", _SECTIONS / "base.py"
-)
-_base_mod = importlib.util.module_from_spec(_base_spec)
-# Register parent package first.
-_sections_pkg = ModuleType("modules.context.sections")
-_sections_pkg.__path__ = [str(_SECTIONS)]
-sys.modules.setdefault("modules.context.sections", _sections_pkg)
-sys.modules["modules.context.sections.base"] = _base_mod
-_base_spec.loader.exec_module(_base_mod)
-BaseSection = _base_mod.BaseSection
-SectionContext = _base_mod.SectionContext
-
-
-# Stub ``modules.tools.discovery.action_registry`` with the real registry
-# class so build_(filtered_)prompt_summary actually works.
-# Use setdefault so graph tests (which may load first) keep their module.
-if "modules.tools.discovery.action_registry" not in sys.modules:
-    _ar_module = ModuleType("modules.tools.discovery.action_registry")
-    sys.modules["modules.tools.discovery.action_registry"] = _ar_module
-else:
-    _ar_module = sys.modules["modules.tools.discovery.action_registry"]
+# Real ActionRegistry classes exposed under the dotted name the section imports.
+_ar_module = ModuleType("modules.tools.discovery.action_registry")
 _ar_module.ActionDefinition = ActionDefinition
 _ar_module.ActionRegistry = ActionRegistry
-# get_action_registry will be assigned per-test via _install_registry().
-
-
-# Stub ``modules.tools.discovery.action_semantic_index`` with a controllable
-# fake. The section calls ``get_action_semantic_index().rank_actions(...)``.
-if "modules.tools.discovery.action_semantic_index" not in sys.modules:
-    _asi_module = ModuleType("modules.tools.discovery.action_semantic_index")
-    sys.modules["modules.tools.discovery.action_semantic_index"] = _asi_module
-else:
-    _asi_module = sys.modules["modules.tools.discovery.action_semantic_index"]
+# get_action_registry assigned per-test via _install_registry().
 
 
 class _FakeSemanticIndex:
@@ -164,20 +153,64 @@ class _FakeSemanticIndex:
         return list(self.next_result)
 
 
+_asi_module = ModuleType("modules.tools.discovery.action_semantic_index")
 _asi_module._fake_singleton = _FakeSemanticIndex()
 _asi_module.get_action_semantic_index = lambda: _asi_module._fake_singleton  # type: ignore[attr-defined]
 
 
-# Finally load the section itself (or reuse if graph tests loaded it first).
-if "modules.context.sections.platform_actions" not in sys.modules:
-    _sec_spec = importlib.util.spec_from_file_location(
-        "modules.context.sections.platform_actions", _SECTIONS / "platform_actions.py"
-    )
-    _sec_mod = importlib.util.module_from_spec(_sec_spec)
-    sys.modules["modules.context.sections.platform_actions"] = _sec_mod
-    _sec_spec.loader.exec_module(_sec_mod)
+# Runtime stubs the section's lazy imports resolve at render() time.
+_RUNTIME_STUBS = {
+    "config": _stub_config_module,
+    "modules.tools.discovery.action_registry": _ar_module,
+    "modules.tools.discovery.action_semantic_index": _asi_module,
+}
+_runtime_live_snapshot: dict = {}
 
-PlatformActionsSection = sys.modules["modules.context.sections.platform_actions"].PlatformActionsSection
+
+def _install_runtime_stubs() -> None:
+    """Install runtime stubs, remembering whatever was there to restore later."""
+    global _runtime_live_snapshot
+    _runtime_live_snapshot = {k: sys.modules.get(k) for k in _RUNTIME_STUBS}
+    sys.modules.update(_RUNTIME_STUBS)
+
+
+def _restore_runtime_stubs() -> None:
+    _restore(_runtime_live_snapshot)
+
+
+# ---------------------------------------------------------------------------
+# Import-time block: install just enough to bind BaseSection / SectionContext /
+# PlatformActionsSection from disk, then restore sys.modules. The section's
+# top-level import is ``from modules.context.sections.base import ...``; base's
+# is ``from modules.context.estimator import TokenEstimator`` — both resolve
+# from the dotted stubs we install here. config / registry / index are only
+# touched at render() time, so they stay out of the import entirely.
+# ---------------------------------------------------------------------------
+sys.modules["modules.context.estimator"] = _estimator_mod
+
+_sections_pkg = ModuleType("modules.context.sections")
+_sections_pkg.__path__ = [str(_SECTIONS)]
+sys.modules["modules.context.sections"] = _sections_pkg
+
+_base_spec = importlib.util.spec_from_file_location(
+    "modules.context.sections.base", _SECTIONS / "base.py"
+)
+_base_mod = importlib.util.module_from_spec(_base_spec)
+sys.modules["modules.context.sections.base"] = _base_mod
+_base_spec.loader.exec_module(_base_mod)
+BaseSection = _base_mod.BaseSection
+SectionContext = _base_mod.SectionContext
+
+_sec_spec = importlib.util.spec_from_file_location(
+    "modules.context.sections.platform_actions", _SECTIONS / "platform_actions.py"
+)
+_sec_mod = importlib.util.module_from_spec(_sec_spec)
+sys.modules["modules.context.sections.platform_actions"] = _sec_mod
+_sec_spec.loader.exec_module(_sec_mod)
+PlatformActionsSection = _sec_mod.PlatformActionsSection
+
+# Collection-safe: undo every sys.modules mutation made during import.
+_restore(_PRE_IMPORT_SNAPSHOT)
 
 
 # ---------------------------------------------------------------------------
@@ -236,7 +269,7 @@ def _ctx(query: str | None = "__unset__") -> SectionContext:
 
 
 def _set_flag(enabled: bool, top_k: int = 3) -> None:
-    cfg = sys.modules["config"].config
+    cfg = _stub_config_module.config
     cfg.SEMANTIC_TOOL_ROUTING = enabled
     cfg.SEMANTIC_TOOL_ROUTING_TOP_K = top_k
 
@@ -247,12 +280,15 @@ def _run(coro):
 
 @pytest.fixture(autouse=True)
 def _reset_state():
-    """Reset stub state between tests."""
+    """Install runtime stubs + reset stub state around each test."""
+    _install_runtime_stubs()
     _set_flag(True, top_k=3)
     _install_index_result(result=[])
-    yield
-    _set_flag(True, top_k=3)
-    _install_index_result(result=[])
+    try:
+        yield
+    finally:
+        _install_index_result(result=[])
+        _restore_runtime_stubs()
 
 
 # ---------------------------------------------------------------------------

--- a/orchestrator/tests/test_platform_actions_section_graph.py
+++ b/orchestrator/tests/test_platform_actions_section_graph.py
@@ -6,9 +6,13 @@ These tests verify:
 3. Graph path is never reached when TOOL_ROUTING_GRAPH=False
 4. Chain hints are rendered for multi-action sequences
 
-Strategy: imports the SAME PlatformActionsSection that the existing PRD-138
-tests set up. Monkeypatches config and graph_router at the pytest-function level
-so there are ZERO sys.modules conflicts regardless of collection order.
+Collection-pollution discipline (PRD-142 W2-S2b): the section is loaded with
+import-time stubs (estimator / base) that are restored immediately, so this
+module leaves sys.modules untouched at collection time. The runtime stubs the
+section imports lazily inside ``render()`` (config / action_registry /
+action_semantic_index / graph_router) are (re)installed per-test by the autouse
+fixture and torn down after each test. Each platform-actions test file is fully
+self-contained — no cross-file ``setdefault`` coupling.
 """
 from __future__ import annotations
 
@@ -22,111 +26,108 @@ from unittest.mock import MagicMock
 
 import pytest
 
-# ---------------------------------------------------------------------------
-# The existing test file (test_platform_actions_section.py) may or may not
-# have run first. We need the same PlatformActionsSection class and stubs.
-# Strategy: replicate the EXACT module-level setup from that file, but guard
-# with setdefault so whichever loads first wins — they're identical.
-# ---------------------------------------------------------------------------
-
 _THIS = Path(__file__).resolve()
 _ORCH = _THIS.parents[1]
 _SECTIONS = _ORCH / "modules" / "context" / "sections"
 _DISCOVERY = _ORCH / "modules" / "tools" / "discovery"
 
-# Load ActionRegistry class (private, doesn't interfere)
+
+# ---------------------------------------------------------------------------
+# Watched sys.modules keys — snapshot now, restore after the import-time block.
+# ---------------------------------------------------------------------------
+_IMPORT_KEYS = (
+    "modules.context.estimator",
+    "modules.context.sections",
+    "modules.context.sections.base",
+    "modules.context.sections.platform_actions",
+)
+# Read by the section's LAZY imports at render() time — live only during tests.
+_RUNTIME_KEYS = (
+    "config",
+    "modules.tools.discovery.action_registry",
+    "modules.tools.discovery.action_semantic_index",
+    "modules.tools.discovery.graph_router",
+)
+_GUARD_KEYS = (
+    "modules",
+    "modules.context",
+    "modules.tools",
+    "modules.tools.discovery",
+)
+_PRE_IMPORT_SNAPSHOT = {
+    k: sys.modules.get(k) for k in (_IMPORT_KEYS + _RUNTIME_KEYS + _GUARD_KEYS)
+}
+
+
+def _restore(snapshot: dict) -> None:
+    """Restore sys.modules to a captured snapshot (None ⇒ delete the key)."""
+    for key, original in snapshot.items():
+        if original is None:
+            sys.modules.pop(key, None)
+        else:
+            sys.modules[key] = original
+
+
+# ---------------------------------------------------------------------------
+# Pre-load the real ActionRegistry under a private name (no pollution).
+# ---------------------------------------------------------------------------
 _ar_spec = importlib.util.spec_from_file_location(
     "action_registry_gt", _DISCOVERY / "action_registry.py"
 )
 _ar_mod = importlib.util.module_from_spec(_ar_spec)
-sys.modules.setdefault("action_registry_gt", _ar_mod)
-if not hasattr(_ar_mod, "ActionDefinition"):
-    _ar_spec.loader.exec_module(_ar_mod)
+sys.modules["action_registry_gt"] = _ar_mod
+_ar_spec.loader.exec_module(_ar_mod)
 ActionDefinition = _ar_mod.ActionDefinition
 ActionRegistry = _ar_mod.ActionRegistry
 
-# Ensure package stubs
-for pkg in ("modules", "modules.context", "modules.tools", "modules.tools.discovery"):
-    if pkg not in sys.modules:
-        m = ModuleType(pkg)
-        m.__path__ = []
-        sys.modules[pkg] = m
 
-# TokenEstimator
-if "modules.context.estimator" not in sys.modules:
-    _est = ModuleType("modules.context.estimator")
-    class _E:
-        def estimate(self, c: str) -> int:
-            return len(c) // 4 + 1
-    _est.TokenEstimator = _E
-    sys.modules["modules.context.estimator"] = _est
+# ---------------------------------------------------------------------------
+# Build stub module objects (installed transiently for import, then per-test).
+# ---------------------------------------------------------------------------
+class _StubConfig:
+    SEMANTIC_TOOL_ROUTING = True
+    SEMANTIC_TOOL_ROUTING_TOP_K = 3
+    TOOL_ROUTING_GRAPH = False
+    PLATFORM_ACTIONS_MAX_TOKENS = 4000
 
-# Config stub — must have all attrs both test files need
-if "config" not in sys.modules:
-    _cm = ModuleType("config")
-    class _C:
-        SEMANTIC_TOOL_ROUTING = True
-        SEMANTIC_TOOL_ROUTING_TOP_K = 3
-        TOOL_ROUTING_GRAPH = False
-    _cm.config = _C()
-    sys.modules["config"] = _cm
-else:
-    # Ensure TOOL_ROUTING_GRAPH exists on whatever config is already loaded
-    _existing_cfg = sys.modules["config"].config
-    if not hasattr(_existing_cfg, "TOOL_ROUTING_GRAPH"):
-        _existing_cfg.TOOL_ROUTING_GRAPH = False
 
-# BaseSection / SectionContext
-if "modules.context.sections" not in sys.modules:
-    _sp = ModuleType("modules.context.sections")
-    _sp.__path__ = [str(_SECTIONS)]
-    sys.modules["modules.context.sections"] = _sp
-if "modules.context.sections.base" not in sys.modules:
-    _bs = importlib.util.spec_from_file_location(
-        "modules.context.sections.base", _SECTIONS / "base.py"
-    )
-    _bm = importlib.util.module_from_spec(_bs)
-    sys.modules["modules.context.sections.base"] = _bm
-    _bs.loader.exec_module(_bm)
+_stub_config_module = ModuleType("config")
+_stub_config_module.config = _StubConfig()
 
-SectionContext = sys.modules["modules.context.sections.base"].SectionContext
 
-# Action registry stub
-if "modules.tools.discovery.action_registry" not in sys.modules:
-    _arm = ModuleType("modules.tools.discovery.action_registry")
-    _arm.ActionDefinition = ActionDefinition
-    _arm.ActionRegistry = ActionRegistry
-    _arm.get_action_registry = lambda: None
-    sys.modules["modules.tools.discovery.action_registry"] = _arm
+class _NoopEstimator:
+    def estimate(self, c: str) -> int:
+        return len(c) // 4 + 1
 
-_ar_module = sys.modules["modules.tools.discovery.action_registry"]
-# Ensure our classes are there
-if not hasattr(_ar_module, "get_action_registry"):
-    _ar_module.get_action_registry = lambda: None
 
-# Action semantic index stub
-if "modules.tools.discovery.action_semantic_index" not in sys.modules:
-    _asim = ModuleType("modules.tools.discovery.action_semantic_index")
+_estimator_mod = ModuleType("modules.context.estimator")
+_estimator_mod.TokenEstimator = _NoopEstimator
 
-    class _FSI:
-        def __init__(self):
-            self.calls: List[dict] = []
-            self.next_result: List[Tuple[str, float]] = []
-            self.exception: Optional[Exception] = None
 
-        async def rank_actions(self, query, top_k=15, exclude_admin=True, exclude_promoted=True):
-            self.calls.append({"query": query, "top_k": top_k, "exclude_admin": exclude_admin, "exclude_promoted": exclude_promoted})
-            if self.exception:
-                raise self.exception
-            return list(self.next_result)
+_ar_module = ModuleType("modules.tools.discovery.action_registry")
+_ar_module.ActionDefinition = ActionDefinition
+_ar_module.ActionRegistry = ActionRegistry
+_ar_module.get_action_registry = lambda: None  # replaced per-test via _install_registry()
 
-    _asim._fake_singleton = _FSI()
-    _asim.get_action_semantic_index = lambda: _asim._fake_singleton
-    sys.modules["modules.tools.discovery.action_semantic_index"] = _asim
 
-_asi_module = sys.modules["modules.tools.discovery.action_semantic_index"]
+class _FakeSemanticIndex:
+    def __init__(self):
+        self.calls: List[dict] = []
+        self.next_result: List[Tuple[str, float]] = []
+        self.exception: Optional[Exception] = None
 
-# Graph router stub — this is the NEW module for PRD-139
+    async def rank_actions(self, query, top_k=15, exclude_admin=True, exclude_promoted=True):
+        self.calls.append({"query": query, "top_k": top_k, "exclude_admin": exclude_admin, "exclude_promoted": exclude_promoted})
+        if self.exception:
+            raise self.exception
+        return list(self.next_result)
+
+
+_asi_module = ModuleType("modules.tools.discovery.action_semantic_index")
+_asi_module._fake_singleton = _FakeSemanticIndex()
+_asi_module.get_action_semantic_index = lambda: _asi_module._fake_singleton
+
+
 class _FakeGraphRouter:
     """Controllable fake for GraphRouter used by all tests in this file."""
 
@@ -143,23 +144,60 @@ class _FakeGraphRouter:
 
 
 _fake_graph_router = _FakeGraphRouter()
-
 _grm = ModuleType("modules.tools.discovery.graph_router")
 _grm.get_graph_router = lambda: _fake_graph_router
 _grm.GraphRouter = _FakeGraphRouter
-sys.modules["modules.tools.discovery.graph_router"] = _grm
 
-# Load the section module (or reuse existing). The section uses lazy imports
-# so whatever is in sys.modules at CALL TIME is what gets resolved.
-if "modules.context.sections.platform_actions" not in sys.modules:
-    _ss = importlib.util.spec_from_file_location(
-        "modules.context.sections.platform_actions", _SECTIONS / "platform_actions.py"
-    )
-    _sm = importlib.util.module_from_spec(_ss)
-    sys.modules["modules.context.sections.platform_actions"] = _sm
-    _ss.loader.exec_module(_sm)
 
-PlatformActionsSection = sys.modules["modules.context.sections.platform_actions"].PlatformActionsSection
+# Runtime stubs the section's lazy imports resolve at render() time.
+_RUNTIME_STUBS = {
+    "config": _stub_config_module,
+    "modules.tools.discovery.action_registry": _ar_module,
+    "modules.tools.discovery.action_semantic_index": _asi_module,
+    "modules.tools.discovery.graph_router": _grm,
+}
+_runtime_live_snapshot: dict = {}
+
+
+def _install_runtime_stubs() -> None:
+    """Install runtime stubs, remembering whatever was there to restore later."""
+    global _runtime_live_snapshot
+    _runtime_live_snapshot = {k: sys.modules.get(k) for k in _RUNTIME_STUBS}
+    sys.modules.update(_RUNTIME_STUBS)
+
+
+def _restore_runtime_stubs() -> None:
+    _restore(_runtime_live_snapshot)
+
+
+# ---------------------------------------------------------------------------
+# Import-time block: bind SectionContext / PlatformActionsSection from disk,
+# then restore sys.modules (collection-safe). config / registry / index /
+# graph_router are render()-time only, so they stay out of the import.
+# ---------------------------------------------------------------------------
+sys.modules["modules.context.estimator"] = _estimator_mod
+
+_sections_pkg = ModuleType("modules.context.sections")
+_sections_pkg.__path__ = [str(_SECTIONS)]
+sys.modules["modules.context.sections"] = _sections_pkg
+
+_base_spec = importlib.util.spec_from_file_location(
+    "modules.context.sections.base", _SECTIONS / "base.py"
+)
+_base_mod = importlib.util.module_from_spec(_base_spec)
+sys.modules["modules.context.sections.base"] = _base_mod
+_base_spec.loader.exec_module(_base_mod)
+SectionContext = _base_mod.SectionContext
+
+_sec_spec = importlib.util.spec_from_file_location(
+    "modules.context.sections.platform_actions", _SECTIONS / "platform_actions.py"
+)
+_sec_mod = importlib.util.module_from_spec(_sec_spec)
+sys.modules["modules.context.sections.platform_actions"] = _sec_mod
+_sec_spec.loader.exec_module(_sec_mod)
+PlatformActionsSection = _sec_mod.PlatformActionsSection
+
+_restore(_PRE_IMPORT_SNAPSHOT)
 
 
 # ---------------------------------------------------------------------------
@@ -195,7 +233,7 @@ def _ctx(query: str = "test query", agent_id: Optional[int] = None) -> SectionCo
 
 
 def _set_flags(semantic: bool = True, graph: bool = False, top_k: int = 3) -> None:
-    cfg = sys.modules["config"].config
+    cfg = _stub_config_module.config
     cfg.SEMANTIC_TOOL_ROUTING = semantic
     cfg.SEMANTIC_TOOL_ROUTING_TOP_K = top_k
     cfg.TOOL_ROUTING_GRAPH = graph
@@ -220,13 +258,16 @@ def _run(coro):
 
 @pytest.fixture(autouse=True)
 def _reset_state():
+    _install_runtime_stubs()
     _set_flags(semantic=True, graph=False, top_k=3)
     _reset_graph_router()
     _reset_semantic_index()
-    yield
-    _set_flags(semantic=True, graph=False, top_k=3)
-    _reset_graph_router()
-    _reset_semantic_index()
+    try:
+        yield
+    finally:
+        _reset_graph_router()
+        _reset_semantic_index()
+        _restore_runtime_stubs()
 
 
 # ---------------------------------------------------------------------------

--- a/orchestrator/tests/test_playbook_scheduler.py
+++ b/orchestrator/tests/test_playbook_scheduler.py
@@ -1,19 +1,18 @@
-"""Unit tests for RecipeSchedulerService.
+"""Unit tests for PlaybookSchedulerService.
 
 Tests the scheduler in isolation with mocked APScheduler, DB, and executor.
-Follows async test pattern from test_plugin_runtime_integration.py.
+
+apscheduler is imported at the TOP of services.playbook_scheduler, so we must
+satisfy that import before importing the service. apscheduler is not installed
+in the local venv (it IS in CI), so we install minimal stubs ONLY where absent,
+import the service, then restore sys.modules — the stubs never reach the
+collection of sibling test modules. (PRD-142 W2-S2b.)
 """
 import sys
 import types
-import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-
-# ---------------------------------------------------------------------------
-# Stub apscheduler modules before importing recipe_scheduler
-# ---------------------------------------------------------------------------
-_mock_apscheduler = MagicMock()
 
 
 class _FakeCronTrigger:
@@ -30,24 +29,58 @@ class _FakeCronTrigger:
         return MagicMock(name="CronTrigger")
 
 
-sys.modules.setdefault("apscheduler", _mock_apscheduler)
-sys.modules.setdefault("apscheduler.schedulers", _mock_apscheduler)
-sys.modules.setdefault("apscheduler.schedulers.asyncio", MagicMock(AsyncIOScheduler=MagicMock))
-sys.modules.setdefault("apscheduler.jobstores", _mock_apscheduler)
-sys.modules.setdefault("apscheduler.jobstores.memory", MagicMock(MemoryJobStore=MagicMock))
-sys.modules.setdefault("apscheduler.triggers", _mock_apscheduler)
-sys.modules.setdefault("apscheduler.triggers.cron", MagicMock(CronTrigger=_FakeCronTrigger))
+# ---------------------------------------------------------------------------
+# apscheduler stubs: snapshot -> install-if-absent -> import -> restore.
+# ---------------------------------------------------------------------------
+_APS_KEYS = (
+    "apscheduler",
+    "apscheduler.schedulers",
+    "apscheduler.schedulers.asyncio",
+    "apscheduler.jobstores",
+    "apscheduler.jobstores.memory",
+    "apscheduler.triggers",
+    "apscheduler.triggers.cron",
+)
+_APS_SNAPSHOT = {k: sys.modules.get(k) for k in _APS_KEYS}
 
-# Now we can import
-from services.recipe_scheduler import RecipeSchedulerService, get_recipe_scheduler
-import services.recipe_scheduler as sched_mod
 
-# Replace the real CronTrigger with our fake so schedule_recipe validation works
+def _install_apscheduler_stubs():
+    _pkg = MagicMock()
+    stubs = {
+        "apscheduler": _pkg,
+        "apscheduler.schedulers": _pkg,
+        "apscheduler.schedulers.asyncio": MagicMock(AsyncIOScheduler=MagicMock),
+        "apscheduler.jobstores": _pkg,
+        "apscheduler.jobstores.memory": MagicMock(MemoryJobStore=MagicMock),
+        "apscheduler.triggers": _pkg,
+        "apscheduler.triggers.cron": MagicMock(CronTrigger=_FakeCronTrigger),
+    }
+    for name, mod in stubs.items():
+        if name not in sys.modules:
+            sys.modules[name] = mod
+
+
+def _restore_apscheduler_stubs():
+    for k, prior in _APS_SNAPSHOT.items():
+        if prior is None:
+            sys.modules.pop(k, None)
+        else:
+            sys.modules[k] = prior
+
+
+_install_apscheduler_stubs()
+from services.playbook_scheduler import PlaybookSchedulerService, get_playbook_scheduler
+import services.playbook_scheduler as sched_mod
+
+# Replace the (real-or-stub) CronTrigger with our fake so cron validation is
+# deterministic regardless of whether apscheduler is installed.
 sched_mod.CronTrigger = _FakeCronTrigger
+_restore_apscheduler_stubs()
 
 
 # ---------------------------------------------------------------------------
-# Helper: mock modules for lazy imports inside _load_cron_recipes / _fire_recipe
+# Helpers: mock modules for the lazy imports inside _load_cron_playbooks /
+# _fire_playbook.
 # ---------------------------------------------------------------------------
 
 def _make_db_mock(query_results=None, first_result=None):
@@ -65,10 +98,9 @@ def _make_db_mock(query_results=None, first_result=None):
     return mock_db, db_module
 
 
-def _make_recipe_model_mock():
+def _make_playbook_model_mock():
     """Create a WorkflowTemplate mock with SQLAlchemy-like column attributes."""
     model = MagicMock()
-    # SQLAlchemy column descriptors used in .filter()
     model.schedule_config = MagicMock()
     model.workspace_id = MagicMock()
     model.steps = MagicMock()
@@ -76,19 +108,23 @@ def _make_recipe_model_mock():
 
 
 def _lazy_import_patches(db_module, extra_modules=None):
-    """Build a sys.modules dict for patching lazy imports in _fire_recipe / _load_cron_recipes."""
-    recipe_model = _make_recipe_model_mock()
+    """sys.modules dict patching the lazy imports in _fire_playbook /
+    _load_cron_playbooks. ``WorkflowTemplate`` (aliased WorkflowPlaybook),
+    ``RecipeExecution``, ``api.recipe_executor`` and ``launch_recipe_task`` keep
+    their source names — the scheduler module was renamed but those symbols were
+    not."""
+    playbook_model = _make_playbook_model_mock()
     mock_core_models = MagicMock()
-    mock_core_models.WorkflowTemplate = recipe_model
-
-    mock_exec_module = MagicMock()
-    mock_exec_module.execute_recipe_direct = AsyncMock()
+    mock_core_models.WorkflowTemplate = playbook_model
 
     modules = {
         "core.database.database": db_module,
         "core.models": mock_core_models,
         "core.models.core": MagicMock(RecipeExecution=MagicMock()),
-        "api.recipe_executor": mock_exec_module,
+        "api.recipe_executor": MagicMock(launch_recipe_task=MagicMock()),
+        "services.concurrency_guard": MagicMock(
+            check_concurrency=AsyncMock(return_value=MagicMock(allowed=True, reason=""))
+        ),
         "sqlalchemy": sys.modules.get("sqlalchemy", MagicMock()),
     }
     if extra_modules:
@@ -106,11 +142,11 @@ class TestSchedulerLifecycle:
     @pytest.mark.asyncio
     async def test_start_standalone_creates_own_scheduler(self):
         """start() without shared scheduler creates AsyncIOScheduler."""
-        svc = RecipeSchedulerService()
+        svc = PlaybookSchedulerService()
 
         mock_sched_instance = MagicMock()
         mock_load = AsyncMock()
-        svc._load_cron_recipes = mock_load
+        svc._load_cron_playbooks = mock_load
 
         with patch.object(sched_mod, "AsyncIOScheduler", return_value=mock_sched_instance), \
              patch.object(sched_mod, "MemoryJobStore", return_value=MagicMock()):
@@ -124,24 +160,24 @@ class TestSchedulerLifecycle:
     @pytest.mark.asyncio
     async def test_start_with_shared_scheduler(self):
         """start(scheduler=X) uses shared scheduler, does not create its own."""
-        svc = RecipeSchedulerService()
+        svc = PlaybookSchedulerService()
 
         shared_sched = MagicMock()
         mock_load = AsyncMock()
-        svc._load_cron_recipes = mock_load
+        svc._load_cron_playbooks = mock_load
 
         await svc.start(scheduler=shared_sched)
 
         assert svc._scheduler is shared_sched
         assert svc._owns_scheduler is False
-        # Should NOT have called start on the shared scheduler (UnifiedScheduler handles that)
+        # Should NOT call start on the shared scheduler (UnifiedScheduler owns that)
         shared_sched.start.assert_not_called()
         mock_load.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_stop_shuts_down_owned_scheduler(self):
         """stop() calls scheduler.shutdown() only when we own it."""
-        svc = RecipeSchedulerService()
+        svc = PlaybookSchedulerService()
         mock_sched = MagicMock()
         svc._scheduler = mock_sched
         svc._owns_scheduler = True
@@ -153,7 +189,7 @@ class TestSchedulerLifecycle:
     @pytest.mark.asyncio
     async def test_stop_shared_scheduler_no_shutdown(self):
         """stop() does NOT shutdown the shared scheduler."""
-        svc = RecipeSchedulerService()
+        svc = PlaybookSchedulerService()
         mock_sched = MagicMock()
         svc._scheduler = mock_sched
         svc._owns_scheduler = False
@@ -165,7 +201,7 @@ class TestSchedulerLifecycle:
     @pytest.mark.asyncio
     async def test_stop_no_scheduler_is_noop(self):
         """stop() with no scheduler does not error."""
-        svc = RecipeSchedulerService()
+        svc = PlaybookSchedulerService()
         svc._scheduler = None
         await svc.stop()  # should not raise
 
@@ -175,77 +211,77 @@ class TestSchedulerLifecycle:
 # ===========================================================================
 
 class TestScheduleUnschedule:
-    """Tests for schedule_recipe() and unschedule_recipe()."""
+    """Tests for schedule_playbook() and unschedule_playbook()."""
 
-    def test_schedule_recipe_valid_cron(self, mock_recipe):
-        """schedule_recipe() with valid cron adds a job via add_job."""
-        svc = RecipeSchedulerService()
+    def test_schedule_playbook_valid_cron(self, mock_playbook):
+        """schedule_playbook() with valid cron adds a job via add_job."""
+        svc = PlaybookSchedulerService()
         mock_sched = MagicMock()
         mock_sched.get_job.return_value = None
         svc._scheduler = mock_sched
 
-        svc.schedule_recipe(mock_recipe)
+        svc.schedule_playbook(mock_playbook)
 
         mock_sched.add_job.assert_called_once()
         call_kwargs = mock_sched.add_job.call_args
-        assert call_kwargs.kwargs["id"] == "recipe_cron_42"
+        assert call_kwargs.kwargs["id"] == "playbook_cron_42"
         assert call_kwargs.kwargs["replace_existing"] is True
 
-    def test_schedule_recipe_replaces_existing(self, mock_recipe):
+    def test_schedule_playbook_replaces_existing(self, mock_playbook):
         """If job already exists, removes it then adds new one."""
-        svc = RecipeSchedulerService()
+        svc = PlaybookSchedulerService()
         mock_sched = MagicMock()
         mock_sched.get_job.return_value = MagicMock()  # job exists
         svc._scheduler = mock_sched
 
-        svc.schedule_recipe(mock_recipe)
+        svc.schedule_playbook(mock_playbook)
 
-        mock_sched.remove_job.assert_called_once_with("recipe_cron_42")
+        mock_sched.remove_job.assert_called_once_with("playbook_cron_42")
         mock_sched.add_job.assert_called_once()
 
-    def test_schedule_recipe_invalid_cron(self, mock_recipe):
+    def test_schedule_playbook_invalid_cron(self, mock_playbook):
         """Invalid cron expression logs error, no job added."""
-        mock_recipe.schedule_config = {"type": "cron", "cron_expression": "not valid cron"}
+        mock_playbook.schedule_config = {"type": "cron", "cron_expression": "not valid cron"}
 
-        svc = RecipeSchedulerService()
+        svc = PlaybookSchedulerService()
         mock_sched = MagicMock()
         svc._scheduler = mock_sched
 
-        svc.schedule_recipe(mock_recipe)
+        svc.schedule_playbook(mock_playbook)
 
         mock_sched.add_job.assert_not_called()
 
-    def test_schedule_recipe_no_expression(self, mock_recipe):
+    def test_schedule_playbook_no_expression(self, mock_playbook):
         """Missing cron_expression early-returns without adding job."""
-        mock_recipe.schedule_config = {"type": "cron"}
+        mock_playbook.schedule_config = {"type": "cron"}
 
-        svc = RecipeSchedulerService()
+        svc = PlaybookSchedulerService()
         mock_sched = MagicMock()
         svc._scheduler = mock_sched
 
-        svc.schedule_recipe(mock_recipe)
+        svc.schedule_playbook(mock_playbook)
 
         mock_sched.add_job.assert_not_called()
 
-    def test_unschedule_recipe(self):
-        """unschedule_recipe() removes job by recipe ID."""
-        svc = RecipeSchedulerService()
+    def test_unschedule_playbook(self):
+        """unschedule_playbook() removes job by playbook ID."""
+        svc = PlaybookSchedulerService()
         mock_sched = MagicMock()
         mock_sched.get_job.return_value = MagicMock()  # job exists
         svc._scheduler = mock_sched
 
-        svc.unschedule_recipe(1)
+        svc.unschedule_playbook(1)
 
-        mock_sched.remove_job.assert_called_once_with("recipe_cron_1")
+        mock_sched.remove_job.assert_called_once_with("playbook_cron_1")
 
-    def test_unschedule_recipe_not_found(self):
-        """unschedule_recipe() with no existing job does not error."""
-        svc = RecipeSchedulerService()
+    def test_unschedule_playbook_not_found(self):
+        """unschedule_playbook() with no existing job does not error."""
+        svc = PlaybookSchedulerService()
         mock_sched = MagicMock()
         mock_sched.get_job.return_value = None
         svc._scheduler = mock_sched
 
-        svc.unschedule_recipe(999)
+        svc.unschedule_playbook(999)
 
         mock_sched.remove_job.assert_not_called()
 
@@ -254,23 +290,23 @@ class TestScheduleUnschedule:
 # Load from DB
 # ===========================================================================
 
-class TestLoadCronRecipes:
-    """Tests for _load_cron_recipes()."""
+class TestLoadCronPlaybooks:
+    """Tests for _load_cron_playbooks()."""
 
     @pytest.mark.asyncio
-    async def test_load_cron_recipes(self, mock_recipe, mock_recipe_manual):
-        """_load_cron_recipes queries DB and schedules only cron-type recipes."""
-        svc = RecipeSchedulerService()
+    async def test_load_cron_playbooks(self, mock_playbook, mock_playbook_manual):
+        """_load_cron_playbooks queries DB and schedules only cron-type playbooks."""
+        svc = PlaybookSchedulerService()
         mock_sched = MagicMock()
         mock_sched.get_job.return_value = None
         svc._scheduler = mock_sched
 
-        mock_db, db_module = _make_db_mock(query_results=[mock_recipe, mock_recipe_manual])
+        mock_db, db_module = _make_db_mock(query_results=[mock_playbook, mock_playbook_manual])
 
         with patch.dict(sys.modules, _lazy_import_patches(db_module)):
-            await svc._load_cron_recipes()
+            await svc._load_cron_playbooks()
 
-        # Only the cron recipe should be scheduled (manual is skipped)
+        # Only the cron playbook should be scheduled (manual is skipped)
         assert mock_sched.add_job.call_count == 1
 
 
@@ -278,17 +314,17 @@ class TestLoadCronRecipes:
 # Fire
 # ===========================================================================
 
-class TestFireRecipe:
-    """Tests for _fire_recipe()."""
+class TestFirePlaybook:
+    """Tests for _fire_playbook()."""
 
     @pytest.mark.asyncio
-    async def test_fire_recipe_success(self, mock_recipe):
-        """Re-fetches recipe, creates RecipeExecution, calls launch_recipe_task."""
-        svc = RecipeSchedulerService()
+    async def test_fire_playbook_success(self, mock_playbook):
+        """Re-fetches playbook, creates RecipeExecution, calls launch_recipe_task."""
+        svc = PlaybookSchedulerService()
         mock_sched = MagicMock()
         svc._scheduler = mock_sched
 
-        mock_db, db_module = _make_db_mock(first_result=mock_recipe)
+        mock_db, db_module = _make_db_mock(first_result=mock_playbook)
         mock_launch = MagicMock()
         mock_execution_cls = MagicMock()
 
@@ -298,18 +334,44 @@ class TestFireRecipe:
         }
 
         with patch.dict(sys.modules, _lazy_import_patches(db_module, extra)):
-            await svc._fire_recipe(mock_recipe.id, str(mock_recipe.workspace_id))
+            await svc._fire_playbook(mock_playbook.id, str(mock_playbook.workspace_id))
 
-        # Should have added a RecipeExecution to the DB
+        # Created + committed exactly one execution (concurrency allowed -> no rollback)
         mock_db.add.assert_called_once()
         mock_db.commit.assert_called_once()
-        # Should have launched the recipe task
+        # Launched the playbook task
         mock_launch.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_fire_recipe_deleted(self, mock_recipe):
-        """Recipe no longer in DB -> unschedules, no execution."""
-        svc = RecipeSchedulerService()
+    async def test_fire_playbook_concurrency_blocked(self, mock_playbook):
+        """Concurrency limit reached -> rolls back execution, does not launch."""
+        svc = PlaybookSchedulerService()
+        mock_sched = MagicMock()
+        svc._scheduler = mock_sched
+
+        mock_db, db_module = _make_db_mock(first_result=mock_playbook)
+        mock_launch = MagicMock()
+
+        extra = {
+            "api.recipe_executor": MagicMock(launch_recipe_task=mock_launch),
+            "services.concurrency_guard": MagicMock(
+                check_concurrency=AsyncMock(return_value=MagicMock(allowed=False, reason="at capacity"))
+            ),
+        }
+
+        with patch.dict(sys.modules, _lazy_import_patches(db_module, extra)):
+            await svc._fire_playbook(mock_playbook.id, str(mock_playbook.workspace_id))
+
+        # Pending execution added then deleted (commit for both add and rollback)
+        mock_db.add.assert_called_once()
+        mock_db.delete.assert_called_once()
+        # Never launched
+        mock_launch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_fire_playbook_deleted(self, mock_playbook):
+        """Playbook no longer in DB -> unschedules, no execution."""
+        svc = PlaybookSchedulerService()
         mock_sched = MagicMock()
         mock_sched.get_job.return_value = MagicMock()
         svc._scheduler = mock_sched
@@ -317,31 +379,31 @@ class TestFireRecipe:
         mock_db, db_module = _make_db_mock(first_result=None)
 
         with patch.dict(sys.modules, _lazy_import_patches(db_module)):
-            await svc._fire_recipe(mock_recipe.id, str(mock_recipe.workspace_id))
+            await svc._fire_playbook(mock_playbook.id, str(mock_playbook.workspace_id))
 
         # Should unschedule
-        mock_sched.remove_job.assert_called_once_with(f"recipe_cron_{mock_recipe.id}")
+        mock_sched.remove_job.assert_called_once_with(f"playbook_cron_{mock_playbook.id}")
         # Should NOT create an execution
         mock_db.add.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_fire_recipe_no_longer_cron(self, mock_recipe):
-        """Recipe changed to manual -> unschedules, no execution."""
-        svc = RecipeSchedulerService()
+    async def test_fire_playbook_no_longer_cron(self, mock_playbook):
+        """Playbook changed to manual -> unschedules, no execution."""
+        svc = PlaybookSchedulerService()
         mock_sched = MagicMock()
         mock_sched.get_job.return_value = MagicMock()
         svc._scheduler = mock_sched
 
-        # Recipe is now manual
-        mock_recipe.schedule_config = {"type": "manual"}
+        # Playbook is now manual
+        mock_playbook.schedule_config = {"type": "manual"}
 
-        mock_db, db_module = _make_db_mock(first_result=mock_recipe)
+        mock_db, db_module = _make_db_mock(first_result=mock_playbook)
 
         with patch.dict(sys.modules, _lazy_import_patches(db_module)):
-            await svc._fire_recipe(mock_recipe.id, str(mock_recipe.workspace_id))
+            await svc._fire_playbook(mock_playbook.id, str(mock_playbook.workspace_id))
 
         # Should unschedule
-        mock_sched.remove_job.assert_called_once_with(f"recipe_cron_{mock_recipe.id}")
+        mock_sched.remove_job.assert_called_once_with(f"playbook_cron_{mock_playbook.id}")
         # Should NOT create an execution
         mock_db.add.assert_not_called()
 
@@ -355,12 +417,12 @@ class TestGetStatus:
 
     def test_get_status_with_jobs(self):
         """get_status() returns active flag and job list."""
-        svc = RecipeSchedulerService()
+        svc = PlaybookSchedulerService()
         mock_sched = MagicMock()
         mock_sched.running = True
 
         mock_job = MagicMock()
-        mock_job.id = "recipe_cron_42"
+        mock_job.id = "playbook_cron_42"
         mock_job.next_run_time.isoformat.return_value = "2026-03-02T09:00:00"
         mock_job.trigger = MagicMock(__str__=lambda self: "cron[hour='9']")
         mock_sched.get_jobs.return_value = [mock_job]
@@ -370,11 +432,11 @@ class TestGetStatus:
         status = svc.get_status()
         assert status["active"] is True
         assert len(status["jobs"]) == 1
-        assert status["jobs"][0]["id"] == "recipe_cron_42"
+        assert status["jobs"][0]["id"] == "playbook_cron_42"
 
     def test_get_status_no_scheduler(self):
         """get_status() with no scheduler returns inactive."""
-        svc = RecipeSchedulerService()
+        svc = PlaybookSchedulerService()
         svc._scheduler = None
 
         status = svc.get_status()
@@ -387,16 +449,16 @@ class TestGetStatus:
 # ===========================================================================
 
 class TestSingleton:
-    """Tests for get_recipe_scheduler() singleton."""
+    """Tests for get_playbook_scheduler() singleton."""
 
     def test_singleton_returns_same_instance(self):
-        """get_recipe_scheduler() returns same instance on repeated calls."""
+        """get_playbook_scheduler() returns same instance on repeated calls."""
         # Reset singleton
-        sched_mod._recipe_scheduler = None
+        sched_mod._playbook_scheduler = None
 
-        svc1 = get_recipe_scheduler()
-        svc2 = get_recipe_scheduler()
+        svc1 = get_playbook_scheduler()
+        svc2 = get_playbook_scheduler()
         assert svc1 is svc2
 
         # Clean up
-        sched_mod._recipe_scheduler = None
+        sched_mod._playbook_scheduler = None

--- a/orchestrator/tests/test_plugin_assignment_api.py
+++ b/orchestrator/tests/test_plugin_assignment_api.py
@@ -39,6 +39,13 @@ from api.agent_plugins import (  # noqa: E402
     UpdateAgentPluginsBody,
 )
 
+# Collection-safe (PRD-142 W2-S2b): drop the auth/jwt stubs we installed so a
+# pathless ``core.auth.*`` stub doesn't shadow the real submodule when sibling
+# test modules are collected afterwards. api.agent_plugins has already bound the
+# symbols it needs at its own import time, so removing the stubs is safe.
+for _k in _stubs:
+    sys.modules.pop(_k, None)
+
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/orchestrator/tests/test_prd139_telemetry.py
+++ b/orchestrator/tests/test_prd139_telemetry.py
@@ -36,15 +36,32 @@ class MockToolExecutionLog:
             setattr(self, k, v)
 
 
-# Pre-patch the model import before loading the module
+# telemetry.py imports ToolExecutionLog lazily *inside* write_telemetry(), so
+# the fake model only needs to be live while this file's tests run — not at
+# import. Installing it in setup_module (and restoring in teardown_module)
+# keeps the fake out of sibling modules' collection/runtime. (PRD-142 W2-S2b.)
 _mock_composio_cache = MagicMock()
 _mock_composio_cache.ToolExecutionLog = MockToolExecutionLog
-sys.modules["core.models.composio_cache"] = _mock_composio_cache
 
 _spec.loader.exec_module(telemetry_mod)
 
 write_telemetry = telemetry_mod.write_telemetry
 fire_telemetry = telemetry_mod.fire_telemetry
+
+_saved_composio_cache = None
+
+
+def setup_module(module):
+    global _saved_composio_cache
+    _saved_composio_cache = sys.modules.get("core.models.composio_cache")
+    sys.modules["core.models.composio_cache"] = _mock_composio_cache
+
+
+def teardown_module(module):
+    if _saved_composio_cache is None:
+        sys.modules.pop("core.models.composio_cache", None)
+    else:
+        sys.modules["core.models.composio_cache"] = _saved_composio_cache
 
 
 @pytest.fixture

--- a/orchestrator/tests/test_skills_section.py
+++ b/orchestrator/tests/test_skills_section.py
@@ -22,33 +22,61 @@ class _FakeEstimator:
 
 
 _estimator_stub.TokenEstimator = _FakeEstimator
-sys.modules.setdefault("modules", types.ModuleType("modules"))
-sys.modules["modules"].__path__ = []
-sys.modules.setdefault("modules.context", types.ModuleType("modules.context"))
-sys.modules["modules.context"].__path__ = []
-sys.modules["modules.context.estimator"] = _estimator_stub
-sys.modules.setdefault("modules.context.sections", types.ModuleType("modules.context.sections"))
-sys.modules["modules.context.sections"].__path__ = []
 
-_base_mod = importlib.util.module_from_spec(
-    importlib.util.spec_from_file_location(
+
+def _load_sections_isolated():
+    """Load base.py + skills.py under a fake module graph, then restore.
+
+    The fakes only need to exist while the target files execute — the loaded
+    classes capture their dependencies at exec time. Restoring sys.modules
+    afterwards stops the fake ``modules`` package (with an emptied ``__path__``)
+    from leaking into the collection of sibling test modules. (PRD-142 W2-S2b.)
+    """
+    _keys = (
+        "modules",
+        "modules.context",
+        "modules.context.estimator",
+        "modules.context.sections",
         "modules.context.sections.base",
-        _ROOT / "modules" / "context" / "sections" / "base.py",
     )
-)
-sys.modules["modules.context.sections.base"] = _base_mod
-_base_mod.__spec__.loader.exec_module(_base_mod)
+    _saved = {k: sys.modules.get(k) for k in _keys}
+    try:
+        # Assign fresh fake packages — never mutate a real cached package's
+        # __path__ in place (setdefault + __path__=[] would corrupt the real
+        # ``modules`` package if it was already imported).
+        for _name in ("modules", "modules.context", "modules.context.sections"):
+            _pkg = types.ModuleType(_name)
+            _pkg.__path__ = []
+            sys.modules[_name] = _pkg
+        sys.modules["modules.context.estimator"] = _estimator_stub
 
-_skills_mod = importlib.util.module_from_spec(
-    importlib.util.spec_from_file_location(
-        "modules.context.sections.skills",
-        _ROOT / "modules" / "context" / "sections" / "skills.py",
-    )
-)
-_skills_mod.__spec__.loader.exec_module(_skills_mod)
+        _base_mod = importlib.util.module_from_spec(
+            importlib.util.spec_from_file_location(
+                "modules.context.sections.base",
+                _ROOT / "modules" / "context" / "sections" / "base.py",
+            )
+        )
+        sys.modules["modules.context.sections.base"] = _base_mod
+        _base_mod.__spec__.loader.exec_module(_base_mod)
 
-SkillsSection = _skills_mod.SkillsSection
-SectionContext = _base_mod.SectionContext
+        _skills_mod = importlib.util.module_from_spec(
+            importlib.util.spec_from_file_location(
+                "modules.context.sections.skills",
+                _ROOT / "modules" / "context" / "sections" / "skills.py",
+            )
+        )
+        _skills_mod.__spec__.loader.exec_module(_skills_mod)
+
+        return _skills_mod.SkillsSection, _base_mod.SectionContext
+    finally:
+        for _k, _v in _saved.items():
+            if _v is None:
+                sys.modules.pop(_k, None)
+            else:
+                sys.modules[_k] = _v
+
+
+SkillsSection, SectionContext = _load_sections_isolated()
 
 
 # ---------------------------------------------------------------------------
@@ -77,7 +105,10 @@ def _make_ctx(agent):
 
 
 def _render(section, ctx):
-    return asyncio.get_event_loop().run_until_complete(section.render(ctx))
+    # asyncio.run() creates a fresh loop per call, so this is robust when a
+    # prior test in the same process already ran asyncio.run() (which leaves
+    # no current event loop on 3.10). get_event_loop() would raise there.
+    return asyncio.run(section.render(ctx))
 
 
 # ── Primary skill not truncated ─────────────────────────────────────

--- a/orchestrator/tests/test_tool_router_semantic.py
+++ b/orchestrator/tests/test_tool_router_semantic.py
@@ -58,6 +58,31 @@ _SNAPSHOT: Dict[str, Optional[types.ModuleType]] = {
     k: sys.modules.get(k) for k in _DISCOVERY_KEYS
 }
 
+# The low-level stubs below SHADOW real importable packages (core,
+# core.database.database, modules.tools.*, config). Left in sys.modules after
+# this module imports, they poison the collection of every sibling test that
+# imports the real ``core.*`` / ``modules.tools.*`` tree. We snapshot them
+# before install and restore at module level right after tool_router is loaded
+# (its top-level imports are already bound by then). ``config`` is read lazily
+# at runtime, so the autouse fixture re-installs it per-test. (PRD-142 W2-S2b.)
+_LOW_LEVEL_KEYS = (
+    "core",
+    "core.database",
+    "core.database.database",
+    "modules",
+    "modules.tools",
+    # _install_discovery_stubs() creates this package object via _ensure_pkg;
+    # snapshot+restore it here too so a pathless stub never leaks to siblings.
+    "modules.tools.discovery",
+    "modules.tools.registry",
+    "modules.tools.execution",
+    "modules.tools.formatting",
+    "modules.tools.formatting.result_formatter",
+    "config",
+)
+_LOW_LEVEL_SNAPSHOT: Dict[str, Optional[types.ModuleType]] = {}
+_FAKE_CONFIG_MOD: Optional[types.ModuleType] = None
+
 
 # ---------------------------------------------------------------------------
 # Fakes wired into sys.modules BEFORE we import tool_router.
@@ -78,6 +103,11 @@ def _ensure_pkg(name: str) -> types.ModuleType:
 
 
 def _install_low_level_stubs():
+    # Snapshot every key we are about to shadow BEFORE touching it, so the
+    # module-level restore can return sys.modules to its real state.
+    for _k in _LOW_LEVEL_KEYS:
+        _LOW_LEVEL_SNAPSHOT.setdefault(_k, sys.modules.get(_k))
+
     # core.database.database.SessionLocal — sync no-op factory
     _ensure_pkg("core")
     _ensure_pkg("core.database")
@@ -126,8 +156,20 @@ def _install_low_level_stubs():
 
         config_mod.config = _FakeConfig()
         sys.modules["config"] = config_mod
+    global _FAKE_CONFIG_MOD
+    _FAKE_CONFIG_MOD = sys.modules["config"]
     fake_config_cls = type(sys.modules["config"].config)
     return fake_config_cls
+
+
+def _restore_low_level_snapshot():
+    """Undo _install_low_level_stubs at module level so the leaked stubs never
+    reach the collection of sibling test modules."""
+    for _k, _prior in _LOW_LEVEL_SNAPSHOT.items():
+        if _prior is None:
+            sys.modules.pop(_k, None)
+        else:
+            sys.modules[_k] = _prior
 
 
 _FAKE_CONFIG_CLS = _install_low_level_stubs()
@@ -210,6 +252,14 @@ def _install_discovery_stubs():
     attribute that ``tool_router`` reads via
     ``from modules.tools.discovery import get_action_registry``."""
     pkg = _ensure_pkg("modules.tools.discovery")
+    # tool_router.py top-level-imports modules.tools.discovery.signal_recorder
+    # (NOT stubbed; it's leaf-loadable — stdlib-only top imports). Point the
+    # (possibly pathless) discovery package at the real dir so that real
+    # submodule resolves, while our action_registry / action_semantic_index
+    # stubs below still shadow via their explicit sys.modules entries.
+    _real_discovery_dir = str(_ORCH / "modules" / "tools" / "discovery")
+    if _real_discovery_dir not in getattr(pkg, "__path__", []):
+        pkg.__path__ = [_real_discovery_dir]
     global _PKG_ATTR_SNAPSHOT
     _PKG_ATTR_SNAPSHOT = (
         getattr(pkg, _DISCOVERY_PKG_ATTR)
@@ -257,6 +307,7 @@ def _load_tool_router():
 
 tool_router = _load_tool_router()
 _restore_discovery_snapshot()
+_restore_low_level_snapshot()
 
 
 # ---------------------------------------------------------------------------
@@ -270,6 +321,9 @@ _restore_discovery_snapshot()
 @pytest.fixture(autouse=True)
 def _swap_in_router_stubs():
     """Swap our discovery stubs in for the duration of one test."""
+    prior_config = sys.modules.get("config")
+    if _FAKE_CONFIG_MOD is not None:
+        sys.modules["config"] = _FAKE_CONFIG_MOD
     prior_ar = sys.modules.get("modules.tools.discovery.action_registry")
     prior_asi = sys.modules.get("modules.tools.discovery.action_semantic_index")
     pkg = _ensure_pkg("modules.tools.discovery")
@@ -300,6 +354,10 @@ def _swap_in_router_stubs():
                 delattr(pkg, _DISCOVERY_PKG_ATTR)
         else:
             setattr(pkg, _DISCOVERY_PKG_ATTR, prior_pkg_attr)
+        if prior_config is None:
+            sys.modules.pop("config", None)
+        else:
+            sys.modules["config"] = prior_config
         _FAKE_CONFIG_CLS.SEMANTIC_TOOL_ROUTING = False
         _FAKE_CONFIG_CLS.SEMANTIC_TOOL_ROUTING_TOP_K = 15
 

--- a/orchestrator/tests/test_unified_memory.py
+++ b/orchestrator/tests/test_unified_memory.py
@@ -52,10 +52,22 @@ _mock_config_obj.MEMORY_PROMOTION_BATCH_SIZE = 50
 
 _config_mod = types.ModuleType("config")
 _config_mod.config = _mock_config_obj
-sys.modules.setdefault("config", _config_mod)
+
+# Install the mock ``config`` for the importlib loads below, then restore so the
+# collection of sibling test modules never sees this fake (PRD-142 W2-S2b): a
+# pathless ``config`` stub left in sys.modules shadows the real config package
+# for every file collected afterwards. The loaded services import config lazily
+# inside their methods, so the autouse fixture re-installs it for each test.
+_config_snapshot = sys.modules.get("config")
+sys.modules["config"] = _config_mod
 
 _ums_mod = _load("unified_memory_service", "modules/memory/unified_memory_service.py")
 _cr_mod = _load("context_router", "modules/memory/context_router.py")
+
+if _config_snapshot is None:
+    sys.modules.pop("config", None)
+else:
+    sys.modules["config"] = _config_snapshot
 
 MemoryNamespace = _ums_mod.MemoryNamespace
 SessionMemory = _ums_mod.SessionMemory
@@ -79,10 +91,18 @@ CONV_ID = "conv-test-001"
 
 @pytest.fixture(autouse=True)
 def _reset_singleton():
-    """Reset singleton between tests."""
+    """Reset singleton + install the mock ``config`` for the duration of the test."""
+    _prev_config = sys.modules.get("config")
+    sys.modules["config"] = _config_mod
     UnifiedMemoryService._instance = None
-    yield
-    UnifiedMemoryService._instance = None
+    try:
+        yield
+    finally:
+        UnifiedMemoryService._instance = None
+        if _prev_config is None:
+            sys.modules.pop("config", None)
+        else:
+            sys.modules["config"] = _prev_config
 
 
 @pytest.fixture

--- a/orchestrator/tests/test_vector_field.py
+++ b/orchestrator/tests/test_vector_field.py
@@ -31,59 +31,81 @@ if _orchestrator_root not in sys.path:
     sys.path.insert(0, _orchestrator_root)
 
 # ---------------------------------------------------------------------------
-# Stub qdrant_client before any project module imports it.
-# This prevents ModuleNotFoundError when qdrant_client is not installed.
-# ---------------------------------------------------------------------------
-_qdrant_stub = MagicMock()
-_qdrant_stub.AsyncQdrantClient = MagicMock
-# Expose every qdrant_client.models symbol the adapter uses
-_models_stub = MagicMock()
-for _sym in ("Distance", "FieldCondition", "Filter", "MatchValue",
-             "PayloadSchemaType", "PointStruct", "VectorParams"):
-    setattr(_models_stub, _sym, MagicMock())
-_qdrant_stub.models = _models_stub
-sys.modules.setdefault("qdrant_client", _qdrant_stub)
-sys.modules.setdefault("qdrant_client.models", _models_stub)
-
-# ---------------------------------------------------------------------------
-# Import the module under test ONCE after stubs are in place.
+# Import VectorFieldSharedContext under stubbed heavy deps, then restore.
 # Monkey-patching the instance (not the constructor) avoids re-import races.
 # ---------------------------------------------------------------------------
-_fake_config_for_import = MagicMock()
-_fake_config_for_import.QDRANT_URL = "http://localhost:6333"
-_fake_config_for_import.QDRANT_API_KEY = ""
-_fake_config_for_import.FIELD_DECAY_RATE = 0.1
-_fake_config_for_import.FIELD_REINFORCE_BONUS = 0.05
-_fake_config_for_import.FIELD_REINFORCE_CAP = 2.0
-_fake_config_for_import.FIELD_ARCHIVAL_THRESHOLD = 0.05
-_fake_config_for_import.FIELD_BOUNDARY_PERMEABILITY = 1.0
-_fake_config_for_import.FIELD_EMBEDDING_DIM = 2048
+def _import_vector_field_isolated():
+    """Load VectorFieldSharedContext with qdrant_client / core.llm / core.ports
+    stubbed, then restore sys.modules.
 
-# Import the real SharedContextPort ABC BEFORE stubbing core.*
-# (vector_field.py subclasses it — MagicMock would break object.__new__)
-from core.ports.context import SharedContextPort  # noqa: E402
+    The adapter captures the real SharedContextPort base at class-definition
+    time, so the stubs can be torn down once the import completes. Restoring
+    sys.modules stops the MagicMock ``core.ports.context`` (and the qdrant /
+    core.llm stubs) from leaking into sibling modules' collection. (PRD-142
+    W2-S2b.)
+    """
+    _keys = (
+        "qdrant_client", "qdrant_client.models", "config",
+        "core.llm", "core.llm.embedding_manager", "core.ports.context",
+    )
+    _saved = {k: sys.modules.get(k) for k in _keys}
+    try:
+        _qdrant_stub = MagicMock()
+        _qdrant_stub.AsyncQdrantClient = MagicMock
+        # Expose every qdrant_client.models symbol the adapter uses
+        _models_stub = MagicMock()
+        for _sym in ("Distance", "FieldCondition", "Filter", "MatchValue",
+                     "PayloadSchemaType", "PointStruct", "VectorParams"):
+            setattr(_models_stub, _sym, MagicMock())
+        _qdrant_stub.models = _models_stub
+        sys.modules.setdefault("qdrant_client", _qdrant_stub)
+        sys.modules.setdefault("qdrant_client.models", _models_stub)
 
-# Stub heavy transitive imports so we don't need the full dep tree
-_config_mod = MagicMock()
-_config_mod.config = _fake_config_for_import
-sys.modules.setdefault("config", _config_mod)
+        _fake_config_for_import = MagicMock()
+        _fake_config_for_import.QDRANT_URL = "http://localhost:6333"
+        _fake_config_for_import.QDRANT_API_KEY = ""
+        _fake_config_for_import.FIELD_DECAY_RATE = 0.1
+        _fake_config_for_import.FIELD_REINFORCE_BONUS = 0.05
+        _fake_config_for_import.FIELD_REINFORCE_CAP = 2.0
+        _fake_config_for_import.FIELD_ARCHIVAL_THRESHOLD = 0.05
+        _fake_config_for_import.FIELD_BOUNDARY_PERMEABILITY = 1.0
+        _fake_config_for_import.FIELD_EMBEDDING_DIM = 2048
 
-# Stub core.llm chain so EmbeddingManager import doesn't pull the world
-_core_stub = MagicMock()
-sys.modules.setdefault("core.llm", _core_stub)
-sys.modules.setdefault("core.llm.embedding_manager", _core_stub)
+        # Import the real SharedContextPort ABC BEFORE stubbing core.*
+        # (vector_field.py subclasses it — MagicMock would break object.__new__)
+        from core.ports.context import SharedContextPort
 
-# Re-register the real ports module so the subclass import resolves
-_ports_ctx_mod = MagicMock()
-_ports_ctx_mod.SharedContextPort = SharedContextPort
-sys.modules["core.ports.context"] = _ports_ctx_mod
+        # Stub heavy transitive imports so we don't need the full dep tree
+        _config_mod = MagicMock()
+        _config_mod.config = _fake_config_for_import
+        sys.modules.setdefault("config", _config_mod)
 
-with (
-    patch("modules.context.adapters.vector_field.AsyncQdrantClient", return_value=MagicMock()),
-    patch("modules.context.adapters.vector_field.EmbeddingManager", return_value=MagicMock()),
-    patch("modules.context.adapters.vector_field.config", _fake_config_for_import),
-):
-    from modules.context.adapters.vector_field import VectorFieldSharedContext
+        # Stub core.llm chain so EmbeddingManager import doesn't pull the world
+        _core_stub = MagicMock()
+        sys.modules.setdefault("core.llm", _core_stub)
+        sys.modules.setdefault("core.llm.embedding_manager", _core_stub)
+
+        # Re-register a ports module exposing the real ABC so the subclass resolves
+        _ports_ctx_mod = MagicMock()
+        _ports_ctx_mod.SharedContextPort = SharedContextPort
+        sys.modules["core.ports.context"] = _ports_ctx_mod
+
+        with (
+            patch("modules.context.adapters.vector_field.AsyncQdrantClient", return_value=MagicMock()),
+            patch("modules.context.adapters.vector_field.EmbeddingManager", return_value=MagicMock()),
+            patch("modules.context.adapters.vector_field.config", _fake_config_for_import),
+        ):
+            from modules.context.adapters.vector_field import VectorFieldSharedContext
+        return VectorFieldSharedContext
+    finally:
+        for _k, _v in _saved.items():
+            if _v is None:
+                sys.modules.pop(_k, None)
+            else:
+                sys.modules[_k] = _v
+
+
+VectorFieldSharedContext = _import_vector_field_isolated()
 
 # ---------------------------------------------------------------------------
 # Fixtures & helpers


### PR DESCRIPTION
…lection

Module-level sys.modules monkeypatches leaked fake/pathless packages into the collection of sibling test modules — the 38 pre-existing collection errors that kept `pytest tests/` at exit 2. Convert them to snapshot/restore around the import block, plus an autouse runtime-stub fixture where the module under test imports stubs lazily at call time.

- Camp-1 (snapshot/restore around import) for files whose under-test classes bind deps at exec time: deliverables_api, exec_workspace_deliverable, vector_field, prd139_telemetry, eval_graph_mode, tool_router_semantic, unified_memory.
- Camp-2 (import-time load + autouse runtime fixture) for files whose target imports stubs lazily at render/call time: platform_actions_section(_graph), identity_section (consumers.chatbot.personality), action_semantic_index (setup_module/teardown_module for core.llm/core.cache).
- Auth-stub files (agents_api_plugins, plugin_assignment_api): drop the jwt/clerk stubs once the API module has bound its symbols, so a pathless core.auth.* stub no longer shadows the real submodule downstream.
- Rename the dead recipe scheduler test to playbook scheduler (services .recipe_scheduler -> services.playbook_scheduler); conftest fixtures mock_recipe -> mock_playbook.
- Make identity/skills section tests order-independent: the deprecated asyncio.get_event_loop().run_until_complete() raised once any prior test in the process had called asyncio.run(); switch to asyncio.run().

Full per-file leak sweep is CLEAN across 97 files. The remaining runtime failures the now-collectable net surfaces (vector_field, agent/plugin API assertions) are pre-existing and identical at baseline — out of scope for W2-S2b, left for the WS-G/H/I gap-closing workstreams.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation and stability across the test suite by enhancing dependency management between test modules, preventing cross-test contamination
  * Strengthened test infrastructure to ensure more reliable and deterministic test execution through improved setup and teardown procedures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->