### PR TITLE
PRD-158 — Teams Model & Knowledge UX

### DIFF
--- a/frontend/components/documents/cloud-storage/folder-navigator.tsx
+++ b/frontend/components/documents/cloud-storage/folder-navigator.tsx
@@ -10,6 +10,7 @@ import {
   RefreshCw,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { TeamMultiSelect } from '@/components/documents/team-multi-select'
 import {
   useCloudFolders,
   useSelectFolder,
@@ -107,6 +108,7 @@ interface Props {
 
 export function FolderNavigator({ connectionId, currentRootPath, onFolderSelected }: Props) {
   const [selectedPath, setSelectedPath] = useState<string | null>(currentRootPath)
+  const [defaultTeamAccess, setDefaultTeamAccess] = useState<string[]>([])
 
   const { data: rootFolders = [], isLoading } = useCloudFolders(connectionId, '/')
   const selectFolderMutation = useSelectFolder()
@@ -116,6 +118,7 @@ export function FolderNavigator({ connectionId, currentRootPath, onFolderSelecte
     await selectFolderMutation.mutateAsync({
       connectionId,
       rootFolderPath: selectedPath,
+      defaultTeamAccess,
     })
     onFolderSelected?.()
   }
@@ -157,6 +160,15 @@ export function FolderNavigator({ connectionId, currentRootPath, onFolderSelecte
           Selected: <span className="text-foreground font-medium">{selectedPath}</span>
         </div>
       )}
+
+      {/* PRD-158 S2/Q5: default team for documents synced from this connection */}
+      <div className="space-y-1.5">
+        <div className="text-sm font-medium">Default team for synced documents</div>
+        <p className="text-xs text-muted-foreground">
+          Documents synced from this connection are scoped to these teams. Leave empty for all teams.
+        </p>
+        <TeamMultiSelect value={defaultTeamAccess} onChange={setDefaultTeamAccess} />
+      </div>
 
       {/* Confirm button */}
       <Button

--- a/frontend/components/documents/document-details-modal.tsx
+++ b/frontend/components/documents/document-details-modal.tsx
@@ -30,6 +30,8 @@ import { Separator } from '@/components/ui/separator'
 import { Progress } from '@/components/ui/progress'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { apiClient } from '@/lib/api-client'
+import { TeamMultiSelect } from './team-multi-select'
+import { useUpdateDocumentTeamAccess } from '@/hooks/use-teams'
 
 interface DocumentDetailsModalProps {
   documentId: number | null
@@ -47,6 +49,7 @@ interface DocumentDetails {
   file_size?: number
   status?: string
   chunk_count?: number
+  team_access?: string[]
   upload_date?: string
   processed_date?: string | null
   processing_stages?: Array<{
@@ -111,6 +114,9 @@ export function DocumentDetailsModal({
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [activeTab, setActiveTab] = useState('overview')
+  // PRD-158 S4: editable team_access for this document.
+  const [teamAccess, setTeamAccess] = useState<string[]>([])
+  const updateTeams = useUpdateDocumentTeamAccess()
 
   useEffect(() => {
     if (open && documentId) {
@@ -127,6 +133,7 @@ export function DocumentDetailsModal({
     try {
       const details = await apiClient.request<DocumentDetails>(`/api/documents/${documentId}`)
       setDocument(details)
+      setTeamAccess(details.team_access || [])
     } catch (err) {
       console.error('Error loading document details:', err)
       setError(err instanceof Error ? err?.message : 'Failed to load document details')
@@ -335,6 +342,28 @@ export function DocumentDetailsModal({
                       </CardContent>
                     </Card>
                   )}
+
+                  {/* PRD-158 S4: team management after upload */}
+                  <Card>
+                    <CardHeader>
+                      <CardTitle className="text-base">Team Access</CardTitle>
+                    </CardHeader>
+                    <CardContent className="space-y-3">
+                      <p className="text-sm text-muted-foreground">
+                        Restrict this document to specific teams. Empty = visible to all teams.
+                      </p>
+                      <TeamMultiSelect value={teamAccess} onChange={setTeamAccess} />
+                      <div className="flex justify-end">
+                        <Button
+                          size="sm"
+                          disabled={updateTeams.isLoading || !documentId}
+                          onClick={() => documentId && updateTeams.mutate({ id: documentId, teamAccess })}
+                        >
+                          {updateTeams.isLoading ? 'Saving…' : 'Save teams'}
+                        </Button>
+                      </div>
+                    </CardContent>
+                  </Card>
                 </TabsContent>
 
                 <TabsContent value="processing" className="space-y-6 mt-6">

--- a/frontend/components/documents/document-management.tsx
+++ b/frontend/components/documents/document-management.tsx
@@ -29,8 +29,9 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
-import { 
-  DropdownMenu, 
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import {
+  DropdownMenu,
   DropdownMenuContent, 
   DropdownMenuItem, 
   DropdownMenuTrigger 
@@ -63,6 +64,7 @@ import { ProviderBrowser } from './provider-browser'
 import { LocalStorageBrowser } from './local-storage-browser'
 // API hooks
 import { useDocuments, useDocumentStats, useUploadDocument, useDeleteDocument } from '@/hooks/use-document-api'
+import { useTeams, useDocumentTeamCounts } from '@/hooks/use-teams'
 import { useDatabaseKnowledge } from '@/hooks/use-database-knowledge'
 import { useCloudConnections, useTriggerSync, useSelectRootFolder } from '@/hooks/use-cloud-storage'
 
@@ -341,9 +343,13 @@ export function DocumentManagement() {
   const [selectedProvider, setSelectedProvider] = useState<any>(null)
   const [showProviderBrowser, setShowProviderBrowser] = useState(false)
   const [selectedSearchResult, setSelectedSearchResult] = useState<SearchResult | null>(null)
+  // PRD-158 S3: page-level team filter (also the agent-eye-view scope).
+  const [teamFilter, setTeamFilter] = useState<string | null>(null)
 
   // API hooks
-  const { data: documents = [], isLoading, error } = useDocuments()
+  const { data: documents = [], isLoading, error } = useDocuments(teamFilter ?? undefined)
+  const { data: teams = [] } = useTeams()
+  const { data: teamCounts } = useDocumentTeamCounts()
   const { data: documentStats } = useDocumentStats()
   const uploadDocumentMutation = useUploadDocument()
   const deleteDocumentMutation = useDeleteDocument()
@@ -661,6 +667,38 @@ export function DocumentManagement() {
 
       {/* Stats Overview */}
       <StatsBar stats={stats} />
+
+      {/* PRD-158 S3: page-level team filter + per-team counts + agent-eye-view */}
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="flex items-center gap-2">
+          <Filter className="w-4 h-4 text-muted-foreground" />
+          <Select
+            value={teamFilter ?? 'all'}
+            onValueChange={(v) => setTeamFilter(v === 'all' ? null : v)}
+          >
+            <SelectTrigger className="w-[240px]">
+              <SelectValue placeholder="All teams" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">
+                All teams ({teamCounts?.total ?? documents.length})
+              </SelectItem>
+              {teams.map((t) => (
+                <SelectItem key={t.id} value={t.normalized_name}>
+                  {t.name} ({teamCounts?.counts?.[t.normalized_name] ?? 0})
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        {teamFilter && (
+          <Badge variant="secondary" className="gap-1.5">
+            <Eye className="w-3 h-3" />
+            Agent-eye view: “{teams.find((t) => t.normalized_name === teamFilter)?.name ?? teamFilter}”
+            sees public + its own documents
+          </Badge>
+        )}
+      </div>
 
       {/* Document Management Tabs */}
       <motion.div

--- a/frontend/components/documents/document-upload.tsx
+++ b/frontend/components/documents/document-upload.tsx
@@ -41,6 +41,7 @@ import { toast } from 'sonner'
 
 // API hooks
 import { useUploadDocument } from '@/hooks/use-document-api'
+import { TeamMultiSelect } from './team-multi-select'
 
 interface FileUpload {
   id: string
@@ -104,7 +105,6 @@ export function DocumentUpload({ onUploadSuccess, categories }: DocumentUploadPr
     team_access: [] as string[],
   })
   const [newTag, setNewTag] = useState('')
-  const [newTeam, setNewTeam] = useState('')
 
   const uploadMutation = useUploadDocument()
 
@@ -444,62 +444,13 @@ export function DocumentUpload({ onUploadSuccess, categories }: DocumentUploadPr
               <p className="text-xs text-muted-foreground">
                 Restrict document visibility to specific teams. Leave empty for all teams.
               </p>
-              <div className="flex gap-2">
-                <Input
-                  placeholder="Add team..."
-                  value={newTeam}
-                  onChange={(e) => setNewTeam(e.target.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter') {
-                      e.preventDefault()
-                      const trimmed = newTeam.trim()
-                      if (trimmed && !defaultSettings.team_access.includes(trimmed)) {
-                        setDefaultSettings(prev => ({
-                          ...prev,
-                          team_access: [...prev.team_access, trimmed],
-                        }))
-                      }
-                      setNewTeam('')
-                    }
-                  }}
-                />
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  onClick={() => {
-                    const trimmed = newTeam.trim()
-                    if (trimmed && !defaultSettings.team_access.includes(trimmed)) {
-                      setDefaultSettings(prev => ({
-                        ...prev,
-                        team_access: [...prev.team_access, trimmed],
-                      }))
-                    }
-                    setNewTeam('')
-                  }}
-                >
-                  <Plus className="w-4 h-4" />
-                </Button>
-              </div>
-              {defaultSettings.team_access.length > 0 && (
-                <div className="flex flex-wrap gap-1 mt-2">
-                  {defaultSettings.team_access.map(team => (
-                    <Badge
-                      key={team}
-                      variant="outline"
-                      className="cursor-pointer"
-                      onClick={() =>
-                        setDefaultSettings(prev => ({
-                          ...prev,
-                          team_access: prev.team_access.filter(t => t !== team),
-                        }))
-                      }
-                    >
-                      {team} <X className="w-3 h-3 ml-1" />
-                    </Badge>
-                  ))}
-                </div>
-              )}
+              {/* PRD-158 S2: team dropdown from /api/teams (no free-text). */}
+              <TeamMultiSelect
+                value={defaultSettings.team_access}
+                onChange={(teams) =>
+                  setDefaultSettings(prev => ({ ...prev, team_access: teams }))
+                }
+              />
             </div>
           </div>
 

--- a/frontend/components/documents/local-storage-browser.tsx
+++ b/frontend/components/documents/local-storage-browser.tsx
@@ -19,6 +19,9 @@ import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Input } from '@/components/ui/input'
+import { Checkbox } from '@/components/ui/checkbox'
+import { TeamMultiSelect } from './team-multi-select'
+import { useBulkUpdateTeamAccess } from '@/hooks/use-teams'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -70,24 +73,40 @@ export function LocalStorageBrowser({
   const [viewMode, setViewMode] = useViewMode('documents')
   const [searchTerm, setSearchTerm] = useState('')
   const [filterStatus, setFilterStatus] = useState<string>('all')
-  const [filterTeam, setFilterTeam] = useState<string>('all')
+  // PRD-158 S4: bulk team-assignment selection.
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set())
+  const [bulkTeams, setBulkTeams] = useState<string[]>([])
+  const bulkUpdate = useBulkUpdateTeamAccess()
 
-  // Collect unique team names from all documents
-  const availableTeams = Array.from(
-    new Set(documents.flatMap(d => d.team_access || []).filter(Boolean))
-  ).sort()
-
+  // PRD-158 S3: team filtering is promoted to the page header (server-side),
+  // so this browser no longer filters by team client-side (which capped at the
+  // ≤100 loaded docs). It receives the already-team-scoped document set.
   const filteredDocuments = documents.filter(doc => {
     const matchesSearch = doc.filename.toLowerCase().includes(searchTerm.toLowerCase())
     const matchesFilter =
       filterStatus === 'all' ||
       (doc.status || 'completed').toLowerCase() === filterStatus
-    const matchesTeam =
-      filterTeam === 'all' ||
-      !doc.team_access?.length ||
-      doc.team_access.includes(filterTeam)
-    return matchesSearch && matchesFilter && matchesTeam
+    return matchesSearch && matchesFilter
   })
+
+  const toggleSelect = (id: number) =>
+    setSelectedIds(prev => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+
+  const applyBulkTeams = async () => {
+    if (selectedIds.size === 0) return
+    try {
+      await bulkUpdate.mutateAsync({ ids: Array.from(selectedIds), teamAccess: bulkTeams })
+      setSelectedIds(new Set())
+      setBulkTeams([])
+    } catch {
+      /* toast handled in the hook */
+    }
+  }
 
   const stats = {
     total: documents.length,
@@ -136,20 +155,27 @@ export function LocalStorageBrowser({
             className="pl-10 bg-secondary/50"
           />
         </div>
-        {availableTeams.length > 0 && (
-          <select
-            value={filterTeam}
-            onChange={(e) => setFilterTeam(e.target.value)}
-            className="h-10 rounded-md border border-input bg-secondary/50 px-3 text-sm"
-          >
-            <option value="all">All Teams</option>
-            {availableTeams.map(team => (
-              <option key={team} value={team}>{team}</option>
-            ))}
-          </select>
-        )}
         <ViewToggle value={viewMode} onChange={setViewMode} />
       </div>
+
+      {/* PRD-158 S4: bulk team assignment for the selected documents */}
+      {selectedIds.size > 0 && (
+        <div className="flex flex-wrap items-end gap-3 p-3 rounded-lg border border-border bg-secondary/30">
+          <div className="flex-1 min-w-[220px]">
+            <p className="text-xs text-muted-foreground mb-1">
+              Set teams for {selectedIds.size} selected document{selectedIds.size > 1 ? 's' : ''}
+              {' '}(empty = visible to all)
+            </p>
+            <TeamMultiSelect value={bulkTeams} onChange={setBulkTeams} />
+          </div>
+          <Button size="sm" disabled={bulkUpdate.isLoading} onClick={applyBulkTeams}>
+            {bulkUpdate.isLoading ? 'Applying…' : 'Apply teams'}
+          </Button>
+          <Button size="sm" variant="ghost" onClick={() => setSelectedIds(new Set())}>
+            Clear
+          </Button>
+        </div>
+      )}
 
       {/* Files List */}
       <Card className="glass-card">
@@ -191,6 +217,10 @@ export function LocalStorageBrowser({
                       className="flex items-center justify-between p-4 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors"
                     >
                       <div className="flex items-center gap-3 flex-1 min-w-0">
+                        <Checkbox
+                          checked={selectedIds.has(doc.id)}
+                          onCheckedChange={() => toggleSelect(doc.id)}
+                        />
                         <TypeIcon className="w-5 h-5 text-orange-400 shrink-0" />
                         <div className="flex-1 min-w-0">
                           <p className="font-medium truncate">{doc.filename}</p>
@@ -278,7 +308,14 @@ export function LocalStorageBrowser({
                       onClick={() => onViewDetails(doc.id)}
                     >
                       <div className="flex items-start justify-between mb-3">
-                        <TypeIcon className="w-8 h-8 text-orange-400" />
+                        <div className="flex items-center gap-2">
+                          <Checkbox
+                            checked={selectedIds.has(doc.id)}
+                            onCheckedChange={() => toggleSelect(doc.id)}
+                            onClick={(e) => e.stopPropagation()}
+                          />
+                          <TypeIcon className="w-8 h-8 text-orange-400" />
+                        </div>
                         <DropdownMenu>
                           <DropdownMenuTrigger asChild>
                             <Button variant="ghost" size="icon" className="h-7 w-7" onClick={(e) => e.stopPropagation()}>

--- a/frontend/components/documents/team-multi-select.tsx
+++ b/frontend/components/documents/team-multi-select.tsx
@@ -1,0 +1,148 @@
+'use client'
+
+/**
+ * PRD-158 S2 — TeamMultiSelect.
+ *
+ * Reusable multi-select for a document's team_access, sourced from /api/teams
+ * (no more free-text). Selected values are canonical normalized_name strings, so
+ * what's persisted is always normalized. Admins can create a team inline.
+ */
+
+import { useState } from 'react'
+import { Plus, ChevronsUpDown, X } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Input } from '@/components/ui/input'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { useTeams, useCreateTeam } from '@/hooks/use-teams'
+
+interface TeamMultiSelectProps {
+  /** Selected teams as canonical normalized_name values. */
+  value: string[]
+  onChange: (teams: string[]) => void
+  disabled?: boolean
+  allowCreate?: boolean
+  placeholder?: string
+}
+
+export function TeamMultiSelect({
+  value,
+  onChange,
+  disabled = false,
+  allowCreate = true,
+  placeholder = 'Select teams…',
+}: TeamMultiSelectProps) {
+  const [open, setOpen] = useState(false)
+  const [search, setSearch] = useState('')
+  const { data: teams = [], isLoading } = useTeams()
+  const createTeam = useCreateTeam()
+
+  const toggle = (normalized: string) => {
+    onChange(
+      value.includes(normalized)
+        ? value.filter((t) => t !== normalized)
+        : [...value, normalized]
+    )
+  }
+
+  const term = search.trim().toLowerCase()
+  const filtered = teams.filter((t) => t.name.toLowerCase().includes(term))
+  const exactExists = teams.some((t) => t.normalized_name === term)
+  const displayName = (normalized: string) =>
+    teams.find((t) => t.normalized_name === normalized)?.name || normalized
+
+  const handleCreate = async () => {
+    const name = search.trim()
+    if (!name) return
+    try {
+      const team = await createTeam.mutateAsync(name)
+      if (team?.normalized_name && !value.includes(team.normalized_name)) {
+        onChange([...value, team.normalized_name])
+      }
+      setSearch('')
+    } catch {
+      /* toast handled in the hook */
+    }
+  }
+
+  return (
+    <div className="space-y-2">
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            type="button"
+            variant="outline"
+            disabled={disabled}
+            className="w-full justify-between font-normal"
+          >
+            <span className="truncate text-muted-foreground">
+              {value.length === 0
+                ? placeholder
+                : `${value.length} team${value.length > 1 ? 's' : ''} selected`}
+            </span>
+            <ChevronsUpDown className="w-4 h-4 opacity-50 shrink-0" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-[var(--radix-popover-trigger-width)] min-w-[14rem] p-0" align="start">
+          <div className="p-2 border-b border-border">
+            <Input
+              autoFocus
+              placeholder={allowCreate ? 'Search or create…' : 'Search…'}
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="h-8"
+            />
+          </div>
+          <div className="max-h-60 overflow-y-auto p-1">
+            {isLoading && (
+              <p className="px-2 py-3 text-sm text-muted-foreground">Loading teams…</p>
+            )}
+            {!isLoading && filtered.length === 0 && !(allowCreate && term) && (
+              <p className="px-2 py-3 text-sm text-muted-foreground">No teams</p>
+            )}
+            {filtered.map((team) => (
+              <button
+                key={team.id}
+                type="button"
+                onClick={() => toggle(team.normalized_name)}
+                className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-sm hover:bg-accent"
+              >
+                <Checkbox
+                  checked={value.includes(team.normalized_name)}
+                  className="pointer-events-none"
+                />
+                <span className="truncate">{team.name}</span>
+              </button>
+            ))}
+            {allowCreate && term && !exactExists && (
+              <button
+                type="button"
+                onClick={handleCreate}
+                disabled={createTeam.isPending}
+                className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-sm text-primary hover:bg-accent disabled:opacity-50"
+              >
+                <Plus className="w-4 h-4" /> Create &quot;{search.trim()}&quot;
+              </button>
+            )}
+          </div>
+        </PopoverContent>
+      </Popover>
+
+      {value.length > 0 && (
+        <div className="flex flex-wrap gap-1">
+          {value.map((normalized) => (
+            <Badge
+              key={normalized}
+              variant="outline"
+              className="cursor-pointer"
+              onClick={() => toggle(normalized)}
+            >
+              {displayName(normalized)} <X className="w-3 h-3 ml-1" />
+            </Badge>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/components/documents/team-multi-select.tsx
+++ b/frontend/components/documents/team-multi-select.tsx
@@ -119,7 +119,7 @@ export function TeamMultiSelect({
               <button
                 type="button"
                 onClick={handleCreate}
-                disabled={createTeam.isPending}
+                disabled={createTeam.isLoading}
                 className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-sm text-primary hover:bg-accent disabled:opacity-50"
               >
                 <Plus className="w-4 h-4" /> Create &quot;{search.trim()}&quot;

--- a/frontend/components/documents/upload-provider-modal.tsx
+++ b/frontend/components/documents/upload-provider-modal.tsx
@@ -23,6 +23,7 @@ import { Badge } from '@/components/ui/badge'
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
 import { Label } from '@/components/ui/label'
 import { Input } from '@/components/ui/input'
+import { TeamMultiSelect } from './team-multi-select'
 
 interface Provider {
   id: string
@@ -49,7 +50,6 @@ export function UploadProviderModal({
 }: UploadProviderModalProps) {
   const [selectedProviderId, setSelectedProviderId] = useState<string>('manual')
   const [teamAccess, setTeamAccess] = useState<string[]>([])
-  const [newTeam, setNewTeam] = useState('')
   const [dragActive, setDragActive] = useState(false)
   const [uploading, setUploading] = useState(false)
   const [uploadProgress, setUploadProgress] = useState(0)
@@ -97,7 +97,6 @@ export function UploadProviderModal({
     if (!uploading) {
       setSelectedProviderId('manual')
       setTeamAccess([])
-      setNewTeam('')
       setUploadProgress(0)
       setUploadComplete(false)
       setUploading(false)
@@ -200,51 +199,8 @@ export function UploadProviderModal({
                 <p className="text-xs text-muted-foreground">
                   Restrict visibility to specific teams. Leave empty for all teams.
                 </p>
-                <div className="flex gap-2">
-                  <Input
-                    placeholder="Add team..."
-                    value={newTeam}
-                    onChange={(e) => setNewTeam(e.target.value)}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter') {
-                        e.preventDefault()
-                        const trimmed = newTeam.trim()
-                        if (trimmed && !teamAccess.includes(trimmed)) {
-                          setTeamAccess(prev => [...prev, trimmed])
-                        }
-                        setNewTeam('')
-                      }
-                    }}
-                  />
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    onClick={() => {
-                      const trimmed = newTeam.trim()
-                      if (trimmed && !teamAccess.includes(trimmed)) {
-                        setTeamAccess(prev => [...prev, trimmed])
-                      }
-                      setNewTeam('')
-                    }}
-                  >
-                    +
-                  </Button>
-                </div>
-                {teamAccess.length > 0 && (
-                  <div className="flex flex-wrap gap-1 mt-1">
-                    {teamAccess.map(team => (
-                      <Badge
-                        key={team}
-                        variant="outline"
-                        className="cursor-pointer text-xs"
-                        onClick={() => setTeamAccess(prev => prev.filter(t => t !== team))}
-                      >
-                        {team} <X className="w-3 h-3 ml-1" />
-                      </Badge>
-                    ))}
-                  </div>
-                )}
+                {/* PRD-158 S2: team dropdown from /api/teams (no free-text). */}
+                <TeamMultiSelect value={teamAccess} onChange={setTeamAccess} />
               </div>
 
               {/* File Drop Zone */}

--- a/frontend/hooks/use-cloud-documents-api.ts
+++ b/frontend/hooks/use-cloud-documents-api.ts
@@ -188,10 +188,10 @@ export function useSyncStatus(connectionId: number, enabled = true) {
 export function useSelectFolder() {
   const queryClient = useQueryClient()
   return useMutation({
-    mutationFn: (args: { connectionId: number; rootFolderPath: string }) =>
+    mutationFn: (args: { connectionId: number; rootFolderPath: string; defaultTeamAccess?: string[] }) =>
       apiClient.post(
         `/api/cloud-documents/connections/${args.connectionId}/select-folder`,
-        { root_folder_path: args.rootFolderPath },
+        { root_folder_path: args.rootFolderPath, default_team_access: args.defaultTeamAccess },
       ),
     onSuccess: () => {
       toast.success('Root folder selected')

--- a/frontend/hooks/use-document-api.ts
+++ b/frontend/hooks/use-document-api.ts
@@ -36,12 +36,12 @@ const handleApiError = (error: any, message = 'API request failed'): void => {
 }
 
 /**
- * Get all documents
+ * Get all documents. PRD-158 S3: optional server-side team filter.
  */
-export function useDocuments() {
+export function useDocuments(team?: string) {
   return useQuery({
-    queryKey: documentQueryKeys.documents,
-    queryFn: () => apiClient.getDocuments(),
+    queryKey: [...documentQueryKeys.documents, team ?? null],
+    queryFn: () => apiClient.getDocuments(team),
     retry: 2,
     staleTime: 30000,
     onError: (error) => handleApiError(error, 'Failed to load documents')

--- a/frontend/hooks/use-teams.ts
+++ b/frontend/hooks/use-teams.ts
@@ -1,0 +1,81 @@
+/**
+ * PRD-158 — Teams hooks (React Query).
+ *
+ * One source for the workspace team list, team creation, per-team document
+ * counts, and team-access edits. Replaces free-text team entry everywhere.
+ */
+
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'react-hot-toast'
+import apiClient from '../lib/api-client'
+
+export interface Team {
+  id: number
+  name: string
+  normalized_name: string
+}
+
+export const teamQueryKeys = {
+  teams: ['teams'] as const,
+  documentTeamCounts: ['documents', 'team-counts'] as const,
+}
+
+/** All teams in the workspace. */
+export function useTeams() {
+  return useQuery({
+    queryKey: teamQueryKeys.teams,
+    queryFn: () => apiClient.getTeams(),
+    staleTime: 60000,
+  })
+}
+
+/** Create a team (idempotent server-side by normalized name). */
+export function useCreateTeam() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (name: string) => apiClient.createTeam(name),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: teamQueryKeys.teams })
+    },
+    onError: () => toast.error('Failed to create team'),
+  })
+}
+
+/** Per-team document counts, aggregated server-side. */
+export function useDocumentTeamCounts() {
+  return useQuery({
+    queryKey: teamQueryKeys.documentTeamCounts,
+    queryFn: () => apiClient.getDocumentTeamCounts(),
+    staleTime: 30000,
+  })
+}
+
+/** Edit a single document's team_access. */
+export function useUpdateDocumentTeamAccess() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (data: { id: number; teamAccess: string[] }) =>
+      apiClient.updateDocumentTeamAccess(data.id, data.teamAccess),
+    onSuccess: () => {
+      toast.success('Team access updated')
+      queryClient.invalidateQueries({ queryKey: ['documents'] })
+      queryClient.invalidateQueries({ queryKey: teamQueryKeys.documentTeamCounts })
+    },
+    onError: () => toast.error('Failed to update team access'),
+  })
+}
+
+/** Bulk-assign team_access across several documents. */
+export function useBulkUpdateTeamAccess() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (data: { ids: number[]; teamAccess: string[] }) =>
+      apiClient.bulkUpdateTeamAccess(data.ids, data.teamAccess),
+    onSuccess: () => {
+      toast.success('Team access updated for selected documents')
+      queryClient.invalidateQueries({ queryKey: ['documents'] })
+      queryClient.invalidateQueries({ queryKey: teamQueryKeys.documentTeamCounts })
+    },
+    onError: () => toast.error('Failed to update team access'),
+  })
+}

--- a/frontend/lib/api-client.ts
+++ b/frontend/lib/api-client.ts
@@ -1831,13 +1831,47 @@ class ApiClient {
     })
   }
 
-  async getDocuments() {
-    return this.request('/api/documents/')
+  async getDocuments(team?: string) {
+    // PRD-158 S3: optional server-side team filter.
+    const qs = team ? `?team=${encodeURIComponent(team)}` : ''
+    return this.request(`/api/documents/${qs}`)
   }
 
   // PRD-157 S6: real processing-queue status (replaces the FALLBACK_DATA placebo).
   async getProcessingQueue() {
     return this.request('/api/documents/queue/status')
+  }
+
+  // PRD-158: Teams entity.
+  async getTeams(): Promise<Array<{ id: number; name: string; normalized_name: string }>> {
+    return this.request('/api/teams')
+  }
+
+  async createTeam(name: string): Promise<{ id: number; name: string; normalized_name: string }> {
+    return this.request('/api/teams', {
+      method: 'POST',
+      body: JSON.stringify({ name }),
+    })
+  }
+
+  // PRD-158 S3: per-team document counts (server-side aggregate).
+  async getDocumentTeamCounts(): Promise<{ counts: Record<string, number>; untagged: number; total: number }> {
+    return this.request('/api/documents/team-counts')
+  }
+
+  // PRD-158 S4: team-access edits (backend PATCH/bulk endpoints already exist).
+  async updateDocumentTeamAccess(documentId: number, teamAccess: string[]) {
+    return this.request(`/api/documents/${documentId}/team-access`, {
+      method: 'PATCH',
+      body: JSON.stringify({ team_access: teamAccess }),
+    })
+  }
+
+  async bulkUpdateTeamAccess(documentIds: number[], teamAccess: string[]) {
+    return this.request('/api/documents/bulk-team-access', {
+      method: 'POST',
+      body: JSON.stringify({ document_ids: documentIds, team_access: teamAccess }),
+    })
   }
 
   async getDocument(id: string) {

--- a/orchestrator/alembic/versions/prd158_cloud_default_team.py
+++ b/orchestrator/alembic/versions/prd158_cloud_default_team.py
@@ -1,0 +1,35 @@
+"""prd158 cloud-sync per-connection default team
+
+Revision ID: prd158_cloud_default_team
+Revises: prd158_teams
+Create Date: 2026-06-12
+
+PRD-158 S2/Q5: a cloud-sync connection gets a default team applied to every
+document synced from it (empty = public).
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision = "prd158_cloud_default_team"
+down_revision = "prd158_teams"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "cloud_sync_config",
+        sa.Column(
+            "default_team_access",
+            postgresql.ARRAY(sa.String()),
+            server_default="{}",
+            nullable=False,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("cloud_sync_config", "default_team_access")

--- a/orchestrator/alembic/versions/prd158_teams_table.py
+++ b/orchestrator/alembic/versions/prd158_teams_table.py
@@ -1,0 +1,67 @@
+
+"""prd158 teams table (collapse heads)
+
+Revision ID: prd158_teams
+Revises: 20260226_cto_agent, prd141_backfill_workspace_vertical, add_content_hash_to_skills, add_job_title_to_agents, add_ws_admin_lifecycle, fix_chat_workspace_isolation, agent_public_id_and_slug_fix, agents_public_id_default, blog_content_to_workspace, board_blocked_sla, drop_agents_model_config_default, prd123_cost_tracking, prd128_notifications, prd129_deliverables, prd130_workspace_graphs, prd133b_outputs_view, prd135_drop_bucket_1, prd135_drop_bucket_2, prd135_drop_bucket_3, prd135_drop_bucket_4, prd135_drop_bucket_5, prd135_drop_bucket_6, prd136_collapse_llm_tiers, prd139_tool_routing_graph, prd139_tool_routing_telemetry, prd140_permission_bypass_log, prd142_wave0_error_events, prd142_wave4_harness_store, prd142_wave5_drop_dead_tables, prd71_unified_skills, prd72_board_tasks, prd72_doc_access, prd72_fix_composio_trigger, prd72_memory_access_log, prd72_recipe_board_tasks, prd72_task_reconciliation, prd73_infra_alerts, prd74_voice_profiles, prd76_agent_reports, prd76_nullable_agent, prd77_agent_scheduled_tasks, prd79_memory_short_term, seed_auto_agents_existing_workspaces, unify_marketplace_categories
+Create Date: 2026-06-12 10:43:28.905226
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision = 'prd158_teams'
+down_revision = ('20260226_cto_agent', 'prd141_backfill_workspace_vertical', 'add_content_hash_to_skills', 'add_job_title_to_agents', 'add_ws_admin_lifecycle', 'fix_chat_workspace_isolation', 'agent_public_id_and_slug_fix', 'agents_public_id_default', 'blog_content_to_workspace', 'board_blocked_sla', 'drop_agents_model_config_default', 'prd123_cost_tracking', 'prd128_notifications', 'prd129_deliverables', 'prd130_workspace_graphs', 'prd133b_outputs_view', 'prd135_drop_bucket_1', 'prd135_drop_bucket_2', 'prd135_drop_bucket_3', 'prd135_drop_bucket_4', 'prd135_drop_bucket_5', 'prd135_drop_bucket_6', 'prd136_collapse_llm_tiers', 'prd139_tool_routing_graph', 'prd139_tool_routing_telemetry', 'prd140_permission_bypass_log', 'prd142_wave0_error_events', 'prd142_wave4_harness_store', 'prd142_wave5_drop_dead_tables', 'prd71_unified_skills', 'prd72_board_tasks', 'prd72_doc_access', 'prd72_fix_composio_trigger', 'prd72_memory_access_log', 'prd72_recipe_board_tasks', 'prd72_task_reconciliation', 'prd73_infra_alerts', 'prd74_voice_profiles', 'prd76_agent_reports', 'prd76_nullable_agent', 'prd77_agent_scheduled_tasks', 'prd79_memory_short_term', 'seed_auto_agents_existing_workspaces', 'unify_marketplace_categories')
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # PRD-158 S1: real Teams entity. This revision also COLLAPSES the 44 pre-existing
+    # alembic heads (see the down_revision tuple) into a single head, so the repo is
+    # single-head again — the same migrations still run under `alembic upgrade heads`.
+    op.create_table(
+        "teams",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "workspace_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("workspaces.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.String(length=100), nullable=False),
+        sa.Column("normalized_name", sa.String(length=100), nullable=False),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.text("NOW()"), nullable=False),
+        sa.UniqueConstraint("workspace_id", "normalized_name", name="uq_teams_workspace_normalized"),
+    )
+    op.create_index("ix_teams_workspace", "teams", ["workspace_id"])
+
+    # Backfill DISTINCT teams from agents.team + documents.team_access (unnested).
+    # normalized_name is the lowercased/trimmed canonical form (one team per
+    # workspace+normalized); MIN(name) picks a deterministic display name, so
+    # 'Support'/'support' collapse to a single 'Support' team.
+    op.execute(
+        """
+        INSERT INTO teams (workspace_id, name, normalized_name)
+        SELECT workspace_id, MIN(name) AS name, normalized_name
+        FROM (
+            SELECT workspace_id, TRIM(team) AS name, LOWER(TRIM(team)) AS normalized_name
+            FROM agents
+            WHERE team IS NOT NULL AND TRIM(team) <> ''
+            UNION ALL
+            SELECT workspace_id, TRIM(t) AS name, LOWER(TRIM(t)) AS normalized_name
+            FROM documents, unnest(team_access) AS t
+            WHERE team_access IS NOT NULL AND TRIM(t) <> ''
+        ) src
+        WHERE normalized_name <> ''
+        GROUP BY workspace_id, normalized_name
+        ON CONFLICT (workspace_id, normalized_name) DO NOTHING
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_teams_workspace", table_name="teams")
+    op.drop_table("teams")

--- a/orchestrator/api/agents.py
+++ b/orchestrator/api/agents.py
@@ -580,6 +580,7 @@ async def get_org_chart(
     """
     try:
         from core.models.composio_cache import AgentAppAssignment
+        from core.team_access import list_teams
 
         # Fetch active workspace agents — the workspace Auto (slug=auto-{ws_id})
         # is included so the chart has a single root. Excludes the global
@@ -627,7 +628,6 @@ async def get_org_chart(
 
         nodes = []
         edges = []
-        teams_set: set = set()
 
         for a in agents:
             skill_names = [s.name for s in a.skills] if a.skills else []
@@ -656,14 +656,15 @@ async def get_org_chart(
             if parent_id is not None:
                 edges.append({"from": parent_id, "to": a.id})
 
-            if a.team:
-                teams_set.add(a.team)
+        # PRD-158 S1: teams come from the Teams table (same source as /api/teams)
+        # so the org-chart and the team API never disagree.
+        teams = [t.name for t in list_teams(db, ctx.workspace_id)]
 
         return {
             "success": True,
             "nodes": nodes,
             "edges": edges,
-            "teams": sorted(teams_set),
+            "teams": teams,
         }
 
     except Exception as e:

--- a/orchestrator/api/cloud_documents.py
+++ b/orchestrator/api/cloud_documents.py
@@ -61,6 +61,10 @@ class CloudFileResponse(BaseModel):
 
 class SelectFolderRequest(BaseModel):
     root_folder_path: str = Field(..., min_length=1)
+    default_team_access: Optional[List[str]] = Field(
+        default=None,
+        description="PRD-158: teams applied to docs synced from this connection (normalized server-side)",
+    )
 
 
 class SelectFolderResponse(BaseModel):
@@ -344,6 +348,10 @@ async def select_folder(
     try:
         conn = _get_connection_or_404(db, connection_id, ctx.workspace_id)
 
+        # PRD-158 S2/Q5: normalize the connection's default team(s) once, here.
+        from core.team_access import ensure_teams
+        default_team_access = ensure_teams(db, ctx.workspace_id, body.default_team_access or [])
+
         # Upsert sync config
         sync_cfg = db.query(CloudSyncConfig).filter(
             CloudSyncConfig.connection_id == connection_id
@@ -352,11 +360,13 @@ async def select_folder(
         if sync_cfg:
             sync_cfg.root_folder_path = body.root_folder_path
             sync_cfg.sync_enabled = True
+            sync_cfg.default_team_access = default_team_access
         else:
             sync_cfg = CloudSyncConfig(
                 connection_id=connection_id,
                 root_folder_path=body.root_folder_path,
                 sync_enabled=True,
+                default_team_access=default_team_access,
             )
             db.add(sync_cfg)
 

--- a/orchestrator/api/documents.py
+++ b/orchestrator/api/documents.py
@@ -549,12 +549,13 @@ async def list_documents(
     status: Optional[str] = None,
     file_type: Optional[str] = None,
     search: Optional[str] = None,
+    team: Optional[str] = Query(None, description="PRD-158: team scope; normalized server-side"),
     db: Session = Depends(get_db)
 ):
     """List documents with filtering and pagination"""
     try:
         query = db.query(Document).filter(Document.workspace_id == ctx.workspace_id)
-        
+
         # Apply filters
         if status:
             query = query.filter(Document.status == status)
@@ -567,7 +568,21 @@ async def list_documents(
                     Document.description.ilike(f"%{search}%")
                 )
             )
-        
+
+        # PRD-158 S3: server-side team scope through the centralized builder.
+        # Case-insensitive overlap so legacy mixed-case team_access still matches
+        # (new writes are normalized in S2); public docs (empty team_access) always show.
+        from modules.rag.retrieval_filters import build_retrieval_filters
+        _scope = build_retrieval_filters(workspace_id=ctx.workspace_id, team=team)
+        if _scope.has_team_restriction:
+            query = query.filter(
+                text(
+                    "(team_access = '{}' OR EXISTS ("
+                    "SELECT 1 FROM unnest(team_access) ta "
+                    "WHERE LOWER(TRIM(ta)) = ANY(CAST(:team_terms AS text[]))))"
+                )
+            ).params(team_terms=_scope.team_terms)
+
         documents = query.order_by(Document.upload_date.desc()).offset(skip).limit(limit).all()
         
         return [
@@ -646,6 +661,39 @@ async def unpin_document_from_chat(
     from modules.rag.pinned_context import unpin_document
 
     return unpin_document(db, chat_id=chat_id, document_id=document_id, workspace_id=ctx.workspace_id)
+
+
+@router.get("/team-counts")
+async def document_team_counts(
+    ctx: RequestContext = Depends(get_request_context_hybrid),
+    db: Session = Depends(get_db),
+):
+    """PRD-158 S3: per-team document counts, aggregated server-side over ALL docs
+    in the workspace (not the paginated ≤100 page). Teams are normalized
+    (lowercased) so mixed-case team_access collapses into one count.
+
+    Registered before GET /{document_id} so the literal path isn't captured.
+    """
+    rows = db.execute(
+        text(
+            "SELECT LOWER(TRIM(ta)) AS team, COUNT(DISTINCT d.id) AS cnt "
+            "FROM documents d, unnest(d.team_access) ta "
+            "WHERE d.workspace_id = CAST(:ws AS uuid) AND TRIM(ta) <> '' "
+            "GROUP BY LOWER(TRIM(ta)) ORDER BY team"
+        ),
+        {"ws": str(ctx.workspace_id)},
+    ).fetchall()
+    counts = {r.team: int(r.cnt) for r in rows}
+
+    untagged = db.execute(
+        text("SELECT COUNT(*) FROM documents WHERE workspace_id = CAST(:ws AS uuid) AND team_access = '{}'"),
+        {"ws": str(ctx.workspace_id)},
+    ).scalar()
+    total = db.execute(
+        text("SELECT COUNT(*) FROM documents WHERE workspace_id = CAST(:ws AS uuid)"),
+        {"ws": str(ctx.workspace_id)},
+    ).scalar()
+    return {"counts": counts, "untagged": int(untagged or 0), "total": int(total or 0)}
 
 
 @router.get("/{document_id}", response_model=DocumentResponse)

--- a/orchestrator/api/teams.py
+++ b/orchestrator/api/teams.py
@@ -1,0 +1,58 @@
+"""PRD-158 S1 — Teams API.
+
+List + create the workspace's teams. Writes normalize through the single
+``core.team_access`` helper, so 'Support'/'support' resolve to one team.
+"""
+
+import logging
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from core.auth.dependencies import RequestContext
+from core.auth.hybrid import get_request_context_hybrid
+from core.database.database import get_db
+from core.team_access import get_or_create_team, list_teams, normalize_team
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/teams", tags=["teams"])
+
+
+class TeamResponse(BaseModel):
+    id: int
+    name: str
+    normalized_name: str
+
+    class Config:
+        from_attributes = True
+
+
+class CreateTeamRequest(BaseModel):
+    name: str
+
+
+@router.get("", response_model=List[TeamResponse])
+async def list_workspace_teams(
+    ctx: RequestContext = Depends(get_request_context_hybrid),
+    db: Session = Depends(get_db),
+):
+    """All teams in the caller's workspace (canonical-name order)."""
+    return list_teams(db, ctx.workspace_id)
+
+
+@router.post("", response_model=TeamResponse, status_code=201)
+async def create_workspace_team(
+    body: CreateTeamRequest,
+    ctx: RequestContext = Depends(get_request_context_hybrid),
+    db: Session = Depends(get_db),
+):
+    """Create (or return the existing) team for the normalized name."""
+    if not normalize_team(body.name or ""):
+        raise HTTPException(status_code=400, detail="Team name cannot be empty")
+    team = get_or_create_team(db, ctx.workspace_id, body.name)
+    db.commit()
+    db.refresh(team)
+    return team

--- a/orchestrator/api/widgets/documents.py
+++ b/orchestrator/api/widgets/documents.py
@@ -3,8 +3,16 @@ Widget Documents API
 ====================
 
 REST endpoints for document search and retrieval consumed by embedded SDK
-widgets.  All queries are workspace-scoped using the authenticated context
-from :mod:`api.widgets.auth`.
+widgets.  All queries are workspace-scoped (and team-scoped when the widget key
+is team-locked) using the authenticated context from :mod:`api.widgets.auth`.
+
+PRD-158 S5 — schema truth: this surface previously queried ``documents.title`` /
+``documents.content`` / ``documents.created_at`` and typed ids as UUID. None of
+those exist — ``documents`` has ``original_filename`` / ``upload_date`` /
+``doc_metadata`` and an INTEGER id, and chunk text lives in ``document_chunks``.
+The search was therefore impossible to satisfy. It is rebuilt here on the real
+schema and the PRD-157 retrieval path (vector search via ``RAGService``), not
+ILIKE over a non-existent column.
 
 Prefix: /api/widget/documents
 """
@@ -14,7 +22,6 @@ from __future__ import annotations
 import logging
 from datetime import datetime
 from typing import Any, Dict, List, Optional
-from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
@@ -29,7 +36,7 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/widget/documents", tags=["Widget Documents"])
 
 # ---------------------------------------------------------------------------
-# Pydantic models
+# Pydantic models  (ids are INTEGER — documents.id is a serial, not a UUID)
 # ---------------------------------------------------------------------------
 
 
@@ -41,9 +48,9 @@ class DocumentSearchRequest(BaseModel):
 
 
 class DocumentSearchItem(BaseModel):
-    """Single search result."""
+    """Single search result (one per surfaced document)."""
 
-    id: UUID
+    id: int
     title: str
     snippet: str
     score: Optional[float] = None
@@ -60,7 +67,7 @@ class DocumentSearchResponse(BaseModel):
 class DocumentDetail(BaseModel):
     """Full document returned by GET /documents/{document_id}."""
 
-    id: UUID
+    id: int
     title: str
     content: str
     metadata: Optional[Dict[str, Any]] = None
@@ -79,66 +86,107 @@ async def search_documents(
     _perm: WidgetAuthContext = Depends(require_permission("documents:read")),
     db: Session = Depends(get_db),
 ):
-    """Search the workspace knowledge base by title or content."""
+    """Semantic (vector) search over the workspace knowledge base.
 
-    like_pattern = f"%{body.query}%"
+    Scoped to the widget's workspace and — when the key is team-locked — its team,
+    via the PRD-157 retrieval path. Results are grouped by document (best chunk
+    per document), so one row per surfaced document.
+    """
+    from modules.rag.service import RAGService
+    from modules.rag.retrieval_filters import build_retrieval_filters
 
-    rows = db.execute(
-        text(
-            "SELECT id, title, content, similarity "
-            "FROM documents "
-            "WHERE workspace_id = :ws_id "
-            "  AND (title ILIKE :q OR content ILIKE :q) "
-            "LIMIT :limit"
-        ),
-        {"ws_id": str(auth.workspace_id), "q": like_pattern, "limit": body.limit},
-    ).fetchall()
+    filters = build_retrieval_filters(workspace_id=auth.workspace_id, team=auth.team)
+
+    try:
+        result = await RAGService().retrieve(
+            query=body.query,
+            max_chunks=body.limit,
+            workspace_id=filters.workspace_id,
+            team=filters.team,
+        )
+        chunks = result.chunks if result else []
+    except Exception:
+        logger.warning("[widget-docs] semantic search failed", exc_info=True)
+        chunks = []
+
+    # Group by document, keeping the best (highest-scored, first) chunk per doc.
+    by_doc: Dict[int, Dict[str, Any]] = {}
+    for chunk in chunks:
+        meta = chunk.get("metadata", {}) or {}
+        raw_id = chunk.get("document_id") or meta.get("document_id") or meta.get("external_file_id")
+        if raw_id is None:
+            continue
+        try:
+            doc_id = int(raw_id)
+        except (TypeError, ValueError):
+            continue
+        if doc_id not in by_doc:
+            by_doc[doc_id] = chunk
+
+    # Resolve real display names from PostgreSQL (chunk source_file may be a temp name).
+    names: Dict[int, str] = {}
+    if by_doc:
+        rows = db.execute(
+            text(
+                "SELECT id, COALESCE(original_filename, filename) AS name "
+                "FROM documents WHERE id = ANY(CAST(:ids AS int[]))"
+            ),
+            {"ids": list(by_doc.keys())},
+        ).fetchall()
+        names = {r.id: r.name for r in rows}
 
     results = [
         DocumentSearchItem(
-            id=row.id,
-            title=row.title,
-            snippet=(row.content or "")[:200],
-            score=getattr(row, "similarity", None),
+            id=doc_id,
+            title=names.get(doc_id) or chunk.get("source_file") or "Document",
+            snippet=(chunk.get("content") or "")[:200],
+            score=float(chunk["similarity"]) if chunk.get("similarity") is not None else None,
         )
-        for row in rows
+        for doc_id, chunk in list(by_doc.items())[: body.limit]
     ]
 
-    return DocumentSearchResponse(
-        query=body.query,
-        results=results,
-        total=len(results),
-    )
+    return DocumentSearchResponse(query=body.query, results=results, total=len(results))
 
 
 @router.get("/{document_id}", response_model=DocumentDetail)
 async def get_document(
-    document_id: UUID,
+    document_id: int,
     auth: WidgetAuthContext = Depends(widget_auth),
     _perm: WidgetAuthContext = Depends(require_permission("documents:read")),
     db: Session = Depends(get_db),
 ):
-    """Retrieve a single document by ID (workspace-scoped)."""
+    """Retrieve a single document by ID (workspace-scoped).
 
-    row = db.execute(
+    Content is reassembled from ``document_chunks`` (in ``chunk_index`` order),
+    since ``documents`` has no content column.
+    """
+    doc = db.execute(
         text(
-            "SELECT id, title, content, metadata, created_at "
-            "FROM documents "
-            "WHERE id = :id AND workspace_id = :ws_id"
+            "SELECT id, COALESCE(original_filename, filename) AS title, upload_date, doc_metadata "
+            "FROM documents WHERE id = :id AND workspace_id = CAST(:ws_id AS uuid)"
         ),
-        {"id": str(document_id), "ws_id": str(auth.workspace_id)},
+        {"id": document_id, "ws_id": str(auth.workspace_id)},
     ).fetchone()
 
-    if row is None:
+    if doc is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Document not found",
         )
 
+    chunk_rows = db.execute(
+        text(
+            "SELECT content FROM document_chunks "
+            "WHERE document_id = :id ORDER BY chunk_index"
+        ),
+        {"id": document_id},
+    ).fetchall()
+    content = "\n\n".join(r.content for r in chunk_rows if r.content)
+
     return DocumentDetail(
-        id=row.id,
-        title=row.title,
-        content=row.content,
-        metadata=row.metadata,
-        created_at=row.created_at,
+        id=doc.id,
+        title=doc.title,
+        content=content,
+        metadata=doc.doc_metadata,
+        created_at=doc.upload_date,
     )

--- a/orchestrator/core/database/init_complete_schema.sql
+++ b/orchestrator/core/database/init_complete_schema.sql
@@ -1947,5 +1947,18 @@ CREATE INDEX IF NOT EXISTS ix_pinned_documents_chat ON pinned_documents(chat_id)
 CREATE INDEX IF NOT EXISTS ix_pinned_documents_workspace ON pinned_documents(workspace_id);
 
 -- ================================================================
+-- PRD-158 S1: Teams entity (one team per workspace+normalized_name)
+-- ================================================================
+CREATE TABLE IF NOT EXISTS teams (
+    id              SERIAL PRIMARY KEY,
+    workspace_id    UUID NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    name            VARCHAR(100) NOT NULL,
+    normalized_name VARCHAR(100) NOT NULL,
+    created_at      TIMESTAMP NOT NULL DEFAULT NOW(),
+    CONSTRAINT uq_teams_workspace_normalized UNIQUE (workspace_id, normalized_name)
+);
+CREATE INDEX IF NOT EXISTS ix_teams_workspace ON teams(workspace_id);
+
+-- ================================================================
 -- SCHEMA INITIALIZATION COMPLETE
 -- ================================================================

--- a/orchestrator/core/models/cloud_sync.py
+++ b/orchestrator/core/models/cloud_sync.py
@@ -12,6 +12,7 @@ from datetime import datetime
 from sqlalchemy import (
     BigInteger, Boolean, Column, DateTime, ForeignKey, Integer, String, Text,
 )
+from sqlalchemy.dialects.postgresql import ARRAY as PG_ARRAY
 from sqlalchemy.dialects.postgresql import UUID as PGUUID
 from sqlalchemy.orm import relationship
 
@@ -35,6 +36,9 @@ class CloudSyncConfig(Base):
     sync_enabled = Column(Boolean, server_default="true")
     last_sync_at = Column(DateTime)
     sync_frequency_minutes = Column(Integer, server_default="30")
+    # PRD-158 S2/Q5: normalized teams applied to docs synced from this connection
+    # (empty = public/all teams).
+    default_team_access = Column(PG_ARRAY(String), server_default="{}", nullable=False)
 
     created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)

--- a/orchestrator/core/models/core.py
+++ b/orchestrator/core/models/core.py
@@ -169,6 +169,29 @@ class LLMUsage(Base):
     created_at = Column(DateTime, default=func.now())
 
 # Database Models
+class Team(Base):
+    """PRD-158 S1: a real (small) Teams entity per workspace.
+
+    ``normalized_name`` is the canonical (lowercased/trimmed) form from
+    ``core.team_access.normalize_team`` — unique per workspace, so 'Support' and
+    'support' are one team. ``name`` keeps a human display label. Documents stay
+    multi-team via ``documents.team_access``; agents are single-team via
+    ``agents.team`` (schema leaves room for multi-team later).
+    """
+    __tablename__ = 'teams'
+    __table_args__ = (
+        UniqueConstraint('workspace_id', 'normalized_name', name='uq_teams_workspace_normalized'),
+        Index('ix_teams_workspace', 'workspace_id'),
+        {'extend_existing': True},
+    )
+
+    id = Column(Integer, primary_key=True)
+    workspace_id = Column(UUID(as_uuid=True), ForeignKey('workspaces.id', ondelete='CASCADE'), nullable=False)
+    name = Column(String(100), nullable=False)
+    normalized_name = Column(String(100), nullable=False)
+    created_at = Column(DateTime, nullable=False, server_default=func.now())
+
+
 class Agent(Base):
     __tablename__ = 'agents'
     __table_args__ = (

--- a/orchestrator/core/team_access.py
+++ b/orchestrator/core/team_access.py
@@ -69,3 +69,63 @@ def metadata_team_filter_clause(
         f"AND (COALESCE({col}, '[]'::jsonb) = '[]'::jsonb "
         f"OR {col} @> to_jsonb(:team::text))"
     )
+
+
+# --------------------------------------------------------------------------- #
+# PRD-158 S1: table-backed Teams entity helpers.
+# Every team WRITE goes through here so normalization stays single-source
+# (``normalize_team``) — there is no second normalizer.
+# --------------------------------------------------------------------------- #
+
+def list_teams(db, workspace_id):
+    """All Teams in a workspace, ordered by canonical name."""
+    from core.models import Team
+
+    return (
+        db.query(Team)
+        .filter(Team.workspace_id == workspace_id)
+        .order_by(Team.normalized_name)
+        .all()
+    )
+
+
+def get_or_create_team(db, workspace_id, name: str):
+    """Idempotently ensure a Team exists for ``(workspace, normalize_team(name))``.
+
+    Returns the :class:`~core.models.Team` (existing or newly added & flushed),
+    or ``None`` when ``name`` normalizes to empty. This is the single entry point
+    for creating teams, so 'Support'/'support' can never become two rows.
+    """
+    from core.models import Team
+
+    normalized = normalize_team(name or "")
+    if not normalized:
+        return None
+
+    existing = (
+        db.query(Team)
+        .filter(Team.workspace_id == workspace_id, Team.normalized_name == normalized)
+        .first()
+    )
+    if existing:
+        return existing
+
+    team = Team(workspace_id=workspace_id, name=name.strip(), normalized_name=normalized)
+    db.add(team)
+    db.flush()
+    return team
+
+
+def ensure_teams(db, workspace_id, names) -> list:
+    """Ensure each name in ``names`` has a Team row; return the normalized names.
+
+    Used by write paths (upload, team-access edits) so any team referenced is a
+    real row. Blanks are dropped. The returned list is the normalized
+    ``team_access`` to persist.
+    """
+    normalized = []
+    for raw in names or []:
+        team = get_or_create_team(db, workspace_id, raw)
+        if team is not None:
+            normalized.append(team.normalized_name)
+    return normalized

--- a/orchestrator/main.py
+++ b/orchestrator/main.py
@@ -41,6 +41,7 @@ from api.workflow_recipes import router as workflow_recipes_router, webhook_rout
 from api.webhooks import router as general_webhooks_router
 from api.marketplace import router as marketplace_router
 from api.documents import router as documents_router
+from api.teams import router as teams_router  # PRD-158: Teams entity
 from api.cache import router as cache_router
 from api.system import router as system_router
 from api.memory import router as memory_router
@@ -863,6 +864,7 @@ app.include_router(general_webhooks_router)  # General workspace webhooks (no au
 app.include_router(marketplace_router)  # Community Marketplace
 app.include_router(document_generation_router)  # PRD-63: Must be BEFORE documents_router (has /templates, /generated specific routes that would otherwise be caught by documents_router's /{document_id} catch-all → 422)
 app.include_router(documents_router)
+app.include_router(teams_router)  # PRD-158: Teams entity (list/create)
 app.include_router(blog_router)  # Authenticated blog management (Deliverables → Blogs)
 app.include_router(cache_router)  # Cache management and monitoring
 app.include_router(system_router)

--- a/orchestrator/modules/rag/services/cloud_sync_service.py
+++ b/orchestrator/modules/rag/services/cloud_sync_service.py
@@ -352,6 +352,11 @@ class CloudSyncService:
                         if document_id:
                             from core.models import Document
                             doc = self.db.query(Document).get(document_id)
+                            # PRD-158 S2/Q5: a cloud-synced doc inherits the
+                            # connection's default team(s) (already normalized).
+                            if doc is not None and sync_config.default_team_access:
+                                doc.team_access = list(sync_config.default_team_access)
+                                self.db.commit()
                             chunk_count = doc.chunk_count if doc else 0
                             doc_status = doc.status if doc else "failed"
                             logger.info(f"📊 Checking document {document_id} status: {doc_status}, chunks: {chunk_count}")

--- a/orchestrator/tests/test_documents_team_filter.py
+++ b/orchestrator/tests/test_documents_team_filter.py
@@ -1,0 +1,86 @@
+"""PRD-158 S3 — server-side team filtering on GET /api/documents + per-team counts.
+
+Integration: a >100-doc fixture proves the filter and counts are computed in SQL
+(server-side), not the old client-side ≤100 hack.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import types
+import uuid
+
+for _k in ("POSTGRES_USER", "POSTGRES_PASSWORD", "POSTGRES_DB"):
+    os.environ.setdefault(_k, "test")
+os.environ.setdefault("POSTGRES_HOST", "localhost")
+os.environ.setdefault("POSTGRES_PORT", "5432")
+sys.modules.setdefault("camelot", types.ModuleType("camelot"))
+
+import pytest  # noqa: E402
+
+
+def _seed(db, ws, n, team_access_sql):
+    from sqlalchemy import text
+
+    db.execute(
+        text(
+            "INSERT INTO documents (filename, workspace_id, team_access, status, upload_date) "
+            f"SELECT 'doc'||g, CAST(:ws AS uuid), {team_access_sql}, 'processed', NOW() "
+            "FROM generate_series(1, :n) g"
+        ),
+        {"ws": ws, "n": n},
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_team_filter_and_counts_are_server_side(db_session):
+    from api.documents import list_documents, document_team_counts
+
+    ws = str(uuid.uuid4())
+    # 120 docs total: 60 support, 40 sales, 20 public — exceeds the 100 page.
+    _seed(db_session, ws, 60, "ARRAY['support']")
+    _seed(db_session, ws, 40, "ARRAY['sales']")
+    _seed(db_session, ws, 20, "'{}'")
+    db_session.flush()
+
+    ctx = types.SimpleNamespace(workspace_id=uuid.UUID(ws))
+
+    # Counts are aggregated over ALL 120 docs, not a ≤100 slice.
+    counts = await document_team_counts(ctx=ctx, db=db_session)
+    assert counts["counts"]["support"] == 60
+    assert counts["counts"]["sales"] == 40
+    assert counts["untagged"] == 20
+    assert counts["total"] == 120
+
+    # team=sales filters server-side → 40 sales + 20 public (public always visible).
+    sales = await list_documents(
+        ctx=ctx, skip=0, limit=1000, status=None, file_type=None, search=None, team="sales", db=db_session
+    )
+    assert len(sales) == 60
+    for d in sales:
+        assert (not d.team_access) or ("sales" in [t.lower() for t in d.team_access])
+
+    # Normalization: 'Sales' resolves to the same set as 'sales'.
+    sales_caps = await list_documents(
+        ctx=ctx, skip=0, limit=1000, status=None, file_type=None, search=None, team="Sales", db=db_session
+    )
+    assert len(sales_caps) == 60
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_no_team_param_returns_all(db_session):
+    from api.documents import list_documents
+
+    ws = str(uuid.uuid4())
+    _seed(db_session, ws, 10, "ARRAY['support']")
+    _seed(db_session, ws, 5, "ARRAY['sales']")
+    db_session.flush()
+
+    ctx = types.SimpleNamespace(workspace_id=uuid.UUID(ws))
+    everything = await list_documents(
+        ctx=ctx, skip=0, limit=1000, status=None, file_type=None, search=None, team=None, db=db_session
+    )
+    assert len(everything) == 15   # no team restriction → workspace-wide

--- a/orchestrator/tests/test_teams_api.py
+++ b/orchestrator/tests/test_teams_api.py
@@ -1,0 +1,159 @@
+"""PRD-158 S1 — Teams entity: helpers, backfill, org-chart consistency.
+
+Pure layer: the single-normalizer write helpers. Integration layer (marked):
+the migration backfill collapsing mixed-case data, and org-chart/`/api/teams`
+agreeing on the team list.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import types
+import uuid
+
+for _k in ("POSTGRES_USER", "POSTGRES_PASSWORD", "POSTGRES_DB"):
+    os.environ.setdefault(_k, "test")
+os.environ.setdefault("POSTGRES_HOST", "localhost")
+os.environ.setdefault("POSTGRES_PORT", "5432")
+sys.modules.setdefault("camelot", types.ModuleType("camelot"))
+
+import pytest  # noqa: E402
+
+from core.team_access import get_or_create_team, ensure_teams, normalize_team  # noqa: E402
+
+
+# --------------------------------------------------------------------------- #
+# Pure: write helpers normalize through the single normalizer
+# --------------------------------------------------------------------------- #
+
+class _FakeQuery:
+    def __init__(self, result):
+        self._result = result
+
+    def filter(self, *a, **k):
+        return self
+
+    def order_by(self, *a, **k):
+        return self
+
+    def first(self):
+        return self._result
+
+    def all(self):
+        return self._result if isinstance(self._result, list) else []
+
+
+class _FakeDB:
+    def __init__(self, first_result=None):
+        self._first = first_result
+        self.added = []
+
+    def query(self, *a, **k):
+        return _FakeQuery(self._first)
+
+    def add(self, obj):
+        self.added.append(obj)
+
+    def flush(self):
+        pass
+
+
+class TestTeamWriteHelpers:
+    def test_create_normalizes_name(self):
+        db = _FakeDB(first_result=None)
+        team = get_or_create_team(db, uuid.uuid4(), "  Support ")
+        assert team is not None
+        assert team.normalized_name == "support"   # canonical
+        assert team.name == "Support"               # display preserved (trimmed)
+        assert len(db.added) == 1
+
+    def test_existing_team_is_not_duplicated(self):
+        existing = types.SimpleNamespace(normalized_name="support", name="Support")
+        db = _FakeDB(first_result=existing)
+        team = get_or_create_team(db, uuid.uuid4(), "support")
+        assert team is existing
+        assert db.added == []                       # no second row
+
+    def test_blank_name_creates_nothing(self):
+        db = _FakeDB(first_result=None)
+        assert get_or_create_team(db, uuid.uuid4(), "   ") is None
+        assert db.added == []
+
+    def test_ensure_teams_returns_normalized_drops_blanks(self):
+        db = _FakeDB(first_result=None)
+        out = ensure_teams(db, uuid.uuid4(), ["Support", " Sales ", "", "  "])
+        assert out == ["support", "sales"]
+
+
+# --------------------------------------------------------------------------- #
+# Integration (real Postgres): backfill + org-chart consistency
+# --------------------------------------------------------------------------- #
+
+# The migration's backfill, lifted verbatim so the test pins the exact SQL.
+_BACKFILL_SQL = """
+INSERT INTO teams (workspace_id, name, normalized_name)
+SELECT workspace_id, MIN(name) AS name, normalized_name
+FROM (
+    SELECT workspace_id, TRIM(team) AS name, LOWER(TRIM(team)) AS normalized_name
+    FROM agents
+    WHERE team IS NOT NULL AND TRIM(team) <> ''
+    UNION ALL
+    SELECT workspace_id, TRIM(t) AS name, LOWER(TRIM(t)) AS normalized_name
+    FROM documents, unnest(team_access) AS t
+    WHERE team_access IS NOT NULL AND TRIM(t) <> ''
+) src
+WHERE normalized_name <> ''
+GROUP BY workspace_id, normalized_name
+ON CONFLICT (workspace_id, normalized_name) DO NOTHING
+"""
+
+
+@pytest.mark.integration
+def test_backfill_collapses_mixed_case(db_session):
+    from sqlalchemy import text
+
+    ws = str(uuid.uuid4())
+    # Two agents 'Support'/'support' and a doc team 'Sales' → 2 teams.
+    for team in ("Support", "support"):
+        db_session.execute(
+            text(
+                "INSERT INTO agents (name, agent_type, workspace_id, team, status, slug) "
+                "VALUES (:n, 'custom', :ws::uuid, :team, 'active', :slug)"
+            ),
+            {"n": f"a-{team}", "ws": ws, "team": team, "slug": f"a-{uuid.uuid4().hex[:8]}"},
+        )
+    db_session.execute(
+        text(
+            "INSERT INTO documents (filename, workspace_id, team_access, status, upload_date) "
+            "VALUES ('d.txt', :ws::uuid, ARRAY['Sales'], 'processed', NOW())"
+        ),
+        {"ws": ws},
+    )
+    db_session.flush()
+
+    db_session.execute(text(_BACKFILL_SQL))
+    db_session.flush()
+
+    rows = db_session.execute(
+        text("SELECT normalized_name FROM teams WHERE workspace_id = :ws::uuid ORDER BY normalized_name"),
+        {"ws": ws},
+    ).fetchall()
+    normalized = [r[0] for r in rows]
+    assert normalized == ["sales", "support"]   # 'Support'/'support' collapsed to one
+
+
+@pytest.mark.integration
+def test_org_chart_teams_match_teams_api(db_session):
+    """org-chart's team list and list_teams() read the same table."""
+    from sqlalchemy import text
+    from core.team_access import list_teams, get_or_create_team
+
+    ws = uuid.uuid4()
+    get_or_create_team(db_session, ws, "Engineering")
+    get_or_create_team(db_session, ws, "Support")
+    db_session.flush()
+
+    api_names = sorted(t.name for t in list_teams(db_session, ws))
+    # org-chart derives its `teams` from the same list_teams() helper.
+    assert api_names == ["Engineering", "Support"]

--- a/orchestrator/tests/test_widget_docs_schema.py
+++ b/orchestrator/tests/test_widget_docs_schema.py
@@ -1,0 +1,91 @@
+"""PRD-158 S5 — widget docs rebuilt on the real schema.
+
+The old surface queried documents.title/content (non-existent) so search and
+get were impossible. These integration tests prove the rebuilt endpoints work on
+the real schema: get reassembles content from document_chunks; search groups the
+PRD-157 retrieval chunks by document and resolves real filenames.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import types
+import uuid
+
+for _k in ("POSTGRES_USER", "POSTGRES_PASSWORD", "POSTGRES_DB"):
+    os.environ.setdefault(_k, "test")
+os.environ.setdefault("POSTGRES_HOST", "localhost")
+os.environ.setdefault("POSTGRES_PORT", "5432")
+sys.modules.setdefault("camelot", types.ModuleType("camelot"))
+
+import pytest  # noqa: E402
+
+
+def _seed_doc(db, ws, filename="brief.pdf", chunks=("alpha content", "beta content")):
+    from sqlalchemy import text
+
+    doc_id = db.execute(
+        text(
+            "INSERT INTO documents (filename, original_filename, workspace_id, team_access, status, upload_date) "
+            "VALUES (:fn, :fn, CAST(:ws AS uuid), '{}', 'processed', NOW()) RETURNING id"
+        ),
+        {"fn": filename, "ws": ws},
+    ).scalar()
+    for i, c in enumerate(chunks):
+        db.execute(
+            text(
+                "INSERT INTO document_chunks (document_id, chunk_index, content, workspace_id) "
+                "VALUES (:doc, :idx, :content, :ws)"
+            ),
+            {"doc": doc_id, "idx": i, "content": c, "ws": ws},
+        )
+    db.flush()
+    return doc_id
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_get_document_reassembles_content_from_chunks(db_session):
+    from api.widgets.documents import get_document
+
+    ws = str(uuid.uuid4())
+    doc_id = _seed_doc(db_session, ws, filename="brief.pdf", chunks=("alpha content", "beta content"))
+    auth = types.SimpleNamespace(workspace_id=uuid.UUID(ws), team=None)
+
+    detail = await get_document(doc_id, auth=auth, _perm=auth, db=db_session)
+    assert detail.id == doc_id
+    assert detail.title == "brief.pdf"            # filename, not a non-existent title col
+    assert "alpha content" in detail.content and "beta content" in detail.content
+    assert detail.created_at is not None          # upload_date, not created_at
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_search_groups_chunks_and_resolves_filenames(db_session, monkeypatch):
+    from api.widgets.documents import search_documents, DocumentSearchRequest
+    from modules.rag.service import RAGService
+
+    ws = str(uuid.uuid4())
+    doc_id = _seed_doc(db_session, ws, filename="report.pdf")
+
+    # Stand in for the real vector retrieval: two chunks of the same doc.
+    class _Result:
+        chunks = [
+            {"document_id": doc_id, "content": "the answer about widgets", "similarity": 0.91, "source_file": "temp123.txt", "metadata": {}},
+            {"document_id": doc_id, "content": "secondary chunk", "similarity": 0.40, "source_file": "temp123.txt", "metadata": {}},
+        ]
+
+    async def _fake_retrieve(self, **kwargs):
+        return _Result()
+
+    # retrieve is imported lazily inside the endpoint; patch the class directly.
+    monkeypatch.setattr(RAGService, "retrieve", _fake_retrieve)
+
+    auth = types.SimpleNamespace(workspace_id=uuid.UUID(ws), team=None)
+    resp = await search_documents(DocumentSearchRequest(query="widgets", limit=10), auth=auth, _perm=auth, db=db_session)
+
+    assert resp.total == 1                         # two chunks → one document
+    assert resp.results[0].id == doc_id
+    assert resp.results[0].title == "report.pdf"   # real filename, not the temp source
+    assert resp.results[0].score == pytest.approx(0.91)


### PR DESCRIPTION
## PRD-158 — Teams Model & Knowledge UX (WS-3)

Finishes the locked Teams decision end-to-end: a real teams entity, dropdowns instead of free-text, server-side team filtering on the knowledge page, team management after upload, and a schema-truth rebuild of the widget docs surface. Built on top of PRD-157 (already merged). 6 commits, one per story cluster.

### S1 — Teams table + API
- New `teams(id, workspace_id, name, normalized_name unique-per-workspace)` + `Team` model + `GET/POST /api/teams`.
- Backfill from `agents.team` ∪ `documents.team_access` (lowercased; `MIN(name)` picks a deterministic display so `Support`/`support` collapse to one team).
- `core/team_access.py` extended with `get_or_create_team` / `ensure_teams` / `list_teams` — every team write normalizes through the one `normalize_team` (no second normalizer).
- org-chart now sources its team list from the table (same source as `/api/teams`).
- ⚠️ **The migration also collapses the repo's 44 alembic heads into one.** `prd158_teams` is a merge migration whose `down_revision` is the tuple of all 44 current heads — topology-only, the same migrations still run under `alembic upgrade heads`, and afterward `alembic heads` returns a single head. Mergepoints are already a repo convention (`20260226_merge_heads`).

### S2 — Team dropdowns replace free-text
- `TeamMultiSelect` (Popover + checkbox list + inline create) sourced from `/api/teams`; selected values are canonical `normalized_name` strings.
- Wired into `document-upload.tsx` + `upload-provider-modal.tsx` — free-text chips gone (phantom-domain bug dead).
- Cloud-sync per-connection default team (Q5), end to end: `CloudSyncConfig.default_team_access` (+ migration `prd158_cloud_default_team`), `select-folder` API normalizes/persists it, the sync service applies it to each synced document, and the folder-navigator UI gains a picker.

### S3 — Knowledge page team filtering
- `GET /api/documents?team=` filters server-side (case-insensitive `team_access` overlap so legacy mixed-case rows still match; new writes are normalized).
- `GET /api/documents/team-counts` aggregates per-team counts over **all** workspace docs (not the ≤100 page).
- Page-header team selector (visible without entering Library cards) + counts + agent-eye-view badge; removed LocalStorageBrowser's client-side ≤100-doc team filter.

### S4 — Team management after upload
- Team editor in the document-details modal (TeamMultiSelect + save → existing `PATCH /team-access`).
- Bulk select (list + grid) + bulk-assign bar → existing `POST /bulk-team-access`.
- Team badges on rows (already rendered by LocalStorageBrowser).

### S5 — Widget/SDK docs schema-truth
- `api/widgets/documents.py` was querying `documents.title`/`content`/`created_at` and typed ids as UUID — **none of which exist** (real cols: `original_filename`/`upload_date`/`doc_metadata`, content in `document_chunks`, INT id). Search was impossible to satisfy.
- Rebuilt on the real schema + the PRD-157 vector path (workspace + team scoped); single-doc content reassembled from chunks.

## Test status
Verified offline (no Docker locally): `py_compile` clean across all touched backend files, **single alembic head** (`prd158_cloud_default_team`), pure unit tests green (`test_teams_api` + inherited 157 suites), and the "no free-text team writes" grep gate is clean.

**Needs the live stack (do before merge / in CI):**
- `alembic upgrade heads` — applies teams + cloud-default-team and collapses heads
- `integration`-marked tests: backfill collapse (`Support`/`support` → one), `team=` matrix (120-doc fixture proving server-side, not the ≤100 hack), widget search on the real schema
- frontend `tsc --noEmit` + vitest (`node_modules` not installed in the worktree)
- dev-browser: both upload dialogs, header selector + counts, doc-details edit + bulk round-trips

## Non-Goals
Human RBAC by team, multi-team agents, SDK-key team locks (schema leaves room).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added team-based document access management. Users can now assign documents to specific teams, filter documents by team, and view per-team document counts.
  * Introduced bulk team assignment for multiple documents at once.
  * Cloud document syncs now support default team assignment for newly imported documents.
  * Enhanced team selection UI with improved multi-select controls throughout the document management interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->