### PR TITLE
ci: run test net on push to any branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,12 +2,17 @@ name: test
 
 # PRD-142 Wave 2 (W2-S3) — the Test Net's enforcement gate.
 #
-# Runs the orchestrator pytest suite on every PR against a real Postgres
-# service so DB-touching tests connect instead of hanging. (W2-S2 traced a
-# pre-existing hang in test_82c_wiring to psycopg2.connect blocking forever
-# when no Postgres is present — see that test's decompose path.) A per-test
-# timeout is the safety net: any future hang fails fast instead of burning
-# the whole job.
+# Runs the orchestrator pytest suite against a real Postgres service so
+# DB-touching tests connect instead of hanging. (W2-S2 traced a pre-existing
+# hang in test_82c_wiring to psycopg2.connect blocking forever when no
+# Postgres is present — see that test's decompose path.) A per-test timeout
+# is the safety net: any future hang fails fast instead of burning the whole
+# job.
+#
+# Triggers on push to ANY branch so a red suite surfaces on the feature
+# branch — before a PR is opened — not only at PR time. The pull_request
+# trigger is kept so the gate also evaluates the merged result. Concurrency
+# cancels superseded runs on the same ref so rapid pushes don't queue.
 #
 # Introduced NON-REQUIRED on purpose. The net is expected to surface
 # pre-existing gaps that Wave 2 (WS-G golden journeys, WS-H untested
@@ -18,11 +23,14 @@ name: test
 on:
   push:
     branches:
-      - main
-      - "ralph/**"
+      - "**"
   pull_request:
     branches:
       - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   orchestrator-tests:


### PR DESCRIPTION
## Summary
- Triggers the `orchestrator-tests` job on **push to any branch** (`'**'`), not just `main`/`ralph/**`, so a red suite surfaces on the feature branch *before* a PR is opened.
- Keeps the `pull_request` → `main` trigger so the gate still evaluates the merged result at PR time.
- Adds a `concurrency` group keyed on `workflow + ref` with `cancel-in-progress: true` so rapid pushes cancel superseded runs instead of queuing.

## Why
Today the suite only runs on PR (and push to main/ralph). A failing test isn't visible until the PR exists. Running on every push gives feedback at the point of work and avoids opening a PR that's already red.

## Notes
- Job/context name is unchanged (`orchestrator-tests`) — no impact on the planned required-check flip.
- No change to the job body, services, or env.

## Test plan
- [ ] Push to this branch triggers a single `orchestrator-tests` run.
- [ ] A second quick push cancels the first (concurrency).
- [ ] PR against main still triggers the job.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* **Testing Infrastructure Improvements**
  * Extended test automation to run on all branches for broader coverage.
  * Implemented concurrent workflow management to prevent test conflicts and improve reliability.
  * Added timeout safeguards for test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->