### PR TITLE
test(prd-142): finish greening the orchestrator suite for the CI gate

### DIFF
--- a/orchestrator/tests/services/test_deliverable_service.py
+++ b/orchestrator/tests/services/test_deliverable_service.py
@@ -25,6 +25,7 @@ from services.deliverable_service import (
     _infer_artifact_type,
     _humanize_basename,
     _slugify,
+    _workspace_file_url,
 )
 
 
@@ -358,7 +359,13 @@ class TestGetDeliverable:
 
         assert out["success"] is True
         assert out["deliverable"]["content"] is None
-        assert out["deliverable"]["content_url"] == "https://cdn/q3.png"
+        # content_url is recomputed fresh from the workspace path (not echoed
+        # from the row's stored preview_url) — older rows had stale preview_url
+        # pointing at /files/content (JSON), so the service always rebuilds the
+        # binary /files/raw URL for images.
+        assert out["deliverable"]["content_url"] == _workspace_file_url(
+            WORKSPACE_ID, "charts/q3.png"
+        )
 
     @pytest.mark.asyncio
     async def test_get_read_file_failure_sets_content_error(self):

--- a/orchestrator/tests/test_82c_wiring.py
+++ b/orchestrator/tests/test_82c_wiring.py
@@ -33,6 +33,7 @@ _orchestrator_root = str(Path(__file__).resolve().parent.parent)
 if _orchestrator_root not in sys.path:
     sys.path.insert(0, _orchestrator_root)
 
+from config import COMPLEXITY_TOKEN_BUDGET
 from core.models.orchestration_enums import (
     BudgetStatus,
     ComplexityTier,
@@ -514,7 +515,12 @@ class TestWiringSynthesisPrompt:
         assert result[1]["title"] == "Research ML"
 
     def test_auto_verification_criteria_generated(self):
-        """E2E: synthesis tasks get auto-generated verification criteria."""
+        """E2E: synthesis tasks get auto-generated verification criteria.
+
+        Synthesis deliberately emits only a min_length floor — no
+        required_sections, because the planner can't predict the agent's
+        headings (see _auto_synthesis_verification_criteria).
+        """
         task = _mock_task(task_type=TaskType.SYNTHESIS.value)
         upstream = [
             {"title": "Research AI", "output": "x" * 2000},
@@ -523,9 +529,8 @@ class TestWiringSynthesisPrompt:
 
         criteria = CoordinatorService._auto_synthesis_verification_criteria(task, upstream)
 
-        section_check = next(c for c in criteria if c["type"] == "required_sections")
-        assert "Research AI" in section_check["value"]
-        assert "Research ML" in section_check["value"]
+        # No required_sections — exact-heading checks were removed.
+        assert not any(c["type"] == "required_sections" for c in criteria)
 
         length_check = next(c for c in criteria if c["type"] == "min_length")
         assert length_check["value"] == 2000  # 50% of 4000
@@ -582,6 +587,9 @@ class TestWiringTemplateParallelGroups:
             _mock_agent(agent_id=3, name="analyst"),
             _mock_agent(agent_id=4, name="search"),
             _mock_agent(agent_id=5, name="reviewer"),
+            _mock_agent(agent_id=6, name="designer"),
+            _mock_agent(agent_id=7, name="coder"),
+            _mock_agent(agent_id=8, name="admin"),
         ]
         for template in TEMPLATE_REGISTRY:
             tasks = render_template(template, "Test validation goal")
@@ -602,7 +610,7 @@ class TestWiringTokenEstimate:
     """Prove token estimation uses COMPLEXITY_TOKEN_BUDGET, not flat rate."""
 
     def test_estimate_varies_by_complexity(self):
-        """E2E: simple + complex + moderate != 2000 * 3."""
+        """E2E: simple + complex + moderate != 2000 * 3 — sums per-tier config."""
         tasks = [
             _planned_task("t1", complexity="simple", seq=1),
             _planned_task("t2", complexity="complex", seq=2, deps=["t1"]),
@@ -612,8 +620,12 @@ class TestWiringTokenEstimate:
         estimate = _estimate_token_budget(tasks)
         flat = 2000 * 3
         assert estimate != flat
-        # simple(5000) + complex(35000) + moderate(15000) = 55000
-        assert estimate == 55000
+        expected = (
+            COMPLEXITY_TOKEN_BUDGET["simple"]
+            + COMPLEXITY_TOKEN_BUDGET["complex"]
+            + COMPLEXITY_TOKEN_BUDGET["moderate"]
+        )
+        assert estimate == expected
 
     def test_synthesis_complexity_uses_config(self):
         """E2E: 'synthesis' complexity tier maps to its own budget."""
@@ -622,7 +634,7 @@ class TestWiringTokenEstimate:
                           task_type="synthesis"),
         ]
         estimate = _estimate_token_budget(tasks)
