### PR TITLE
fix(agents): resolve output-token budget from agent settings, not power mode

### DIFF
--- a/orchestrator/api/agent_endpoints.py
+++ b/orchestrator/api/agent_endpoints.py
@@ -803,7 +803,7 @@ async def switch_agent_model(
             "provider": new_model.provider,
             "model_id": new_model_id,
             "temperature": request.get("temperature", new_model.default_temperature),
-            "max_tokens": request.get("max_tokens", min(2000, new_model.max_output_tokens)),
+            "max_tokens": request.get("max_tokens", new_model.max_output_tokens),
             "top_p": current_config.get("top_p", 1.0),
             "frequency_penalty": current_config.get("frequency_penalty", 0.0),
             "presence_penalty": current_config.get("presence_penalty", 0.0),

--- a/orchestrator/core/llm/defaults.py
+++ b/orchestrator/core/llm/defaults.py
@@ -18,6 +18,13 @@ DEFAULT_LLM_MODEL = "google/gemini-2.5-flash"
 # (category=content_creation, key=blog_cover_model). See config.BLOG_COVER_MODEL.
 DEFAULT_IMAGE_GEN_MODEL = "google/gemini-3-pro-image-preview"
 
+# Last-resort output-token budget — used only when neither the agent's configured
+# Max Output Tokens nor the selected model's registry ceiling is available. The
+# per-agent setting is the source of truth; the model's own max_output_tokens is
+# the preferred fallback. This is the single named default; there are no other
+# hardcoded token numbers in the agent/coordinator budget path.
+DEFAULT_MAX_OUTPUT_TOKENS = 8000
+
 
 def get_default_model_config() -> dict:
     """Return a fresh default model_config dict."""
@@ -25,7 +32,7 @@ def get_default_model_config() -> dict:
         "provider": DEFAULT_LLM_PROVIDER,
         "model_id": DEFAULT_LLM_MODEL,
         "temperature": 0.7,
-        "max_tokens": 2000,
+        "max_tokens": DEFAULT_MAX_OUTPUT_TOKENS,
         "top_p": 1.0,
         "frequency_penalty": 0.0,
         "presence_penalty": 0.0,

--- a/orchestrator/modules/agents/factory/agent_factory.py
+++ b/orchestrator/modules/agents/factory/agent_factory.py
@@ -23,6 +23,7 @@ from sqlalchemy.orm import Session
 
 from config import config
 from core.llm import LLMConfig, LLMManager, LLMProvider, LLMResponse, create_llm_manager
+from core.llm.defaults import DEFAULT_MAX_OUTPUT_TOKENS
 from core.models import Agent, Base, PriorityLevel, Skill
 from core.models.composio_cache import AgentAppAssignment, ComposioAppCache
 
@@ -63,7 +64,7 @@ class ModelConfiguration:
     provider: str
     model_id: str
     temperature: float = 0.7
-    max_tokens: int = 2000
+    max_tokens: int = DEFAULT_MAX_OUTPUT_TOKENS
     top_p: float = 1.0
     frequency_penalty: float = 0.0
     presence_penalty: float = 0.0
@@ -88,7 +89,7 @@ class ModelConfiguration:
             provider=data.get("provider") or DEFAULT_LLM_PROVIDER,
             model_id=data.get("model_id", DEFAULT_LLM_MODEL),
             temperature=data.get("temperature", 0.7),
-            max_tokens=data.get("max_tokens", 2000),
+            max_tokens=data.get("max_tokens", DEFAULT_MAX_OUTPUT_TOKENS),
             top_p=data.get("top_p", 1.0),
             frequency_penalty=data.get("frequency_penalty", 0.0),
             presence_penalty=data.get("presence_penalty", 0.0),
@@ -131,7 +132,7 @@ class AgentMetadata:
                 provider=provider,
                 model_id=self.preferred_model,
                 temperature=self.temperature or 0.7,
-                max_tokens=self.max_tokens or 2000,
+                max_tokens=self.max_tokens or DEFAULT_MAX_OUTPUT_TOKENS,
             )
         return ModelConfiguration.get_default()
 
@@ -245,13 +246,13 @@ class AgentFactory:
                     "provider": DEFAULT_LLM_PROVIDER,
                     "model": DEFAULT_LLM_MODEL,
                     "temperature": 0.7,
-                    "max_tokens": 2000,
+                    "max_tokens": DEFAULT_MAX_OUTPUT_TOKENS,
                     "context_window": 8192,
                 }
 
             # Lookup context window from LLM models registry
             context_window = 8192
