### PR TITLE
Ralph/prd 142 wave3 primitive hardening

### DIFF
--- a/frontend/components/command-center/is-it-working-strip.tsx
+++ b/frontend/components/command-center/is-it-working-strip.tsx
@@ -6,9 +6,10 @@
  * platform working?" from the real Wave 0 analytics endpoints.
  *
  * Mirrors StatsStrip's idiom exactly: label + mono value + tone + delta.
- * Honest zero/pending states — the PRIMITIVES cell shows "—" / "metric
- * pending" (like StatsStrip's CACHE-HIT) rather than fabricate a health
- * signal; per-primitive health (US-006) lands in Wave 3.
+ * Honest zero/pending states — a cell shows "—" rather than fabricate a
+ * signal. PRIMITIVES reads the W3-S2 /primitive-health endpoint (8 canonical
+ * primitives); a primitive with no heartbeat finding renders as "awaiting
+ * checks" rather than a fake green.
  */
 
 import type { SparklineTone } from './sparkline'
@@ -17,6 +18,7 @@ import {
   useMissionSuccessRate,
   useErrorsBySubsystem,
   useWidgetEngagement,
+  usePrimitiveHealth,
 } from '@/hooks/use-analytics-api'
 
 interface Cell {
@@ -45,6 +47,14 @@ export function IsItWorkingStrip() {
 
   const sessions = widget?.sessions ?? 0
   const widgetEvents = widget?.by_event_type?.reduce((sum, ev) => sum + ev.count, 0) ?? 0
+
+  const { data: health } = usePrimitiveHealth()
+  const prim = health?.primitives ?? []
+  const primTotal = prim.length
+  const primKnown = prim.filter((p) => p.status !== 'unknown').length
+  const primGreen = prim.filter((p) => p.status === 'green').length
+  const primDegraded = prim.filter((p) => p.status === 'degraded').length
+  const primDown = prim.filter((p) => p.status === 'down').length
 
   const cells: Cell[] = [
     {
@@ -75,9 +85,16 @@ export function IsItWorkingStrip() {
     },
     {
       label: 'PRIMITIVES',
-      value: '—',
-      tone: 'muted',
-      delta: 'metric pending',
+      value: primKnown > 0 ? `${primGreen}/${primTotal}` : '—',
+      tone: primDown > 0 ? 'err' : primDegraded > 0 ? 'warn' : primKnown > 0 ? 'ok' : 'muted',
+      delta:
+        primKnown === 0
+          ? 'awaiting checks'
+          : primDown > 0
+            ? `${primDown} down`
+            : primDegraded > 0
+              ? `${primDegraded} degraded`
+              : 'all green',
     },
   ]
 

--- a/frontend/hooks/use-analytics-api.ts
+++ b/frontend/hooks/use-analytics-api.ts
@@ -5,6 +5,7 @@ import type {
   MissionSuccessRateMetric,
   ErrorsBySubsystemMetric,
   WidgetEngagementMetric,
+  PrimitiveHealthMetric,
 } from '@/lib/api-client'
 
 export const analyticsQueryKeys = {
@@ -85,6 +86,13 @@ export function useWidgetEngagement(window: string = '7d') {
   return useQuery<WidgetEngagementMetric>({
     queryKey: ['analytics', 'widget-engagement', window],
     queryFn: () => apiClient.getWidgetEngagement(window)
+  })
+}
+
+export function usePrimitiveHealth() {
+  return useQuery<PrimitiveHealthMetric>({
+    queryKey: ['analytics', 'primitive-health'],
+    queryFn: () => apiClient.getPrimitiveHealth()
   })
 }
 

--- a/frontend/lib/api-client.ts
+++ b/frontend/lib/api-client.ts
@@ -67,6 +67,15 @@ export interface WidgetEngagementMetric {
   generated_at: string
 }
 
+export interface PrimitiveHealthMetric {
+  primitives: Array<{
+    name: string
+    status: 'green' | 'degraded' | 'down' | 'unknown'
+    last_checked: string | null
+  }>
+  generated_at: string
+}
+
 // Mock configuration interface
 interface MockConfig {
   enabled: boolean
@@ -2244,6 +2253,10 @@ class ApiClient {
 
   async getWidgetEngagement(window: string = '7d'): Promise<WidgetEngagementMetric> {
     return this.request<WidgetEngagementMetric>(`/api/analytics/widget-engagement?window=${encodeURIComponent(window)}`)
+  }
+
+  async getPrimitiveHealth(): Promise<PrimitiveHealthMetric> {
+    return this.request<PrimitiveHealthMetric>('/api/analytics/primitive-health')
   }
 
   async getAgentAnalytics(timeRange: string) {

--- a/orchestrator/scripts/init_test_db.py
+++ b/orchestrator/scripts/init_test_db.py
@@ -14,6 +14,11 @@ from core.database.database import Base, engine
 from core.models import *  # Import all models
 from core.models.cloud_sync import CloudDocument, CloudSyncConfig, CloudSyncJob
 from core.models.composio import ComposioConnection, ComposioEntity
+# PRD-79 memory tables (L2 memory_short_term etc.) are defined under
+# modules.memory, not core.models, so `from core.models import *` never
+# registers them on Base. Import the module so create_all builds memory_short_term
+# — the L2 transcript store the memory restart/isolation tests depend on.
+import modules.memory.models  # noqa: F401,E402  (registers MemoryShortTerm on Base)
 
 def init_db():
     """Create all tables from models."""

--- a/orchestrator/tests/conftest.py
+++ b/orchestrator/tests/conftest.py
@@ -14,24 +14,42 @@ if _orchestrator_root not in sys.path:
 
 
 @pytest.fixture(autouse=True)
-def _repair_stubbed_consumers_chatbot():
-    """Rebind ``consumers.chatbot`` onto the ``consumers`` parent if a sibling
-    leaked a hand-built stub into ``sys.modules``.
+def _repair_stubbed_package_bindings():
+    """Repair parent->child module attribute bindings that sibling tests broke.
 
-    Several unit tests (test_memory_single_write_path, test_tool_loop_*, etc.)
-    inject ``types.ModuleType`` stubs for ``consumers`` and ``consumers.chatbot``
-    directly into ``sys.modules`` to dodge the heavy package __init__. A real
-    ``import`` sets the child as an attribute on the parent module; a manual
-    sys.modules insert does NOT. pytest's ``monkeypatch.setattr("a.b.c", ...)``
-    walks attributes from the top package, so a later sibling that monkeypatches
-    ``consumers.chatbot.<x>`` trips on ``'module' object ... has no attribute
-    'chatbot'``. Rebinding here is idempotent and a no-op once the real package
-    is loaded.
+    Many unit tests inject ``types.ModuleType`` stubs straight into
+    ``sys.modules`` (for ``consumers``, ``consumers.chatbot``, ``modules``,
+    ``modules.tools`` ...) to dodge a heavy package __init__ that pulls optional
+    deps (asyncpg / pdfplumber / tiktoken / camelot). A real ``import a.b`` binds
+    ``b`` as an attribute on package ``a``; a manual ``sys.modules['a.b'] = stub``
+    does NOT. Worse, replacing ``sys.modules['a']`` with a bare stub drops every
+    real child attribute it used to carry.
+
+    pytest's ``monkeypatch.setattr("a.b.c.attr", ...)`` resolves its target by
+    walking attributes from the top package (``getattr(a, 'b')`` ...). When a
+    sibling has left ``a`` as a stub missing ``b``, that walk raises
+    ``"'module' object at a.b has no attribute 'b'"`` in whatever test is
+    collected after the leak — e.g. test_w1s9 patching
+    ``modules.tools.discovery.platform_executor.PlatformActionExecutor`` trips on
+    ``modules.tools``; an earlier sibling tripped on ``consumers.chatbot``.
+
+    This autouse fixture re-binds every dotted ``sys.modules`` entry onto its
+    parent package when the parent is missing that attribute. It is
+    *fill-missing only* — it never overwrites an existing binding, so it cannot
+    change a target a healthy test already resolves — and is idempotent / a
+    no-op once the real packages are loaded. A failed repair must never break
+    collection, so setattr errors are swallowed.
     """
-    parent = sys.modules.get("consumers")
-    child = sys.modules.get("consumers.chatbot")
-    if parent is not None and child is not None and getattr(parent, "chatbot", None) is not child:
-        parent.chatbot = child
+    for name, mod in list(sys.modules.items()):
+        if mod is None or "." not in name:
+            continue
+        parent_name, _, child_attr = name.rpartition(".")
+        parent = sys.modules.get(parent_name)
+        if parent is not None and not hasattr(parent, child_attr):
+            try:
+                setattr(parent, child_attr, mod)
+            except Exception:
+                pass
     yield
 
 

--- a/orchestrator/tests/conftest.py
+++ b/orchestrator/tests/conftest.py
@@ -13,6 +13,28 @@ if _orchestrator_root not in sys.path:
     sys.path.insert(0, _orchestrator_root)
 
 
+@pytest.fixture(autouse=True)
+def _repair_stubbed_consumers_chatbot():
+    """Rebind ``consumers.chatbot`` onto the ``consumers`` parent if a sibling
+    leaked a hand-built stub into ``sys.modules``.
+
+    Several unit tests (test_memory_single_write_path, test_tool_loop_*, etc.)
+    inject ``types.ModuleType`` stubs for ``consumers`` and ``consumers.chatbot``
+    directly into ``sys.modules`` to dodge the heavy package __init__. A real
+    ``import`` sets the child as an attribute on the parent module; a manual
+    sys.modules insert does NOT. pytest's ``monkeypatch.setattr("a.b.c", ...)``
+    walks attributes from the top package, so a later sibling that monkeypatches
+    ``consumers.chatbot.<x>`` trips on ``'module' object ... has no attribute
+    'chatbot'``. Rebinding here is idempotent and a no-op once the real package
+    is loaded.
+    """
+    parent = sys.modules.get("consumers")
+    child = sys.modules.get("consumers.chatbot")
+    if parent is not None and child is not None and getattr(parent, "chatbot", None) is not child:
+        parent.chatbot = child
+    yield
+
+
 # ---- Database mock ----
 
 @pytest.fixture

--- a/orchestrator/tests/test_chat_failure_path.py
+++ b/orchestrator/tests/test_chat_failure_path.py
@@ -53,11 +53,16 @@ if str(_ORCH) not in sys.path:
 
 # Stub parent packages so importing ``modules.tools.execution.tool_loop``
 # does NOT drag in the rest of modules.tools (heavy registry side effects).
+# Record what we create so ``teardown_module`` can drop these path-only stubs
+# again — a leaked bare ``modules`` stub has no ``tools`` attribute and breaks
+# later siblings' ``monkeypatch.setattr("modules.tools.…")`` getattr walks.
+_LEAKED_PARENT_STUBS = {}
 for _pkg in ("modules", "modules.tools", "modules.tools.execution"):
     if _pkg not in sys.modules:
         _stub = _types.ModuleType(_pkg)
         _stub.__path__ = [str(_ORCH / _pkg.replace(".", "/"))]
         sys.modules[_pkg] = _stub
+        _LEAKED_PARENT_STUBS[_pkg] = _stub
 
 # Same trick for ``consumers.chatbot.primitive_heartbeat``: stub the parent
 # packages so importing the leaf does NOT trigger consumers/chatbot/__init__
@@ -68,6 +73,7 @@ for _pkg in ("consumers", "consumers.chatbot"):
         _stub = _types.ModuleType(_pkg)
         _stub.__path__ = [str(_ORCH / _pkg.replace(".", "/"))]
         sys.modules[_pkg] = _stub
+        _LEAKED_PARENT_STUBS[_pkg] = _stub
 
 from modules.tools.execution.tool_loop import (  # noqa: E402
     RoundState,
@@ -84,6 +90,18 @@ if "services" not in sys.modules:
     _services_stub = _types.ModuleType("services")
     _services_stub.__path__ = [str(_ORCH / "services")]
     sys.modules["services"] = _services_stub
+    _LEAKED_PARENT_STUBS["services"] = _services_stub
+
+
+def teardown_module(module):
+    """Drop the path-only parent stubs this module installed (modules.*,
+    consumers.*, services) so they don't poison sibling tests' attribute
+    walks. Identity-checked so we never evict a real import or another test's
+    replacement; runs after this file's tests, which DO need the stubs for the
+    run-time ``_load_primitive_heartbeat`` loads."""
+    for _name, _stub in _LEAKED_PARENT_STUBS.items():
+        if sys.modules.get(_name) is _stub:
+            del sys.modules[_name]
 
 
 def _load_primitive_heartbeat():

--- a/orchestrator/tests/test_memory_single_write_path.py
+++ b/orchestrator/tests/test_memory_single_write_path.py
@@ -51,7 +51,8 @@ for _pkg in ("consumers", "consumers.chatbot"):
 
 # ``intent_classifier`` is the only sibling smart_orchestrator imports at
 # module level; stub it so we don't trigger its dependency chain either.
-if "consumers.chatbot.intent_classifier" not in sys.modules:
+_ic_stub_installed = "consumers.chatbot.intent_classifier" not in sys.modules
+if _ic_stub_installed:
     _ic_stub = types.ModuleType("consumers.chatbot.intent_classifier")
     _ic_stub.Intent = MagicMock()
     _ic_stub.IntentResult = MagicMock()
@@ -66,6 +67,15 @@ if "consumers.chatbot.intent_classifier" not in sys.modules:
 sys.modules.setdefault("camelot", types.ModuleType("camelot"))
 
 from consumers.chatbot.smart_orchestrator import SmartChatOrchestrator  # noqa: E402
+
+# De-pollute: our intent_classifier stub is intentionally partial (no
+# SmartIntentClassifier). Once smart_orchestrator is imported we no longer need
+# it, so drop it to let a later-collected sibling (e.g.
+# test_w2s9_reasoning_entry) import the REAL module — its __path__ resolves via
+# the consumers.chatbot package stub above. Leaving the stub cached caused the
+# "(unknown location)" collection error in the full-suite CI run.
+if _ic_stub_installed:
+    sys.modules.pop("consumers.chatbot.intent_classifier", None)
 
 # Unbound — invoked with an explicit fake ``self``.
 _orchestrator_store_exchange = SmartChatOrchestrator.store_exchange

--- a/orchestrator/tests/test_rag_ingest_atomicity.py
+++ b/orchestrator/tests/test_rag_ingest_atomicity.py
@@ -127,11 +127,16 @@ if "PIL" not in sys.modules:
 # ``test_memory_single_write_path``.
 # ---------------------------------------------------------------------------
 
+# Record the path-only parent stubs we create so ``teardown_module`` can drop
+# them again — a leaked bare ``modules`` stub has no ``tools`` attribute and
+# breaks later siblings' ``monkeypatch.setattr("modules.tools.…")`` walks.
+_LEAKED_PARENT_STUBS = {}
 for _pkg in ("modules", "modules.rag", "modules.rag.ingestion"):
     if _pkg not in sys.modules:
         _stub = types.ModuleType(_pkg)
         _stub.__path__ = [str(ORCH_ROOT / _pkg.replace(".", "/"))]
         sys.modules[_pkg] = _stub
+        _LEAKED_PARENT_STUBS[_pkg] = _stub
 
 # semantic_chunker / multimodal are referenced from manager.py inside ``try``
 # blocks — they fail to import gracefully. Pre-stub so the try block fails
@@ -152,6 +157,8 @@ _mm_stub.FormulaProcessor = MagicMock
 _mm_stub.ImageProcessor = MagicMock
 _mm_stub.MultimodalDocumentProcessor = MagicMock
 sys.modules.setdefault("modules.rag.ingestion.multimodal", _mm_stub)
+_LEAKED_PARENT_STUBS["modules.rag.chunking.semantic_chunker"] = _sc_stub
+_LEAKED_PARENT_STUBS["modules.rag.ingestion.multimodal"] = _mm_stub
 
 import importlib.util  # noqa: E402
 
@@ -161,7 +168,19 @@ _spec = importlib.util.spec_from_file_location(
 )
 _manager_mod = importlib.util.module_from_spec(_spec)
 sys.modules["modules.rag.ingestion.manager"] = _manager_mod
+_LEAKED_PARENT_STUBS["modules.rag.ingestion.manager"] = _manager_mod
 _spec.loader.exec_module(_manager_mod)
+
+
+def teardown_module(module):
+    """Drop the path-only ``modules.*`` stubs this module installed so they
+    don't poison sibling tests' attribute walks (e.g. a bare ``modules`` stub
+    with no ``tools`` attr breaking ``monkeypatch.setattr("modules.tools.…")``).
+    Identity-checked so we never evict a real import or another test's stub."""
+    for _name, _stub in _LEAKED_PARENT_STUBS.items():
+        if sys.modules.get(_name) is _stub:
+            del sys.modules[_name]
+
 
 DocumentChunk = _manager_mod.DocumentChunk
 DocumentManager = _manager_mod.DocumentManager

--- a/orchestrator/tests/test_rag_ingest_atomicity.py
+++ b/orchestrator/tests/test_rag_ingest_atomicity.py
@@ -444,7 +444,7 @@ async def test_s3_vector_metadata_uses_workspace_scoped_backend():
 # ===========================================================================
 
 
-def test_delete_document_removes_s3_vectors_when_s3_mode():
+def test_delete_document_removes_s3_vectors_when_s3_mode(monkeypatch):
     """``delete_document`` must drop the chunk-vectors from the S3 backend
     when ``use_s3_vectors=True`` — today the manager tears down Postgres
     rows only, leaving orphan vectors per workspace per deleted doc.
@@ -455,9 +455,14 @@ def test_delete_document_removes_s3_vectors_when_s3_mode():
     mgr = _bare_manager(s3_backend=backend)
 
     # Replace psycopg2.connect with a recording conn so the postgres delete
-    # path runs without a real DB.
+    # path runs without a real DB. Use monkeypatch (not a raw module assign):
+    # ``_manager_mod.psycopg2`` is the one shared psycopg2 module, so a raw
+    # ``psycopg2.connect = ...`` leaks the mock process-wide and the next test
+    # to open a REAL connection on the shared engine (test_w2s5) gets a fake
+    # conn fed to SQLAlchemy's on_connect ``register_uuid`` → TypeError.
+    # monkeypatch restores the real connect at teardown.
     fake_conn = _RecordingConn()
-    _manager_mod.psycopg2.connect = MagicMock(return_value=fake_conn)
+    monkeypatch.setattr(_manager_mod.psycopg2, "connect", MagicMock(return_value=fake_conn))
 
     ok = mgr.delete_document(42)
     assert ok is True
@@ -467,21 +472,22 @@ def test_delete_document_removes_s3_vectors_when_s3_mode():
     )
 
 
-def test_delete_document_skips_s3_when_legacy_pgvector_mode():
+def test_delete_document_skips_s3_when_legacy_pgvector_mode(monkeypatch):
     """In legacy pgvector mode there are no S3 vectors to drop — the
     delete path must NOT call delete_documents on a backend that does not
     own those vectors."""
     backend = MagicMock()
     mgr = _bare_manager(use_s3=False, s3_backend=backend)
 
-    _manager_mod.psycopg2.connect = MagicMock(return_value=_RecordingConn())
+    # monkeypatch so the global psycopg2.connect is restored at teardown.
+    monkeypatch.setattr(_manager_mod.psycopg2, "connect", MagicMock(return_value=_RecordingConn()))
 
     mgr.delete_document(7)
 
     backend.delete_documents.assert_not_called()
 
 
-def test_delete_document_does_not_raise_when_s3_cleanup_fails():
+def test_delete_document_does_not_raise_when_s3_cleanup_fails(monkeypatch):
     """Postgres commit has already happened by the time we ask S3 to drop
     its vectors — an S3 outage at that point is a logged warning, not a
     user-visible 500. Otherwise a flaky S3 would block deletes the
@@ -490,7 +496,8 @@ def test_delete_document_does_not_raise_when_s3_cleanup_fails():
     backend.delete_documents = MagicMock(side_effect=RuntimeError("S3 outage"))
     mgr = _bare_manager(s3_backend=backend)
 
-    _manager_mod.psycopg2.connect = MagicMock(return_value=_RecordingConn())
+    # monkeypatch so the global psycopg2.connect is restored at teardown.
+    monkeypatch.setattr(_manager_mod.psycopg2, "connect", MagicMock(return_value=_RecordingConn()))
 
     # Must NOT raise — S3 failure is best-effort after the postgres commit.
     ok = mgr.delete_document(42)

--- a/orchestrator/tests/test_smart_orchestrator_store_exchange.py
+++ b/orchestrator/tests/test_smart_orchestrator_store_exchange.py
@@ -39,7 +39,8 @@ for _pkg in ("consumers", "consumers.chatbot"):
         _stub.__path__ = [str(_ORCH / _pkg.replace(".", "/"))]
         sys.modules[_pkg] = _stub
 
-if "consumers.chatbot.intent_classifier" not in sys.modules:
+_ic_stub_installed = "consumers.chatbot.intent_classifier" not in sys.modules
+if _ic_stub_installed:
     _ic_stub = types.ModuleType("consumers.chatbot.intent_classifier")
     _ic_stub.Intent = MagicMock()
     _ic_stub.IntentResult = MagicMock()
@@ -49,6 +50,13 @@ if "consumers.chatbot.intent_classifier" not in sys.modules:
 sys.modules.setdefault("camelot", types.ModuleType("camelot"))
 
 from consumers.chatbot.smart_orchestrator import SmartChatOrchestrator  # noqa: E402
+
+# De-pollute: drop our partial intent_classifier stub (no SmartIntentClassifier)
+# once smart_orchestrator is imported, so a later-collected sibling can import
+# the REAL module instead of inheriting this stub. See the matching note in
+# test_memory_single_write_path — leaving it cached broke full-suite collection.
+if _ic_stub_installed:
+    sys.modules.pop("consumers.chatbot.intent_classifier", None)
 
 # Unbound coroutine function — invoked with an explicit fake ``self`` below.
 store_exchange = SmartChatOrchestrator.store_exchange

--- a/orchestrator/tests/test_tool_loop_characterization.py
+++ b/orchestrator/tests/test_tool_loop_characterization.py
@@ -37,11 +37,26 @@ _ORCH = Path(__file__).resolve().parents[1]
 if str(_ORCH) not in sys.path:
     sys.path.insert(0, str(_ORCH))
 
+# Record the path-only parent stubs we create so ``teardown_module`` can drop
+# them again. Left in ``sys.modules`` a bare ``modules`` stub has no ``tools``
+# attribute, so a later sibling's ``monkeypatch.setattr("modules.tools.…")``
+# fails walking ``getattr(modules, "tools")``.
+_LEAKED_PARENT_STUBS = {}
 for _pkg in ("modules", "modules.tools", "modules.tools.execution"):
     if _pkg not in sys.modules:
         _stub = _types.ModuleType(_pkg)
         _stub.__path__ = [str(_ORCH / _pkg.replace(".", "/"))]
         sys.modules[_pkg] = _stub
+        _LEAKED_PARENT_STUBS[_pkg] = _stub
+
+
+def teardown_module(module):
+    """Drop the path-only parent stubs this module installed (identity-checked
+    so we never evict a real import or another test's replacement)."""
+    for _name, _stub in _LEAKED_PARENT_STUBS.items():
+        if sys.modules.get(_name) is _stub:
+            del sys.modules[_name]
+
 
 from modules.tools.execution.tool_loop import ToolLoopExecutor  # noqa: E402
 

--- a/orchestrator/tests/test_tool_loop_converged.py
+++ b/orchestrator/tests/test_tool_loop_converged.py
@@ -25,11 +25,26 @@ _ORCH = Path(__file__).resolve().parents[1]
 if str(_ORCH) not in sys.path:
     sys.path.insert(0, str(_ORCH))
 
+# Record the path-only parent stubs we create so ``teardown_module`` can drop
+# them again. Left in ``sys.modules`` a bare ``modules`` stub has no ``tools``
+# attribute, so a later sibling's ``monkeypatch.setattr("modules.tools.…")``
+# fails walking ``getattr(modules, "tools")``.
+_LEAKED_PARENT_STUBS = {}
 for _pkg in ("modules", "modules.tools", "modules.tools.execution"):
     if _pkg not in sys.modules:
         _stub = _types.ModuleType(_pkg)
         _stub.__path__ = [str(_ORCH / _pkg.replace(".", "/"))]
         sys.modules[_pkg] = _stub
+        _LEAKED_PARENT_STUBS[_pkg] = _stub
+
+
+def teardown_module(module):
+    """Drop the path-only parent stubs this module installed (identity-checked
+    so we never evict a real import or another test's replacement)."""
+    for _name, _stub in _LEAKED_PARENT_STUBS.items():
+        if sys.modules.get(_name) is _stub:
+            del sys.modules[_name]
+
 
 from modules.tools.execution.tool_loop import (  # noqa: E402
     RoundState,

--- a/orchestrator/tests/test_tool_router_semantic.py
+++ b/orchestrator/tests/test_tool_router_semantic.py
@@ -133,10 +133,15 @@ def _install_low_level_stubs():
         reg_mod.get_tool_registry = lambda db_session=None: fake_registry
         sys.modules["modules.tools.registry"] = reg_mod
 
-    if "modules.tools.execution" not in sys.modules:
-        exec_mod = types.ModuleType("modules.tools.execution")
-        exec_mod.UnifiedToolExecutor = MagicMock()
-        sys.modules["modules.tools.execution"] = exec_mod
+    # Always shadow with our complete stub — the snapshot above preserves any
+    # prior entry for restore. A `not in sys.modules` guard here would inherit
+    # a half-initialised modules.tools.execution left by an earlier-collected
+    # test (its real __init__ pulls a long exec_* chain and can land in
+    # sys.modules without UnifiedToolExecutor bound), which is the
+    # "(unknown location)" collection error this suite hit in CI.
+    exec_mod = types.ModuleType("modules.tools.execution")
+    exec_mod.UnifiedToolExecutor = MagicMock()
+    sys.modules["modules.tools.execution"] = exec_mod
 
     if "modules.tools.formatting.result_formatter" not in sys.modules:
         _ensure_pkg("modules.tools.formatting")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * The primitives health indicator now displays real-time status counts and descriptive messages (e.g., "awaiting checks," "X down," "all green") instead of a static placeholder.

* **Bug Fixes**
  * Improved test isolation to prevent module-level state leakage across test suites, ensuring reliable test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->