### PR TITLE
test(prd-142): Wave 2 WS-H/WS-I test net (golden journeys + chat/RAG/verification)

### DIFF
--- a/orchestrator/tests/security/test_w2s7_fail_closed_authz_gate.py
+++ b/orchestrator/tests/security/test_w2s7_fail_closed_authz_gate.py
@@ -32,11 +32,17 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 # Lean-venv shim: importing any modules.tools submodule runs modules/tools/__init__.py,
-# which eagerly pulls modules.rag (camelot + sentence_transformers PDF/ML ingestion) —
-# wholly unrelated to the authz gate under test. Those are declared deps installed in
-# CI (requirements.txt: camelot-py, opencv-python-headless); when absent from a lean
-# local venv they break collection. Stub the package only when the heavy stack is
-# genuinely unlocatable — a no-op in CI where the real stack is present.
+# which eagerly pulls modules.rag's ingestion chain — its multimodal PDF processor does
+# ``import camelot`` at module top. camelot is a declared dep installed in CI
+# (requirements.txt: camelot-py, opencv-python-headless) but often absent from a lean
+# local venv, where it breaks collection — wholly unrelated to the authz gate under test.
+#
+# Stub the missing *leaf* (camelot), never the whole ``modules.rag`` package. A package
+# stub with no ``__path__`` poisons ``sys.modules['modules.rag']`` for every later test
+# that imports the real ``modules.rag.service`` (e.g. the W2-S10 RAG suite), failing
+# their collection with "'modules.rag' is not a package". Stubbing the leaf lets the real
+# package import normally. This is the blessed pattern used across the suite
+# (test_w2s9/test_w2s10/test_golden_journeys all setdefault a camelot ModuleType).
 #
 # Probe defensively. A sibling module (tests/test_l3_distill_input.py) seeds a bare
 # ``types.ModuleType("camelot")`` into ``sys.modules`` to dodge the same heavy import.
@@ -44,15 +50,17 @@ import pytest
 # ``ValueError: camelot.__spec__ is None`` on a spec-less cached module rather than
 # returning it. Treat both "raised" and "found" as "import chain already satisfied"
 # (real dep or sibling stub) and skip our shim; only stub when camelot is truly absent.
-def _rag_chain_unlocatable() -> bool:  # pragma: no cover - env-dependent
+def _camelot_unlocatable() -> bool:  # pragma: no cover - env-dependent
     try:
         return _ilu.find_spec("camelot") is None
     except ValueError:
         return False  # spec-less camelot stub already present → chain satisfied
 
 
-if _rag_chain_unlocatable():  # pragma: no cover - env-dependent
-    _sys.modules.setdefault("modules.rag", MagicMock())
+if _camelot_unlocatable():  # pragma: no cover - env-dependent
+    import types as _types
+
+    _sys.modules.setdefault("camelot", _types.ModuleType("camelot"))
 
 from core.security.hierarchy_permissions import PermissionDecision
 import modules.tools.discovery.platform_executor as pe

