### PR TITLE
feat(prd-142): W4 §12.3 — autonomy→HARNESS auto-apply ceiling + setter audit

### DIFF
--- a/orchestrator/config.py
+++ b/orchestrator/config.py
@@ -508,6 +508,16 @@ class Config:
     # config changes back onto the platform). HIGH RISK — default OFF. Nothing
     # in Phase 5 may take effect unless this is true.
     HARNESS_SELF_MANAGEMENT_ENABLED: bool = os.getenv("HARNESS_SELF_MANAGEMENT_ENABLED", "false").lower() == "true"
+    # PRD-142 Wave 4 (§12.3): HARNESS risk thresholds — Railway-overridable env vars
+    # (change in Railway + restart, no file edit). Auto-apply ceilings: a prescription
+    # auto-applies only when its risk_score <= the workspace's ceiling; higher risk is
+    # queued for human approval. Workspaces at autonomy=full get the higher ceiling,
+    # standard workspaces the lower one.
+    HARNESS_AUTO_APPLY_MAX_RISK_STANDARD: int = int(os.getenv("HARNESS_AUTO_APPLY_MAX_RISK_STANDARD", "2"))
+    HARNESS_AUTO_APPLY_MAX_RISK_FULL: int = int(os.getenv("HARNESS_AUTO_APPLY_MAX_RISK_FULL", "3"))
+    # Escalation threshold: prescriptions at or above this risk are flagged high
+    # priority and escalated for human approval (when self-management is on).
+    HARNESS_HIGH_PRIORITY_RISK: int = int(os.getenv("HARNESS_HIGH_PRIORITY_RISK", "4"))
 
     # =============================================================================
     # PRD-130 — Business Intake Wizard (PoC)