-            max_tokens = 2000
+            max_tokens = DEFAULT_MAX_OUTPUT_TOKENS
             try:
                 from core.models import LLMModel
                 llm_model = self.db_session.query(LLMModel).filter_by(model_id=model).first()
@@ -276,7 +277,7 @@ class AgentFactory:
                 "provider": DEFAULT_LLM_PROVIDER,
                 "model": DEFAULT_LLM_MODEL,
                 "temperature": 0.7,
-                "max_tokens": 2000,
+                "max_tokens": DEFAULT_MAX_OUTPUT_TOKENS,
                 "context_window": 8192,
             }
 
@@ -295,7 +296,7 @@ class AgentFactory:
                 model = DEFAULT_LLM_MODEL
 
             context_window = 8192
-            max_tokens = 2000
+            max_tokens = DEFAULT_MAX_OUTPUT_TOKENS
             try:
                 from core.models import LLMModel
                 llm_model = self.db_session.query(LLMModel).filter_by(model_id=model).first()
@@ -320,9 +321,24 @@ class AgentFactory:
                 "provider": DEFAULT_LLM_PROVIDER,
                 "model": DEFAULT_LLM_MODEL,
                 "temperature": 0.7,
-                "max_tokens": 2000,
+                "max_tokens": DEFAULT_MAX_OUTPUT_TOKENS,
                 "context_window": 8192,
             }
