### PR TITLE
fix(mission): route tasks by capability, not agent name

### DIFF
--- a/orchestrator/modules/coordination/agent_matcher.py
+++ b/orchestrator/modules/coordination/agent_matcher.py
@@ -74,6 +74,11 @@ _ROLE_SYNONYMS: Dict[str, List[str]] = {
     "admin": ["admin", "operations", "ops", "configure", "setup", "workspace"],
 }
 
+# Canonical capability vocabulary the mission planner assigns from. Tasks bind
+# to one of these CAPABILITIES (not a specific agent name); the matcher then
+# scores every active agent for the capability and dispatches the best fit.
+CANONICAL_ROLES: frozenset = frozenset(_ROLE_SYNONYMS)
+
 
 # ---------------------------------------------------------------------------
 # Result dataclass

--- a/orchestrator/modules/coordination/planner.py
+++ b/orchestrator/modules/coordination/planner.py
@@ -27,6 +27,7 @@ from core.llm import create_llm_manager
 from core.models.core import Agent
 from core.utils.exception_telemetry import record_error
 from core.models.orchestration_enums import ComplexityTier, TaskType
+from modules.coordination.agent_matcher import CANONICAL_ROLES, _compute_skill_match
 from modules.coordination.templates import match_template, render_template
 from services.orchestration_deps import (
     CyclicDependencyError,
@@ -684,7 +685,9 @@ name (e.g. "research", "analysis"). Tasks in the same parallel_group MUST NOT \
 depend on each other.
 - After parallel groups converge, include a "synthesis" task (task_type="synthesis") \
 that merges and integrates the outputs of the parallel tasks.
-- Every task must specify an agent_role matching one of the available agents.
+- Every task must specify an agent_role naming the CAPABILITY it needs (e.g. \
+researcher, writer, analyst, summarizer) — NOT a specific agent's name. The \
+platform routes each capability to the best-fit agent.
 - The plan MUST contain between 3 and 20 tasks inclusive.
 - Return ONLY a single JSON object (no markdown, no explanation).
 """
@@ -853,7 +856,9 @@ Rules:
 Tasks in the same parallel_group MUST NOT depend on each other.
 - After parallel groups converge, include a "synthesis" task (task_type="synthesis") \
 that merges the parallel outputs.
-- Every task must specify an agent_role matching one of the available agents.
+- Every task must specify an agent_role naming the CAPABILITY it needs (e.g. \
+researcher, writer, analyst, summarizer) — NOT a specific agent's name. The \
+platform routes each capability to the best-fit agent.
 - The plan MUST contain between 3 and 20 tasks inclusive.
 - Return ONLY a single JSON object (no markdown, no explanation).
 """
@@ -904,8 +909,36 @@ def _build_replan_prompt(
     return "\n".join(parts)
 
 
+# A capability role is "fillable" when at least one active agent has a
+# non-trivial skill/description/tag match for it. Below this floor the matcher
+# would return NO_AGENT_AVAILABLE at dispatch, so the plan is rejected up front
+# rather than failing a task at runtime.
+_ROLE_FILLABILITY_FLOOR = 0.3
+
+
+def _best_role_fit(role: str, agents: Sequence[Agent]) -> float:
+    """Highest capability fit any *active* agent has for ``role`` (0.0 = none)."""
+    role_lower = (role or "").lower()
+    return max(
+        (
+            _compute_skill_match(a, role_lower)
+            for a in agents
+            if getattr(a, "status", None) == "active"
+        ),
+        default=0.0,
+    )
+
+
 def _render_agent_roster(agents: Sequence[Agent]) -> str:
-    """Render available agents as a concise description for the planner prompt."""
+    """Render available agents by CAPABILITY for the planner prompt.
+
+    Agents are listed by what they can do (skills, focus, tags) so the planner
+    understands the roster's coverage — but never as a ``role: <name>`` mapping.
+    Binding a task to a specific agent NAME is what mis-routed research work to a
+    non-research agent (the matcher scores an exact name match at 1.0). Instead
+    the planner must choose ``agent_role`` from the canonical capability
+    vocabulary, and the matcher resolves each capability to the best-fit agent.
+    """
     if not agents:
         return "(No agents available)\n"
 
@@ -933,13 +966,23 @@ def _render_agent_roster(agents: Sequence[Agent]) -> str:
 
         desc = (agent.description or "")[:120]
         lines.append(
-            f"- **{agent.name}** (role: {agent.name.lower()})"
-            f" — {desc}"
+            f"- {agent.name}: {desc}"
             f"{skills_text}{tags_text}"
             f"{f' | Model: {model_id}' if model_id else ''}"
         )
 
-    return "\n".join(lines) if lines else "(No active agents)\n"
+    if not lines:
+        return "(No active agents)\n"
+
+    vocab = ", ".join(sorted(CANONICAL_ROLES))
+    return (
+        "\n".join(lines)
+        + "\n\n"
+        + "Set each task's `agent_role` to the CAPABILITY the task needs, chosen "
+        + f"from: {vocab}.\n"
+        + "Do NOT use an agent's name as the role — the platform routes each "
+        + "capability to the best-fit agent listed above.\n"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -1341,35 +1384,16 @@ def _validate_plan(
     except InvalidDependencyError as exc:
         errors.append(str(exc))
 
-    # 4. Agent role matching
-    active_agent_names = set()
-    for agent in agents:
-        if agent.status == "active":
-            active_agent_names.add(agent.name.lower())
-            # Also match by skill names
-            try:
-                if agent.skills:
-                    for s in agent.skills:
-                        if s.name:
-                            active_agent_names.add(s.name.lower())
-            except Exception:
-                pass
-            # Also match by tags
-            if agent.tags and isinstance(agent.tags, list):
-                for t in agent.tags:
-                    active_agent_names.add(str(t).lower())
-
+    # 4. Agent role capability coverage.
+    #    A role is a CAPABILITY (researcher, writer, ...), valid when some active
+    #    agent can actually fill it — scored the same way the matcher dispatches.
+    #    This catches unfillable roles at plan time instead of failing the task
+    #    with NO_AGENT_AVAILABLE at dispatch.
     for task in tasks:
-        role_lower = task.agent_role.lower()
-        # Fuzzy: check if role matches any agent name, skill, or tag
-        matched = any(
-            role_lower == name or role_lower in name or name in role_lower
-            for name in active_agent_names
-        )
-        if not matched:
+        if _best_role_fit(task.agent_role, agents) < _ROLE_FILLABILITY_FLOOR:
             errors.append(
                 f"Task '{task.title}' references agent_role '{task.agent_role}' "
-                f"which does not match any active agent"
+                f"which no active agent can fill"
             )
 
     # 5. Parallel group cross-dependency check (PRD-82C)

--- a/orchestrator/tests/test_planner_capability_routing.py
+++ b/orchestrator/tests/test_planner_capability_routing.py
@@ -1,0 +1,157 @@
+"""Regression net for capability-based agent routing.
+
+The mission planner used to present each agent to the LLM as
+``**NAME** (role: name.lower())`` — teaching it to bind a task to a specific
+agent NAME. The matcher scores an exact name match at 1.0, so a blog/research
+task tagged ``agent_role="vector"`` would land on VECTOR (a growth strategist)
+instead of a research agent, then loop and time out.
+
+These tests pin the fix:
+
+1. The matcher routes a *capability* role ("research") to the research-capable
+   agent, never the growth agent — proving capability roles work.
+2. ``_render_agent_roster`` no longer teaches name-as-role and instead lists
+   the canonical capability vocabulary.
+3. ``_best_role_fit`` (the validation seam) accepts a fillable capability and
+   rejects a role no active agent can satisfy.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+_ORCH = Path(__file__).resolve().parents[1]
+if str(_ORCH) not in sys.path:
+    sys.path.insert(0, str(_ORCH))
+
+from modules.coordination.agent_matcher import (  # noqa: E402
+    CANONICAL_ROLES,
+    _compute_skill_match,
+)
+from modules.coordination.planner import (  # noqa: E402
+    _best_role_fit,
+    _render_agent_roster,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fakes — minimal Agent shape the matcher/planner read.
+# ---------------------------------------------------------------------------
+
+
+def _skill(name: str) -> SimpleNamespace:
+    return SimpleNamespace(name=name)
+
+
+def _agent(name, description, *, skills=(), tags=(), status="active",
+           model_id="gpt-4o") -> SimpleNamespace:
+    return SimpleNamespace(
+        name=name,
+        description=description,
+        skills=[_skill(s) for s in skills],
+        tags=list(tags),
+        status=status,
+        model_config={"model_id": model_id},
+    )
+
+
+_SCOUT = _agent(
+    "SCOUT",
+    "Research specialist that investigates topics and gathers sources via web search",
+    skills=["research", "web_search", "source_analysis"],
+    tags=["research"],
+)
+_VECTOR = _agent(
+    "VECTOR",
+    "Growth strategist focused on marketing funnels and conversion optimisation",
+    skills=["growth_strategy", "marketing"],
+    tags=["growth"],
+)
+_SCRIBE = _agent(
+    "SCRIBE",
+    "Writer that drafts long-form blog content and articles",
+    skills=["writing", "copywriting", "blog"],
+    tags=["writer"],
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. Capability routing — the core "stop picking by name" proof.
+# ---------------------------------------------------------------------------
+
+
+def test_research_role_routes_to_research_agent_over_growth_agent():
+    """A capability role 'research' must score the research agent far above
+    the growth agent — the growth agent should not be a candidate at all."""
+    scout_score = _compute_skill_match(_SCOUT, "research")
+    vector_score = _compute_skill_match(_VECTOR, "research")
+
+    assert scout_score >= 0.6, f"research agent should match 'research', got {scout_score}"
+    assert vector_score == 0.0, f"growth agent must NOT match 'research', got {vector_score}"
+    assert scout_score > vector_score
+
+
+def test_writer_role_routes_to_writer_not_research_agent():
+    assert _compute_skill_match(_SCRIBE, "writer") >= 0.6
+    assert _compute_skill_match(_SCRIBE, "writer") > _compute_skill_match(_SCOUT, "writer")
+
+
+def test_exact_name_match_is_the_mechanism_we_route_around():
+    """Documents WHY name-binding mis-routed: an agent's own name scores 1.0,
+    which beats any capability fit. The roster fix stops the LLM emitting names
+    so this 1.0 path is never reached for a capability task."""
+    assert _compute_skill_match(_VECTOR, "vector") == 1.0
+    # ...and that same growth agent is a 0.0 fit for the research work it wrongly got.
+    assert _compute_skill_match(_VECTOR, "research") == 0.0
+
+
+# ---------------------------------------------------------------------------
+# 2. Roster no longer teaches name-as-role.
+# ---------------------------------------------------------------------------
+
+
+def test_roster_does_not_present_name_as_role():
+    roster = _render_agent_roster([_SCOUT, _VECTOR, _SCRIBE])
+    assert "(role:" not in roster, "roster must not map agent name to a role"
+    assert "scout" not in roster.lower().split("agent_role")[0] or "(role:" not in roster
+
+
+def test_roster_lists_canonical_capability_vocabulary_and_steers_off_names():
+    roster = _render_agent_roster([_SCOUT, _VECTOR, _SCRIBE])
+    assert "agent_role" in roster
+    # The canonical capabilities the planner should choose from are surfaced.
+    assert "research" in roster and "writer" in roster
+    # Explicitly steered away from binding to a name.
+    assert "name" in roster.lower()
+
+
+def test_roster_skips_inactive_agents():
+    inactive = _agent("GHOST", "inactive", status="inactive")
+    roster = _render_agent_roster([_SCOUT, inactive])
+    assert "SCOUT" in roster
+    assert "GHOST" not in roster
+
+
+# ---------------------------------------------------------------------------
+# 3. Validation seam — capability coverage, not name matching.
+# ---------------------------------------------------------------------------
+
+
+def test_best_role_fit_accepts_fillable_capability():
+    assert _best_role_fit("research", [_SCOUT, _VECTOR]) >= 0.6
+    assert _best_role_fit("writer", [_SCOUT, _SCRIBE]) >= 0.6
+
+
+def test_best_role_fit_rejects_unfillable_role():
+    assert _best_role_fit("underwater_basket_weaving", [_SCOUT, _VECTOR, _SCRIBE]) == 0.0
+
+
+def test_best_role_fit_ignores_inactive_agents():
+    only_inactive = _agent("SCOUT", "research", skills=["research"], status="inactive")
+    assert _best_role_fit("research", [only_inactive]) == 0.0
+
+
+def test_canonical_roles_cover_research_and_writer():
+    assert "research" in CANONICAL_ROLES
+    assert "writer" in CANONICAL_ROLES


### PR DESCRIPTION
## Summary
- The mission planner bound each task to a specific agent **name** (`agent_role` was rendered as `role: <agentname>`), and the matcher's exact-name match (skill score `1.0`) then beat every capability-based candidate. A blog/research mission could therefore pin a research task to **VECTOR** — a growth strategist with zero research fit — purely because the plan named it.
- The planner now presents agents **by capability only**, instructs both the plan and replan prompts to set `agent_role` to a capability drawn from the canonical vocabulary (`researcher`, `writer`, `analyst`, …), and validates each task by **capability coverage** (`_best_role_fit >= floor`) instead of fuzzy name/skill/tag matching. `CANONICAL_ROLES` (derived from the matcher's role synonyms) is the single source of truth.
- Result: capability `research` routes to **SCOUT** (≥0.6 fit), never **VECTOR** (`0.0`, below the `0.4` threshold). The exact-name-scores-1.0 mechanism that let "vector" win is routed around.

## Test plan
- [x] `tests/test_planner_capability_routing.py` — 10 tests, green on the `main` base
- [x] capability `research` → research agent (≥0.6), not growth agent (`0.0`)
- [x] exact name match still scores `1.0` (the mechanism this routes around)
- [x] roster contains no `(role:` and lists the capability vocab + steers off agent names
- [x] `_best_role_fit` accepts fillable / rejects unfillable / ignores inactive agents
- [ ] CI: `orchestrator-tests` + `ioc-scan`

## Notes
Part 1 of 2 from the mission-loop fix. The companion **large-file write resilience** fix depends on the converged `ToolLoopExecutor` (Ralph's Wave 3, not yet on `main`) and will follow once Wave 3 merges.