--- a/orchestrator/modules/tools/discovery/handlers_autonomy.py
+++ b/orchestrator/modules/tools/discovery/handlers_autonomy.py
@@ -48,19 +48,44 @@ async def get_autonomy_level(
 async def set_autonomy_level(
     db: Session, workspace_id: UUID, params: Dict[str, Any]
 ) -> Dict[str, Any]:
-    """Persist a new autonomy ``level`` to ``workspace.settings.autonomy``."""
-    from core.services.auto_autonomy import set_autonomy_level as _set
+    """Persist a new autonomy ``level`` to ``workspace.settings.autonomy``.
+
+    Writes an audit line (PRD-142 Wave 4, HIGH-2) on every change — actor, prior
+    level, new level — because this dial can disable the confirmation gate, so
+    "who turned full autonomy on, and when" must be reconstructable.
+    """
+    from core.services.auto_autonomy import (
+        get_autonomy_level as _get,
+        set_autonomy_level as _set,
+    )
 
     level = params.get("level")
     if not level:
         return {"success": False, "error": "level is required (standard | full)"}
 
+    # Actor + prior level, captured before the write for the audit trail. The
+    # executor re-mints _agent_id server-side, so it can't be spoofed by the LLM.
+    actor = params.get("_agent_id")
+    try:
+        previous = _get(db, workspace_id)
+    except Exception:
+        previous = "unknown"
+
     try:
         result = _set(db, workspace_id, level)
         db.commit()
+        # Audit record — greppable in Loki; the durable "who flipped the gate" trail.
+        logger.info(
+            "[autonomy][audit] workspace=%s actor_agent=%s level %s -> %s",
+            workspace_id, actor, previous, result["level"],
+        )
         return {
             "success": True,
-            "data": {**result, "meaning": _LEVEL_MEANING.get(result["level"], "")},
+            "data": {
+                **result,
+                "previous_level": previous,
+                "meaning": _LEVEL_MEANING.get(result["level"], ""),
+            },
         }
     except ValueError as exc:
         return {"success": False, "error": str(exc)}

--- a/orchestrator/services/harness_service.py
+++ b/orchestrator/services/harness_service.py
@@ -394,13 +394,22 @@ class HarnessService:
         Workspaces running at autonomy=full get the higher ``_FULL`` ceiling;
         everyone else gets ``_STANDARD``. Both are Railway-overridable config
         (HARNESS_AUTO_APPLY_MAX_RISK_*). The level is read via auto_autonomy, which
-        fails safe to standard on a missing/corrupt setting — so the ceiling can
-        only widen on a deliberate, valid full-autonomy opt-in.
+        fails safe to standard on a missing/corrupt setting — and a failed read
+        (DB error mid-tick) fails safe here too, so a lookup problem can only
+        NARROW the ceiling, never widen it, and never aborts the tick.
         """
         from config import config
         from core.services.auto_autonomy import is_full_autonomy
 
-        if is_full_autonomy(db, workspace_id):
+        try:
+            full = is_full_autonomy(db, workspace_id)
+        except Exception:
+            logger.warning(
+                "[HARNESS] autonomy lookup failed for %s — using standard ceiling",
+                workspace_id, exc_info=True,
+            )
+            full = False
+        if full:
             return config.HARNESS_AUTO_APPLY_MAX_RISK_FULL
         return config.HARNESS_AUTO_APPLY_MAX_RISK_STANDARD
 

--- a/orchestrator/services/harness_service.py
+++ b/orchestrator/services/harness_service.py
@@ -35,9 +35,9 @@ _CRON_EXPRESSION = {"day_of_week": "sun", "hour": 2, "minute": 0}  # Sunday 2AM 
 _MIN_AGENTS = 3
 _MIN_DATA_DAYS = 7
 
-# Risk thresholds
-_AUTO_APPLY_MAX_RISK = 2
-_HIGH_PRIORITY_RISK = 4
+# Risk thresholds live in config (Railway-overridable env vars), read at use:
+#   HARNESS_AUTO_APPLY_MAX_RISK_STANDARD / _FULL — auto-apply ceilings (§12.3)
+#   HARNESS_HIGH_PRIORITY_RISK — escalation / high-priority threshold
 
 # Sentinel proposed_value meaning "a human must supply the real value" — emitted
 # by _phase_prescribe for changes it can detect but not safely decide (model,
@@ -292,6 +292,8 @@ class HarnessService:
             ws = db.query(WsModel).get(workspace_id)
             ws_settings = ws.settings if ws else None
             allow_auto = self._workspace_allows_auto_apply(ws_settings)
+            # §12.3: full-autonomy workspaces get the higher auto-apply risk ceiling.
+            max_risk = self._auto_apply_max_risk(db, workspace_id)
 
             # ----- 5-phase pipeline -----
             # Commit before each phase so the connection is not idle-in-
@@ -307,7 +309,10 @@ class HarnessService:
             end_open_transaction(db)
             prescriptions = await self._phase_prescribe(workspace_id, diagnosis, metrics, db)
             end_open_transaction(db)
-            changelog = await self._phase_apply(workspace_id, prescriptions, db, allow_auto_apply=allow_auto)
+            changelog = await self._phase_apply(
+                workspace_id, prescriptions, db,
+                allow_auto_apply=allow_auto, max_risk=max_risk,
+            )
             end_open_transaction(db)
             baseline, artifacts = await self._phase_baseline(
                 workspace_id, metrics, diagnosis, prescriptions, changelog, db,
@@ -381,6 +386,23 @@ class HarnessService:
             return True
         harness = workspace_settings.get("orchestrator", {}).get("harness", {})
         return harness.get("mode", "full_auto") == "full_auto"
+
+    @staticmethod
+    def _auto_apply_max_risk(db: "Session", workspace_id: UUID) -> int:
+        """§12.3: the auto-apply risk ceiling for this workspace.
+
+        Workspaces running at autonomy=full get the higher ``_FULL`` ceiling;
+        everyone else gets ``_STANDARD``. Both are Railway-overridable config
+        (HARNESS_AUTO_APPLY_MAX_RISK_*). The level is read via auto_autonomy, which
+        fails safe to standard on a missing/corrupt setting — so the ceiling can
+        only widen on a deliberate, valid full-autonomy opt-in.
+        """
+        from config import config
+        from core.services.auto_autonomy import is_full_autonomy
+
+        if is_full_autonomy(db, workspace_id):
+            return config.HARNESS_AUTO_APPLY_MAX_RISK_FULL
+        return config.HARNESS_AUTO_APPLY_MAX_RISK_STANDARD
 
     # ------------------------------------------------------------------
     # Dormancy check
@@ -659,12 +681,13 @@ class HarnessService:
     def _prescribe_tool_removals(
         self, issues, rejected_signatures, today, start_seq
     ):
-        """Turn tool_failure issues (W4-S10) into QUEUED (risk 3, human-reviewed)
-        tool_assignment_remove prescriptions — only when the failing action cleanly
-        maps to a removable Composio app. Removing a tool is consequential, so it is
-        never auto-applied (risk 3 = queued, not <= _AUTO_APPLY_MAX_RISK); when the
-        action has no clean app mapping the issue is surfaced in the diagnosis but
-        no removal is proposed. Returns (prescriptions, next_seq)."""
+        """Turn tool_failure issues (W4-S10) into risk-3 tool_assignment_remove
+        prescriptions — only when the failing action cleanly maps to a removable
+        Composio app. Removing a tool is consequential: at standard autonomy it is
+        queued for human review (risk 3 > the standard auto-apply ceiling); at full
+        autonomy the ceiling rises to 3 (§12.3) so it auto-applies. When the action
+        has no clean app mapping the issue is surfaced in the diagnosis but no
+        removal is proposed. Returns (prescriptions, next_seq)."""
         out: List[Dict[str, Any]] = []
         seq = start_seq
         for issue in issues:
@@ -861,12 +884,19 @@ class HarnessService:
         prescriptions: List[Dict[str, Any]],
         db: "Session",
         allow_auto_apply: bool = True,
+        max_risk: Optional[int] = None,
     ) -> Dict[str, Any]:
-        """Execute safe changes (risk ≤ 2), queue risky ones as board tasks.
+        """Execute safe changes (risk <= the workspace ceiling), queue risky ones.
 
-        When allow_auto_apply is False (manual mode), ALL prescriptions are
-        queued as board tasks regardless of risk score.
+        ``max_risk`` is this workspace's auto-apply ceiling (§12.3 — higher at
+        autonomy=full); it defaults to the standard ceiling when a direct caller
+        omits it. When allow_auto_apply is False (manual mode), ALL prescriptions
+        are queued as board tasks regardless of risk score.
         """
+        from config import config
+        if max_risk is None:
+            max_risk = config.HARNESS_AUTO_APPLY_MAX_RISK_STANDARD
+        high_priority_risk = config.HARNESS_HIGH_PRIORITY_RISK
         logger.info(
             "[HARNESS] Phase 4 APPLY — workspace %s (auto_apply=%s)",
             workspace_id, allow_auto_apply,
@@ -893,7 +923,7 @@ class HarnessService:
             target_name = rx.get("target_name", "unknown")
             change_type = rx.get("change_type", "unknown")
 
-            if allow_auto_apply and risk <= _AUTO_APPLY_MAX_RISK:
+            if allow_auto_apply and risk <= max_risk:
                 # Auto-apply
                 result = await self._auto_apply_prescription(executor, rx)
                 if result.get("success"):
@@ -916,7 +946,7 @@ class HarnessService:
                     })
             else:
                 # Queue as board task
