### PR TITLE
ci(security): add malware-scan IOC gate to block backdoor re-infection

### DIFF
--- a/.github/workflows/malware-scan.yml
+++ b/.github/workflows/malware-scan.yml
@@ -1,0 +1,53 @@
+name: malware-scan
+
+# Defensive IOC scan for the DPRK / Rejolut supply-chain backdoor family that
+# infected frontend/postcss.config.js (the evil-merge incident, 2026-06). The
+# loader smuggled itself into a merge commit whose blob was in neither parent,
+# so branch-level review never saw it and it rode forward on main. This job
+# greps the whole tree for the loader's signatures and fails the build on a
+# hit, so a re-infected blob can't reach main unnoticed again.
+#
+# Pairs with branch protection (PR required, no force-push, enforce_admins):
+# pull_request catches a payload before it merges; push catches anything that
+# lands on main directly.
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  ioc-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Scan working tree for backdoor IOCs
+        run: |
+          # Fixed-string signatures of the loader family:
+          #   fromCharCode(127) — the String.fromCharCode(127) decode delimiter,
+          #                       present in every variant of this loader.
+          #   global.i=         — campaign-tag assignment (e.g. global.i='5-3-346').
+          #   global['_V']      — campaign-tag global used by the require() hijack.
+          # grep -l exits 0 (and prints the matching files) on a hit, 1 when clean;
+          # the if-guard keeps that exit code from aborting the step prematurely.
+          # Exclude this file by name: it necessarily contains the IOC strings
+          # (the grep patterns and the comments above) and would self-match.
+          if grep -rIlF \
+               --exclude-dir=node_modules \
+               --exclude-dir=.git \
+               --exclude=malware-scan.yml \
+               -e 'fromCharCode(127)' \
+               -e 'global.i=' \
+               -e "global['_V']" \
+               . ; then
+            echo "::error::Supply-chain backdoor IOC detected in the file(s) listed above. Build blocked — do not merge. See the DPRK postcss incident write-up before clearing."
+            exit 1
+          fi
+          echo "Clean — no backdoor IOCs found in the tree."


### PR DESCRIPTION
## Summary
Adds `.github/workflows/malware-scan.yml` — a CI gate that greps the whole tree for the DPRK / Rejolut supply-chain loader's signatures and **fails the build on a hit**. This closes the gap that let the 2026-06 incident through: the loader smuggled itself into a *merge commit* whose blob existed in neither parent, so branch-level review never saw it and it rode forward on `main` (cleaned in #417).

**IOCs matched** (fixed-string):
- `fromCharCode(127)` — the `String.fromCharCode(127)` decode delimiter, present in every variant of this loader
- `global.i=` — campaign-tag assignment (e.g. `global.i='5-3-346'`)
- `global['_V']` — campaign-tag global used by the `require()` hijack

**Triggers:** `pull_request` → main (catches a payload before merge) and `push` → main (catches anything landing directly). Pairs with existing branch protection (PR required, no force-push, `enforce_admins`).

**Validated locally:**
- No false positives on the current tree (clean exit).
- Detects a planted known-bad sample.
- Excludes its own file by name (the scanner necessarily contains the signature strings).
- No untrusted `${{ github.event.* }}` input in `run:` (no injection surface); `permissions: contents: read`.

## Test plan
- [ ] This PR's `ioc-scan` job runs and passes (tree is clean post-#417)
- [ ] After merge: confirm a test PR carrying a planted IOC is blocked