### PR TITLE
fix(prd-142): restore power_mode + routing tool registration (dropped in #429 merge)

### DIFF
--- a/orchestrator/modules/tools/discovery/platform_actions.py
+++ b/orchestrator/modules/tools/discovery/platform_actions.py
@@ -34,6 +34,8 @@ from .actions_harness import register_harness_actions
 from .actions_graph import register_graph_actions
 from .actions_auto_reporting import register_auto_reporting_actions
 from .actions_notifications import register_notifications_actions
+from .actions_routing import register_routing_actions  # PRD-142 Wave 4 (W4-S6)
+from .actions_power import register_power_actions  # PRD-142 Wave 4 (W4-S5)
 from .actions_autonomy import register_autonomy_actions
 
 
@@ -62,6 +64,8 @@ def register_all_actions(registry: ActionRegistry) -> None:
     register_graph_actions(registry)
     register_auto_reporting_actions(registry)
     register_notifications_actions(registry)
+    register_routing_actions(registry)  # PRD-142 Wave 4 (W4-S6): routing-rule tool
+    register_power_actions(registry)  # PRD-142 Wave 4 (W4-S5): power-mode tool
     register_autonomy_actions(registry)
 
     # Workspace tools (file I/O, grep, exec, git)

--- a/orchestrator/tests/test_platform_actions_registration.py
+++ b/orchestrator/tests/test_platform_actions_registration.py
@@ -1,0 +1,67 @@
+"""Regression guard: register_all_actions() wires every Wave-4 platform tool.
+
+Two PRs touched platform_actions.py's registration block — #428 (power_mode S5,
+routing S6) and #429 (autonomy S14/S15). A merge resolved the conflict by keeping
+the autonomy registration and silently dropping power + routing, while their
+handlers stayed wired in platform_executor — so the actions vanished from the
+tool registry (and the LLM tool schema) with no test failure.
+
+This pins that the single entry point actually registers all of them, so a
+future conflict can't drop one unnoticed. Dummy POSTGRES_* + the apscheduler stub
+let the action-module import chain load without a DB or the prod-only scheduler.
+"""
+import os
+import sys
+import types
+
+os.environ.setdefault("POSTGRES_USER", "test")
+os.environ.setdefault("POSTGRES_PASSWORD", "test")
+os.environ.setdefault("POSTGRES_HOST", "localhost")
+os.environ.setdefault("POSTGRES_PORT", "5432")
+os.environ.setdefault("POSTGRES_DB", "test")
+
+
+def _install_fake_apscheduler():
+    if "apscheduler" in sys.modules:
+        return
+    aps = types.ModuleType("apscheduler")
+    schedulers = types.ModuleType("apscheduler.schedulers")
+    asyncio_mod = types.ModuleType("apscheduler.schedulers.asyncio")
+    asyncio_mod.AsyncIOScheduler = type("AsyncIOScheduler", (), {})
+    jobstores = types.ModuleType("apscheduler.jobstores")
+    memory_mod = types.ModuleType("apscheduler.jobstores.memory")
+    memory_mod.MemoryJobStore = type("MemoryJobStore", (), {})
+    aps.schedulers = schedulers
+    aps.jobstores = jobstores
+    schedulers.asyncio = asyncio_mod
+    jobstores.memory = memory_mod
+    sys.modules.update({
+        "apscheduler": aps,
+        "apscheduler.schedulers": schedulers,
+        "apscheduler.schedulers.asyncio": asyncio_mod,
+        "apscheduler.jobstores": jobstores,
+        "apscheduler.jobstores.memory": memory_mod,
+    })
+
+
+_install_fake_apscheduler()
+
+from modules.tools.discovery.action_registry import ActionRegistry  # noqa: E402
+from modules.tools.discovery.platform_actions import register_all_actions  # noqa: E402
+
+
+def test_register_all_actions_wires_wave4_tools():
+    reg = ActionRegistry()
+    register_all_actions(reg)
+    # _actions is the registry's name->definition map; read it directly rather
+    # than get() (which would trigger a second full init).
+    for name in (
+        "platform_set_power_mode",        # W4-S5
+        "platform_create_routing_rule",   # W4-S6
+        "platform_set_autonomy_level",    # W4-S14/S15
+        "platform_get_autonomy_level",    # W4-S14/S15
+    ):
+        assert reg._actions.get(name) is not None, (
+            f"{name} is not registered by register_all_actions — a merge likely "
+            "dropped its register_*_actions() call from platform_actions.py"
+        )


### PR DESCRIPTION
## Restore power_mode + routing tool registration (regression from the #429 merge)

**Bug:** when #429 (autonomy dial) merged after #428, a `platform_actions.py` conflict was resolved by keeping `register_autonomy_actions` and **silently dropping `register_routing_actions` (W4-S6) and `register_power_actions` (W4-S5)** — both the imports and the `register_*_actions(registry)` calls.

**Impact:** the handlers stayed wired in `platform_executor` (dispatch map intact), so the actions still execute if invoked directly — but they vanished from the **action registry**, so `platform_set_power_mode` and `platform_create_routing_rule` are no longer surfaced in the LLM tool schema. S5 + S6 were effectively dead on `main`.

**Fix:**
- Restore the two imports + two `register_*_actions(registry)` calls in `platform_actions.py` (autonomy was already present; now all three are).
- Add `tests/test_platform_actions_registration.py` — a regression guard that executes `register_all_actions()` and asserts every Wave-4 tool (`platform_set_power_mode`, `platform_create_routing_rule`, `platform_set_autonomy_level`, `platform_get_autonomy_level`) is registered, so a future merge can't silently drop one.

`platform_executor.py` was verified intact (all three dispatch entries + handler imports present) — only the registration block regressed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored registration of platform actions for power mode and routing management.
  * Ensured all platform tool actions are consistently registered during system initialization.

* **Tests**
  * Added regression test to verify complete registration of platform actions, including power management, routing control, and autonomy level settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->