-        assert estimate == 20000  # COMPLEXITY_TOKEN_BUDGET["synthesis"]
+        assert estimate == COMPLEXITY_TOKEN_BUDGET["synthesis"]
 
 
 # ===========================================================================
@@ -807,6 +819,6 @@ class TestWiringSynthesisAutoInsertion:
             PlannedDependency("t_synth", "t4"),
         ]
 
-        new_tasks, _ = _ensure_synthesis_tasks(tasks, deps)
+        new_tasks, new_deps = _ensure_synthesis_tasks(tasks, deps)
         assert len(new_tasks) == 4
         assert len(new_deps) == 3

--- a/orchestrator/tests/test_agents_api_plugins.py
+++ b/orchestrator/tests/test_agents_api_plugins.py
@@ -67,6 +67,17 @@ def _make_full_agent(assigned_plugins=None):
     agent.skills = []
     agent.assigned_plugins = assigned_plugins if assigned_plugins is not None else []
     agent.workspace_id = uuid4()
+    # Optional AgentResponse fields read via getattr() — set explicitly so the
+    # MagicMock does not auto-create truthy attributes that fail Pydantic v2
+    # strict validation (these are Optional[...] = None on AgentResponse).
+    agent.public_id = None
+    agent.job_title = None
+    agent.model_usage_stats = None
+    agent.is_system_agent = False
+    agent.slug = None
+    agent.required_role = None
+    agent.marketplace_category = None
+    agent.voice_profile_id = None
     return agent
 
 

--- a/orchestrator/tests/test_budget_gate.py
+++ b/orchestrator/tests/test_budget_gate.py
@@ -63,14 +63,21 @@ def _make_task(
     return task
 
 
-def _make_run(*, run_id=None, max_concurrent=2, token_budget_estimate=None, tokens_used=0):
-    """Create a mock OrchestrationRun."""
+def _make_run(*, run_id=None, max_concurrent=2, token_budget_estimate=None, tokens_used=0, config=None):
+    """Create a mock OrchestrationRun.
+
+    `config` mirrors the real OrchestrationRun.config JSONB column (DB default
+    '{}'). Defaulting to an empty dict is required: the budget gate reads
+    ``run.config.get("budget_pause_disabled")`` and a bare MagicMock would make
+    that truthy, short-circuiting the gate to "allow".
+    """
     run = MagicMock()
     run.id = run_id or uuid4()
     run.max_concurrent = max_concurrent
     run.token_budget_estimate = token_budget_estimate
     run.tokens_used = tokens_used
     run.state = RunState.RUNNING.value
+    run.config = {} if config is None else config
     return run
 
 

--- a/orchestrator/tests/test_context/test_modes.py
+++ b/orchestrator/tests/test_context/test_modes.py
@@ -114,7 +114,7 @@ class TestSectionRegistry:
         "identity", "skills", "composio", "plugins",
         "platform_actions", "memory", "tools",
         "task_context", "playbook_context", "datetime_context",
-        "conversation", "custom",
+        "business_graph", "conversation", "custom",
         "onboarding", "mission_context", "agent_roster",
     }
 

