### PR TITLE
feat(auth): board SDK-key read access via scope-gated dependency (PRD…

### DIFF
--- a/orchestrator/api/api_keys.py
+++ b/orchestrator/api/api_keys.py
@@ -17,6 +17,7 @@ from sqlalchemy.orm import Session
 
 from core.auth.dependencies import RequestContext
 from core.auth.hybrid import get_request_context_hybrid
+from core.auth.scopes import TASKS_READ
 from core.database.database import get_db
 from core.services.api_key_service import ApiKeyService
 
@@ -34,6 +35,9 @@ VALID_PERMISSIONS = [
     "agents:execute",
     "workflows:read",
     "workflows:execute",
+    # Board task scopes (PRD-09). Named constant = single source of truth shared
+    # with the board auth gate in core/auth/hybrid.py.
+    TASKS_READ,
 ]
 
 

--- a/orchestrator/api/board_tasks.py
+++ b/orchestrator/api/board_tasks.py
@@ -15,8 +15,9 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from sqlalchemy.orm import Session
 
-from core.auth.hybrid import get_request_context_hybrid
+from core.auth.hybrid import get_request_context_hybrid, require_task_context
 from core.auth.dependencies import RequestContext
+from core.auth.scopes import TASKS_READ
 from core.database.database import get_db
 from core.models.core import BoardTask
 from core.models import Agent
@@ -204,13 +205,24 @@ async def _dispatch_task_complete(db: Session, workspace_id, task: BoardTask) ->
 
 # ── Helpers ──────────────────────────────────────────────────────────
 
-def _enrich_with_agents(tasks: list, db: Session) -> list:
-    """Join agent info onto task dicts."""
+def _enrich_with_agents(tasks: list, db: Session, workspace_id) -> list:
+    """Join agent info onto task dicts.
+
+    Agents are resolved within ``workspace_id`` only: a task whose
+    ``assigned_agent_id`` points at another workspace's agent yields no ``agent``
+    block rather than leaking that agent's name/icon (defense-in-depth tenant
+    isolation — board reads are now reachable by per-workspace SDK keys).
+    """
     agent_ids = {t.assigned_agent_id for t in tasks if t.assigned_agent_id}
     if not agent_ids:
         return [t.to_dict() for t in tasks]
 
-    agents = {a.id: a for a in db.query(Agent).filter(Agent.id.in_(agent_ids)).all()}
+    agents = {
+        a.id: a
+        for a in db.query(Agent)
+        .filter(Agent.id.in_(agent_ids), Agent.workspace_id == workspace_id)
+        .all()
+    }
 
     result = []
     for t in tasks:
@@ -298,7 +310,7 @@ async def create_task(
 
 @router.get("")
 async def list_tasks(
-    ctx: RequestContext = Depends(get_request_context_hybrid),
+    ctx: RequestContext = Depends(require_task_context(TASKS_READ)),
     db: Session = Depends(get_db),
     status: Optional[str] = Query(None, description="Comma-separated statuses"),
     agent_id: Optional[int] = Query(None),
@@ -342,7 +354,7 @@ async def list_tasks(
     )
 
     return {
-        "tasks": _enrich_with_agents(tasks, db),
+        "tasks": _enrich_with_agents(tasks, db, ctx.workspace_id),
         "total": total,
     }
 
@@ -350,7 +362,7 @@ async def list_tasks(
 @router.get("/{task_id}")
 async def get_task(
     task_id: int,
-    ctx: RequestContext = Depends(get_request_context_hybrid),
+    ctx: RequestContext = Depends(require_task_context(TASKS_READ)),
     db: Session = Depends(get_db),
 ):
     """Get a single board task."""
@@ -361,7 +373,7 @@ async def get_task(
     if not task:
         raise HTTPException(status_code=404, detail="Task not found")
 
-    enriched = _enrich_with_agents([task], db)
+    enriched = _enrich_with_agents([task], db, ctx.workspace_id)
     return enriched[0]
 
 

--- a/orchestrator/api/widgets/auth.py
+++ b/orchestrator/api/widgets/auth.py
@@ -18,13 +18,13 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass, field
 from typing import Callable, List, Optional
-from urllib.parse import urlparse
 from uuid import UUID
 
 import jwt
 from fastapi import Depends, HTTPException, Request, status
 from sqlalchemy.orm import Session
 
+from core.auth.hybrid import _extract_origin
 from core.database.database import get_db
 from core.services.api_key_service import ApiKeyService
 from config import config
@@ -68,18 +68,6 @@ def _extract_bearer_token(request: Request) -> Optional[str]:
     if len(parts) != 2 or parts[0].lower() != "bearer":
         return None
     return parts[1]
-
-
-def _extract_origin(request: Request) -> Optional[str]:
-    """Return the origin hostname from the Origin or Referer header."""
-    origin = request.headers.get("Origin") or request.headers.get("Referer")
-    if not origin:
-        return None
-    try:
-        parsed = urlparse(origin)
-        return parsed.hostname or origin
-    except Exception:
-        return origin
 
 
 def _try_jwt(token: str) -> Optional[dict]:

--- a/orchestrator/core/auth/dependencies.py
+++ b/orchestrator/core/auth/dependencies.py
@@ -36,7 +36,7 @@ class RequestContext:
 
     workspace_id: UUID
     user: UserContext
-    auth_type: str = "anonymous"  # "clerk" | "api_key" | "anonymous"
+    auth_type: str = "anonymous"  # "clerk" | "api_key" | "sdk_key" | "anonymous"
     api_key_id: Optional[str] = None
     admin_all_workspaces: bool = False  # When True, endpoints should skip workspace filtering
 

--- a/orchestrator/core/auth/hybrid.py
+++ b/orchestrator/core/auth/hybrid.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import hmac as _hmac
 import logging
 import secrets
-from typing import Optional
+from typing import Callable, Optional
+from urllib.parse import urlparse
 from uuid import UUID, uuid4
 
 from fastapi import HTTPException, Request, status
@@ -14,6 +15,7 @@ from config import config
 from core.auth.clerk import get_clerk_auth
 from core.auth.dependencies import RequestContext, UserContext
 from core.database.database import SessionLocal
+from core.services.api_key_service import ApiKeyService
 
 logger = logging.getLogger(__name__)
 
@@ -490,6 +492,162 @@ def _get_bearer_token(request: Request) -> Optional[str]:
     if not auth.lower().startswith("bearer "):
         return None
     return auth.split(" ", 1)[1].strip()
+
+
+def _extract_origin(request: Request) -> Optional[str]:
+    """Return the request origin hostname from the Origin (or Referer) header.
+
+    Shared by the board SDK path and the widget plane (``api/widgets/auth.py``
+    imports this) so origin matching is identical across planes. Returns None
+    when neither header is present.
+    """
+    origin = request.headers.get("Origin") or request.headers.get("Referer")
+    if not origin:
+        return None
+    try:
+        parsed = urlparse(origin)
+        return parsed.hostname or origin
+    except Exception:
+        return origin
+
+
+# ---------------------------------------------------------------------------
+# SDK-key auth for the board plane (PRD-09 Slice 2, Step 0)
+# ---------------------------------------------------------------------------
+#
+# A narrow, scope-gated path that lets a per-workspace SDK key (ak_pub_* /
+# ak_srv_*) authenticate to the board task endpoints — WITHOUT modifying the
+# shared `get_request_context_hybrid`, which backs ~96 routers / 657 call sites.
+# Modifying that shared dependency would make every endpoint accept SDK keys,
+# and since almost none of them check scopes, one key would grant full-platform
+# access. So the SDK path is wired only into `api/board_tasks.py` reads via the
+# `require_task_context` factory below.
+
+
+def _sdk_key_has_scope(permissions: Optional[list], required_scope: str) -> bool:
+    """Return True only when *permissions* EXPLICITLY grants *required_scope*.
+
+    SECURITY — this deliberately DIVERGES from ``ApiKeyService.check_permissions``
+    and the widget plane's ``require_permission``, which treat an empty/None list
+    as "unrestricted — all permissions granted". On the board plane an empty or
+    null permission list grants NOTHING: the large population of already-issued
+    publishable keys (chat/widget keys with null or unrelated permissions) must
+    not be able to reach the task board. Least privilege — no scope, no access.
+    """
+    if not permissions:
+        return False
+    return required_scope in permissions
+
+
+def _resolve_sdk_key_context(
+    request: Request, db, *, required_scope: str
+) -> RequestContext:
+    """Resolve an SDK key into a :class:`RequestContext` for the board plane.
+
+    Mirrors the widget plane's key validation (``api/widgets/auth.py``) but adds
+    the explicit scope gate and binds the workspace to the KEY only — never to
+    env defaults, query params, or ``request.state`` (cross-tenant guard).
+    """
+    token = _get_bearer_token(request)
+    if not token:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing bearer token"
+        )
+
+    record = ApiKeyService.validate_api_key(db, token)
+    if record is None:
+        logger.warning(
+            "Board SDK auth: key rejected (prefix=%s…) — not found, revoked, or expired",
+            token[:11],
+        )
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired API key",
+        )
+
+    # Least-privilege scope gate (see _sdk_key_has_scope).
+    if not _sdk_key_has_scope(record.permissions, required_scope):
+        logger.warning(
+            "Board SDK auth: key %s lacks required scope %s",
+            record.key_prefix, required_scope,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"API key lacks required scope: {required_scope}",
+        )
+
+    # Defense-in-depth origin check — only when a browser Origin is present.
+    # (Desktop / ak_srv_ callers omit Origin; allowed_domains is a browser-CORS
+    # control and gives server keys no protection — scope + workspace binding
+    # are the real controls there.)
+    origin = _extract_origin(request)
+    if origin and not ApiKeyService.check_domain(record, origin):
+        logger.warning(
+            "Board SDK auth: origin %s not allowed for key %s",
+            origin, record.key_prefix,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Origin not allowed for this API key",
+        )
+
+    # Cross-tenant guard: bind to the key's workspace. An X-Workspace-ID header
+    # may only MATCH it, never override it. We never consult env defaults /
+    # query params / request.state for an SDK key.
+    workspace_id = record.workspace_id
+    raw_ws_header = (request.headers.get("x-workspace-id") or "").strip()
+    if raw_ws_header and _parse_uuid(raw_ws_header) != workspace_id:
+        logger.warning(
+            "Board SDK auth: workspace header mismatch for key %s", record.key_prefix
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Workspace mismatch between API key and header",
+        )
+
+    if not _workspace_exists(db, workspace_id):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid workspace_id"
+        )
+    _assert_workspace_usable(db, workspace_id, is_admin=False)
+
+    result = RequestContext(
+        workspace_id=workspace_id,
+        user=UserContext(id=f"sdk:{record.id}", role="service", system_role="service"),
+        auth_type="sdk_key",
+        api_key_id=str(record.id),
+    )
+    _enrich_log_context(result)
+    return result
+
+
+def require_task_context(required_scope: str) -> Callable:
+    """FastAPI dependency factory for the board plane.
+
+    The returned dependency authenticates EITHER:
+    - a per-workspace SDK key (``ak_pub_*`` / ``ak_srv_*``) bearing
+      *required_scope* (via :func:`_resolve_sdk_key_context`), OR
+    - anything ``get_request_context_hybrid`` already accepts (Clerk JWT, env
+      admin key, anonymous, CORS preflight) — delegated UNCHANGED.
+
+    Purely additive: existing Clerk/env callers behave exactly as before. Wired
+    only into ``api/board_tasks.py``; the shared dependency is not modified, so
+    SDK-key acceptance does not leak to the other routers.
+    """
+
+    async def _dep(request: Request) -> RequestContext:
+        token = _get_bearer_token(request)
+        if token and token.startswith(("ak_pub_", "ak_srv_")):
+            db = SessionLocal()
+            try:
+                return _resolve_sdk_key_context(
+                    request, db, required_scope=required_scope
+                )
+            finally:
+                db.close()
+        return await get_request_context_hybrid(request)
+
+    return _dep
 
 
 async def get_request_context_hybrid(request: Request) -> RequestContext:

--- a/orchestrator/core/auth/scopes.py
+++ b/orchestrator/core/auth/scopes.py
@@ -1,0 +1,22 @@
+"""
+Auth scope constants — single source of truth.
+
+Centralises the permission-scope strings used to gate SDK API keys so the
+key-minting allowlist (``api/api_keys.py``) and the board auth gate
+(``core/auth/hybrid.py``) reference the *same* value rather than duplicated
+string literals (honours the project's no-hardcoded-values rule).
+
+Scope format is ``"<resource>:<action>"``, matching the existing convention in
+``VALID_PERMISSIONS`` (e.g. ``"documents:read"``, ``"agents:execute"``).
+"""
+
+from __future__ import annotations
+
+# Board task read access for SDK keys (PRD-09 Slice 2 — read-only board).
+TASKS_READ = "tasks:read"
+
+# NOTE: ``tasks:write`` / ``tasks:execute`` (board write-back and the
+# agent-launching / approval actions) are introduced in Slice 3, where the
+# write-vs-execute split is designed alongside the mutation endpoints. They are
+# intentionally NOT defined yet — a mintable scope that gates nothing would be a
+# misleading half-state.

--- a/orchestrator/tests/test_board_sdk_auth.py
+++ b/orchestrator/tests/test_board_sdk_auth.py
@@ -1,0 +1,291 @@
+"""Tests for the board SDK-key auth unlock (PRD-09 Slice 2, Step 0).
+
+Pure-function / monkeypatched style (no live DB), mirroring
+``test_api_key_domain_check.py``. Covers three layers:
+
+1. ``_sdk_key_has_scope`` — the least-privilege scope gate (the security crux:
+   empty/None permissions must be DENIED, diverging from
+   ``ApiKeyService.check_permissions`` which treats empty as "all").
+2. ``_resolve_sdk_key_context`` — the SDK-key → RequestContext resolver, incl.
+   the cross-tenant guard (binds to the key's workspace, never env defaults).
+3. ``require_task_context`` — the dependency factory: routes ``ak_*`` bearers to
+   the SDK path and delegates everything else (Clerk / env key / anon / OPTIONS)
+   to the untouched ``get_request_context_hybrid``.
+"""
+
+import asyncio
+from types import SimpleNamespace
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from core.auth import hybrid
+from core.auth.dependencies import RequestContext, UserContext
+from core.auth.hybrid import (
+    _extract_origin,
+    _resolve_sdk_key_context,
+    _sdk_key_has_scope,
+    require_task_context,
+)
+from core.auth.scopes import TASKS_READ
+
+WS = UUID("11111111-1111-1111-1111-111111111111")
+OTHER_WS = UUID("22222222-2222-2222-2222-222222222222")
+
+
+# --------------------------------------------------------------------------- #
+# Test doubles
+# --------------------------------------------------------------------------- #
+
+class _Headers:
+    """Case-insensitive header mapping, like Starlette's ``Headers``."""
+
+    def __init__(self, data: dict):
+        self._data = {k.lower(): v for k, v in (data or {}).items()}
+
+    def get(self, key, default=None):
+        return self._data.get(key.lower(), default)
+
+
+class _FakeRequest:
+    def __init__(self, headers=None, method="GET"):
+        self.headers = _Headers(headers)
+        self.method = method
+        self.query_params = _Headers({})
+        self.state = SimpleNamespace()
+
+
+def _key(*, workspace_id=WS, permissions, allowed_domains=None, key_id=None):
+    return SimpleNamespace(
+        id=key_id or uuid4(),
+        workspace_id=workspace_id,
+        permissions=permissions,
+        allowed_domains=allowed_domains,
+        key_prefix="ak_pub_test",
+    )
+
+
+def _patch_valid(monkeypatch, record):
+    """Make validate_api_key return *record* and the workspace checks pass."""
+    monkeypatch.setattr(hybrid.ApiKeyService, "validate_api_key", lambda db, token: record)
+    monkeypatch.setattr(hybrid, "_workspace_exists", lambda db, ws: True)
+    monkeypatch.setattr(hybrid, "_assert_workspace_usable", lambda db, ws, *, is_admin=False: None)
+
+
+def _resolve(req):
+    return _resolve_sdk_key_context(req, object(), required_scope=TASKS_READ)
+
+
+# --------------------------------------------------------------------------- #
+# 0. Shared origin extraction (used by both board + widget planes)
+# --------------------------------------------------------------------------- #
+
+class TestExtractOrigin:
+    def test_origin_header_returns_hostname(self):
+        assert _extract_origin(_FakeRequest({"Origin": "https://app.example.com"})) == "app.example.com"
+
+    def test_referer_fallback_strips_path(self):
+        assert _extract_origin(_FakeRequest({"Referer": "https://app.example.com/x/y"})) == "app.example.com"
+
+    def test_none_when_no_origin_or_referer(self):
+        assert _extract_origin(_FakeRequest({})) is None
+
+
+# --------------------------------------------------------------------------- #
+# 1. Scope gate — the least-privilege crux
+# --------------------------------------------------------------------------- #
+
+class TestSdkKeyHasScope:
+    def test_none_permissions_denied(self):
+        # SECURITY: unlike check_permissions, empty/None must NOT mean "all".
+        assert _sdk_key_has_scope(None, TASKS_READ) is False
+
+    def test_empty_permissions_denied(self):
+        assert _sdk_key_has_scope([], TASKS_READ) is False
+
+    def test_unrelated_scope_denied(self):
+        # An existing chat/widget key cannot reach the board.
+        assert _sdk_key_has_scope(["chat"], TASKS_READ) is False
+
+    def test_exact_scope_granted(self):
+        assert _sdk_key_has_scope(["tasks:read"], TASKS_READ) is True
+
+    def test_scope_among_others_granted(self):
+        assert _sdk_key_has_scope(["chat", "tasks:read"], TASKS_READ) is True
+
+
+# --------------------------------------------------------------------------- #
+# 2. Resolver
+# --------------------------------------------------------------------------- #
+
+class TestResolveSdkKeyContext:
+    def test_valid_read_key_returns_sdk_context(self, monkeypatch):
+        rec = _key(permissions=["tasks:read"])
+        _patch_valid(monkeypatch, rec)
+        ctx = _resolve(_FakeRequest({"Authorization": "Bearer ak_pub_abc"}))
+        assert isinstance(ctx, RequestContext)
+        assert ctx.auth_type == "sdk_key"
+        assert ctx.workspace_id == WS
+        assert ctx.api_key_id == str(rec.id)
+        assert ctx.user.role == "service"
+        assert ctx.user.id == f"sdk:{rec.id}"
+
+    def test_missing_token_401(self, monkeypatch):
+        # Defensive: resolver called with no bearer at all.
+        with pytest.raises(HTTPException) as e:
+            _resolve(_FakeRequest({}))
+        assert e.value.status_code == 401
+
+    def test_invalid_or_revoked_key_401(self, monkeypatch):
+        monkeypatch.setattr(hybrid.ApiKeyService, "validate_api_key", lambda db, token: None)
+        with pytest.raises(HTTPException) as e:
+            _resolve(_FakeRequest({"Authorization": "Bearer ak_pub_bad"}))
+        assert e.value.status_code == 401
+
+    def test_missing_scope_403(self, monkeypatch):
+        _patch_valid(monkeypatch, _key(permissions=["chat"]))
+        with pytest.raises(HTTPException) as e:
+            _resolve(_FakeRequest({"Authorization": "Bearer ak_pub_abc"}))
+        assert e.value.status_code == 403
+
+    def test_null_permissions_key_403(self, monkeypatch):
+        # The common case: an existing publishable chat key with null perms.
+        _patch_valid(monkeypatch, _key(permissions=None))
+        with pytest.raises(HTTPException) as e:
+            _resolve(_FakeRequest({"Authorization": "Bearer ak_pub_abc"}))
+        assert e.value.status_code == 403
+
+    def test_origin_not_allowed_403(self, monkeypatch):
+        _patch_valid(monkeypatch, _key(permissions=["tasks:read"], allowed_domains=["good.com"]))
+        with pytest.raises(HTTPException) as e:
+            _resolve(_FakeRequest(
+                {"Authorization": "Bearer ak_pub_abc", "Origin": "https://evil.com"}
+            ))
+        assert e.value.status_code == 403
+
+    def test_origin_allowed_ok(self, monkeypatch):
+        _patch_valid(monkeypatch, _key(permissions=["tasks:read"], allowed_domains=["good.com"]))
+        ctx = _resolve(_FakeRequest(
+            {"Authorization": "Bearer ak_pub_abc", "Origin": "https://good.com"}
+        ))
+        assert ctx.workspace_id == WS
+
+    def test_no_origin_skips_domain_check(self, monkeypatch):
+        # Desktop / server keys send no Origin -> domain gate must not block.
+        _patch_valid(monkeypatch, _key(permissions=["tasks:read"], allowed_domains=["good.com"]))
+        ctx = _resolve(_FakeRequest({"Authorization": "Bearer ak_pub_abc"}))
+        assert ctx.workspace_id == WS
+
+    def test_workspace_header_mismatch_403(self, monkeypatch):
+        _patch_valid(monkeypatch, _key(permissions=["tasks:read"]))
+        with pytest.raises(HTTPException) as e:
+            _resolve(_FakeRequest({
+                "Authorization": "Bearer ak_pub_abc",
+                "X-Workspace-ID": str(OTHER_WS),
+            }))
+        assert e.value.status_code == 403
+
+    def test_workspace_header_match_ok(self, monkeypatch):
+        _patch_valid(monkeypatch, _key(permissions=["tasks:read"]))
+        ctx = _resolve(_FakeRequest({
+            "Authorization": "Bearer ak_pub_abc",
+            "X-Workspace-ID": str(WS),
+        }))
+        assert ctx.workspace_id == WS
+
+    def test_soft_deleted_workspace_400(self, monkeypatch):
+        monkeypatch.setattr(hybrid.ApiKeyService, "validate_api_key",
+                            lambda db, token: _key(permissions=["tasks:read"]))
+        monkeypatch.setattr(hybrid, "_workspace_exists", lambda db, ws: False)
+        monkeypatch.setattr(hybrid, "_assert_workspace_usable", lambda db, ws, *, is_admin=False: None)
+        with pytest.raises(HTTPException) as e:
+            _resolve(_FakeRequest({"Authorization": "Bearer ak_pub_abc"}))
+        assert e.value.status_code == 400
+
+    def test_paused_workspace_403(self, monkeypatch):
+        monkeypatch.setattr(hybrid.ApiKeyService, "validate_api_key",
+                            lambda db, token: _key(permissions=["tasks:read"]))
+        monkeypatch.setattr(hybrid, "_workspace_exists", lambda db, ws: True)
+
+        def _raise(db, ws, *, is_admin=False):
+            raise HTTPException(status_code=403, detail="Workspace is disabled.")
+
+        monkeypatch.setattr(hybrid, "_assert_workspace_usable", _raise)
+        with pytest.raises(HTTPException) as e:
+            _resolve(_FakeRequest({"Authorization": "Bearer ak_pub_abc"}))
+        assert e.value.status_code == 403
+
+    def test_env_default_workspace_is_ignored(self, monkeypatch):
+        # CROSS-TENANT REGRESSION: a divergent DEFAULT_WORKSPACE_ID / WORKSPACE_ID
+        # must NOT change the resolved workspace — binding is to the key only.
+        _patch_valid(monkeypatch, _key(workspace_id=WS, permissions=["tasks:read"]))
+        monkeypatch.setattr(hybrid.config, "DEFAULT_WORKSPACE_ID", str(OTHER_WS), raising=False)
+        monkeypatch.setattr(hybrid.config, "WORKSPACE_ID", str(OTHER_WS), raising=False)
+        ctx = _resolve(_FakeRequest({"Authorization": "Bearer ak_pub_abc"}))
+        assert ctx.workspace_id == WS
+
+
+# --------------------------------------------------------------------------- #
+# 3. Dependency factory — routing + additive delegation (no regression)
+# --------------------------------------------------------------------------- #
+
+class TestRequireTaskContext:
+    def test_sdk_bearer_routes_to_resolver(self, monkeypatch):
+        rec = _key(permissions=["tasks:read"])
+        _patch_valid(monkeypatch, rec)
+        monkeypatch.setattr(hybrid, "SessionLocal",
+                            lambda: SimpleNamespace(close=lambda: None))
+        dep = require_task_context(TASKS_READ)
+        ctx = asyncio.run(dep(_FakeRequest({"Authorization": "Bearer ak_pub_abc"})))
+        assert ctx.auth_type == "sdk_key"
+        assert ctx.workspace_id == WS
+
+    def test_srv_key_prefix_also_routes_to_resolver(self, monkeypatch):
+        rec = _key(permissions=["tasks:read"])
+        _patch_valid(monkeypatch, rec)
+        monkeypatch.setattr(hybrid, "SessionLocal",
+                            lambda: SimpleNamespace(close=lambda: None))
+        dep = require_task_context(TASKS_READ)
+        ctx = asyncio.run(dep(_FakeRequest({"Authorization": "Bearer ak_srv_abc"})))
+        assert ctx.auth_type == "sdk_key"
+
+    def test_session_is_closed_even_on_error(self, monkeypatch):
+        closed = {"v": False}
+        monkeypatch.setattr(hybrid.ApiKeyService, "validate_api_key", lambda db, token: None)
+        monkeypatch.setattr(
+            hybrid, "SessionLocal",
+            lambda: SimpleNamespace(close=lambda: closed.__setitem__("v", True)),
+        )
+        dep = require_task_context(TASKS_READ)
+        with pytest.raises(HTTPException):
+            asyncio.run(dep(_FakeRequest({"Authorization": "Bearer ak_pub_bad"})))
+        assert closed["v"] is True
+
+    def _delegating_dep(self, monkeypatch, sentinel):
+        async def fake_hybrid(request):
+            return sentinel
+        monkeypatch.setattr(hybrid, "get_request_context_hybrid", fake_hybrid)
+        return require_task_context(TASKS_READ)
+
+    def test_clerk_bearer_delegates_to_hybrid(self, monkeypatch):
+        sentinel = RequestContext(workspace_id=WS, user=UserContext(), auth_type="clerk")
+        dep = self._delegating_dep(monkeypatch, sentinel)
+        ctx = asyncio.run(dep(_FakeRequest({"Authorization": "Bearer eyJhbGciOi"})))
+        assert ctx is sentinel
+
+    def test_x_api_key_no_bearer_delegates(self, monkeypatch):
+        sentinel = RequestContext(workspace_id=WS, user=UserContext(), auth_type="api_key")
+        dep = self._delegating_dep(monkeypatch, sentinel)
+        ctx = asyncio.run(dep(_FakeRequest({"X-Api-Key": "envkey"})))
+        assert ctx is sentinel
+
+    def test_options_delegates(self, monkeypatch):
+        sentinel = RequestContext(workspace_id=WS, user=UserContext(), auth_type="anonymous")
+        dep = self._delegating_dep(monkeypatch, sentinel)
+        ctx = asyncio.run(dep(_FakeRequest({}, method="OPTIONS")))
+        assert ctx is sentinel
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
…-09 Slice 2)

Let a per-workspace SDK key (ak_pub_*) bearing an explicit tasks:read scope authenticate to the board read endpoints (GET /api/v1/tasks, GET /api/v1/tasks/{id}) WITHOUT modifying the shared get_request_context_hybrid (657 call sites). New require_task_context() routes ak_* bearers through a least-privilege scope gate (empty perms = DENY, unlike check_permissions) and binds the workspace to the key only; everything else delegates to hybrid unchanged.

Also: scope _enrich_with_agents to the caller's workspace (cross-tenant agent leak), share _extract_origin across board+widget planes, log SDK auth rejections. 27 unit tests; security + architecture reviewed.