--- a/orchestrator/tests/test_golden_journeys.py
+++ b/orchestrator/tests/test_golden_journeys.py
@@ -1,0 +1,349 @@
+"""PRD-142 Wave 2 · WS-H — golden-journey backbone (J1–J10).
+
+The ten journeys in ``docs/architecture/TEST-PLAN.md`` §5 are the platform's
+load-bearing user flows. This module is their *backbone*: one ``golden``-marked
+test per journey, selectable with ``-m golden``.
+
+Honesty over theatre. There is no in-process FastAPI/TestClient harness in this
+repo, and several journeys cross live external boundaries (Clerk auth, Shopify,
+an LLM, S3, the scheduler). Faking those would test the fakes, not the platform —
+and the project's rule is that integration coverage hits real backends, never
+mocks. So each journey is implemented at the highest layer that can be proven
+*honestly today*:
+
+* **Implemented now** (no external service, deterministic or real local PG):
+  J2 reasoning-entry decision, J5 RAG ingest→select→assemble pipeline,
+  J10 cross-workspace isolation (real Postgres, the P0 security property).
+* **Tracked gaps** — journeys that need infrastructure this suite can't stand up
+  offline ``pytest.skip`` with a precise reason naming exactly what they need.
+  They are not silent: ``-m golden`` lists them every run, so the backbone shows
+  the whole map and the holes in it. Filling them is Wave 2.3 / Wave 3 work
+  (recorded fixtures for the LLM/Shopify legs, an app-level client fixture).
+
+The implemented journeys compose primitives that W2-S9 (reasoning) and W2-S10
+(RAG, verification) unit-test in isolation; here they are wired end-to-end so a
+break *between* the units is caught, which the unit tests cannot see.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import types
+from uuid import uuid4
+
+for _k in ("POSTGRES_USER", "POSTGRES_PASSWORD"):
+    os.environ.setdefault(_k, "test")
+os.environ.setdefault("POSTGRES_HOST", "127.0.0.1")
+os.environ.setdefault("POSTGRES_PORT", "5432")
+os.environ.setdefault("POSTGRES_DB", "test_db")
+
+# consumers/RAG import chains pull camelot (optional PDF dep, absent in test env).
+sys.modules.setdefault("camelot", types.ModuleType("camelot"))
+
+from unittest.mock import MagicMock  # noqa: E402
+
+import pytest  # noqa: E402
+
+pytestmark = pytest.mark.golden
+
+
+# ===========================================================================
+# J1 — signup → onboarding (Mission Zero wizard)
+# ===========================================================================
+
+
+def test_j1_signup_to_onboarding():
+    pytest.skip(
+        "needs an app-level client + Clerk auth: the journey is "
+        "POST /auth → workspace provisioning → Mission Zero wizard "
+        "(VOYAGER/BLUEPRINT/SCRIBE/FORGE). No in-process FastAPI harness exists "
+        "yet and Clerk can't be exercised offline. Fill in Wave 2.3 with an app "
+        "client fixture + a stubbed auth principal."
+    )
+
+
+# ===========================================================================
+# J2 — chat → reasoning entry → action routing
+# The decision every chat turn makes, before any LLM/tool runs. Deterministic.
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_j2_chat_reasoning_entry_routes_message():
+    """A chat turn enters AutoBrain.assess and emerges with the (complexity,
+    action, tool) decision that downstream routing depends on. Two ends of the
+    table: free chitchat resolves with no tools; a platform query routes to the
+    very ``platform_list_agents`` tool whose isolation J10 then proves."""
+    from consumers.chatbot.auto import Action, AutoBrain, Complexity
+
+    brain = AutoBrain(db=MagicMock(), workspace_id="ws-golden")
+    brain._redis = None
+    brain._cache_lookup = lambda *a, **k: None
+    brain._cache_store = lambda *a, **k: None
+
+    greeting = await brain.assess("hey there")
+    assert greeting.complexity is Complexity.ATOM
+    assert greeting.action is Action.RESPOND
+    assert greeting.tool_hints == []  # free turn, no tools, no spend
+
+    platform = await brain.assess("list my agents")
+    assert platform.complexity is Complexity.MOLECULE
+    assert platform.action is Action.RESPOND
+    assert "platform_list_agents" in platform.matched_tools  # routes to the scoped tool
+
+
+# ===========================================================================
+# J3 — widget → vertical plugin → response (generic AND shopify)
+# ===========================================================================
+
+
+def test_j3_widget_plugin_response():
+    pytest.skip(
+        "needs the widget app endpoint + plugin runtime: POST /widget/chat → "
+        "per-vertical plugin (generic + shopify) → response. Requires the "
+        "app-level client and a loaded plugin; the Shopify leg also needs "
+        "recorded product fixtures. Fill with the app client fixture (generic) "
+        "and recorded Shopify fixtures (vertical)."
+    )
+
+
+# ===========================================================================
+# J4 — mission lifecycle + restart durability
+# ===========================================================================
+
+
+def test_j4_mission_lifecycle_and_restart_durability():
+    pytest.skip(
+        "the restart-durability half is ALREADY a real-DB regression: see "
+        "test_w2s6_restart_recovery_realdb.py (reap_orphaned_runs sweeps stale "
+        "in-flight rows to terminal on boot) and test_w2s5_idle_in_tx_realdb.py. "
+        "The create→plan→execute→verify half needs the coordinator + an LLM; "
+        "fill with recorded LLM fixtures in Wave 3 rather than duplicate W2-S6."
+    )
+
+
+# ===========================================================================
+# J5 — document → RAG ingest → retrieval-assembly
+# The ingest→quality→budget→assemble pipeline, composed. Deterministic.
+# ===========================================================================
+
+
+def test_j5_document_rag_ingest_and_assembly():
+    """A raw document flows through the real retrieval primitives end-to-end:
+    chunk → score quality → knapsack-select within a token budget → assemble a
+    context block. W2-S10 unit-tests each primitive; this proves they *compose*
+    into a usable, budget-respecting context — the break a unit test can't see."""
+    from modules.rag.service import RAGService
+
+    svc = RAGService.__new__(RAGService)  # bypass DB-reading __init__
+
+    document = (
+        "The quarterly revenue grew twenty percent driven by enterprise "
+        "expansion and net revenue retention above one hundred and twenty "
+        "percent across the install base this fiscal year overall. " * 8
+    )
+
+    # 1. Ingest: chunk the document.
+    chunks = svc._basic_chunk(document)
+    assert len(chunks) >= 2, "document should split into multiple chunks"
+
+    # 2. Score + weigh each chunk (quality as value, length as token weight).
+    texts = [c["content"] for c in chunks]
+    values = [svc._calculate_content_quality(t) for t in texts]
+    weights = [max(1, len(t) // 4) for t in texts]  # ~4 chars/token
+    assert all(v > 0.0 for v in values)
+
+    # 3. Select the best chunks that fit a tight token budget.
+    budget = max(weights)  # only room for roughly one chunk
+    selected = svc._knapsack_dp(values, weights, budget, max_items=len(texts))
+    assert selected, "knapsack should select at least one chunk within budget"
+    assert sum(weights[i] for i in selected) <= budget, "selection must fit the budget"
+
+    # 4. Assemble the selected chunks into a context block.
+    picked = [
+        {"source_file": "q4.md", "similarity": values[i], "content": texts[i]}
+        for i in selected
+    ]
+    context = svc._format_context(picked, "how did revenue grow")
+    assert "## Retrieved Context for: how did revenue grow" in context
+    assert any(texts[i][:20] in context for i in selected)
+
+
+# ===========================================================================
+# J6 — marketplace install → cascade → agent usable
+# ===========================================================================
+
+
+def test_j6_marketplace_install_cascade():
+    pytest.skip(
+        "needs DB + S3 + the install service: install a template → cascade "
+        "(agents, skills, plugins, playbooks) → newly-installed agent is usable. "
+        "Requires real S3 (plugin payloads) and the cascade installer. Fill with "
+        "a local-DB + minio/S3-stub fixture in Wave 3."
+    )
+
+
+# ===========================================================================
+# J7 — playbook schedule → run → recover
+# ===========================================================================
+
+
+def test_j7_playbook_schedule_run_recover():
+    pytest.skip(
+        "needs the scheduler + agent execution: schedule a cron Playbook → run → "
+        "recover a failed step. Run/recover require the coordinator + an LLM. "
+        "Fill with recorded LLM fixtures + a time-travel scheduler clock in Wave 3."
+    )
+
+
+# ===========================================================================
+# J8 — NL2SQL
+# ===========================================================================
+
+
+def test_j8_nl2sql_query():
+    pytest.skip(
+        "PRD-142 lists NL2SQL as STRETCH, rolled to Wave 3. Needs DB + an LLM to "
+        "translate NL → SQL → result. Fill with recorded LLM fixtures + a seeded "
+        "local DB in Wave 3."
+    )
+
+
+# ===========================================================================
+# J9 — Shopify sync → Knowledge Graph → FBT proactive opener (the moat)
+# ===========================================================================
+
+
+def test_j9_shopify_sync_to_fbt_opener():
+    pytest.skip(
+        "the moat journey: Shopify sync → Knowledge Graph (frequently-bought-"
+        "together edges) → per-product proactive opener. Needs a live Shopify "
+        "store + the KG build + the widget. Fill with recorded Shopify webhook/"
+        "product fixtures driving a real local KG build in Wave 2.3 — this is the "
+        "highest-value gap to close next."
+    )
+
+
+# ===========================================================================
+# J10 — cross-workspace isolation (the P0 security property) — REAL Postgres
+# ===========================================================================
+
+_EPHEMERAL_HOSTS = {"localhost", "127.0.0.1", "::1"}
+_EPHEMERAL_DBS = {"test_db", "test"}
+
+
+@pytest.fixture(scope="module")
+def safe_session():
+    """A session against a *disposable* local Postgres only — never production.
+
+    create_engine is lazy, so we read engine.url to gate on host/db before
+    opening any connection (a Railway URL is rejected without a byte sent). Skips
+    cleanly when no local PG is reachable, keeping the DB-less run green.
+    """
+    from sqlalchemy import text
+    from sqlalchemy.orm import sessionmaker
+
+    from core.database.database import engine
+
+    url = engine.url
+    if (url.host or "").lower() not in _EPHEMERAL_HOSTS or (
+        url.database or ""
+    ).lower() not in _EPHEMERAL_DBS:
+        pytest.skip(
+            f"refusing to run the write+commit isolation test against a "
+            f"non-ephemeral database ({url.host}/{url.database})"
+        )
+    try:
+        with engine.connect() as conn:
+            conn.execute(text("SELECT 1"))
+    except Exception as exc:
+        pytest.skip(f"no reachable Postgres for integration test: {exc}")
+
+    session = sessionmaker(bind=engine)()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture
+def two_workspaces(safe_session):
+    """Commit two workspaces, each owning one agent. Tears down exactly those
+    rows (a commit can't be rolled back)."""
+    from core.models import Agent
+    from core.models.workspaces import Workspace
+
+    db = safe_session
+    ws_a = Workspace(id=uuid4(), name="golden-j10-a")
+    ws_b = Workspace(id=uuid4(), name="golden-j10-b")
+    db.add_all([ws_a, ws_b])
+    db.flush()
+
+    atlas = Agent(
+        name="Atlas Scout", agent_type="custom", slug="atlas-scout", workspace_id=ws_a.id
+    )
+    borg = Agent(
+        name="Borg Drone", agent_type="custom", slug="borg-drone", workspace_id=ws_b.id
+    )
+    db.add_all([atlas, borg])
+    db.commit()
+
+    ids = types.SimpleNamespace(
+        db=db, ws_a=ws_a.id, ws_b=ws_b.id, atlas=atlas.id, borg=borg.id
+    )
+    try:
+        yield ids
+    finally:
+        # The seed rows were committed (a commit can't be rolled back), so they
+        # must be DELETEd explicitly. The leading rollback only resets any
+        # failed-transaction state the test body may have left so the DELETEs can
+        # issue — it does NOT undo the seed. Agents are deleted before workspaces
+        # (FK child-first) in one transaction; if any step raises we roll the
+        # delete-tx back to leave a clean session for the next test and re-raise
+        # so the leak is loud, never silent.
+        db.rollback()
+        try:
+            db.query(Agent).filter(Agent.id.in_([ids.atlas, ids.borg])).delete(
+                synchronize_session=False
+            )
+            db.query(Workspace).filter(
+                Workspace.id.in_([ids.ws_a, ids.ws_b])
+            ).delete(synchronize_session=False)
+            db.commit()
+        except Exception:
+            db.rollback()
+            raise
+
+
+@pytest.mark.integration
+def test_j10_agent_lookup_is_workspace_isolated(two_workspaces):
+    """The real ``resolve_agent`` path (behind every platform agent tool) must
+    never resolve an agent outside the caller's workspace — by name *or* by exact
+    id. This is the P0 cross-workspace leak guard: drop the
+    ``Agent.workspace_id == workspace_id`` filter and every cross assertion trips.
+    """
+    from modules.tools.discovery.handlers_assignments import resolve_agent
+
+    ids = two_workspaces
+    db = ids.db
+
+    # In-workspace lookups succeed.
+    a_agent, a_err = resolve_agent(db, ids.ws_a, {"agent_name": "Atlas"})
+    assert a_err is None and a_agent is not None
+    assert a_agent.id == ids.atlas and a_agent.workspace_id == ids.ws_a
+
+    b_agent, b_err = resolve_agent(db, ids.ws_b, {"agent_id": ids.borg})
+    assert b_err is None and b_agent is not None and b_agent.id == ids.borg
+
+    # Cross-workspace by NAME is invisible.
+    leaked, err = resolve_agent(db, ids.ws_a, {"agent_name": "Borg"})
+    assert leaked is None and err is not None
+
+    # Cross-workspace by EXACT id is still blocked (the strongest guarantee:
+    # knowing the victim's primary key does not grant access).
+    leaked_by_id, err2 = resolve_agent(db, ids.ws_a, {"agent_id": ids.borg})
+    assert leaked_by_id is None and err2 is not None
+
+    leaked_sym, err3 = resolve_agent(db, ids.ws_b, {"agent_id": ids.atlas})
+    assert leaked_sym is None and err3 is not None

--- a/orchestrator/tests/test_w2s10_mission_verification.py
+++ b/orchestrator/tests/test_w2s10_mission_verification.py
@@ -1,0 +1,288 @@
+"""PRD-142 Wave 2 · WS-I / W2-S10 — mission-verification tests.
+
+The verification stack decides ``pass | fail | partial`` for *every* task a
+mission produces. It was wholly untested. The two layers below the LLM judge
+are fully deterministic, so their verdicts can be pinned exactly with no spend
+and no network:
+
+* ``DeterministicChecker`` — eight pure check handlers (length, regex, JSON
+  schema, keywords, sections, URLs, word-count) plus the ``must_pass``
+  short-circuit. A ``must_pass`` failure aborts before the LLM judge is ever
+  reached; ``required_sections`` is special-cased to *never* short-circuit.
+* ``VerificationService`` — the empty-output guard, the deterministic
+  short-circuit, and the per-run output-hash cache (PRD-82B US-007) that skips
+  a second LLM call when a retry produces byte-identical output.
+* ``_select_verifier_model`` — the cross-model guarantee: the verifier must be
+  a *different* model family than the executor, so a model never grades itself.
+
+The LLM judge itself (Stage 2) is stubbed everywhere here — these tests assert
+the deterministic gating *around* it, and prove the judge is not called when
+the deterministic layer already has a verdict (the cost guard).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import types
+from uuid import uuid4
+
+# config import pulls Postgres env; seed harmless defaults. Nothing here
+# touches a real DB, vector store, or network.
+for _k in ("POSTGRES_USER", "POSTGRES_PASSWORD", "POSTGRES_DB"):
+    os.environ.setdefault(_k, "test")
+os.environ.setdefault("POSTGRES_HOST", "localhost")
+os.environ.setdefault("POSTGRES_PORT", "5432")
+
+# Defensive: some coordination imports can reach the RAG package, which pulls
+# camelot (an optional PDF dep absent from the test env). Stub it.
+sys.modules.setdefault("camelot", types.ModuleType("camelot"))
+
+from unittest.mock import AsyncMock  # noqa: E402
+
+import pytest  # noqa: E402
+
+from modules.coordination import verification as verif  # noqa: E402
+from modules.coordination.deterministic_checks import (  # noqa: E402
+    DeterministicChecker,
+)
+from modules.coordination.verification import (  # noqa: E402
+    VERDICT_FAIL,
+    VERDICT_PASS,
+    VerificationResult,
+    VerificationService,
+    _select_verifier_model,
+)
+
+
+# ================================================ DeterministicChecker
+# Eight pure handlers — no LLM, no DB. Pin pass + fail for each.
+
+
+def _check(output, criteria):
+    return DeterministicChecker().check(output, criteria)
+
+
+def test_no_criteria_passes_trivially():
+    out = _check("anything at all", None)
+    assert out.passed is True
+    assert out.failures == []
+    assert out.short_circuited is False
+
+
+def test_min_and_max_length():
+    assert _check("short", [{"type": "min_length", "value": 100}]).passed is False
+    assert _check("x" * 200, [{"type": "min_length", "value": 100}]).passed is True
+    assert _check("x" * 200, [{"type": "max_length", "value": 100}]).passed is False
+    assert _check("ok", [{"type": "max_length", "value": 100}]).passed is True
+
+
+def test_format_regex():
+    crit = [{"type": "format_regex", "value": r"^\d{4}-\d{2}-\d{2}$"}]
+    assert _check("2026-06-05", crit).passed is True
+    assert _check("not a date", crit).passed is False
+
+
+def test_contains_keywords_is_case_insensitive():
+    crit = [{"type": "contains_keywords", "value": ["Revenue", "GROWTH"]}]
+    assert _check("Q4 revenue and growth were strong", crit).passed is True
+    out = _check("only revenue here", crit)
+    assert out.passed is False
+    assert "growth" in out.failures[0].description.lower()
+
+
+def test_word_count_range():
+    crit = [{"type": "word_count_range", "value": [3, 5]}]
+    assert _check("one two three four", crit).passed is True
+    assert _check("one two", crit).passed is False
+    assert _check("one two three four five six", crit).passed is False
+
+
+def test_json_schema_validates_structure_and_required_props():
+    crit = [
+        {
+            "type": "json_schema",
+            "value": {
+                "type": "object",
+                "required": ["name", "count"],
+                "properties": {"name": {"type": "string"}, "count": {"type": "integer"}},
+            },
+        }
+    ]
+    assert _check('{"name": "x", "count": 3}', crit).passed is True
+    assert _check("not json at all", crit).passed is False
+    assert _check('{"name": "x"}', crit).passed is False  # missing 'count'
+    assert _check('{"name": "x", "count": "3"}', crit).passed is False  # wrong type
+
+
+def test_url_valid_passes_when_no_urls_present():
+    # No URLs in the text → nothing to validate → pass.
+    assert _check("plain prose, no links", [{"type": "url_valid", "value": None}]).passed is True
+    assert _check(
+        "see https://example.com/path", [{"type": "url_valid", "value": None}]
+    ).passed is True
+
+
+def test_unknown_check_type_is_skipped_not_failed():
+    # An unknown handler is logged and skipped, not counted as a failure.
+    out = _check("whatever", [{"type": "no_such_check", "value": 1}])
+    assert out.passed is True
+    assert out.failures == []
+
+
+# ---- short-circuit semantics (the cost-relevant invariants) ----
+
+
+def test_must_pass_failure_short_circuits():
+    out = _check(
+        "tiny",
+        [
+            {"type": "min_length", "value": 100, "must_pass": True},
+            {"type": "contains_keywords", "value": ["unreached"]},
+        ],
+    )
+    assert out.passed is False
+    assert out.short_circuited is True
+    # Stops at the first must_pass failure — the second check never runs.
+    assert len(out.failures) == 1
+    assert out.failures[0].check_type == "min_length"
+
+
+def test_non_must_pass_failures_accumulate_without_short_circuit():
+    out = _check(
+        "tiny",
+        [
+            {"type": "min_length", "value": 100},
+            {"type": "contains_keywords", "value": ["missing"]},
+        ],
+    )
+    assert out.passed is False
+    assert out.short_circuited is False
+    assert len(out.failures) == 2
+
+
+def test_required_sections_never_short_circuits_even_if_must_pass():
+    """An LLM planner can't predict the exact headings an agent will emit, so
+    ``required_sections`` is force-demoted out of must_pass. A miss is recorded
+    as a soft failure, never a short-circuit."""
+    out = _check(
+        "# Intro\n\nbody only, no summary",
+        [{"type": "required_sections", "value": ["Summary"], "must_pass": True}],
+    )
+    assert out.short_circuited is False
+    assert out.passed is False
+    assert out.failures[0].must_pass is False
+
+
+# ================================================== VerificationService
+# Deterministic gating around the (stubbed) LLM judge.
+
+
+@pytest.mark.asyncio
+async def test_empty_output_fails_without_touching_the_judge():
+    svc = VerificationService()
+    svc._run_llm_judge = AsyncMock(side_effect=AssertionError("judge must not run"))
+    out = await svc.verify_task("t", "desc", "   ", None)
+    assert out.verdict == VERDICT_FAIL
+    assert out.deterministic_passed is False
+    svc._run_llm_judge.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_must_pass_failure_fails_closed_without_the_judge():
+    """Deterministic short-circuit → FAIL with no LLM spend (cost guard)."""
+    svc = VerificationService()
+    svc._run_llm_judge = AsyncMock(side_effect=AssertionError("judge must not run"))
+    out = await svc.verify_task(
+        "Report",
+        "Write a long report",
+        "too short",
+        [{"type": "min_length", "value": 5000, "must_pass": True}],
+    )
+    assert out.verdict == VERDICT_FAIL
+    assert out.deterministic_passed is False
+    assert out.deterministic_failures  # populated
+    svc._run_llm_judge.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_output_hash_cache_skips_second_judge_call():
+    """PRD-82B US-007: identical output on retry returns the cached verdict
+    without a second LLM call. Cache is class-level and keyed by
+    (run_id, task_id, sha256(output))."""
+    run_id, task_id = uuid4(), uuid4()
+    VerificationService.clear_cache(run_id)  # isolate from any prior run
+    svc = VerificationService()
+    judged = VerificationResult(verdict=VERDICT_PASS, reasoning="judged once")
+    svc._run_llm_judge = AsyncMock(return_value=judged)
+
+    try:
+        first = await svc.verify_task(
+            "t", "d", "identical output", None, run_id=run_id, task_id=task_id
+        )
+        second = await svc.verify_task(
+            "t", "d", "identical output", None, run_id=run_id, task_id=task_id
+        )
+
+        assert first is judged
+        assert second is judged
+        svc._run_llm_judge.assert_awaited_once()  # the retry hit the cache
+    finally:
+        # Class-level cache: always purge, even if an assertion above fails, so
+        # this run's entries can never bleed into another test.
+        VerificationService.clear_cache(run_id)
+
+
+def test_output_hash_is_deterministic_and_input_sensitive():
+    h = VerificationService._output_hash
+    assert h("same") == h("same")
+    assert h("a") != h("b")
+    assert len(h("x")) == 64  # sha256 hexdigest
+
+
+def test_clear_cache_is_scoped_to_one_run():
+    run_a, run_b = uuid4(), uuid4()
+    task = uuid4()
+    res = VerificationResult(verdict=VERDICT_PASS)
+    VerificationService._cache[(run_a, task, "h1")] = res
+    VerificationService._cache[(run_a, task, "h2")] = res
+    VerificationService._cache[(run_b, task, "h3")] = res
+
+    try:
+        removed = VerificationService.clear_cache(run_a)
+
+        assert removed == 2
+        assert not any(k[0] == run_a for k in VerificationService._cache)
+        assert (run_b, task, "h3") in VerificationService._cache
+    finally:
+        # Leave the class-level cache exactly as we found it, pass or fail.
+        VerificationService.clear_cache(run_a)
+        VerificationService.clear_cache(run_b)
+
+
+# ============================================== cross-model verifier guarantee
+
+
+def test_verifier_is_always_a_different_family_than_executor(monkeypatch):
+    """A model must never grade its own family. Given a mapping, an Anthropic
+    executor is verified by a non-Anthropic model and vice-versa."""
+    monkeypatch.setattr(
+        verif,
+        "_parse_verifier_model_mapping",
+        lambda: {"anthropic": "gpt-4o-mini", "openai": "claude-3-5-sonnet"},
+    )
+
+    for_claude = _select_verifier_model("claude-opus-4-1")
+    for_gpt = _select_verifier_model("gpt-4o")
+
+    assert "claude" not in for_claude.lower()  # Anthropic executor → non-Anthropic verifier
+    assert "gpt" not in for_gpt.lower()        # OpenAI executor → non-OpenAI verifier
+
+
+def test_verifier_falls_back_when_executor_family_unknown(monkeypatch):
+    monkeypatch.setattr(verif, "_parse_verifier_model_mapping", lambda: {})
+    monkeypatch.setattr(
+        verif.Config, "COORDINATOR_VERIFIER_FALLBACK_MODEL", "fallback-model", raising=False
+    )
+    # No executor and no mapping → the configured fallback.
+    assert _select_verifier_model(None) == "fallback-model"

--- a/orchestrator/tests/test_w2s10_rag_primitives.py
+++ b/orchestrator/tests/test_w2s10_rag_primitives.py
@@ -1,0 +1,157 @@
+"""PRD-142 Wave 2 · WS-I / W2-S10 — RAG primitive tests.
+
+The full RAG round-trip (embed → vector store → retrieve) can only be proven
+honestly against real infrastructure, and faking the embedder + vector store
+would just test the fakes. So instead of mock-theater, this pins the *real,
+deterministic* building blocks of ingest and retrieval — pure functions that
+need no embeddings, no vector DB, and no network:
+
+* ``_basic_chunk`` — the fallback ingest-chunking primitive (fixed-size windows,
+  drops slivers).
+* ``_calculate_content_quality`` — the per-chunk quality score that down-weights
+  ASCII-art / boilerplate before the knapsack picks a context budget.
+* ``_knapsack_dp`` — the 0/1 knapsack that selects the highest-value chunks that
+  fit the token budget. **A real suboptimality is documented below** (see the
+  xfail): when ``max_items`` binds before the token budget, it can pick a
+  lower-value set. Flagged for fix — the test net surfaced it.
+* ``_format_context`` — assembles selected chunks into the prompt context block.
+
+All four are exercised on a bare instance (``__new__`` bypasses the DB-reading
+``RAGConfig`` in ``__init__``) since none of them touch instance state.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import types
+
+for _k in ("POSTGRES_USER", "POSTGRES_PASSWORD", "POSTGRES_DB"):
+    os.environ.setdefault(_k, "test")
+os.environ.setdefault("POSTGRES_HOST", "localhost")
+os.environ.setdefault("POSTGRES_PORT", "5432")
+
+# modules/rag/__init__ pulls camelot (optional PDF dep, absent in test env).
+sys.modules.setdefault("camelot", types.ModuleType("camelot"))
+
+import pytest  # noqa: E402
+
+from modules.rag.service import RAGService  # noqa: E402
+
+
+def _svc() -> RAGService:
+    """Bare RAGService — bypasses __init__ (which constructs RAGConfig and
+    reads system_settings from the DB). The methods under test are pure and
+    never touch instance state."""
+    return RAGService.__new__(RAGService)
+
+
+# =========================================================== _basic_chunk
+# Fixed-size ingest chunking; slivers (≤50 stripped chars) are dropped.
+
+
+def test_basic_chunk_splits_into_fixed_windows():
+    chunks = _svc()._basic_chunk("x" * 1200)  # default chunk_size=500
+    assert len(chunks) == 3
+    assert chunks[0]["content"] == "x" * 500
+    assert chunks[-1]["content"] == "x" * 200
+    assert all(c["metadata"] == {} for c in chunks)
+
+
+def test_basic_chunk_drops_short_sliver_tail():
+    # 540 chars → [0:500] kept, [500:540] is a 40-char sliver (≤50) → dropped.
+    assert len(_svc()._basic_chunk("x" * 540)) == 1
+    # 560 chars → tail is 60 chars (>50) → kept.
+    assert len(_svc()._basic_chunk("x" * 560)) == 2
+
+
+def test_basic_chunk_drops_entirely_short_input():
+    assert _svc()._basic_chunk("x" * 30) == []
+
+
+# ============================================= _calculate_content_quality
+# 0.0–1.0 score. ASCII-art penalised; short valid content scored fairly.
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("   ", 0.1),                       # empty / whitespace
+        (" ".join(["w"] * 3), 0.5),         # <5 words
+        (" ".join(["w"] * 15), 0.7),        # <20 words
+        (" ".join(["w"] * 30), 0.85),       # <50 words
+        (" ".join(["w"] * 60), 1.0),        # ≥50 words
+    ],
+)
+def test_content_quality_word_count_bands(text, expected):
+    assert _svc()._calculate_content_quality(text) == expected
+
+
+def test_content_quality_penalises_ascii_art_heavily():
+    art = "│" * 20 + "x" * 60  # >15% box-drawing chars
+    assert _svc()._calculate_content_quality(art) == 0.2
+
+
+# ================================================================ _knapsack_dp
+# 0/1 knapsack: maximise value within token capacity and max_items.
+
+
+def test_knapsack_rejects_degenerate_params():
+    s = _svc()
+    assert s._knapsack_dp([], [], 10, 5) == []
+    assert s._knapsack_dp([1.0], [1], 0, 5) == []      # zero capacity
+    assert s._knapsack_dp([1.0], [1], 10, 0) == []     # zero max_items
+
+
+def test_knapsack_picks_optimal_set_within_capacity():
+    # items (value, weight): A(10,5) B(40,4) C(30,6) D(50,3); cap=10.
+    # Optimal = B+D (value 90, weight 7). A+B+D would weigh 12 > 10.
+    selected = _svc()._knapsack_dp([10, 40, 30, 50], [5, 4, 6, 3], 10, 10)
+    assert selected == [1, 3]
+
+
+def test_knapsack_respects_capacity_bound():
+    # Total weight of all items (18) exceeds capacity (10): result must fit.
+    weights = [5, 4, 6, 3]
+    selected = _svc()._knapsack_dp([10, 40, 30, 50], weights, 10, 10)
+    assert sum(weights[i] for i in selected) <= 10
+
+
+def test_knapsack_honours_max_items_count():
+    # With max_items=2, never return more than 2 indices.
+    selected = _svc()._knapsack_dp([10, 40, 30, 50], [5, 4, 6, 3], 10, 2)
+    assert len(selected) <= 2
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "KNOWN DEFECT (PRD-142 W2-S10): _knapsack_dp is suboptimal when "
+        "max_items binds before the token budget. For values=[10,40,30,50] "
+        "weights=[5,4,6,3] cap=10 max_items=1 it returns index 0 (value 10) "
+        "instead of index 3 (value 50). The 2D DP + greedy item_count tracking "
+        "does not solve the 3-constraint knapsack its docstring promises "
+        "(dp[i][w][k]). Flagged for fix; remove this marker once corrected."
+    ),
+)
+def test_knapsack_is_optimal_when_max_items_binds():
+    # The single most valuable item that fits cap=10 is D (index 3, value 50).
+    selected = _svc()._knapsack_dp([10, 40, 30, 50], [5, 4, 6, 3], 10, 1)
+    assert selected == [3]
+
+
+# ============================================================= _format_context
+
+
+def test_format_context_empty_is_explicit_sentinel():
+    assert _svc()._format_context([], "anything") == "No relevant context found."
+
+
+def test_format_context_renders_sources_with_relevance():
+    out = _svc()._format_context(
+        [{"source_file": "guide.md", "similarity": 0.9, "content": "the answer"}],
+        "my query",
+    )
+    assert "## Retrieved Context for: my query" in out
+    assert "### Source 1: guide.md (relevance: 90%)" in out
+    assert "the answer" in out