--- a/orchestrator/tests/test_memory_fixes.py
+++ b/orchestrator/tests/test_memory_fixes.py
@@ -1,10 +1,8 @@
 import importlib.util
 import pathlib
-import sys
-import types
-import uuid
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
+import httpx
 import pytest
 
 
@@ -19,20 +17,24 @@ def _load_module(module_name: str, relative_path: str):
     return module
 
 
+# Loaded by path (mirroring test_mem0_async_client.py) so monkeypatch targets the
+# exact module objects the client uses.
 mem0_client_module = _load_module(
     "memory_test_mem0_client",
     "modules/memory/integrations/mem0_client.py",
 )
-platform_executor_module = _load_module(
-    "memory_test_platform_executor",
-    "modules/tools/discovery/platform_executor.py",
+workspace_handlers_module = _load_module(
+    "memory_test_workspace_handlers",
+    "modules/tools/discovery/handlers_workspace.py",
 )
 
 Mem0Client = mem0_client_module.Mem0Client
-PlatformActionExecutor = platform_executor_module.PlatformActionExecutor
+get_memory_stats = workspace_handlers_module.get_memory_stats
 
 
 class _FakeResponse:
+    """Stand-in for httpx.Response — only the attributes the client reads."""
+
     def __init__(self, status_code=200, payload=None, text=""):
         self.status_code = status_code
         self._payload = payload
@@ -42,10 +44,14 @@ class _FakeResponse:
         return self._payload
 
 
-def test_mem0_search_sends_search_query_and_prefers_score(monkeypatch):
+@pytest.mark.asyncio
+async def test_mem0_search_sends_search_query_and_prefers_score(monkeypatch):
+    """Mem0Client.search (async httpx) GETs with a ``search_query`` param and
+    re-ranks results by score so the strongest match leads regardless of recency.
+    """
     captured = {}
 
-    def fake_request(method, url, **kwargs):
+    async def fake_request(self, method, url, **kwargs):
         captured["method"] = method
         captured["url"] = url
         captured["kwargs"] = kwargs
@@ -68,46 +74,46 @@ def test_mem0_search_sends_search_query_and_prefers_score(monkeypatch):
             }
         )
 
-    monkeypatch.setattr(
-        mem0_client_module.requests,
-        "request",
-        fake_request,
-    )
+    monkeypatch.setattr(httpx.AsyncClient, "request", fake_request)
 
     client = Mem0Client(api_url="http://mem0.test", api_key="test-key")
-    results = client.search(query="pricing", user_id="ws_123", limit=2)
+    results = await client.search(query="pricing", user_id="ws_123", limit=2)
 
     assert captured["method"] == "GET"
     assert captured["kwargs"]["params"]["user_id"] == "ws_123"
     assert captured["kwargs"]["params"]["search_query"] == "pricing"
     assert results[0]["id"] == "older-strong"
     assert results[1]["id"] == "recent-low"
+    await client.aclose()
+
+
 @pytest.mark.asyncio
 async def test_platform_memory_stats_marks_partial_results(monkeypatch):
-    fake_client = MagicMock()
-    fake_client.api_url = "http://mem0.test"
+    """get_memory_stats scans at most 10 agents and flags partial results.
 
-    def fake_get_all(user_id, limit=200):
-        if user_id == "ws_workspace":
+    The handler resolves the shared UnifiedMemoryService, fetches global + the
+    first 10 agents' memories, and reports scanned_agents / total_agents so a
+    workspace with >10 agents is marked ``partial``.
+    """
+    service = MagicMock()
+    # is_mem0_configured is a property on the real service → plain bool here.
+    service.is_mem0_configured = True
+
+    async def fake_get_all_memories(workspace_id, agent_id=None, limit=200):
+        if agent_id is None:
             return [{"memory": "global memory"}]
