### PR TITLE
feat(prd-143): close discoverability gaps — tool metadata uplift + gr…

### DIFF
--- a/docs/PRDS/PRD-143-AUTO-FULL-PLATFORM-OPERATOR.md
+++ b/docs/PRDS/PRD-143-AUTO-FULL-PLATFORM-OPERATOR.md
@@ -216,4 +216,16 @@ Phase 1 delivers the **enabler** for all three, plus the **one hard safety bound
 
 ---
 
-**This PRD is the Phase-1 plan: the enabler for Auto-as-operator, Rev 2. One boundary instead of many: Auto gets the whole platform; Gerard keeps the watchtower. It builds on PRD-142 Wave 4, PRD-138/139, and PRD-140 — extends, never rebuilds — and enforces the observability lock as a hard, fail-closed invariant that no autonomy level, admin role, or API key can cross. The full catalogue, skills library, and additional concierge journeys follow once the enabler is proven.**
+**This PRD is the Phase-1 plan: the enabler for Auto-as-operator, Rev 2. One boundary instead of many: Auto gets the whole platform; Gerard keeps the watchtower. It builds on PRD-142 Wave 4, PRD-138/139, and PRD-140 — extends, never rebuilds — and enforces the observability lock as a hard, fail-closed invariant that no autonomy level, admin role, or API key can cross.**
+
+---
+
+## Addendum — Discoverability completion (2026-06-10)
+
+Access ≠ discoverability: Auto reaching every API is worthless if it can't tell *what each does, when to use it,* and *find the right one.* This addendum closes that, so the selection stack genuinely serves the full operator surface — not just the happy path.
+
+**Selection metadata — every tool is now self-describing.** Audited all 140 platform tools; the semantic index embeds `name: description | Tags | Examples | Category` (`action_semantic_index._build_embedding_text`), and every operator tool now carries all four — description ("what"), tags + examples ("when to use"). The 4 weak tools found (3 in `actions_field.py` missing tags/examples, 1 thin `platform_cancel_scheduled_task` description) are filled. New tools are auto-indexed (`ensure_indexed` embeds any action not yet in the index from `registry.get_all()`) — no manual reindex needed, ever.
+
+**Graph cold-start — new tools are reachable before they have telemetry.** The S12 telemetry seed only helps tools already in `tool_execution_logs`; a brand-new tool had zero graph signal. New `modules/tools/discovery/metadata_graph_seed.py` seeds GLOBAL `meta_sibling` edges between same-category operator tools straight from the registry, so a new tool surfaces via the graph the moment a sibling is relevant. `GraphRouter._query_edges` now follows `used_after` **and** `meta_sibling`; metadata edges sit at the min-confidence floor so real usage (higher Wilson confidence) always outranks them — metadata is the floor, telemetry wins as it accrues. `super_admin_only` tools are never seeded (the obs lock holds). Wired into the human-applied seed script as an independent step. Tests: 6 new in `test_prd143_graph_seed.py` (pairing, su-exclusion, confidence band, idempotent upsert, dry-run, zero-telemetry routing, real-outranks-meta).
+
+**Net:** for every tool in the operator surface, Auto now knows what it does, when to use it, and can find it via both semantic (auto-indexed) and graph (telemetry + metadata cold-start). The one remaining axis — deep multi-step *skills/knowledge* (rich "use X then Y to achieve Z" guidance, distinct from per-tool discoverability) — is the **PRD-120 skills library**, an open decision (§11 Q6), not a silent deferral.

--- a/orchestrator/modules/tools/discovery/actions_field.py
+++ b/orchestrator/modules/tools/discovery/actions_field.py
@@ -32,6 +32,13 @@ def register_field_actions(registry: ActionRegistry) -> None:
             },
             "required": ["query"],
         },
+        tags=["field", "mission", "shared-context", "coordination", "memory"],
+        examples=[
+            "what have the other agents found so far",
+            "check the field before I start researching",
+            "find prior analysis on competitor pricing from the team",
+            "see what's already known about the EU AI Act",
+        ],
     ))
 
     registry.register(ActionDefinition(
@@ -63,6 +70,13 @@ def register_field_actions(registry: ActionRegistry) -> None:
             },
             "required": ["key", "value"],
         },