--- a/orchestrator/tests/test_w2s9_reasoning_entry.py
+++ b/orchestrator/tests/test_w2s9_reasoning_entry.py
@@ -1,0 +1,323 @@
+"""PRD-142 Wave 2 · WS-I / W2-S9 — chat & reasoning-entry tests.
+
+This is the single biggest coverage hole in the platform: the code that
+decides *what the platform does with every message* had no direct test. The
+three deciders are all deterministic before any LLM call, so their verdict
+tables can be pinned exactly:
+
+* ``AutoBrain.assess`` — complexity (ATOM…ORGANISM) + action
+  (RESPOND/DELEGATE/MISSION). Tier 1 is a Redis cache, Tier 2 is free regex
+  heuristics, Tier 3 is the LLM. We disable the cache and exercise the Tier-2
+  verdict table directly; the Tier-3 fall-through is asserted with the LLM
+  call stubbed (no spend, no network).
+* ``IntentClassifier`` (core, universal-router Tier 2c) — category + action
+  from rule-based patterns.
+* ``SmartIntentClassifier`` (chatbot pipeline) — Intent enum + tool/memory
+  flags.
+
+The last block proves the two classifiers do **not** cross-contaminate: same
+input, independent pipelines, type-distinct results. See
+[[intent-classifier-disambiguation]].
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import types
+
+# auto.py → core.database/config pulls Postgres env at import. Seed harmless
+# defaults; nothing in this module touches a real DB or network.
+os.environ.setdefault("POSTGRES_USER", "test")
+os.environ.setdefault("POSTGRES_PASSWORD", "test")
+os.environ.setdefault("POSTGRES_HOST", "localhost")
+os.environ.setdefault("POSTGRES_PORT", "5432")
+os.environ.setdefault("POSTGRES_DB", "test")
+
+# consumers/__init__.py eagerly imports the chatbot stack → RAG → camelot, an
+# optional PDF table-extraction dep that isn't installed in the test env. Stub
+# it so the import chain resolves (same pattern as test_l3_distill_input.py).
+sys.modules.setdefault("camelot", types.ModuleType("camelot"))
+
+from unittest.mock import AsyncMock, MagicMock  # noqa: E402
+
+import pytest  # noqa: E402
+
+from consumers.chatbot.auto import (  # noqa: E402
+    Action,
+    AutoBrain,
+    Complexity,
+    ComplexityAssessment,
+)
+from consumers.chatbot.intent_classifier import (  # noqa: E402
+    Intent,
+    IntentResult,
+    SmartIntentClassifier,
+)
+from core.services.intent_classifier import (  # noqa: E402
+    IntentClassification,
+    IntentClassifier,
+)
+
+
+# --------------------------------------------------------------- helpers
+
+
+def _brain() -> AutoBrain:
+    """AutoBrain with the Redis cache forced to a miss/no-op.
+
+    Tier 1 must not shadow the Tier-2 heuristics we're exercising, and no test
+    here should touch a real Redis. Overriding the two cache methods on the
+    instance is bulletproof regardless of whether a client was constructed.
+    """
+    brain = AutoBrain(db=MagicMock(), workspace_id="ws-test")
+    brain._redis = None
+    brain._cache_lookup = lambda *a, **k: None
+    brain._cache_store = lambda *a, **k: None
+    return brain
+
+
+# ============================================================ AutoBrain
+# Tier 2 verdict table — deterministic, no LLM.
+
+
+@pytest.mark.asyncio
+async def test_assess_empty_message_is_atom_respond():
+    out = await _brain().assess("   ")
+    assert out.complexity is Complexity.ATOM
+    assert out.action is Action.RESPOND
+    assert out.confidence == 1.0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "message",
+    [
+        "hello",
+        "Hi Auto",
+        "morning auto",
+        "thanks!",
+        "what can you do?",
+        "tell me a joke",
+        "who are you",
+    ],
+)
+async def test_assess_chitchat_is_atom_respond(message):
+    out = await _brain().assess(message)
+    assert out.complexity is Complexity.ATOM, message
+    assert out.action is Action.RESPOND, message
+    assert out.needs_memory is False
+    assert out.tool_hints == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "message,expected_tool",
+    [
+        ("list my agents", "platform_list_agents"),
+        ("show my playbooks", "platform_list_recipes"),
+        ("token usage", "platform_get_llm_usage"),
+        ("what models are available", "platform_list_llms"),
+    ],
+)
+async def test_assess_platform_query_is_molecule_with_tool(message, expected_tool):
+    out = await _brain().assess(message)
+    assert out.complexity is Complexity.MOLECULE, message
+    assert out.action is Action.RESPOND, message
+    assert out.tool_hints == ["platform"]
+    assert expected_tool in out.matched_tools, (message, out.matched_tools)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "message",
+    [
+        "my name is Gerard",
+        "what did we say about the launch date",
+    ],
+)
+async def test_assess_memory_recall_is_cell_needs_memory(message):
+    """Passive self-disclosure / conversational recall → CELL, needs_memory.
+
+    These reach the CELL tier because they match the memory-recall pattern but
+    *not* any platform-tool pattern. Contrast with explicit memory-*search*
+    phrasing, which is intercepted earlier — see the precedence test below.
+    """
+    out = await _brain().assess(message)
+    assert out.complexity is Complexity.CELL, message
+    assert out.action is Action.RESPOND, message
+    assert out.needs_memory is True, message
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "message",
+    [
+        "do you remember when we discussed the Q4 budget",
+        "what do you remember about my preferences",
+        "recall when we set the budget",
+    ],
+)
+async def test_assess_memory_search_phrasing_routes_to_platform_tool(message):
+    """Precedence guard: explicit memory-*search* phrasing is a tool call.
+
+    "do you remember…", "what do you remember…", "recall…" overlap the
+    CELL memory-recall regex, but the MOLECULE platform-query tier is checked
+    *first*, so they route to the ``platform_search_memory`` tool (an active
+    search) rather than passive CELL recall. This ordering is intentional and
+    easy to break by reordering the heuristics — pin it.
+    """
+    out = await _brain().assess(message)
+    assert out.complexity is Complexity.MOLECULE, message
+    assert out.action is Action.RESPOND, message
+    assert out.needs_memory is False, message
+    assert out.tool_hints == ["platform"], message
+    assert "platform_search_memory" in out.matched_tools, (message, out.matched_tools)
+
+
+@pytest.mark.asyncio
+async def test_assess_falls_through_to_llm_when_no_heuristic_matches():
+    """A message that hits no Tier-2 pattern must reach Tier 3 (the LLM),
+    and assess must return whatever the LLM tier produced."""
+    brain = _brain()
+    sentinel = ComplexityAssessment(
+        complexity=Complexity.ORGAN,
+        action=Action.MISSION,
+        reasoning="stub",
+        confidence=0.7,
+    )
+    brain._llm_classify = AsyncMock(return_value=sentinel)
+
+    out = await brain.assess(
+        "research our top 3 competitors, write a positioning report, "
+        "and email it to the leadership team"
+    )
+
+    assert out is sentinel
+    brain._llm_classify.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_assess_heuristic_path_never_calls_the_llm():
+    """Cost guard: a greeting must be resolved for free — the LLM tier is
+    never invoked on a Tier-2 hit."""
+    brain = _brain()
+    brain._llm_classify = AsyncMock(
+        side_effect=AssertionError("LLM must not be called for chitchat")
+    )
+
+    out = await brain.assess("hey there")
+
+    assert out.complexity is Complexity.ATOM
+    brain._llm_classify.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_assess_tier1_cache_short_circuits_before_heuristics():
+    """A cache hit returns immediately without running the heuristics."""
+    brain = AutoBrain(db=MagicMock(), workspace_id="ws-test")
+    cached = ComplexityAssessment(
+        complexity=Complexity.ORGANISM,
+        action=Action.MISSION,
+        reasoning="cached",
+        confidence=0.99,
+    )
+    brain._cache_lookup = lambda *a, **k: cached
+    brain._run_fast_heuristics = MagicMock(
+        side_effect=AssertionError("heuristics must be skipped on a cache hit")
+    )
+
+    out = await brain.assess("hello")  # would be ATOM via heuristics
+
+    assert out is cached
+    brain._run_fast_heuristics.assert_not_called()
+
+
+# ====================================================== IntentClassifier
+# Core / universal-router Tier 2c — category + action.
+
+
+@pytest.mark.parametrize(
+    "query,category",
+    [
+        ("send an email to John", "EMAIL"),
+        ("what's on my calendar tomorrow", "CALENDAR"),
+        ("open a pull request on github", "CODE"),
+        ("post a message to the slack channel", "COMMUNICATION"),
+        ("generate an image of a logo", "IMAGE"),
+        ("run a nl2sql query on the database", "DATABASE"),
+    ],
+)
+def test_core_intent_classifier_category(query, category):
+    out = IntentClassifier().classify(query)
+    assert isinstance(out, IntentClassification)
+    assert out.category == category, (query, out.category)
+
+
+def test_core_intent_classifier_action_create_and_delete():
+    assert IntentClassifier().classify("send an email to John").action_type == "CREATE"
+    assert (
+        IntentClassifier().classify("delete the calendar event").action_type
+        == "DELETE"
+    )
+
+
+def test_core_intent_classifier_unmatched_is_general_low_confidence():
+    out = IntentClassifier().classify("qwerty zxcv")
+    assert out.category == "GENERAL"
+    assert out.action_type == "UNKNOWN"
+    assert out.confidence < 0.5
+
+
+# ================================================ SmartIntentClassifier
+# Chatbot pipeline — Intent enum + tool/memory flags.
+
+
+@pytest.mark.parametrize(
+    "query,intent,requires_tools,requires_memory",
+    [
+        ("hi there", Intent.GREETING, False, False),
+        ("send an email to the team", Intent.EXTERNAL_ACTION, True, False),
+        ("my name is Gerard", Intent.MEMORY_RECALL, False, True),
+        ("how many agents do I have", Intent.DATA_QUERY, True, False),
+    ],
+)
+def test_smart_intent_classifier_table(query, intent, requires_tools, requires_memory):
+    out = SmartIntentClassifier().classify(query)
+    assert isinstance(out, IntentResult)
+    assert out.primary_intent is intent, (query, out.primary_intent)
+    assert out.requires_tools is requires_tools, query
+    assert out.requires_memory is requires_memory, query
+
+
+def test_smart_intent_classifier_empty_is_simple_chitchat():
+    out = SmartIntentClassifier().classify("")
+    assert out.primary_intent is Intent.CHITCHAT
+    assert out.is_simple is True
+    assert out.requires_tools is False
+
+
+# ================================================ no cross-contamination
+
+
+def test_two_classifiers_are_distinct_pipelines():
+    """The universal-router classifier and the chatbot classifier are
+    separate classes with type-distinct results and disjoint vocabularies.
+    Same input → independent classification, no shared state."""
+    assert IntentClassifier is not SmartIntentClassifier
+
+    query = "send an email to John"
+    core = IntentClassifier().classify(query)
+    smart = SmartIntentClassifier().classify(query)
+
+    # Type-distinct results.
+    assert isinstance(core, IntentClassification)
+    assert isinstance(smart, IntentResult)
+
+    # Disjoint vocabularies — one speaks "category", the other "primary_intent".
+    assert hasattr(core, "category") and not hasattr(core, "primary_intent")
+    assert hasattr(smart, "primary_intent") and not hasattr(smart, "category")
+
+    # Both recognise the email action, in their own terms.
+    assert core.category == "EMAIL"
+    assert smart.primary_intent is Intent.EXTERNAL_ACTION


### PR DESCRIPTION
## Summary

Completes **PRD-142 Wave 2 "Test Net"** — the last two workstreams, WS-H (golden journeys) and WS-I (untested primitives). All additions are **test-only**; no production code changes. The deciders pinned here had **zero direct coverage** before this PR.

- **W2-S9 — chat & reasoning entry** (`test_w2s9_reasoning_entry.py`): pins `AutoBrain.assess`'s Tier-2 regex verdict table (ATOM/MOLECULE/CELL × RESPOND/DELEGATE/MISSION) plus both `IntentClassifier` pipelines. The Redis cache is disabled and the LLM tier is stubbed and **asserted unreached** on heuristic hits (cost guard). Pins the intentional **MOLECULE-before-CELL** precedence (memory-*search* phrasing routes to `platform_search_memory`, not passive CELL recall).
- **W2-S10 — verification** (`test_w2s10_mission_verification.py`): `DeterministicChecker` (8 pure handlers + `must_pass` short-circuit) and `VerificationService` (empty-output guard, deterministic short-circuit, output-hash cache, cross-model verifier guarantee). The LLM judge is stubbed and proven **not awaited** when the deterministic layer already has a verdict.
- **W2-S10 — RAG primitives** (`test_w2s10_rag_primitives.py`): the pure `RAGService` building blocks (`_basic_chunk`, `_calculate_content_quality`, `_knapsack_dp`, `_format_context`) via `__new__` to bypass the DB-reading `__init__`.
- **WS-H — golden journeys** (`test_golden_journeys.py`): J2 (chat routing), J5 (RAG composition), **J10 (real-Postgres cross-workspace isolation on `resolve_agent` — the P0 leak guard)**. J1/J3/J4/J6/J7/J8/J9 are `pytest.skip` with precise infra reasons.

**Full orchestrator suite: 1330 passed, 7 skipped, 1 xfailed.** (Verified locally against real PG and by the pre-push hook.)

## Flags for the morning

1. **Real bug surfaced, not hidden** — `test_knapsack_is_optimal_when_max_items_binds` is a **strict xfail** documenting a genuine `_knapsack_dp` suboptimality: when `max_items` binds before the token budget it can pick a lower-value set (for `values=[10,40,30,50] weights=[5,4,6,3] cap=10 max_items=1` it returns index 0 / value 10 instead of index 3 / value 50). The 2D DP + greedy item-count tracking doesn't solve the 3-constraint knapsack its docstring promises. **Fix the DP, then delete the xfail marker.**
2. **Next golden-journey gap** — **J9** (Shopify → Knowledge Graph → frequently-bought-together) is the highest-value skipped journey; it needs recorded Shopify fixtures to run offline. This is the moat workflow worth closing next.
3. **The 7 skips are honest** — each names a real external dependency (recorded fixtures, a running mission worker, NL2SQL which is PRD-deferred to Wave 3), not hidden testable logic.

## Incidental fix

`test_w2s7_fail_closed_authz_gate.py` previously did `setdefault("modules.rag", MagicMock())` when camelot was absent — a `__path__`-less package stub that poisoned `sys.modules['modules.rag']` and broke **collection** of every later test importing the real `modules.rag.service`. Now it stubs the actual missing **leaf** (`camelot`, a `ModuleType`), the blessed pattern used across the suite. `sentence_transformers` is installed; camelot is the only missing leaf in that chain.

## Test plan

- [x] Full suite green locally against real PG (`1330 passed, 7 skipped, 1 xfailed`)
- [x] Each new file passes in isolation AND in full-suite collection order (the pollution that motivated the W2-S7 fix)
- [x] J10 real-DB test gated by an ephemeral-DB guard (localhost/127.0.0.1 + test_db/test only) and deletes exactly the rows it commits, with leak-proof teardown
- [ ] CI `orchestrator-tests` + `ioc-scan` green on this PR
- [ ] Review the `_knapsack_dp` xfail and decide fix-now vs. follow-up ticket

> Not merging and not flipping the required status check in this PR — both await your explicit go-ahead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end test coverage for core platform flows including chat reasoning, agent workspace isolation, and RAG pipelines
  * Expanded mission verification testing to ensure deterministic verification behavior
  * Enhanced test infrastructure for improved dependency management and test isolation
  * Implemented additional coverage for message routing and reasoning entry points

<!-- end of auto-generated comment: release notes by coderabbit.ai -->