-        return [{"memory": f"memory for {user_id}"}]
+        return [{"memory": f"memory for agent {agent_id}"}]
 
-    fake_client.get_all.side_effect = fake_get_all
+    service.get_all_memories = AsyncMock(side_effect=fake_get_all_memories)
 
-    modules_pkg = types.ModuleType("modules")
-    modules_pkg.__path__ = []
-    memory_pkg = types.ModuleType("modules.memory")
-    memory_pkg.__path__ = []
-    integrations_pkg = types.ModuleType("modules.memory.integrations")
-    integrations_pkg.__path__ = []
-    mem0_stub = types.ModuleType("modules.memory.integrations.mem0_client")
-    mem0_stub.Mem0Client = lambda: fake_client
+    # The handler imports get_unified_memory_service() *inside* the function from
+    # the canonical module, so patch the seam there (not on the by-path-loaded
+    # handler module). Otherwise the real singleton runs and the result depends
+    # on whether MEM0_API_URL is configured — non-deterministic across envs.
+    import modules.memory.unified_memory_service as ums
+    monkeypatch.setattr(ums, "get_unified_memory_service", lambda: service)
 
-    monkeypatch.setitem(sys.modules, "modules", modules_pkg)
-    monkeypatch.setitem(sys.modules, "modules.memory", memory_pkg)
-    monkeypatch.setitem(sys.modules, "modules.memory.integrations", integrations_pkg)
-    monkeypatch.setitem(sys.modules, "modules.memory.integrations.mem0_client", mem0_stub)
-
+    # 12 workspace agents → scan caps at 10, partial=True.
     db = MagicMock()
     query_result = MagicMock()
     query_result.filter.return_value.all.return_value = [
@@ -115,8 +121,7 @@ async def test_platform_memory_stats_marks_partial_results(monkeypatch):
     ]
     db.query.return_value = query_result
 
-    executor = PlatformActionExecutor(db=db, workspace_id="workspace")
-    result = await executor._get_memory_stats({})
+    result = await get_memory_stats(db, "workspace", {})
 
     assert result["success"] is True
     assert result["partial"] is True

--- a/orchestrator/tests/test_parallel_decomposition.py
+++ b/orchestrator/tests/test_parallel_decomposition.py
@@ -21,6 +21,7 @@ _orchestrator_root = str(Path(__file__).resolve().parent.parent)
 if _orchestrator_root not in sys.path:
     sys.path.insert(0, _orchestrator_root)
 
+from config import COMPLEXITY_TOKEN_BUDGET
 from modules.coordination.planner import (
     DecompositionResult,
     MissionPlanner,
@@ -235,9 +236,13 @@ class TestTokenEstimate:
         ]
         estimate = _estimate_token_budget(tasks)
         flat_estimate = 2000 * len(tasks)
-        # simple(5000) + complex(35000) + moderate(15000) = 55000
+        # Sum of per-tier config budgets: simple + complex + moderate
         assert estimate != flat_estimate
-        assert estimate == 5000 + 35000 + 15000
+        assert estimate == (
+            COMPLEXITY_TOKEN_BUDGET["simple"]
+            + COMPLEXITY_TOKEN_BUDGET["complex"]
+            + COMPLEXITY_TOKEN_BUDGET["moderate"]
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -419,7 +424,8 @@ class TestTemplateParallelGroups:
         """All rendered templates pass _parse_plan and _validate_plan."""
         agents = [_make_agent("researcher"), _make_agent("writer"),
                   _make_agent("analyst"), _make_agent("search"),
-                  _make_agent("reviewer")]
+                  _make_agent("reviewer"), _make_agent("designer"),
+                  _make_agent("coder"), _make_agent("admin")]
         for template in TEMPLATE_REGISTRY:
             tasks = render_template(template, "Test goal for validation")
             errors: list = []