+        tags=["field", "mission", "share", "findings", "coordination"],
+        examples=[
+            "share this finding with the rest of the team",
+            "record my analysis so other agents can see it",
+            "post this conclusion to the shared field",
+            "let the other agents know what I discovered",
+        ],
     ))
 
     registry.register(ActionDefinition(
@@ -78,4 +92,11 @@ def register_field_actions(registry: ActionRegistry) -> None:
             "type": "object",
             "properties": {},
         },
+        tags=["field", "mission", "convergence", "consensus", "coordination"],
+        examples=[
+            "has the team reached consensus yet",
+            "is the field converged enough to stop researching",
+            "how stable are the agents' findings",
+            "are we done gathering research",
+        ],
     ))

--- a/orchestrator/modules/tools/discovery/actions_scheduling.py
+++ b/orchestrator/modules/tools/discovery/actions_scheduling.py
@@ -86,7 +86,12 @@ def register_scheduling_actions(registry: ActionRegistry) -> None:
 
     registry.register(ActionDefinition(
         name="platform_cancel_scheduled_task",
-        description="Cancel a scheduled task by ID.",
+        description=(
+            "Cancel a scheduled (recurring or one-off) task by its ID so it stops "
+            "running on its schedule. Use when the user wants to stop, disable, or "
+            "remove an automation/cron they previously set up. List scheduled tasks "
+            "first if you don't know the ID."
+        ),
         category="scheduling",
         parameters={
             "type": "object",

--- a/orchestrator/modules/tools/discovery/graph_router.py
+++ b/orchestrator/modules/tools/discovery/graph_router.py
@@ -273,7 +273,11 @@ class GraphRouter:
 
         filters = [
             ToolRoutingEdge.from_action.in_(from_actions),
-            ToolRoutingEdge.edge_type == "used_after",
+            # used_after = learned co-occurrence (telemetry); meta_sibling =
+            # metadata cold-start (PRD-143 metadata_graph_seed) so zero-telemetry
+            # tools are still graph-reachable. Both are confidence-filtered, so
+            # real usage (higher Wilson confidence) outranks metadata edges.
+            ToolRoutingEdge.edge_type.in_(("used_after", "meta_sibling")),
             ToolRoutingEdge.confidence >= min_confidence,
         ]
 

--- a/orchestrator/modules/tools/discovery/metadata_graph_seed.py
+++ b/orchestrator/modules/tools/discovery/metadata_graph_seed.py
@@ -1,0 +1,125 @@
+"""Metadata-based graph cold-start for the tool-routing graph (PRD-143).
+
+Telemetry seeding (``edge_builder`` / ``seed_tool_routing_graph``) only helps
+tools that already appear in ``tool_execution_logs``. A brand-new platform tool
+has ZERO telemetry, so the routing graph gives it no signal until it has been
+used enough times — exactly when discoverability matters least. This closes
+that gap: it seeds GLOBAL ``meta_sibling`` edges straight from the registry's
+own metadata so a new tool is reachable via the graph the moment a sibling is
+relevant, before any usage accrues.
+
+Design (consistent with the existing multi-edge-type graph):
+  * Two operator tools that share a ``category`` are likely co-relevant, so we
+    add a directed ``meta_sibling`` edge between every same-category pair.
+  * Edges are GLOBAL (``workspace_id=None``, ``agent_id=None``) — metadata is
+    app-wide, and ``GraphRouter._query_edges`` already reads global edges.
+  * ``confidence`` sits at the graph's min-confidence floor (nudged up slightly
+    by shared-tag overlap) so meta edges PASS the router's filter but rank
+    BELOW real ``used_after`` edges (higher Wilson confidence) as telemetry
+    accrues — i.e. metadata is the floor, real usage always wins.
+  * They coexist with ``used_after`` rows (the unique key includes
+    ``edge_type``) and SURVIVE the nightly ``edge_builder`` recompute, which
+    only rewrites ``used_after`` and intent-cluster rows.
+  * ``super_admin_only`` tools are NEVER seeded — the obs tier stays off Auto's
+    graph, same invariant the rest of PRD-143 enforces.
+
+Idempotent: re-running upserts the same rows (ON CONFLICT UPDATE), so it
+converges and is safe to apply like a migration.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List, Optional, Tuple
+
+from .action_registry import ActionRegistry
+
+META_EDGE_TYPE = "meta_sibling"
+
+# The graph's default min-confidence floor (GraphRouter._min_confidence). Meta
+# edges sit AT the floor so they pass the filter but never outrank real signal.
+_META_BASE_CONFIDENCE = 0.6
+# Shared tags nudge confidence within a tiny band so the most-related sibling in
+# a category surfaces first — capped well below a strong real edge (Wilson ~0.7+).
+_META_TAG_STEP = 0.01
+_META_MAX_TAG_BONUS = 4
+
+
+def _operator_actions(registry: ActionRegistry):
+    """Operator-tier actions only — super_admin_only (the obs tier) is excluded
+    so the metadata graph never makes an obs tool reachable."""
+    return [
+        a for a in registry.get_all()
+        if not getattr(a, "super_admin_only", False)
+    ]
+
+
+def compute_meta_sibling_pairs(
+    registry: ActionRegistry,
+) -> List[Tuple[str, str, float, float]]:
+    """Directed same-category operator pairs with a metadata weight/confidence.
+
+    Returns ``(from_action, to_action, weight, confidence)`` for every ordered
+    pair of distinct operator tools that share a non-empty ``category``.
+    ``confidence`` rises slightly with shared-tag overlap (capped), ``weight``
+    records the overlap for observability.
+    """
+    actions = _operator_actions(registry)
+    by_category: dict = {}
+    for a in actions:
+        cat = (a.category or "").strip()
+        if not cat:
+            continue
+        by_category.setdefault(cat, []).append(a)
+
+    pairs: List[Tuple[str, str, float, float]] = []
+    for siblings in by_category.values():
+        if len(siblings) < 2:
+            continue
+        for src in siblings:
+            src_tags = set(src.tags or [])
+            for dst in siblings:
+                if src.name == dst.name:
+                    continue
+                shared = len(src_tags & set(dst.tags or []))
+                bonus = min(shared, _META_MAX_TAG_BONUS) * _META_TAG_STEP
+                confidence = _META_BASE_CONFIDENCE + bonus
+                weight = float(shared + 1)
+                pairs.append((src.name, dst.name, weight, confidence))
+    return pairs
+
+
+def seed_meta_sibling_edges(
+    db,
+    registry: ActionRegistry,
+    *,
+    dry_run: bool = False,
+) -> int:
+    """Upsert global ``meta_sibling`` edges from registry metadata.
+
+    Returns the number of edges that would be (or were) written. With
+    ``dry_run`` nothing is written. Reuses ``edge_builder._upsert_edge_row`` so
+    the ON CONFLICT upsert and unique-key semantics match real edges exactly.
+    """
+    from core.services.edge_builder import _upsert_edge_row
+
+    pairs = compute_meta_sibling_pairs(registry)
+    if dry_run:
+        return len(pairs)
+
+    now = datetime.utcnow()
+    for from_action, to_action, weight, confidence in pairs:
+        _upsert_edge_row(
+            db,
+            from_action,
+            to_action,
+            META_EDGE_TYPE,
+            None,  # workspace_id — global
+            None,  # agent_id — global
+            weight,
+            confidence,
+            0,     # sample_count — metadata, not observed usage
+            now,
+        )
+    db.flush()
+    return len(pairs)

--- a/orchestrator/scripts/seed_tool_routing_graph.py
+++ b/orchestrator/scripts/seed_tool_routing_graph.py
@@ -52,6 +52,7 @@ class SeedSummary:
     failed_edges: int = 0
     affinities: int = 0
     intent_clusters: int = 0
+    meta_edges: int = 0
 
 
 async def seed_graph(
@@ -83,6 +84,24 @@ async def seed_graph(
     )
 
 
+def seed_metadata_edges(dry_run: bool = False) -> int:
+    """Seed GLOBAL metadata cold-start edges so zero-telemetry tools are still
+    graph-reachable (PRD-143 metadata_graph_seed).
+
+    A separate concern from the telemetry backfill above: it's app-global (not
+    per-workspace) and reads the registry, not the logs. Idempotent ON CONFLICT
+    upsert. get_db_session commits on context exit (database.py) — matches
+    edge_builder, which never calls db.commit() itself."""
+    from modules.tools.discovery import get_action_registry
+    from modules.tools.discovery.metadata_graph_seed import seed_meta_sibling_edges
+
+    registry = get_action_registry()
+    if dry_run:
+        return seed_meta_sibling_edges(None, registry, dry_run=True)
+    with get_db_session() as db:
+        return seed_meta_sibling_edges(db, registry)
+
+
 def _dry_run_summary(window_days: int, workspace_id: Optional[str]) -> SeedSummary:
     """Read-only preview: load logs, run the pure edge math, count candidates."""
     cutoff = datetime.utcnow() - timedelta(days=window_days)
@@ -95,6 +114,8 @@ def _dry_run_summary(window_days: int, workspace_id: Optional[str]) -> SeedSumma
     # affinities; intent affinities are reported as 0 in a dry run.
     agent_affinities = edge_builder._compute_affinities(logs, {})
 
+    meta_edges = seed_metadata_edges(dry_run=True)
+
     floor = edge_builder._SAMPLE_FLOOR
     return SeedSummary(
         dry_run=True,
@@ -103,6 +124,7 @@ def _dry_run_summary(window_days: int, workspace_id: Optional[str]) -> SeedSumma
         failed_edges=sum(1 for _failed, total in failed_data.values() if total >= floor),
         affinities=len(agent_affinities),
         intent_clusters=0,
+        meta_edges=meta_edges,
     )
 
 
@@ -114,6 +136,7 @@ def _print_summary(summary: SeedSummary, workspace_id: Optional[str]) -> None:
     print(f"  Logs processed:    {summary.logs_processed}")
     print(f"  used_after edges:  {summary.edges}")
     print(f"  failed_after edges:{summary.failed_edges}")
+    print(f"  meta_sibling edges:{summary.meta_edges}")
     print(f"  Affinities:        {summary.affinities}")
     print(f"  Intent clusters:   {summary.intent_clusters}")
     if summary.dry_run:
@@ -166,6 +189,11 @@ def main(argv: Optional[List[str]] = None) -> int:
             dry_run=args.dry_run,
         )
     )
+    # Telemetry backfill (seed_graph) and metadata cold-start are independent
+    # seeds; a dry run already counted meta edges in _dry_run_summary, a real
+    # run writes them here so one human command seeds the whole graph.
+    if not args.dry_run:
+        summary.meta_edges = seed_metadata_edges()
     _print_summary(summary, args.workspace_id)
     return 0
 

--- a/orchestrator/tests/test_graph_router_negative.py
+++ b/orchestrator/tests/test_graph_router_negative.py
@@ -105,18 +105,27 @@ def _aff(action_name, affinity_type, weight, confidence):
 
 
 def _extract_edge_type(filter_clause):
-    """Pull the `edge_type == X` literal out of the and_() expression that
+    """Pull the allowed edge_type literal(s) out of the and_() expression that
     GraphRouter._query_edges passes to db.query(...).filter(...).
 
-    Walks the BooleanClauseList for the binary expression whose left column is
-    `edge_type` and returns its bound value, so the fake DB can honour the same
-    filter the real query would apply.
+    Handles BOTH the scalar `edge_type == X` form and the collection
+    `edge_type.in_((X, Y))` form (PRD-143 added meta_sibling alongside
+    used_after), returning a set of allowed edge_type values so the fake DB can
+    honour the same filter the real query would apply. Returns None when no
+    edge_type clause is present.
     """
     for clause in getattr(filter_clause, "clauses", [filter_clause]):
         left = getattr(clause, "left", None)
+        if getattr(left, "key", None) != "edge_type":
+            continue
         right = getattr(clause, "right", None)
-        if getattr(left, "key", None) == "edge_type" and right is not None:
-            return getattr(right, "value", None)
+        value = getattr(right, "value", None)
+        if value is None:
+            continue
+        # `==` binds a scalar; `.in_((...))` binds a list/tuple of values.
+        if isinstance(value, (list, tuple, set)):
+            return set(value)
+        return {value}
     return None
 
 
@@ -145,7 +154,8 @@ class _FakeEdgeQuery:
     def all(self):
         if self._edge_type is None:
             return list(self._rows)
-        return [r for r in self._rows if r.edge_type == self._edge_type]
+        # _edge_type is a set of allowed edge_types (used_after, meta_sibling).
+        return [r for r in self._rows if r.edge_type in self._edge_type]
 
 
 class _FakeEdgeDB:
@@ -278,9 +288,9 @@ def test_positive_boost_still_applies(router, monkeypatch):
 # ---------------------------------------------------------------------------
 
 def test_failed_after_edge_not_expanded():
-    """_query_edges only ever requests edge_type == 'used_after', so a
-    failed_after edge sitting in the same table is filtered out at the DB layer
-    and can never become a recommended chain.
+    """_query_edges requests edge_type IN ('used_after', 'meta_sibling') only,
+    so a failed_after edge sitting in the same table is filtered out at the DB
+    layer and can never become a recommended chain.
     """
     rows = [
         _edge("good", "next", "used_after", confidence=1.0),

--- a/orchestrator/tests/test_prd143_graph_seed.py
+++ b/orchestrator/tests/test_prd143_graph_seed.py
@@ -467,3 +467,132 @@ def test_unseeded_intent_falls_back_to_semantic(fake_env, monkeypatch):
     chains = asyncio.run(router.rank_chains(QUERY_UNSEEDED, agent_id=None, top_k=10))
 
     assert chains == [("workspace_zip_files", 0.7, ["workspace_zip_files"])]
+
+
+# ===========================================================================
+# Metadata graph cold-start (PRD-143 discoverability gap close)
+# ---------------------------------------------------------------------------
+# metadata_graph_seed seeds GLOBAL meta_sibling edges from registry metadata so
+# a brand-new tool (zero tool_execution_logs) is still reachable via GraphRouter
+# the moment a same-category sibling is relevant. Reuses the _FakeStore upsert
+# idiom above, so idempotency is real row convergence and routing is asserted
+# through the actual GraphRouter expansion path.
+# ===========================================================================
+
+import modules.tools.discovery.metadata_graph_seed as meta_seed  # noqa: E402
+
+
+def _act(name, category, tags=(), su=False):
+    return SimpleNamespace(
+        name=name, category=category, tags=list(tags), super_admin_only=su,
+    )
+
+
+def _fake_registry(actions):
+    return SimpleNamespace(get_all=lambda: list(actions))
+
+
+def test_meta_pairs_same_category_only_and_exclude_su():
+    reg = _fake_registry([
+        _act("platform_list_members", "team", ["team", "members"]),
+        _act("platform_invite_member", "team", ["team", "invite"]),
+        _act("platform_create_agent", "agents", ["agents"]),       # other category
+        _act("platform_query_loki_logs", "monitoring", ["obs"], su=True),  # su tier
+    ])
+    pairs = meta_seed.compute_meta_sibling_pairs(reg)
+    names = {(s, d) for s, d, _w, _c in pairs}
+
+    # same-category 'team' pair, both directions
+    assert ("platform_list_members", "platform_invite_member") in names
+    assert ("platform_invite_member", "platform_list_members") in names
+    # agents has only one operator member -> no pair; cross-category never pairs
+    assert not any("platform_create_agent" in p for p in names)
+    # the super_admin_only (obs) tool is NEVER seeded into the graph
+    assert not any("platform_query_loki_logs" in p for p in names)
+
+
+def test_meta_confidence_at_floor_with_tag_bonus():
+    reg = _fake_registry([
+        _act("a", "c", ["x", "y", "z"]),
+        _act("b", "c", ["x", "y", "z"]),   # 3 shared tags
+        _act("d", "c", []),                # 0 shared with a
+    ])
+    by_pair = {(s, t): (w, c) for s, t, w, c in meta_seed.compute_meta_sibling_pairs(reg)}
+    # base floor 0.6, +0.01 per shared tag (capped) — always <= a strong real edge
+    assert round(by_pair[("a", "b")][1], 4) == 0.63
+    assert round(by_pair[("a", "d")][1], 4) == 0.60
+    assert all(0.60 <= c <= 0.64 for (_w, c) in by_pair.values())
+
+
+def test_meta_seed_upserts_and_is_idempotent(fake_env):
+    store, _ = fake_env
+    reg = _fake_registry([
+        _act("platform_list_members", "team", ["team"]),
+        _act("platform_invite_member", "team", ["team"]),
+    ])
+    n1 = meta_seed.seed_meta_sibling_edges(store, reg)
+    n2 = meta_seed.seed_meta_sibling_edges(store, reg)  # re-run converges
+    assert n1 == n2 == 2
+    meta_rows = [v for v in store.edges.values() if v["edge_type"] == "meta_sibling"]
+    assert len(meta_rows) == 2  # upsert, not duplicate
+    for row in meta_rows:
+        assert row["workspace_id"] is None and row["agent_id"] is None  # global
+        assert row["confidence"] >= 0.6                                  # passes floor
+        assert row["sample_count"] == 0                                  # metadata, not usage
+
+
+def test_meta_dry_run_writes_nothing(fake_env):
+    store, _ = fake_env
+    reg = _fake_registry([_act("a", "c", []), _act("b", "c", [])])
+    n = meta_seed.seed_meta_sibling_edges(store, reg, dry_run=True)
+    assert n == 2
+    assert store.statements == []  # no execute() calls
+
+
+def test_meta_edge_routes_zero_telemetry_sibling(fake_env, monkeypatch):
+    """A new tool with NO telemetry is graph-reachable via a same-category
+    sibling's meta_sibling edge."""
+    store, _ = fake_env
+    reg = _fake_registry([
+        _act("platform_list_members", "team", ["team"]),   # the relevant one
+        _act("platform_invite_member", "team", ["team"]),  # brand-new, zero logs
+    ])
+    meta_seed.seed_meta_sibling_edges(store, reg)
+
+    query = "add a teammate to my workspace"
+    router = _router_over_store(
+        monkeypatch, store, {query: [("platform_list_members", 0.8)]}
+    )
+    chains = asyncio.run(router.rank_chains(query, agent_id=None, top_k=10))
+    chain_actions = [c[2] for c in chains]
+
+    # the zero-telemetry sibling is now reachable through the metadata edge
+    assert ["platform_list_members", "platform_invite_member"] in chain_actions
+
+
+def test_real_used_after_outranks_meta(fake_env, monkeypatch):
+    """When real telemetry exists, used_after (higher Wilson confidence) ranks
+    above a metadata edge from the same entry node — metadata is the floor."""
+    store, _ = fake_env
+    reg = _fake_registry([
+        _act("platform_list_members", "team", ["team"]),
+        _act("platform_invite_member", "team", ["team"]),   # meta target
+    ])
+    meta_seed.seed_meta_sibling_edges(store, reg)
+    # a strong learned edge from the same entry node to a different target
+    edge_builder._upsert_edge_row(
+        store, "platform_list_members", "platform_set_member_role",
+        "used_after", None, None, 40.0, 0.9, 40, datetime.utcnow(),
+    )
+
+    query = "manage my team"
+    router = _router_over_store(
+        monkeypatch, store, {query: [("platform_list_members", 0.8)]}
+    )
+    chains = asyncio.run(router.rank_chains(query, agent_id=None, top_k=10))
+    actions = [c[2] for c in chains]
+
+    real_chain = ["platform_list_members", "platform_set_member_role"]
+    meta_chain = ["platform_list_members", "platform_invite_member"]
+    assert real_chain in actions and meta_chain in actions
+    assert actions.index(real_chain) < actions.index(meta_chain)


### PR DESCRIPTION
…aph cold-start

Access != discoverability. Auto can reach every API but must know what each does, when to use it, and find the right one. Two gaps closed:

1. Selection metadata: audited all 140 tools; the semantic index embeds name+description+tags+examples, so 'what' (description) and 'when to use' (tags/examples) drive ranking. Filled the 4 weak tools — actions_field.py x3 (added tags+examples) and platform_cancel_scheduled_task (thin desc). New tools are auto-indexed from registry.get_all(); no manual reindex.

2. Graph cold-start: the S12 telemetry seed gives a brand-new tool (zero tool_execution_logs) no graph signal. New metadata_graph_seed seeds GLOBAL meta_sibling edges between same-category operator tools from the registry; GraphRouter._query_edges now follows used_after + meta_sibling. Meta edges sit at the min-confidence floor so real usage always outranks them (metadata is the floor). su tools never seeded. Wired into the human seed script as an independent step. 6 new tests; 61 graph/edge/router tests green.

PRD addendum documents the closure. The remaining axis (deep skills/knowledge) is PRD-120, an open decision (Q6) — surfaced, not deferred.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tools are now automatically indexed with enhanced metadata (tags, descriptions, examples, categories) for improved discoverability.
  * Newly added tools become discoverable through metadata-based relationships even with zero usage history.

* **Improvements**
  * Enhanced descriptions for scheduling actions to clarify functionality and user workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->