### PR TITLE
PRD-142 WS-G: real-DB gap regressions + fail-closed authz gate

### DIFF
--- a/orchestrator/modules/tools/discovery/platform_executor.py
+++ b/orchestrator/modules/tools/discovery/platform_executor.py
@@ -549,15 +549,39 @@ class PlatformActionExecutor:
                 except (TypeError, ValueError):
                     target_id = target_id_raw  # leave string IDs alone (UUIDs etc.)
 
-                decision = can_actor_modify(
-                    self.db,
-                    actor_agent_id=actor_id,
-                    target_type=target_type,
-                    workspace_id=self.workspace_id,
-                    target_id=target_id,
-                    change_type="update" if action_def.permission_level == "write" else "delete",
-                    source="platform_tool",
-                )
+                try:
+                    decision = can_actor_modify(
+                        self.db,
+                        actor_agent_id=actor_id,
+                        target_type=target_type,
+                        workspace_id=self.workspace_id,
+                        target_id=target_id,
+                        change_type="update" if action_def.permission_level == "write" else "delete",
+                        source="platform_tool",
+                    )
+                except Exception as e:
+                    # Fail closed: a permission check that errors must DENY, never
+                    # fall through to execution. can_actor_modify's DB probes
+                    # (_agent_row / _reports_to_id) aren't all savepoint-guarded,
+                    # so a transient DB error would otherwise raise out of the gate
+                    # and leave the write's fate to upstream handling. Deny locally
+                    # and escalate to Auto — mirrors the registry-lookup fail-closed
+                    # above.
+                    logger.warning(
+                        "[PlatformExecutor] hierarchy_check_failed action=%s actor=%s "
+                        "target=%s/%s err=%s — denying (fail-closed)",
+                        action_name, actor_id, target_type, target_id, e,
+                    )
+                    return {
+                        "success": False,
+                        "permission_denied": True,
+                        "reason": "permission_check_failed",
+                        "escalation_target": "auto",
+                        "error": (
+                            f"Action '{action_name}' denied — permission check could not be "
+                            "completed. Route this through the auto for arbitration."
+                        ),
+                    }
                 if not decision.allowed:
                     logger.warning(
                         "[PlatformExecutor] hierarchy_denied action=%s actor=%s target=%s/%s reason=%s",

--- a/orchestrator/modules/tools/execution/unified_executor.py
+++ b/orchestrator/modules/tools/execution/unified_executor.py
@@ -16,7 +16,7 @@ modules/tools/execution/exec_*.py for maintainability.
 
 import logging
 import time as _time
-from typing import Dict, Any, Optional, Tuple
+from typing import Dict, Any, Optional
 from uuid import UUID
 from sqlalchemy.orm import Session
 
@@ -39,18 +39,6 @@ from modules.tools.execution.telemetry import fire_telemetry
 # PRD-36: Composio Integration (lazy import to avoid startup overhead)
 _composio_executor = None
 
-# PRD-37: Capability-based validation (lazy import)
-_capability_filter = None
-
-
-def _get_capability_filter(db):
-    """Lazy import of capability filter for execution-time validation."""
-    global _capability_filter
-    try:
-        from modules.tools.services.action_capability_filter import ActionCapabilityFilter
-        return ActionCapabilityFilter(db)
-    except ImportError:
-        return None
 
 def _get_composio_executor(db):
     """Lazy import of Composio executor."""
@@ -185,13 +173,6 @@ class UnifiedToolExecutor:
         return self._composio_executor
 
     @property
-    def capability_filter(self):
-        """Lazy-load capability filter (PRD-37) for execution-time validation."""
-        if not hasattr(self, '_capability_filter') or self._capability_filter is None:
-            self._capability_filter = _get_capability_filter(self.db)
-        return self._capability_filter
-
-    @property
     def platform_tools(self):
         """Lazy-load platform tools (RAG, CodeGraph) only when needed."""
         if self._platform_tools is None:
@@ -214,99 +195,6 @@ class UnifiedToolExecutor:
             from modules.tools.registry import get_tool_registry
             self._tool_registry = get_tool_registry(self.db)
         return self._tool_registry
-
-    # ------------------------------------------------------------------
-    # Validation
-    # ------------------------------------------------------------------
-
-    def validate_composio_action(
-        self,
-        action_id: str,
-        original_intent: Optional[str] = None,
-        allow_destructive: bool = False
-    ) -> Tuple[bool, str]:
-        """
-        PRD-37: Validate that a Composio action is eligible for execution.
-
-        This is the EXECUTION-TIME validation gate (per GPT-5.2 recommendation).
-        Called before executing any Composio action to ensure the action
-        matches the original intent's capabilities.
-
-        Args:
-            action_id: The Composio action ID to validate
-            original_intent: The original user intent (optional)
-            allow_destructive: Whether destructive actions are allowed
-
-        Returns:
-            (eligible, reason) tuple
-        """
-        if not self.capability_filter:
-            # Fail open if capability filter not available
-            logger.debug("Capability filter not available, skipping validation")
-            return True, "Capability filter not available (fail open)"
-
-        if not original_intent:
-            # If no intent provided, can't validate - allow by default
-            return True, "No intent provided for validation"
-
-        try:
-            eligible, reason = self.capability_filter.check_action_eligibility(
-                action_id=action_id,
-                intent=original_intent,
-                allow_destructive=allow_destructive
-            )
-
-            if not eligible:
-                logger.warning(
-                    f"Action validation failed: action={action_id} "
-                    f"intent='{original_intent[:30]}...' reason={reason}"
-                )
-
-            return eligible, reason
-
-        except Exception as e:
-            logger.error(f"Action validation error: {e}")
-            # Fail open on errors to avoid blocking legitimate actions
-            return True, f"Validation error (fail open): {e}"
-
-    def _check_agent_permission(self, agent_id: int, tool_name: str) -> bool:
-        """
-        PRD-17: Check if agent has permission to use this tool.
-
-        Args:
-            agent_id: Agent ID
-            tool_name: Tool name
-
-        Returns:
-            True if allowed, False otherwise
-        """
-        # For now, research tools are always allowed
-        # File ops and shell require explicit permission via AgentToolPermission table
-        research_tools = ['search_knowledge', 'semantic_search', 'search_codebase']
-        if tool_name in research_tools:
-            return True
-
-        # Check AgentToolPermission table for other tools
-        from core.models.tools import AgentToolPermission, Tool
-
-        try:
-            # Find tool in tools table
-            tool = self.db.query(Tool).filter_by(name=tool_name).first()
-            if not tool:
-                logger.warning(f"Tool '{tool_name}' not found in tools table")
-                return False  # Unknown tools not allowed
-
-            # Check if agent has permission
-            permission = self.db.query(AgentToolPermission).filter_by(
-                agent_id=agent_id,
-                tool_id=tool.id,
-                is_active=True
-            ).first()
-
-            return permission is not None
-        except Exception as e:
-            logger.warning(f"Error checking permissions for tool '{tool_name}': {e}")
-            return True  # Default to allow (fail open for now)
 
     # ------------------------------------------------------------------
     # Main dispatch

--- a/orchestrator/tests/security/test_w2s7_fail_closed_authz_gate.py
+++ b/orchestrator/tests/security/test_w2s7_fail_closed_authz_gate.py
@@ -1,0 +1,104 @@
+"""W2-S7 / G3 — fail-closed regression for the platform-write authz gate.
+
+PRD-142 Wave 2 (Test Net). ``PlatformActionExecutor.execute`` gates every
+write/destructive platform action on ``can_actor_modify`` (the PRD-140 hierarchy
+chokepoint). That helper's DB probes (``_agent_row`` / ``_reports_to_id``) are
+not all savepoint-guarded, so a transient DB error mid-check raises *out of* the
+helper. Before the gate was hardened the raise propagated past the executor and
+the write's fate was decided by whatever caught it upstream — a fail-OPEN risk.
+
+These tests pin the fail-CLOSED contract at the gate:
+
+  * a permission check that **raises** must deny locally — ``permission_denied``
+    with reason ``permission_check_failed`` — never fall through to the handler;
+  * the ordinary **explicit-deny** path (``decision.allowed is False``) stays
+    intact and reports the *decision's own* reason, distinct from the error path;
+  * an **allow** decision still flows through the gate to the handler — the
+    fail-closed wrap must not turn legitimate writes into denials.
+
+Pure unit tests: ``can_actor_modify`` is patched (raise / deny / allow), so no
+DB is touched and the failure injection is deterministic. ``platform_update_agent``
+is the gated action under test — it is in ``_HIERARCHY_TARGETS`` and is
+``permission_level="write"``, ``requires_confirmation=False``, so it reaches the
+gate without confirmation/admin short-circuits.
+"""
+from __future__ import annotations
+
+import importlib.util as _ilu
+import sys as _sys
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# Lean-venv shim: importing any modules.tools submodule runs modules/tools/__init__.py,
+# which eagerly pulls modules.rag (camelot + sentence_transformers PDF/ML ingestion) —
+# wholly unrelated to the authz gate under test. Those are declared deps installed in
+# CI (requirements.txt: camelot-py, opencv-python-headless); when absent from a lean
+# local venv they break collection. Stub the package only when the heavy stack is
+# missing (camelot is the proxy) — a no-op in CI where the real stack is present.
+if _ilu.find_spec("camelot") is None:  # pragma: no cover - env-dependent
+    _sys.modules.setdefault("modules.rag", MagicMock())
+
+from core.security.hierarchy_permissions import PermissionDecision
+import modules.tools.discovery.platform_executor as pe
+from modules.tools.discovery.platform_executor import PlatformActionExecutor
+
+pytestmark = pytest.mark.asyncio
+
+# A write action that IS in _HIERARCHY_TARGETS and reaches the gate.
+_GATED_ACTION = "platform_update_agent"
+_PARAMS = {"agent_id": 5, "_agent_id": 3}
+# Owner role neutralises the US-003 admin gate deterministically, regardless of
+# whether the action's admin_only flag defaults differently in future.
+_CALLER = {"workspace_role": "owner"}
+
+
+def _executor() -> PlatformActionExecutor:
+    # db is a MagicMock: can_actor_modify is patched so the gate never queries it,
+    # and on the deny/raise paths the real handler is never reached.
+    return PlatformActionExecutor(MagicMock(), uuid.uuid4())
+
+
+async def test_permission_check_raise_denies_fail_closed():
+    """A permission check that RAISES must deny locally, not propagate or allow."""
+    with patch.object(
+        pe, "can_actor_modify", side_effect=RuntimeError("db connection lost mid-check")
+    ) as cam:
+        result = await _executor().execute(_GATED_ACTION, dict(_PARAMS), _CALLER)
+
+    cam.assert_called_once()  # proves we reached the gate, not an earlier return
+    assert result["success"] is False
+    assert result.get("permission_denied") is True
+    assert result.get("reason") == "permission_check_failed"
+    assert result.get("escalation_target") == "auto"
+
+
+async def test_explicit_deny_still_denies_with_its_own_reason():
+    """The ordinary deny path stays intact and is distinct from the error path."""
+    deny = PermissionDecision(
+        allowed=False, reason="out_of_subtree", escalation_target="auto"
+    )
+    with patch.object(pe, "can_actor_modify", return_value=deny):
+        result = await _executor().execute(_GATED_ACTION, dict(_PARAMS), _CALLER)
+
+    assert result["success"] is False
+    assert result.get("permission_denied") is True
+    # The decision's own reason flows through — NOT the error-path sentinel.
+    assert result.get("reason") == "out_of_subtree"
+
+
+async def test_allow_decision_passes_the_gate():
+    """An allow decision must reach the handler — the wrap must not over-deny."""
+    allow = PermissionDecision(allowed=True, reason="subtree_authority")
+    ex = _executor()
+    sentinel = {"success": True, "_sentinel": "handler-ran"}
+    ex._handlers[_GATED_ACTION] = AsyncMock(return_value=sentinel)
+
+    with patch.object(pe, "can_actor_modify", return_value=allow), patch(
+        "core.security.rate_limiter.check_rate_limit", new=AsyncMock(return_value=None)
+    ):
+        result = await ex.execute(_GATED_ACTION, dict(_PARAMS), _CALLER)
+
+    assert result == sentinel
+    assert result.get("permission_denied") is not True

--- a/orchestrator/tests/security/test_w2s7_fail_closed_authz_gate.py
+++ b/orchestrator/tests/security/test_w2s7_fail_closed_authz_gate.py
@@ -36,8 +36,22 @@ import pytest
 # wholly unrelated to the authz gate under test. Those are declared deps installed in
 # CI (requirements.txt: camelot-py, opencv-python-headless); when absent from a lean
 # local venv they break collection. Stub the package only when the heavy stack is
-# missing (camelot is the proxy) — a no-op in CI where the real stack is present.
-if _ilu.find_spec("camelot") is None:  # pragma: no cover - env-dependent
+# genuinely unlocatable — a no-op in CI where the real stack is present.
+#
+# Probe defensively. A sibling module (tests/test_l3_distill_input.py) seeds a bare
+# ``types.ModuleType("camelot")`` into ``sys.modules`` to dodge the same heavy import.
+# That stub's ``__spec__`` is ``None``, and ``find_spec`` *raises*
+# ``ValueError: camelot.__spec__ is None`` on a spec-less cached module rather than
+# returning it. Treat both "raised" and "found" as "import chain already satisfied"
+# (real dep or sibling stub) and skip our shim; only stub when camelot is truly absent.
+def _rag_chain_unlocatable() -> bool:  # pragma: no cover - env-dependent
+    try:
+        return _ilu.find_spec("camelot") is None
+    except ValueError:
+        return False  # spec-less camelot stub already present → chain satisfied
+
+
+if _rag_chain_unlocatable():  # pragma: no cover - env-dependent
     _sys.modules.setdefault("modules.rag", MagicMock())
 
 from core.security.hierarchy_permissions import PermissionDecision

--- a/orchestrator/tests/test_w2s5_idle_in_tx_realdb.py
+++ b/orchestrator/tests/test_w2s5_idle_in_tx_realdb.py
@@ -1,0 +1,184 @@
+"""PRD-142 Wave 2 · WS-G · W2-S5 — G1: real-DB idle-in-transaction regression.
+
+W1-S9 (PRD-142 Wave 1) fixed the connection leak where a long-lived session
+issues a SELECT — the documented 9-hour idle SELECT on ``agents`` (PRD-135) —
+and then sits ``idle in transaction`` across a long ``await`` (an LLM call or an
+``asyncio.gather`` of agent coroutines), holding row locks and blocking DDL.
+
+The structural fix is ``end_open_transaction(db)`` — a ``commit`` that ends the
+open transaction — called immediately before each such await on the four hot
+surfaces, plus a ``rollback`` in ``get_db``'s ``finally`` so a request handler
+never returns a connection to the pool still ``idle in transaction``.
+
+W1-S9's own tests proved the *ordering* (select < commit < await) with recording
+fakes — no real database. They could not prove that a real Postgres backend
+actually ends up ``idle in transaction`` after the read, nor that the commit
+actually clears it. **This is that missing real-DB regression.** It connects to
+the real test Postgres, hydrates an ``Agent`` (the documented SELECT-on-agents),
+and reads the subject backend's ``state`` from ``pg_stat_activity`` via a
+*second* connection.
+
+Revert guard (the AC): ``test_end_open_transaction_clears_idle_in_tx_across_await``
+**fails** if ``end_open_transaction`` is reverted to a no-op (or removed from the
+hot surfaces) — the post-commit state stays ``idle in transaction`` across the
+await and the final assert trips.
+
+Marked ``integration``: it needs a live Postgres (the CI ``test.yml`` service,
+or a local one). When no database is reachable the module *skips* — it never
+turns the fast, DB-less mock suite red.
+"""
+import asyncio
+import os
+
+import pytest
+from sqlalchemy import text
+
+# Importing core.database.database builds the SQLAlchemy engine at module load,
+# which needs POSTGRES_* creds. setdefault means a real .env / CI service env
+# still wins; this only covers a bare shell so the import doesn't crash before
+# the skip-guard below can run.
+for _k, _v in {
+    "POSTGRES_USER": "test",
+    "POSTGRES_PASSWORD": "test",
+    "POSTGRES_HOST": "127.0.0.1",
+    "POSTGRES_PORT": "5432",
+    "POSTGRES_DB": "test_db",
+}.items():
+    os.environ.setdefault(_k, _v)
+
+from core.database.database import (  # noqa: E402
+    SessionLocal,
+    end_open_transaction,
+    engine,
+    get_db,
+)
+from core.models.core import Agent  # noqa: E402
+
+pytestmark = pytest.mark.integration
+
+IDLE_IN_TX = "idle in transaction"
+
+
+@pytest.fixture(scope="module")
+def live_db():
+    """Skip the whole module unless the real Postgres engine is reachable.
+
+    Keeps the fast, DB-less local run green (skip, not error) while running for
+    real against the CI Postgres service.
+    """
+    try:
+        with engine.connect() as conn:
+            conn.execute(text("SELECT 1"))
+    except Exception as exc:  # OperationalError and friends
+        pytest.skip(f"no reachable Postgres for integration test: {exc}")
+    return engine
+
+
+@pytest.fixture
+def observer(live_db):
+    """A second, independent connection used only to read ``pg_stat_activity``.
+
+    AUTOCOMMIT so each read sees live backend state and the observer never holds
+    a transaction of its own (which would itself show as idle-in-tx). It is a
+    different pooled backend from the subject session, so it can watch the
+    subject's state without perturbing it.
+    """
+    conn = live_db.connect().execution_options(isolation_level="AUTOCOMMIT")
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+def _backend_state(observer_conn, pid):
+    """The ``pg_stat_activity.state`` of backend ``pid`` (None if it is gone)."""
+    return observer_conn.execute(
+        text("SELECT state FROM pg_stat_activity WHERE pid = :pid"),
+        {"pid": pid},
+    ).scalar()
+
+
+def _hydrate_agent_and_pid(db):
+    """Reproduce the hot-surface read: capture the backend pid, then hydrate an
+    ``Agent`` (the documented SELECT-on-agents). The first statement opens the
+    transaction; ``.first()`` runs inside it. Returns the backend pid.
+
+    ``.first()`` may be ``None`` on an empty table — the transaction opens either
+    way, which is all the leak needs.
+    """
+    pid = db.execute(text("SELECT pg_backend_pid()")).scalar()
+    db.query(Agent).first()
+    return pid
+
+
+# ── The leak precondition (proves the regression has teeth) ──────────────────
+
+def test_agents_select_leaves_backend_idle_in_tx(observer):
+    """A hydrate-Agent read really does leave the backend ``idle in transaction``.
+
+    This is the condition the W1-S9 fix exists to clear. Asserting it explicitly
+    on real Postgres stops the fix tests below from passing vacuously if the
+    transaction semantics ever change.
+    """
+    db = SessionLocal()
+    try:
+        pid = _hydrate_agent_and_pid(db)
+        assert _backend_state(observer, pid) == IDLE_IN_TX
+    finally:
+        db.rollback()
+        db.close()
+
+
+# ── The fix clears it across the await (the revert guard) ────────────────────
+
+@pytest.mark.asyncio
+async def test_end_open_transaction_clears_idle_in_tx_across_await(observer):
+    """``end_open_transaction`` must leave the backend ``idle`` — not idle-in-tx —
+    for the duration of the long await it precedes.
+
+    Revert guard: if ``end_open_transaction`` is reverted to a no-op (or removed
+    from the hot surfaces), the backend stays ``idle in transaction`` across the
+    await and the final assert fails. This is the real-DB proof W1-S9 lacked.
+    """
+    db = SessionLocal()
+    try:
+        pid = _hydrate_agent_and_pid(db)
+        assert _backend_state(observer, pid) == IDLE_IN_TX  # the leak, pre-commit
+
+        end_open_transaction(db)  # THE FIX: commit ends the open transaction
+
+        await asyncio.sleep(0.05)  # the long await the connection used to span
+
+        state = _backend_state(observer, pid)
+        assert state == "idle", f"expected backend 'idle' after commit, got {state!r}"
+    finally:
+        db.close()
+
+
+# ── get_db returns a clean connection to the pool ────────────────────────────
+
+def test_get_db_request_does_not_leak_idle_in_tx(observer):
+    """A ``get_db`` request that reads data must not return its connection to the
+    pool ``idle in transaction``.
+
+    Drives the real ``get_db`` generator: a handler hydrates an Agent (opening a
+    transaction), then request teardown runs ``get_db``'s ``finally`` (rollback +
+    close). Asserts the production invariant that the backend ends not-idle-in-tx.
+
+    (``get_db``'s explicit rollback and the QueuePool's reset-on-return are
+    belt-and-suspenders here, so this locks the end-to-end request invariant
+    rather than that single line; the strong revert guard for the commit
+    mechanism is the test above.)
+    """
+    gen = get_db()
+    db = next(gen)
+    pid = _hydrate_agent_and_pid(db)
+    assert _backend_state(observer, pid) == IDLE_IN_TX  # handler left a tx open
+
+    # Finish the request: exhausting the generator runs `finally: rollback/close`.
+    try:
+        next(gen)
+    except StopIteration:
+        pass
+
+    assert _backend_state(observer, pid) != IDLE_IN_TX

--- a/orchestrator/tests/test_w2s6_restart_recovery_realdb.py
+++ b/orchestrator/tests/test_w2s6_restart_recovery_realdb.py
@@ -1,0 +1,201 @@
+"""PRD-142 Wave 2 · WS-G · W2-S6 — G4: real-DB restart-recovery durability.
+
+When the orchestrator restarts, any in-flight row whose background ``asyncio``
+executor died with the old process is stranded forever — a board task stuck
+``in_progress``, a wizard profile stuck ``scraping``, a workflow execution stuck
+``running``. W1-S6 added ``reap_orphaned_runs`` to sweep those three surfaces on
+boot and move each stale orphan to its surface's terminal state.
+
+W1-S6's own tests prove the *contract* against a fake Session — query returns
+seeded rows, staleness is filtered in Python, mutations are asserted on
+``SimpleNamespace`` objects. They never touch Postgres, so they cannot prove the
+mutations actually **persist**: that a real backend ends up terminal after the
+reaper's single end-of-sweep ``commit``, and that a freshly-started job survives.
+**This is that missing real-DB durability regression.** It commits genuine
+orphan rows (the state a crash leaves behind), runs the real reaper, and re-reads
+the rows from Postgres to confirm the terminal transition stuck.
+
+Revert guard (the AC): ``test_reaper_marks_stale_orphans_terminal`` **fails** if
+``reap_orphaned_runs`` is reverted to a no-op or dropped from boot — the rows
+stay in-flight and every terminal assertion trips.
+
+SAFETY — this is the rare test that WRITES AND COMMITS. The transactional
+rollback fixture (root ``conftest.py``) cannot undo a commit, so this test
+deletes exactly the rows it created. To make a stray commit against production
+impossible, the module *skips* unless the engine points at a local, disposable
+test database (CI's Postgres service, or a developer's local ``test_db``); it
+never runs against Railway. Marked ``integration`` so it joins the live-DB job.
+"""
+import os
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.orm import sessionmaker
+
+# Importing core.database.database builds the engine at module load, which needs
+# POSTGRES_* creds. setdefault means a real .env / CI service env still wins;
+# this only covers a bare shell so the import doesn't crash before the
+# ephemeral-DB guard can skip. The defaults are themselves ephemeral-safe.
+for _k, _v in {
+    "POSTGRES_USER": "test",
+    "POSTGRES_PASSWORD": "test",
+    "POSTGRES_HOST": "127.0.0.1",
+    "POSTGRES_PORT": "5432",
+    "POSTGRES_DB": "test_db",
+}.items():
+    os.environ.setdefault(_k, _v)
+
+import core.boot.reaper as reaper  # noqa: E402
+from core.database.database import engine  # noqa: E402
+from core.models.business_profiles import BusinessProfile  # noqa: E402
+from core.models.core import BoardTask, WorkflowExecution  # noqa: E402
+from core.models.workspaces import Workspace  # noqa: E402
+
+pytestmark = pytest.mark.integration
+
+_ORPHAN = "orphaned_on_restart"  # core.boot.reaper._ORPHAN_REASON
+_EPHEMERAL_HOSTS = {"localhost", "127.0.0.1", "::1"}
+_EPHEMERAL_DBS = {"test_db", "test"}
+
+
+def _is_ephemeral(url) -> bool:
+    """True only for a local, disposable test database — never production.
+
+    create_engine is lazy, so reading ``engine.url`` resolves the configured
+    target WITHOUT connecting. We gate on it before opening any connection, so a
+    Railway URL is rejected without a single byte sent to it.
+    """
+    return (
+        (url.host or "").lower() in _EPHEMERAL_HOSTS
+        and (url.database or "").lower() in _EPHEMERAL_DBS
+    )
+
+
+@pytest.fixture(scope="module")
+def safe_engine():
+    """Refuse to run this WRITE+COMMIT test against anything but an ephemeral DB."""
+    if not _is_ephemeral(engine.url):
+        pytest.skip(
+            "refusing to run the destructive reaper test against a non-ephemeral "
+            f"database ({engine.url.host}/{engine.url.database}); needs a local "
+            "test_db / test"
+        )
+    try:
+        with engine.connect() as conn:
+            conn.execute(text("SELECT 1"))
+    except Exception as exc:  # OperationalError and friends
+        pytest.skip(f"no reachable Postgres for integration test: {exc}")
+    return engine
+
+
+@pytest.fixture
+def seed(safe_engine, monkeypatch):
+    """Commit one stale + one fresh orphan on each of the reaper's three surfaces.
+
+    Stale rows are timestamped well past the staleness cutoff (driven by the live
+    ``BOOT_REAPER_STALE_MINUTES`` so the test tracks the real boundary); fresh
+    rows sit just inside it. Yields a namespace of row ids; tears down by deleting
+    exactly those rows (a commit can't be rolled back).
+    """
+    # Telemetry isn't what G4 proves — W1-S6 covers the record_error fan-out — and
+    # letting it write would couple this test to the error_events schema. Stub it.
+    monkeypatch.setattr(reaper, "record_error", MagicMock())
+    # The sweep must run regardless of the ambient BOOT_REAPER_ENABLED env; the
+    # disabled short-circuit is covered by W1-S6's mock suite.
+    monkeypatch.setattr(reaper.config, "BOOT_REAPER_ENABLED", True)
+
+    stale_min = reaper.config.BOOT_REAPER_STALE_MINUTES
+    now = datetime.now(timezone.utc)
+    old = now - timedelta(minutes=stale_min + 60)   # comfortably past the cutoff
+    fresh = now - timedelta(seconds=1)              # comfortably inside the window
+    old_naive = old.replace(tzinfo=None)            # workflow_executions.started_at is tz-naive
+    fresh_naive = fresh.replace(tzinfo=None)
+
+    db = sessionmaker(bind=safe_engine)()
+    ws = Workspace(id=uuid4(), name="w2s6-reaper-test")
+    db.add(ws)
+    db.flush()  # materialise ws.id for the child FKs
+
+    rows = {
+        "board_stale": BoardTask(workspace_id=ws.id, title="stale", status="in_progress", started_at=old),
+        "board_fresh": BoardTask(workspace_id=ws.id, title="fresh", status="in_progress", started_at=fresh),
+        "prof_stale": BusinessProfile(workspace_id=ws.id, domain="stale.example", status="scraping", updated_at=old),
+        "prof_fresh": BusinessProfile(workspace_id=ws.id, domain="fresh.example", status="scraping", updated_at=fresh),
+        "wfe_stale": WorkflowExecution(workspace_id=ws.id, status="running", started_at=old_naive),
+        "wfe_fresh": WorkflowExecution(workspace_id=ws.id, status="running", started_at=fresh_naive),
+    }
+    db.add_all(rows.values())
+    db.commit()  # the durable state a crash leaves behind
+
+    ns = SimpleNamespace(db=db, now=now, ws_id=ws.id, **{k: v.id for k, v in rows.items()})
+    try:
+        yield ns
+    finally:
+        db.rollback()  # drop any partial tx before the deletes
+        for model, ids in (
+            (BoardTask, [ns.board_stale, ns.board_fresh]),
+            (BusinessProfile, [ns.prof_stale, ns.prof_fresh]),
+            (WorkflowExecution, [ns.wfe_stale, ns.wfe_fresh]),
+        ):
+            db.query(model).filter(model.id.in_(ids)).delete(synchronize_session=False)
+        db.query(Workspace).filter(Workspace.id == ns.ws_id).delete(synchronize_session=False)
+        db.commit()
+        db.close()
+
+
+# ── The leak precondition (proves the regression has teeth) ──────────────────
+
+def test_orphaned_rows_persist_in_flight_until_reaped(seed):
+    """A crash leaves these rows committed and in-flight — the state the reaper
+    exists to clean. Asserting it on real Postgres stops the durability test below
+    from passing vacuously if seeding ever breaks."""
+    db = seed.db
+    assert db.get(BoardTask, seed.board_stale).status == "in_progress"
+    assert db.get(BusinessProfile, seed.prof_stale).status == "scraping"
+    assert db.get(WorkflowExecution, seed.wfe_stale).status == "running"
+
+
+# ── The fix moves stale orphans terminal, and it persists (the revert guard) ──
+
+def test_reaper_marks_stale_orphans_terminal(seed):
+    """Each stale orphan must be committed to its surface's terminal state.
+
+    Revert guard: if ``reap_orphaned_runs`` is reverted to a no-op or removed from
+    boot, the rows stay in_progress/scraping/running and every assertion trips.
+    Re-reading via ``db.get`` after the reaper's commit proves the write persisted,
+    not merely that an in-memory attribute was set — the real-DB proof W1-S6 lacked.
+    """
+    db = seed.db
+    reaped = reaper.reap_orphaned_runs(db, now=seed.now)
+    assert reaped >= 3  # at least our three stale rows (other test data may add more)
+
+    board = db.get(BoardTask, seed.board_stale)
+    assert board.status == "done"  # the board's own failure convention (no 'failed' column)
+    assert board.completed_at is not None
+    assert _ORPHAN in (board.error_message or "")
+
+    prof = db.get(BusinessProfile, seed.prof_stale)
+    assert prof.status == "failed"
+    assert _ORPHAN in str(prof.quality_findings)
+
+    wfe = db.get(WorkflowExecution, seed.wfe_stale)
+    assert wfe.status == "failed"
+    assert wfe.completed_at is not None
+    assert _ORPHAN in (wfe.error_message or "")
+
+
+# ── The staleness gate holds on real Postgres (no premature reaping) ──────────
+
+def test_reaper_leaves_fresh_runs_untouched(seed):
+    """A job that started moments ago is still legitimately running and must
+    survive the sweep — the reaper must not kill live work."""
+    db = seed.db
+    reaper.reap_orphaned_runs(db, now=seed.now)
+
+    assert db.get(BoardTask, seed.board_fresh).status == "in_progress"
+    assert db.get(BusinessProfile, seed.prof_fresh).status == "scraping"
+    assert db.get(WorkflowExecution, seed.wfe_fresh).status == "running"


### PR DESCRIPTION
## Summary

PRD-142 Wave 2 (Test Net) — work stream **WS-G**: three gap regressions that pin behaviours we had no test coverage for, plus one production hardening fix surfaced while building G3.

- **G1 (W2-S5) — idle-in-tx regression** (`tests/test_w2s5_idle_in_tx_realdb.py`): real-DB regression proving long-lived idle transactions don't strand connections / block DDL.
- **G4 (W2-S6) — restart-recovery durability** (`tests/test_w2s6_restart_recovery_realdb.py`): real-DB regression for the boot reaper — orphaned in-flight rows (board/wizard/workflow) persist until reaped, stale orphans are marked terminal, fresh runs are left untouched. Self-seeds + deletes its own rows behind a hard ephemeral-DB guard (never touches a non-test DB).
- **G3 (W2-S7) — fail-closed platform-write authz gate** (`tests/security/test_w2s7_fail_closed_authz_gate.py` + production fix):
  - **Fix:** the hierarchy gate in `PlatformActionExecutor.execute` calls `can_actor_modify`, whose DB probes (`_agent_row` / `_reports_to_id`) aren't all savepoint-guarded — a transient DB error mid-check raised *out of* the gate, leaving the write's fate to upstream handling (fail-open risk). Now wrapped to **fail closed** locally (`permission_denied` + escalate to Auto), mirroring the registry-lookup fail-closed already in that method.
  - **Cleanup:** deleted two genuinely fail-open, **zero-caller** functions — `validate_composio_action` and `_check_agent_permission` in `unified_executor.py` — plus their orphaned `capability_filter` plumbing and an unused import. The live capability-filter path (`tool_router` → `action_capability_filter`) is untouched.

## Test plan

- [x] G3 unit suite GREEN (3/3): induced check-error → deny, explicit-deny intact, allow passes the gate
- [x] G3 RED-verified: removing the fail-closed wrap makes the raise propagate (test fails)
- [x] `tests/security/` suite: 94 passed (25 hierarchy + 3 G3 + rest)
- [x] G1/G4 collect clean; both verified GREEN against ephemeral Postgres in prior runs
- [x] Independent security review: PASS, no holes
- [ ] CI green on real-DB integration tests (G1/G4 require Postgres + camelot/RAG stack, present in CI)

## Notes

- G1/G4 are `pytest.mark.integration` (real ephemeral Postgres). G3 is a pure unit test with `can_actor_modify` patched.
- `test_w2s7` carries a CI-safe shim that stubs `modules.rag` only when `camelot` is absent (lean local venv) — a no-op in CI where `camelot-py` is installed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved permission check error handling—actions now fail securely with clear error messages when permission verification encounters issues, preventing unexpected action execution.

* **Chores**
  * Added comprehensive security and database recovery integration tests to strengthen system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->