--- a/orchestrator/tests/test_plugin_assignment_api.py
+++ b/orchestrator/tests/test_plugin_assignment_api.py
@@ -181,7 +181,12 @@ class TestUpdateAgentPlugins:
         wep_q.filter.return_value.all.return_value = [wep_row]
         delete_q = MagicMock()
         delete_q.filter.return_value.delete.return_value = 2
-        db.query.side_effect = [agent_q, wep_q, delete_q]
+        # PRD-71: endpoint also queries MarketplacePlugin to auto-assign
+        # materialized skills. No plugin rows => no candidate skills, so the
+        # subsequent Skill queries are skipped.
+        plugins_q = MagicMock()
+        plugins_q.filter.return_value.all.return_value = []
+        db.query.side_effect = [agent_q, wep_q, delete_q, plugins_q]
 
         result = await update_agent_plugins(agent_id=42, body=body, ctx=ctx, db=db)
         assert result["success"] is True
@@ -209,7 +214,10 @@ class TestUpdateAgentPlugins:
         wep_q.filter.return_value.all.return_value = [wep_a, wep_b]
         delete_q = MagicMock()
         delete_q.filter.return_value.delete.return_value = 0
-        db.query.side_effect = [agent_q, wep_q, delete_q]
+        # PRD-71: MarketplacePlugin lookup for materialized-skill auto-assign.
+        plugins_q = MagicMock()
+        plugins_q.filter.return_value.all.return_value = []
+        db.query.side_effect = [agent_q, wep_q, delete_q, plugins_q]
 
         result = await update_agent_plugins(agent_id=42, body=body, ctx=ctx, db=db)
         assert len(result["plugin_ids"]) == 2
@@ -253,7 +261,10 @@ class TestUpdateAgentPlugins:
         wep_q.filter.return_value.all.return_value = weps
         delete_q = MagicMock()
         delete_q.filter.return_value.delete.return_value = 0
-        db.query.side_effect = [agent_q, wep_q, delete_q]
+        # PRD-71: MarketplacePlugin lookup for materialized-skill auto-assign.
+        plugins_q = MagicMock()
+        plugins_q.filter.return_value.all.return_value = []
+        db.query.side_effect = [agent_q, wep_q, delete_q, plugins_q]
 
         await update_agent_plugins(agent_id=42, body=body, ctx=ctx, db=db)
 

--- a/orchestrator/tests/test_prd128_notification_dispatcher.py
+++ b/orchestrator/tests/test_prd128_notification_dispatcher.py
@@ -64,7 +64,11 @@ def _make_db(pref_rows: list[tuple]) -> MagicMock:
 
 
 def _run(coro):
-    return asyncio.get_event_loop().run_until_complete(coro)
+    # asyncio.run() spins up a fresh loop per call, so this is immune to the
+    # thread's loop being left at None by an earlier test that used
+    # asyncio.run() itself. get_event_loop() would raise "no current event
+    # loop" once that happens (full-suite ordering pollution).
+    return asyncio.run(coro)
 
 
 def _first_insert_params(db: MagicMock) -> dict:

--- a/orchestrator/tests/test_seed_telemetry.py
+++ b/orchestrator/tests/test_seed_telemetry.py
@@ -108,12 +108,23 @@ class TestRowGeneration:
 # ---------------------------------------------------------------------------
 
 
+def _synthetic_agent(row: Dict[str, Any]) -> int:
+    """Return the *synthetic* agent id (9001/9002/9003) for a generated row.
+
+    ``_build_row`` resolves the synthetic id to a real production agent id for
+    the ``agent_id`` column (see ``_resolve_agent_id``), but preserves the
+    original synthetic id under ``router_decision['synthetic_agent_id']``. Bias
+    assertions are written against the synthetic ids, so read it from there.
+    """
+    return row["router_decision"]["synthetic_agent_id"]
+
+
 class TestAgentBias:
     """Test agent selection bias per category."""
 
     def test_three_synthetic_agents_used(self, synthetic_rows: List[Dict[str, Any]]):
         """All 3 synthetic agents appear in the data."""