+
+    def _model_max_output_tokens(self, model_id: Optional[str]) -> int:
+        """The selected model's own output ceiling from the LLM registry, or the
+        canonical default if the model isn't found. Lets an agent that hasn't set
+        an explicit Max Output Tokens default to what its model actually supports
+        — never a hardcoded literal."""
+        if model_id and self.db_session is not None:
+            try:
+                from core.models import LLMModel
+                m = self.db_session.query(LLMModel).filter_by(model_id=model_id).first()
+                if m and m.max_output_tokens:
+                    return m.max_output_tokens
+            except Exception as e:
+                self.logger.warning(f"max_output_tokens lookup failed for {model_id}: {e}")
+        return DEFAULT_MAX_OUTPUT_TOKENS
 
     def _resolve_provider_for_model(self, provider_str: str, model_id: str) -> tuple[str, str]:
         """Auto-detect and correct provider-model mismatches.
@@ -705,7 +721,7 @@ class AgentFactory:
                     "provider": tier_config.get("provider"),
                     "model": tier_config.get("model"),
                     "temperature": agent_llm_config.get("temperature", tier_config.get("temperature", 0.7)),
-                    "max_tokens": tier_config.get("max_tokens", 2000),
+                    "max_tokens": tier_config.get("max_tokens", DEFAULT_MAX_OUTPUT_TOKENS),
                 }
                 self.logger.info(f"Agent {agent_id} using LLM: {llm_config_dict.get('provider')}/{llm_config_dict.get('model')} (force_llm_tier=system_llm)")
             elif force_llm_tier == "orchestrator_llm" or use_orchestrator_llm:
@@ -715,7 +731,7 @@ class AgentFactory:
                     "provider": orchestrator_llm_config.get("provider"),
                     "model": orchestrator_llm_config.get("model"),
                     "temperature": agent_llm_config.get("temperature", orchestrator_llm_config.get("temperature", 0.7)),
-                    "max_tokens": agent_llm_config.get("max_tokens", orchestrator_llm_config.get("max_tokens", 2000)),
+                    "max_tokens": agent_llm_config.get("max_tokens", orchestrator_llm_config.get("max_tokens", DEFAULT_MAX_OUTPUT_TOKENS)),
                 }
                 self.logger.info(f"Agent {agent_id} using LLM: {llm_config_dict.get('provider')}/{llm_config_dict.get('model')} ({reason})")
             elif agent_has_model:
@@ -723,7 +739,7 @@ class AgentFactory:
                     "provider": agent_model_config["provider"],
                     "model": agent_model_config["model_id"],
                     "temperature": agent_model_config.get("temperature", 0.7),
-                    "max_tokens": agent_model_config.get("max_tokens", 2000),
+                    "max_tokens": agent_model_config.get("max_tokens") or self._model_max_output_tokens(agent_model_config.get("model_id")),
                 }
                 self.logger.info(f"Agent {agent_id} using LLM: {llm_config_dict['provider']}/{llm_config_dict['model']} (agent model_config)")
             else:
@@ -732,7 +748,7 @@ class AgentFactory:
                     "provider": orchestrator_llm_config.get("provider"),
                     "model": orchestrator_llm_config.get("model"),
                     "temperature": agent_llm_config.get("temperature", orchestrator_llm_config.get("temperature", 0.7)),
-                    "max_tokens": agent_llm_config.get("max_tokens", orchestrator_llm_config.get("max_tokens", 2000)),
+                    "max_tokens": agent_llm_config.get("max_tokens", orchestrator_llm_config.get("max_tokens", DEFAULT_MAX_OUTPUT_TOKENS)),
                 }
                 self.logger.info(f"Agent {agent_id} using LLM: {llm_config_dict.get('provider')}/{llm_config_dict.get('model')} (no agent model_config)")
 
@@ -773,7 +789,7 @@ class AgentFactory:
                 provider=provider,
                 model=model_id_str,
                 temperature=llm_config_dict.get("temperature", 0.7),
-                max_tokens=llm_config_dict.get("max_tokens", 2000),
+                max_tokens=llm_config_dict.get("max_tokens", DEFAULT_MAX_OUTPUT_TOKENS),
                 api_key=resolved.api_key if resolved else None,
                 top_p=llm_config_dict.get("top_p"),
                 frequency_penalty=llm_config_dict.get("frequency_penalty"),

--- a/orchestrator/services/coordinator_service.py
+++ b/orchestrator/services/coordinator_service.py
@@ -73,16 +73,19 @@ from services.orchestration_state import (
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
-# Mission Power Modes — per-mode caps for model, tokens, and tool iterations.
+# Mission Power Modes — per-mode caps for the LLM tier and tool iterations.
+# Token budget is deliberately NOT a power-mode concern: it is resolved from
+# the agent's own Max Output Tokens setting (see AgentFactory, falling back to
+# the model's registry ceiling, then DEFAULT_MAX_OUTPUT_TOKENS).
 # "standard" is the default when power_mode is absent from mission config.
 # These are the hardcoded FALLBACK only. Operators retune live values via
 # system_settings (category 'power_modes', key '<mode>'); see
 # _get_power_mode_caps(). Stored settings win; absent keys fall back here.
 # ---------------------------------------------------------------------------
 _POWER_MODE_DEFAULTS: Dict[str, Dict[str, Any]] = {
-    "light":    {"max_tokens": 2_000,  "max_tool_iterations": 5,  "force_llm_tier": "system_llm"},
-    "standard": {"max_tokens": 4_000,  "max_tool_iterations": 10, "force_llm_tier": None},
-    "max":      {"max_tokens": 16_000, "max_tool_iterations": 50, "force_llm_tier": "orchestrator_llm"},
+    "light":    {"max_tool_iterations": 5,  "force_llm_tier": "system_llm"},
+    "standard": {"max_tool_iterations": 10, "force_llm_tier": None},
+    "max":      {"max_tool_iterations": 50, "force_llm_tier": "orchestrator_llm"},
 }
 
 
@@ -1390,11 +1393,12 @@ class CoordinatorService:
             if not agent_runtime:
                 agent_runtime = await factory.activate_agent(agent_id, workspace_dir="/tmp/automatos_workspace")
 
-        if agent_runtime and hasattr(agent_runtime, "llm_manager"):
-            agent_runtime.llm_manager.config.max_tokens = max(
-                agent_runtime.llm_manager.config.max_tokens,
-                mode_caps["max_tokens"],
-            )
+        # The agent's max_tokens budget is resolved by AgentFactory from the
+        # agent's own Max Output Tokens setting (then the model's registry
+        # ceiling, then DEFAULT_MAX_OUTPUT_TOKENS). Power mode governs only the
+        # LLM tier and tool-iteration count — never the token budget. Do not
+        # re-introduce a power-mode token floor here: it silently capped large
+        # mission writes regardless of what the agent was configured to produce.
 
         # Model selection is driven by power_mode + the agent's own configured
         # model. There is intentionally NO synthesis-specific override:

--- a/orchestrator/tests/test_agent_token_budget.py
+++ b/orchestrator/tests/test_agent_token_budget.py
@@ -1,0 +1,125 @@
+"""
+Agent output-token budget is resolved from the agent's own settings.
+=====================================================================
+
+The per-agent "Max Output Tokens" setting is the source of truth for an
+agent's output budget. When the agent has not set one, the budget falls back
+to the selected model's registry ceiling (``LLMModel.max_output_tokens``), and
+only then to the single named constant ``DEFAULT_MAX_OUTPUT_TOKENS``.
+
+Power mode plays NO role in the token budget — it governs only the LLM tier
+and tool-iteration count. There are no hardcoded token literals (the old
+silent ``2000`` defaults and the ``min(2000, ceiling)`` clamp are gone).
+
+These tests are DB-free: ``_model_max_output_tokens`` is exercised against a
+mock session, and the bound method is reached via ``__new__`` so no real
+AgentFactory construction (and no DB) is required.
+"""
+import logging
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+# Ensure orchestrator package is importable
+_orchestrator_root = Path(__file__).resolve().parent.parent
+if str(_orchestrator_root) not in sys.path:
+    sys.path.insert(0, str(_orchestrator_root))
+
+from core.llm.defaults import DEFAULT_MAX_OUTPUT_TOKENS, get_default_model_config
+from modules.agents.factory.agent_factory import AgentFactory, AgentMetadata, ModelConfiguration
+
+
+# --- The single named default -------------------------------------------------
+
+def test_default_model_config_uses_named_constant():
+    """The canonical default config carries DEFAULT_MAX_OUTPUT_TOKENS — not a literal."""
+    assert get_default_model_config()["max_tokens"] == DEFAULT_MAX_OUTPUT_TOKENS
+
+
+def test_named_default_is_not_the_old_2000_literal():
+    """Guard against a silent regression back to the old 2000 cap."""
+    assert DEFAULT_MAX_OUTPUT_TOKENS != 2000
+    assert DEFAULT_MAX_OUTPUT_TOKENS >= 8000
+
+
+# --- ModelConfiguration defaults ----------------------------------------------
+
+def test_model_configuration_dataclass_default():
+    """A ModelConfiguration with no explicit max_tokens defaults to the constant."""
+    mc = ModelConfiguration(provider="openrouter", model_id="x")
+    assert mc.max_tokens == DEFAULT_MAX_OUTPUT_TOKENS
+
+
+def test_from_dict_defaults_to_constant_when_absent():
+    """from_dict with no max_tokens key falls back to the constant, not 2000."""
+    mc = ModelConfiguration.from_dict({"provider": "openrouter", "model_id": "x"})
+    assert mc.max_tokens == DEFAULT_MAX_OUTPUT_TOKENS
+
+
+def test_from_dict_honours_explicit_agent_setting():
+    """An explicit agent setting (the slider value) wins over every fallback."""
+    mc = ModelConfiguration.from_dict({"provider": "openrouter", "model_id": "x", "max_tokens": 16000})
+    assert mc.max_tokens == 16000
+
+
+def test_get_model_config_preferred_model_defaults_to_constant():
+    """The legacy preferred_model path defaults max_tokens to the constant."""
+    meta = AgentMetadata(name="A", agent_type="t", preferred_model="some/model")
+    assert meta.get_model_config().max_tokens == DEFAULT_MAX_OUTPUT_TOKENS
+
+
+def test_get_model_config_preferred_model_honours_explicit():
+    """An explicit max_tokens on the legacy path is preserved."""
+    meta = AgentMetadata(name="A", agent_type="t", preferred_model="some/model", max_tokens=12000)
+    assert meta.get_model_config().max_tokens == 12000
+
+
+# --- _model_max_output_tokens: the model-ceiling fallback ---------------------
+
+def _factory_with_session(session):
+    """Build an AgentFactory shell without running __init__ (no DB needed)."""
+    factory = AgentFactory.__new__(AgentFactory)
+    factory.db_session = session
+    factory.logger = logging.getLogger("test_agent_token_budget")
+    return factory
+
+
+def test_model_ceiling_used_when_model_in_registry():
+    """When the model exists in the registry, its own ceiling is returned."""
+    model_row = MagicMock()
+    model_row.max_output_tokens = 16384
+    db = MagicMock()
+    db.query.return_value.filter_by.return_value.first.return_value = model_row
+
+    factory = _factory_with_session(db)
+    assert factory._model_max_output_tokens("gpt-4o") == 16384
+
+
+def test_constant_fallback_when_model_not_in_registry():
+    """An unknown model falls back to the single named default."""
+    db = MagicMock()
+    db.query.return_value.filter_by.return_value.first.return_value = None
+
+    factory = _factory_with_session(db)
+    assert factory._model_max_output_tokens("ghost/model") == DEFAULT_MAX_OUTPUT_TOKENS
+
+
+def test_constant_fallback_when_no_db_session():
+    """With no DB session there is no registry to consult — use the constant."""
+    factory = _factory_with_session(None)
+    assert factory._model_max_output_tokens("gpt-4o") == DEFAULT_MAX_OUTPUT_TOKENS
+
+
+def test_constant_fallback_when_no_model_id():
+    """A missing model_id resolves to the constant, never a literal."""
+    factory = _factory_with_session(MagicMock())
+    assert factory._model_max_output_tokens(None) == DEFAULT_MAX_OUTPUT_TOKENS
+
+
+def test_db_error_falls_back_to_constant():
+    """A registry lookup failure must not raise — the constant is returned."""
+    db = MagicMock()
+    db.query.side_effect = RuntimeError("db down")
+
+    factory = _factory_with_session(db)
+    assert factory._model_max_output_tokens("gpt-4o") == DEFAULT_MAX_OUTPUT_TOKENS

--- a/orchestrator/tests/test_us010_power_mode_caps.py
+++ b/orchestrator/tests/test_us010_power_mode_caps.py
@@ -36,13 +36,12 @@ def _setting_with(value_dict):
 
 def test_power_mode_reads_system_settings():
     """Stored JSON overrides win over the hardcoded defaults."""
-    db = _db_returning(_setting_with({"max_tool_iterations": 99, "max_tokens": 12345}))
+    db = _db_returning(_setting_with({"max_tool_iterations": 99, "force_llm_tier": "orchestrator_llm"}))
 
     caps = _get_power_mode_caps("standard", db)
 
-    assert caps["max_tool_iterations"] == 99  # overridden
-    assert caps["max_tokens"] == 12345        # overridden
-    assert caps["force_llm_tier"] is None     # untouched 'standard' default
+    assert caps["max_tool_iterations"] == 99             # overridden
+    assert caps["force_llm_tier"] == "orchestrator_llm"  # overridden
 
 
 def test_power_mode_partial_override_keeps_other_defaults():
@@ -52,7 +51,6 @@ def test_power_mode_partial_override_keeps_other_defaults():
     caps = _get_power_mode_caps("light", db)
 
     assert caps["max_tool_iterations"] == 25  # overridden
-    assert caps["max_tokens"] == _POWER_MODE_DEFAULTS["light"]["max_tokens"]
     assert caps["force_llm_tier"] == "system_llm"  # default kept
 
 
@@ -86,7 +84,7 @@ def test_power_mode_db_error_falls_back_to_defaults():
 
 def test_get_power_mode_caps_does_not_mutate_defaults():
     """Resolution copies the default dict; it never mutates the module const."""
-    db = _db_returning(_setting_with({"max_tokens": 999999}))
+    db = _db_returning(_setting_with({"max_tool_iterations": 999999}))
     before = dict(_POWER_MODE_DEFAULTS["standard"])
 
     _get_power_mode_caps("standard", db)


### PR DESCRIPTION
## Summary

The agent's **Max Output Tokens** setting is now the single source of truth for an agent's output budget. Mission writes were being silently capped because the budget came from scattered `2000` literals plus a power-mode floor (`standard = 4000`) that overrode whatever the agent was actually configured to produce. Large mission deliverables were truncated regardless of agent settings — *"all files will be large in a mission, that's the point."*

**Resolution order (new):** agent's stored `max_tokens` → selected model's registry ceiling (`LLMModel.max_output_tokens`) → `DEFAULT_MAX_OUTPUT_TOKENS` (one named constant). **Power mode no longer touches the token budget** — it governs only the LLM tier and tool-iteration count.

## Changes

- **`core/llm/defaults.py`** — add `DEFAULT_MAX_OUTPUT_TOKENS` (the single named default) and use it in `get_default_model_config()`.
- **`modules/agents/factory/agent_factory.py`** — resolve budget as *agent setting → model ceiling → constant*; drop every hardcoded `2000` fallback; add `_model_max_output_tokens()` helper for the model-ceiling step.
- **`api/agent_endpoints.py`** — remove the `min(2000, ceiling)` clamp on model switch so a newly selected model defaults to its full ceiling (the slider dials it down).
- **`services/coordinator_service.py`** — remove the `max_tokens` key from `_POWER_MODE_DEFAULTS` and delete the token-floor override block; power mode = tier + tool iterations only.
- **tests** — new `test_agent_token_budget.py` (12 cases covering the full resolution chain); update `test_us010_power_mode_caps.py` for the removed key.

## Test plan

- [x] New budget-resolution suite (12 tests) — agent setting wins, model ceiling fallback, constant last-resort, DB-error safety
- [x] `test_us010_power_mode_caps.py` updated + green (6)
- [x] `test_synthesis_executor.py` green (9) — exercises the edited `_prepare_task`
- [x] coordinator-importing suites green (no import/collection regression)
- [x] Full orchestrator suite via pre-push hook: **1352 passed, 7 skipped, 1 xfailed**
- [x] No hardcoded token literals remain in the agent/coordinator budget path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Increased default token limit for LLM responses to 8,000 (previously 2,000).

* **Bug Fixes**
  * Power mode no longer applies token output restrictions; token budgets are now managed consistently through agent configuration and model settings.
  * Improved token budget resolution across different agent setup paths.

* **Tests**
  * Added comprehensive token budget validation tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->