-                priority = "high" if risk >= _HIGH_PRIORITY_RISK else "medium"
+                priority = "high" if risk >= high_priority_risk else "medium"
                 try:
                     task_result = await executor.execute("platform_create_task", {
                         "title": f"[HARNESS] {change_type} for {target_name}",
@@ -968,14 +998,16 @@ class HarnessService:
     ) -> None:
         """Notify a human to approve/reject a high-risk queued prescription.
 
-        Only fires for risk >= _HIGH_PRIORITY_RISK, and only when the workspace
-        has a connected channel — otherwise there is nobody to notify and the
+        Only fires for risk >= the escalation threshold (config
+        HARNESS_HIGH_PRIORITY_RISK), and only when the workspace has a connected
+        channel — otherwise there is nobody to notify and the
         board task already stands for in-app review (so we skip silently rather
         than record a phantom escalation). Records an 'escalated' changelog
         entry with whether delivery actually succeeded. Never raises.
         """
+        from config import config
         risk = rx.get("risk_score", 5)
-        if risk < _HIGH_PRIORITY_RISK:
+        if risk < config.HARNESS_HIGH_PRIORITY_RISK:
             return
         if not self._workspace_has_channel(db, workspace_id):
             return

--- a/orchestrator/tests/test_harness_governance_gate.py
+++ b/orchestrator/tests/test_harness_governance_gate.py
@@ -1,0 +1,163 @@
+"""PRD-142 Wave 4 (§12.3): autonomy → HARNESS auto-apply ceiling coupling.
+
+A workspace at autonomy=full gets the higher auto-apply risk ceiling
+(HARNESS_AUTO_APPLY_MAX_RISK_FULL, default 3); everyone else gets the standard
+ceiling (default 2). Both ceilings are Railway-overridable config. These tests
+pin: (1) `_auto_apply_max_risk` selects full vs standard via auto_autonomy, and
+(2) the ceiling actually flips a risk-3 prescription between auto-apply and queue
+in `_phase_apply`.
+
+Dummy POSTGRES_* + the apscheduler stub let the harness_service import chain load.
+"""
+import asyncio
+import os
+import sys
+import types
+from uuid import UUID
+
+os.environ.setdefault("POSTGRES_USER", "test")
+os.environ.setdefault("POSTGRES_PASSWORD", "test")
+os.environ.setdefault("POSTGRES_HOST", "localhost")
+os.environ.setdefault("POSTGRES_PORT", "5432")
+os.environ.setdefault("POSTGRES_DB", "test")
+
+
+def _install_fake_apscheduler():
+    if "apscheduler" in sys.modules:
+        return
+    aps = types.ModuleType("apscheduler")
+    schedulers = types.ModuleType("apscheduler.schedulers")
+    asyncio_mod = types.ModuleType("apscheduler.schedulers.asyncio")
+    asyncio_mod.AsyncIOScheduler = type("AsyncIOScheduler", (), {})
+    jobstores = types.ModuleType("apscheduler.jobstores")
+    memory_mod = types.ModuleType("apscheduler.jobstores.memory")
+    memory_mod.MemoryJobStore = type("MemoryJobStore", (), {})
+    aps.schedulers = schedulers
+    aps.jobstores = jobstores
+    schedulers.asyncio = asyncio_mod
+    jobstores.memory = memory_mod
+    sys.modules.update({
+        "apscheduler": aps,
+        "apscheduler.schedulers": schedulers,
+        "apscheduler.schedulers.asyncio": asyncio_mod,
+        "apscheduler.jobstores": jobstores,
+        "apscheduler.jobstores.memory": memory_mod,
+    })
+
+
+_install_fake_apscheduler()
+
+from config import config  # noqa: E402
+from services.harness_service import get_harness_service  # noqa: E402
+
+_WS = UUID("00000000-0000-0000-0000-000000000001")
+
+
+# --- the ceiling selector --------------------------------------------------
+
+def test_auto_apply_max_risk_full_vs_standard(monkeypatch):
+    import core.services.auto_autonomy as aa
+    svc = get_harness_service()
+
+    monkeypatch.setattr(aa, "is_full_autonomy", lambda db, ws: True)
+    assert svc._auto_apply_max_risk(None, _WS) == config.HARNESS_AUTO_APPLY_MAX_RISK_FULL
+
+    monkeypatch.setattr(aa, "is_full_autonomy", lambda db, ws: False)
+    assert svc._auto_apply_max_risk(None, _WS) == config.HARNESS_AUTO_APPLY_MAX_RISK_STANDARD
+
+
+def test_auto_apply_max_risk_default_full_is_higher_than_standard():
+    # The shipped defaults must actually widen at full, else the coupling is a no-op.
+    assert config.HARNESS_AUTO_APPLY_MAX_RISK_FULL > config.HARNESS_AUTO_APPLY_MAX_RISK_STANDARD
+
+
+# --- the ceiling flips auto-apply vs queue in _phase_apply -----------------
+
+def _patch_phase_apply_side_effects(monkeypatch, svc, applied, executed):
+    async def fake_auto_apply(executor, rx):
+        applied.append(rx["prescription_id"])
+        return {"success": True}
+
+    async def fake_escalate(db, ws, rx, changelog):
+        return None
+
+    async def fake_apply_approved(executor, ws, changelog):
+        return None
+
+    monkeypatch.setattr(svc, "_auto_apply_prescription", fake_auto_apply)
+    monkeypatch.setattr(svc, "_snapshot_current_value", lambda rx: {})
+    monkeypatch.setattr(svc, "_maybe_escalate", fake_escalate)
+    monkeypatch.setattr(svc, "_apply_approved_board_tasks", fake_apply_approved)
+
+    class _FakeExec:
+        def __init__(self, *a, **k):
+            pass
+
+        async def execute(self, name, params):
+            executed.append(name)
+            return {"success": True, "data": {"id": 1}}
+
+    import modules.tools.discovery.platform_executor as pe
+    monkeypatch.setattr(pe, "PlatformActionExecutor", _FakeExec)
+
+
+def _rx3():
+    return {"prescription_id": "rx-3", "risk_score": 3, "change_type": "tag_update", "target_name": "A"}
+
+
+def test_full_ceiling_auto_applies_risk_3(monkeypatch):
+    svc = get_harness_service()
+    applied, executed = [], []
+    _patch_phase_apply_side_effects(monkeypatch, svc, applied, executed)
+
+    asyncio.run(svc._phase_apply(_WS, [_rx3()], None, allow_auto_apply=True, max_risk=3))
+
+    assert applied == ["rx-3"]                       # auto-applied
+    assert "platform_create_task" not in executed    # not queued
+
+
+def test_standard_ceiling_queues_risk_3(monkeypatch):
+    svc = get_harness_service()
+    applied, executed = [], []
+    _patch_phase_apply_side_effects(monkeypatch, svc, applied, executed)
+
+    asyncio.run(svc._phase_apply(_WS, [_rx3()], None, allow_auto_apply=True, max_risk=2))
+
+    assert applied == []                             # NOT auto-applied
+    assert "platform_create_task" in executed        # queued for review
+
+
+def test_default_max_risk_uses_standard_ceiling(monkeypatch):
+    # A direct caller that omits max_risk falls back to the standard config ceiling
+    # (2 by default) — so a risk-3 rx queues, never silently auto-applies.
+    svc = get_harness_service()
+    applied, executed = [], []
+    _patch_phase_apply_side_effects(monkeypatch, svc, applied, executed)
+
+    asyncio.run(svc._phase_apply(_WS, [_rx3()], None, allow_auto_apply=True))
+
+    assert applied == []
+    assert "platform_create_task" in executed
+
+
+# --- HIGH-2: the setter records who flipped the dial + from what -----------
+
+def test_set_autonomy_level_audits_previous_level(monkeypatch):
+    import core.services.auto_autonomy as aa
+    from modules.tools.discovery.handlers_autonomy import set_autonomy_level
+
+    monkeypatch.setattr(aa, "get_autonomy_level", lambda db, ws: "standard")
+    monkeypatch.setattr(aa, "set_autonomy_level", lambda db, ws, level: {"level": level})
+
+    class _DB:
+        def commit(self):
+            pass
+
+        def rollback(self):
+            pass
+
+    out = asyncio.run(set_autonomy_level(_DB(), _WS, {"level": "full", "_agent_id": 7}))
+    assert out["success"] is True
+    assert out["data"]["level"] == "full"
+    # The prior level is captured (returned + logged) so the change is auditable.
+    assert out["data"]["previous_level"] == "standard"

--- a/orchestrator/tests/test_w1s9_idle_in_tx.py
+++ b/orchestrator/tests/test_w1s9_idle_in_tx.py
@@ -471,6 +471,14 @@ class _GetQuery:
     def get(self, *a, **k):
         return self._obj
 
+    # §12.3: the tick now reads the autonomy level via
+    # db.query(Workspace).filter(...).first() — serve the same workspace.
+    def filter(self, *a, **k):
+        return self
+
+    def first(self):
+        return self._obj
+
 
 class _HarnessDB:
     def __init__(self, ws, events):
@@ -532,7 +540,7 @@ async def test_harness_commits_before_each_phase(monkeypatch):
         events.append("prescribe")
         return []
 
-    async def _apply(_ws, _rx, _db, allow_auto_apply=True):
+    async def _apply(_ws, _rx, _db, allow_auto_apply=True, max_risk=None):
         events.append("apply")
         return {"applied": [], "queued": []}
 


### PR DESCRIPTION
## PRD-142 Wave 4 §12.3 — autonomy → HARNESS auto-apply ceiling + setter audit

Completes WS-E US-E2 (the autonomy×HARNESS coupling the PRD specced) + the HIGH-2 audit from the security review.

### §12.3 — the governance coupling
A workspace at `autonomy=full` gets a **higher HARNESS auto-apply risk ceiling** (default **3**); standard workspaces keep the lower ceiling (default **2**). Anything above the ceiling is still **queued for human approval**. The level is read via `auto_autonomy` (fails safe to standard on a missing/corrupt setting), so the ceiling only widens on a deliberate, valid full-autonomy opt-in.

Concrete effect: a risk-3 tool-failure removal (W4-S10) auto-applies at `full`, queues at `standard`.

### Railway-tunable thresholds (no file edits)
The three HARNESS risk thresholds moved out of hardcoded module constants into **config.py env vars** — change them in Railway + restart, no redeploy:
- `HARNESS_AUTO_APPLY_MAX_RISK_STANDARD` (default 2)
- `HARNESS_AUTO_APPLY_MAX_RISK_FULL` (default 3)
- `HARNESS_HIGH_PRIORITY_RISK` (default 4)

### HIGH-2 — setter audit trail
`platform_set_autonomy_level` now records `actor + prior_level -> new_level` on every change (greppable in Loki) and returns `previous_level`. A dial that can disable the confirmation gate must record who flipped it.

### Tests
Ceiling selection (full vs standard), the ceiling flipping a risk-3 rx between auto-apply and queue, default-to-standard fallback, and the setter audit.

### Deliberately NOT here (security-review extras, low-urgency for the confirmed single-owner pilot)
- **Owner-only setter guard (HIGH-1)** — the admin model is workspace-scoped (pre-existing PRD-122); it only bites in *multi-member* workspaces, of which the pilot has none. Raise when multi-member lands.
- **Per-execution full-autonomy tagging** — the other half of HIGH-2; the "who flipped it" record above is the high-value part.

Everything is dormant until `HARNESS_SELF_MANAGEMENT_ENABLED=true`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Risk thresholds for auto-apply prescriptions are now environment-configurable with defaults: standard (2), full-autonomy (3), and high-priority (4).
  * Full-autonomy workspaces can auto-apply higher-risk prescriptions than standard workspaces.
  * Autonomy level changes are audited with previous level recorded for tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->