-        agents_seen = {r["agent_id"] for r in synthetic_rows}
+        agents_seen = {_synthetic_agent(r) for r in synthetic_rows}
         assert agents_seen == set(SYNTHETIC_AGENTS)
 
     def test_sentinel_dominates_reports(self, synthetic_rows: List[Dict[str, Any]]):
@@ -122,7 +133,7 @@ class TestAgentBias:
         report_rows = [r for r in synthetic_rows if r["action_name"] in report_actions]
         if not report_rows:
             pytest.skip("No report action rows generated")
-        agent_counts = Counter(r["agent_id"] for r in report_rows)
+        agent_counts = Counter(_synthetic_agent(r) for r in report_rows)
         # Sentinel should have the highest count for reports
         assert agent_counts[AGENT_SENTINEL] > agent_counts.get(AGENT_SCOUT, 0), (
             f"Sentinel ({agent_counts[AGENT_SENTINEL]}) should dominate reports, "
@@ -134,7 +145,7 @@ class TestAgentBias:
         ws_rows = [r for r in synthetic_rows if r["app_name"] == "WORKSPACE"]
         if not ws_rows:
             pytest.skip("No workspace action rows generated")
-        agent_counts = Counter(r["agent_id"] for r in ws_rows)
+        agent_counts = Counter(_synthetic_agent(r) for r in ws_rows)
         assert agent_counts[AGENT_SCOUT] > agent_counts.get(AGENT_SENTINEL, 0), (
             f"Scout ({agent_counts[AGENT_SCOUT]}) should dominate workspace, "
             f"but Sentinel has {agent_counts.get(AGENT_SENTINEL, 0)}"
@@ -149,7 +160,7 @@ class TestAgentBias:
         target_rows = [r for r in synthetic_rows if r["action_name"] in ops_actions]
         if not target_rows:
             pytest.skip("No agents/missions rows generated")
-        agent_counts = Counter(r["agent_id"] for r in target_rows)
+        agent_counts = Counter(_synthetic_agent(r) for r in target_rows)
         # Ops should have significant presence (not necessarily highest for every action)
         total = len(target_rows)
         ops_share = agent_counts.get(AGENT_OPS, 0) / total

--- a/orchestrator/tests/test_synthesis_executor.py
+++ b/orchestrator/tests/test_synthesis_executor.py
@@ -172,7 +172,10 @@ class TestBuildSynthesisPrompt:
 # ---------------------------------------------------------------------------
 
 class TestAutoSynthesisVerificationCriteria:
-    def test_generates_required_sections_from_titles(self):
+    def test_omits_required_sections(self):
+        """Synthesis deliberately skips required_sections — the planner can't
+        predict the agent's headings, so only a min_length floor is emitted
+        (see _auto_synthesis_verification_criteria)."""
         task = _make_task(task_type=TaskType.SYNTHESIS.value)
         upstream = [
             {"title": "Research AI", "output": "x" * 1000},
@@ -183,11 +186,9 @@ class TestAutoSynthesisVerificationCriteria:
             task, upstream,
         )
 
-        section_check = next(
-            c for c in criteria if c["type"] == "required_sections"
-        )
-        assert "Research AI" in section_check["value"]
-        assert "Research ML" in section_check["value"]
+        assert not any(c["type"] == "required_sections" for c in criteria)
+        # Only the min_length criterion is produced.
+        assert {c["type"] for c in criteria} == {"min_length"}
 
     def test_min_length_is_half_combined(self):
         task = _make_task(task_type=TaskType.SYNTHESIS.value)

--- a/orchestrator/tests/test_tool_execution_tracker.py
+++ b/orchestrator/tests/test_tool_execution_tracker.py
@@ -77,36 +77,43 @@ ToolExecutionTracker = globals_copy["ToolExecutionTracker"]
 # ── Direct tool limits ──────────────────────────────────────────────
 
 
-def test_platform_tool_capped_at_2():
+def test_platform_tool_capped_at_limit():
     tracker = ToolExecutionTracker()
-    for i in range(3):
+    cap = tracker.TOOL_RETRY_LIMITS['platform_default']
+    for i in range(cap + 2):
         skip, _ = tracker.should_skip_execution("platform_get_settings", {"key": f"v{i}"})
         if not skip:
             tracker.record_execution("platform_get_settings", {"key": f"v{i}"})
 
-    assert tracker.tool_counts.get("platform_get_settings") == 2
-    skip, _ = tracker.should_skip_execution("platform_get_settings", {"key": "v3"})
+    assert tracker.tool_counts.get("platform_get_settings") == cap
+    skip, _ = tracker.should_skip_execution("platform_get_settings", {"key": "final"})
     assert skip
 
 
-def test_workspace_tool_capped_at_5():
+def test_workspace_tool_capped_at_limit():
     tracker = ToolExecutionTracker()
-    for i in range(6):
+    cap = tracker.TOOL_RETRY_LIMITS['workspace_default']
+    for i in range(cap + 2):
         skip, _ = tracker.should_skip_execution("workspace_grep", {"query": f"q{i}"})
         if not skip:
             tracker.record_execution("workspace_grep", {"query": f"q{i}"})
 
-    assert tracker.tool_counts.get("workspace_grep") == 5
+    assert tracker.tool_counts.get("workspace_grep") == cap
+    skip, _ = tracker.should_skip_execution("workspace_grep", {"query": "final"})
+    assert skip
 
 
-def test_default_tool_capped_at_3():
+def test_default_tool_capped_at_limit():
     tracker = ToolExecutionTracker()
-    for i in range(4):
+    cap = tracker.TOOL_RETRY_LIMITS['default']
+    for i in range(cap + 2):
         skip, _ = tracker.should_skip_execution("some_custom_tool", {"x": i})
         if not skip:
             tracker.record_execution("some_custom_tool", {"x": i})
 
-    assert tracker.tool_counts.get("some_custom_tool") == 3
+    assert tracker.tool_counts.get("some_custom_tool") == cap
+    skip, _ = tracker.should_skip_execution("some_custom_tool", {"x": 999})
+    assert skip
 
 
 # ── Exact-argument dedup ────────────────────────────────────────────
@@ -149,9 +156,14 @@ def test_dispatcher_counts_by_inner_action():
 
 
 def test_dispatcher_same_action_capped():
-    """Repeated calls to the same dispatcher action should be capped at 2."""
+    """Repeated dispatcher calls are capped by the inner action's prefix limit.
+
+    ``platform_execute:platform_list_agents`` resolves through the inner
+    ``platform_`` prefix to ``platform_default``, not the dispatcher name.
+    """
     tracker = ToolExecutionTracker()
-    for i in range(3):
+    cap = tracker.TOOL_RETRY_LIMITS['platform_default']
+    for i in range(cap + 2):
         skip, _ = tracker.should_skip_execution(
             "platform_execute", {"action": "platform_list_agents", "params": {"page": i}}
         )
@@ -160,9 +172,9 @@ def test_dispatcher_same_action_capped():
                 "platform_execute", {"action": "platform_list_agents", "params": {"page": i}}
             )
 
-    assert tracker.tool_counts.get("platform_execute:platform_list_agents") == 2
+    assert tracker.tool_counts.get("platform_execute:platform_list_agents") == cap
     skip, reason = tracker.should_skip_execution(
-        "platform_execute", {"action": "platform_list_agents", "params": {"page": 99}}
+        "platform_execute", {"action": "platform_list_agents", "params": {"page": 999}}
     )
     assert skip
     assert "platform_execute:platform_list_agents" in reason

--- a/orchestrator/tests/test_w1s1_hotpath_telemetry_io.py
+++ b/orchestrator/tests/test_w1s1_hotpath_telemetry_io.py
@@ -52,16 +52,20 @@ for _k, _v in {
 def test_board_task_failure_emits_board_error(monkeypatch):
     from api import board_tasks as bt_mod
     import core.database.database as db_mod
+    import core.utils.background_tasks as bg_mod
     import modules.agents.factory.agent_factory as factory_mod
 
     rec = MagicMock()
     monkeypatch.setattr(bt_mod, "record_error", rec, raising=False)
 
-    # _launch_task_execution schedules its work via create_task; capture the
-    # coroutine instead of letting it loose on a loop, then drive it ourselves.
+    # _launch_task_execution schedules its work via launch_guarded (W1-S5), which
+    # calls asyncio.create_task in the background_tasks module. Capture the
+    # coroutine there instead of letting it loose on a loop, then drive it
+    # ourselves. (launch_guarded also calls .add_done_callback on the result, so
+    # a MagicMock stands in for the Task fine.)
     captured: dict = {}
     monkeypatch.setattr(
-        bt_mod.asyncio,
+        bg_mod.asyncio,
         "create_task",
         lambda coro: captured.__setitem__("coro", coro) or MagicMock(),
     )
@@ -100,14 +104,16 @@ def test_board_task_success_does_not_emit(monkeypatch):
     """Guardrail: a clean agent execution must NOT record an error."""
     from api import board_tasks as bt_mod
     import core.database.database as db_mod
+    import core.utils.background_tasks as bg_mod
     import modules.agents.factory.agent_factory as factory_mod
 
     rec = MagicMock()
     monkeypatch.setattr(bt_mod, "record_error", rec, raising=False)
 
+    # See failure test: launch_guarded (W1-S5) owns the create_task call now.
     captured: dict = {}
     monkeypatch.setattr(
-        bt_mod.asyncio,
+        bg_mod.asyncio,
         "create_task",
         lambda coro: captured.__setitem__("coro", coro) or MagicMock(),
     )


### PR DESCRIPTION
## Summary
Completes the WS-F green-suite work that PR #416 merged while the `test` job was still red (the gate is non-required by design). Brings the full orchestrator pytest suite to **1260 passed, 0 failed** locally.

Headline fix: `test_prd128_notification_dispatcher.py::_run` used `asyncio.get_event_loop().run_until_complete()`, which raises *"no current event loop"* once an earlier test in the suite calls `asyncio.run()` (that resets the thread loop to `None`). Green in isolation, red in the full suite — pure ordering pollution. Switched to `asyncio.run()`, which spins a fresh loop per call and is immune.

Other buckets realigned to prod contracts:
- **82c wiring / budget gate** — assert against config constants + a real `run.config` dict (a bare MagicMock made `budget_pause_disabled` truthy, short-circuiting the gate)
- **plugin assignment + agents plugins API** — schema / 500 expectations
- **seed + hotpath telemetry** — row-count expectations
- **tool execution tracker** — align cap tests with prod retry limits
- **memory fixes, parallel decomposition, synthesis executor, context modes, deliverable service** — assorted drift

Tests only — no product code changes. `postcss.config.js` is intentionally absent from this diff (already clean on main via #417).

## Test plan
- [x] Full suite green locally (Python 3.10.9): **1260 passed, 0 failed**
- [ ] CI `test` job green on Python 3.11 (this PR)
- [ ] After green: flip the `test` check to **required** in branch protection — repo admin's call per the workflow comment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Improved test reliability across service validation, budget verification, memory operations, and synthesis workflows to ensure consistent test behavior.

* **Chores**
  * Updated internal testing infrastructure for better mock object handling and async operation support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->