### PR TITLE
PRD-159: Memory Quality & Lifecycle (WS-4)

### DIFF
--- a/orchestrator/config.py
+++ b/orchestrator/config.py
@@ -266,6 +266,26 @@ class Config:
             return os.getenv("MEMORY_DISTILL_MODEL", DEFAULT_LLM_MODEL)
 
     @property
+    def MEMORY_RELEVANCE_FLOOR(self) -> float:
+        """Server-side similarity floor for L3 recall (PRD-159 S3).
+
+        Scored search results below this are never injected, so low-relevance
+        junk can't leak into context. Resolves system_settings
+        (memory.relevance_floor) → env MEMORY_RELEVANCE_FLOOR → 0.3."""
+        try:
+            from core.llm.manager import get_system_setting
+            val = get_system_setting(
+                "memory", "relevance_floor",
+                os.getenv("MEMORY_RELEVANCE_FLOOR", "0.3"),
+            )
+            return float(val)
+        except Exception:
+            try:
+                return float(os.getenv("MEMORY_RELEVANCE_FLOOR", "0.3"))
+            except (TypeError, ValueError):
+                return 0.3
+
+    @property
     def COORDINATOR_TASK_MAX_TOKENS(self) -> int:
         """Mission task max_tokens — canonical System LLM max_tokens (PRD-136)."""
         try:

--- a/orchestrator/config.py
+++ b/orchestrator/config.py
@@ -248,6 +248,24 @@ class Config:
             return os.getenv("GRAPHIFY_MODEL")
 
     @property
+    def MEMORY_DISTILL_MODEL(self) -> str:
+        """Cheap-tier model for L3 memory distillation (PRD-159 D11/Q16).
+
+        The distiller runs ~1×/chat turn, so it is deliberately pinned to a cheap
+        model rather than the conversation tier. Resolves system_settings
+        (memory.distill_model) → env MEMORY_DISTILL_MODEL → DEFAULT_LLM_MODEL
+        (already a fast/cheap flash tier)."""
+        from core.llm.defaults import DEFAULT_LLM_MODEL
+        try:
+            from core.llm.manager import get_system_setting
+            return get_system_setting(
+                "memory", "distill_model",
+                os.getenv("MEMORY_DISTILL_MODEL", DEFAULT_LLM_MODEL),
+            )
+        except Exception:
+            return os.getenv("MEMORY_DISTILL_MODEL", DEFAULT_LLM_MODEL)
+
+    @property
     def COORDINATOR_TASK_MAX_TOKENS(self) -> int:
         """Mission task max_tokens — canonical System LLM max_tokens (PRD-136)."""
         try:

--- a/orchestrator/consumers/chatbot/service.py
+++ b/orchestrator/consumers/chatbot/service.py
@@ -1131,8 +1131,13 @@ class StreamingChatService:
         if latest_text and full_response and smart_chat:
             try:
                 _stored = await smart_chat.store(latest_text, full_response, chat_id)
-                if _stored:
-                    _tier = getattr(smart_chat.orchestrator.memory_manager, '_last_tier', 'conversation')
+                _mm = smart_chat.orchestrator.memory_manager
+                _facts_stored = getattr(_mm, '_last_l3_facts_stored', 0)
+                # PRD-159 S5: honest event — emit ONLY after durable facts were
+                # actually persisted to L3, with the real tier. Zero-fact turns
+                # (e.g. "user said hello") produce NO memory_stored event.
+                if _stored and _facts_stored > 0:
+                    _tier = getattr(_mm, '_last_tier', 'conversation')
                     yield self.streaming_handler.format_aisdk_memory_stored(
                         memory={
                             "userMessage": latest_text[:200],

--- a/orchestrator/consumers/chatbot/smart_memory.py
+++ b/orchestrator/consumers/chatbot/smart_memory.py
@@ -81,6 +81,10 @@ class SmartMemoryManager:
         self._cache_ttl = 120  # 2 minutes
         self._storage_queue: List[Tuple] = []
         self._storage_task = None
+        # PRD-159 S5: honest memory_stored SSE — the tier that actually persisted
+        # and how many durable facts were written this turn (0 → no SSE).
+        self._last_tier: Optional[str] = None
+        self._last_l3_facts_stored: int = 0
 
     @property
     def unified_service(self):
@@ -545,6 +549,9 @@ class SmartMemoryManager:
             # visible failure via False return (§H: never silent), even though
             # L2 still got the verbatim turn.
             l3_ok = any(r[1] and not r[1].get("error") for r in results)
+            # PRD-159 S5: how many durable facts actually persisted to L3 this
+            # turn — drives the honest memory_stored SSE (0 → no event fired).
+            self._last_l3_facts_stored = len(facts) if l3_ok else 0
             success = (l3_ok or not facts) and not l3_raised
 
             if success:

--- a/orchestrator/consumers/chatbot/smart_memory.py
+++ b/orchestrator/consumers/chatbot/smart_memory.py
@@ -23,6 +23,21 @@ from datetime import datetime, timedelta
 
 logger = logging.getLogger(__name__)
 
+# PRD-159 S1 — operational memory taxonomy (Zep ontology incl. `procedure`).
+# The distiller emits a {fact, type, importance} object per durable fact; `type`
+# is validated against this set and stored as the memory `category` so recall
+# and the Explorer can filter operational knowledge by kind.
+MEMORY_FACT_TYPES = frozenset({
+    "tool_outcome",     # a tool/Composio call's notable result (failure, quirk, new id)
+    "task_learning",    # what was learned from a mission/task succeeding or failing
+    "playbook_pattern", # a reusable pattern surfaced while running a playbook
+    "user_fact",        # stable fact about the user
+    "business_fact",    # stable fact about their business/domain
+    "preference",       # a stated preference
+    "procedure",        # a how-to / standard operating procedure
+})
+DEFAULT_FACT_TYPE = "task_learning"
+
 
 @dataclass
 class UserContext:
@@ -452,25 +467,17 @@ class SmartMemoryManager:
                 agent_id=agent_id,
             )
 
+            # PRD-159 S1: NO raw-exchange fallback. A failed distill
+            # (``facts is None``) or an exchange with nothing durable
+            # (``facts == []``) writes NOTHING to L3 — the L2 transcript below
+            # still preserves the verbatim turn. This is what ends the
+            # "user said hello" era: junk never reaches Mem0.
             if facts is None:
-                # Distillation failed (LLM/parse error) — fall back to the raw
-                # exchange so a transient outage never drops the memory.
-                l3_messages = [
-                    {"role": "user", "content": user_message[:max_chars]},
-                    {"role": "assistant", "content": assistant_response[:max_chars]},
-                ]
-                distilled = False
-            elif facts:
-                # Durable facts found → store those, not the raw turns.
-                l3_messages = [
-                    {"role": "user", "content": fact[:max_chars]} for fact in facts
-                ]
-                distilled = True
-            else:
-                # facts == [] → nothing durable in this exchange. Skip L3 so we
-                # don't store episodic noise; L2 still keeps the transcript.
-                l3_messages = None
-                distilled = True
+                logger.info(
+                    "[SmartMemory] Distill failed — L3 skipped; transcript kept in L2"
+                )
+                facts = []
+            distilled = True
 
             base_metadata = {
                 "chat_id": chat_id,
@@ -480,26 +487,34 @@ class SmartMemoryManager:
                 "distilled": distilled,
             }
 
-            # PRD-142 W3-S7 (§H "failure path tested — never silently
-            # swallowed"): wrap the L3 write in try/except so a Mem0 outage
-            # cannot prevent the L2 transcript write below. Without this
-            # guard an exception from store_two_tier would skip past the
-            # transcript persistence and lose the turn entirely.
+            # Each durable fact is stored with its OWN typed metadata (category +
+            # importance) so tier/category/importance stay filterable in semantic
+            # search and the Explorer (PRD-159 S1/S3/S5). store_two_tier applies
+            # one metadata dict per call, so we write per fact — facts/turn is
+            # small (0..N), so this stays cheap.
+            # PRD-142 W3-S7 (§H): the L3 write is guarded so a Mem0 outage cannot
+            # prevent the L2 transcript write below.
             results: List[tuple] = []
             l3_raised = False
-            if l3_messages is not None:
+            for fact in facts:
+                fact_meta = {
+                    **base_metadata,
+                    "category": fact["type"],
+                    "importance": fact["importance"],
+                }
                 try:
-                    results = await self.unified_service.store_two_tier(
+                    fact_results = await self.unified_service.store_two_tier(
                         workspace_id=workspace_id,
-                        messages=l3_messages,
+                        messages=[{"role": "user", "content": fact["fact"][:max_chars]}],
                         agent_id=agent_id,
                         tier=tier,
-                        metadata=base_metadata,
+                        metadata=fact_meta,
                     )
+                    results.extend(fact_results)
                 except Exception:
                     l3_raised = True
                     logger.warning(
-                        "[SmartMemory] L3 store_two_tier raised — L2 "
+                        "[SmartMemory] L3 store_two_tier raised for a fact — L2 "
                         "transcript will still persist", exc_info=True,
                     )
 
@@ -530,7 +545,7 @@ class SmartMemoryManager:
             # visible failure via False return (§H: never silent), even though
             # L2 still got the verbatim turn.
             l3_ok = any(r[1] and not r[1].get("error") for r in results)
-            success = (l3_ok or l3_messages is None) and not l3_raised
+            success = (l3_ok or not facts) and not l3_raised
 
             if success:
                 if l3_ok:
@@ -566,23 +581,30 @@ class SmartMemoryManager:
         *,
         workspace_id: str,
         agent_id: Optional[int],
-    ) -> Optional[List[str]]:
-        """Distil 0..N durable facts from a chat exchange for the L3 (Mem0) feed.
+    ) -> Optional[List[Dict[str, Any]]]:
+        """Distil 0..N typed durable facts from a chat exchange for the L3 feed.
+
+        Each fact is ``{"fact": str, "type": <taxonomy>, "importance": float}``.
+        The distiller runs on the cheap model tier (``config.MEMORY_DISTILL_MODEL``)
+        — ~1 LLM call/turn (PRD-159 D11/Q16).
 
         Returns:
-            - ``list[str]`` of durable facts (possibly empty → nothing worth
-              keeping; caller should skip L3),
-            - ``None`` on LLM/parse failure so the caller can fall back to the
-              raw exchange rather than silently dropping the memory.
+            - ``list[dict]`` of typed facts (possibly empty → nothing durable;
+              caller skips L3),
+            - ``None`` on LLM/parse failure. PRD-159 S1: the caller stores
+              NOTHING on failure (no raw-exchange fallback) — the L2 transcript
+              still preserves the verbatim turn.
         """
         prompt = self._build_distill_prompt(user_message, assistant_response)
         try:
             # Imported here (not at module top) so tests can monkeypatch
             # ``core.llm.create_llm_manager`` and have it take effect per call.
             from core.llm import create_llm_manager
+            from config import config
 
             llm = create_llm_manager(
                 service_name="memory_integration",
+                model=config.MEMORY_DISTILL_MODEL,
                 workspace_id=workspace_id,
                 agent_id=agent_id,
                 request_type="memory_distill",
@@ -601,32 +623,56 @@ class SmartMemoryManager:
 
     @staticmethod
     def _build_distill_prompt(user_message: str, assistant_response: str) -> str:
-        """Prompt that asks the LLM for durable knowledge, not interaction logs."""
+        """Prompt for typed operational memory (PRD-159 S1).
+
+        No transient-event exclusion: tool outcomes, task/mission learnings and
+        playbook patterns are exactly the operational memories we now WANT. The
+        ``type`` field classifies them instead of a blanket ban filtering them
+        out.
+        """
         return (
-            "You are curating long-term memory for an AI assistant. From the "
-            "single chat exchange below, extract only DURABLE facts worth "
-            "remembering for future conversations — stable knowledge about the "
-            "user, their business, their domain, their preferences, or decisions "
-            "and constraints that will still matter weeks from now.\n\n"
-            "Do NOT record transient interaction events (e.g. 'user asked to run "
-            "a mission', 'assistant said it would do X', 'user was informed "
-            "that…'). Those are conversation logs, not knowledge.\n\n"
-            "Write each fact as a standalone, third-person statement that makes "
+            "You are curating long-term memory for an AI assistant (\"Auto\"). "
+            "From the single chat exchange below, extract durable facts worth "
+            "remembering for future work — both operational knowledge (what a "
+            "tool call revealed, what a mission/task taught, a reusable playbook "
+            "pattern) and stable knowledge about the user, their business, their "
+            "domain, and their preferences.\n\n"
+            "Classify each fact with a `type` from this taxonomy:\n"
+            "- tool_outcome: a notable result of a tool/integration call "
+            "(a failure + its cause, an auth quirk, a rate limit, a new channel/"
+            "record id, a schema surprise)\n"
+            "- task_learning: what was learned from a mission or task succeeding "
+            "or failing\n"
+            "- playbook_pattern: a reusable pattern/approach surfaced while "
+            "working\n"
+            "- user_fact: a stable fact about the user\n"
+            "- business_fact: a stable fact about their business or domain\n"
+            "- preference: a stated preference (tone, format, tools, cadence)\n"
+            "- procedure: a how-to or standing instruction for getting something "
+            "done\n\n"
+            "Write each `fact` as a standalone, third-person statement that makes "
             "sense without the surrounding conversation. Preserve specifics "
-            "(names, standards, numbers, spellings).\n\n"
-            "Return ONLY a JSON array of strings. If nothing durable is worth "
-            "keeping, return an empty array [].\n\n"
+            "(names, standards, numbers, ids, spellings). Set `importance` in "
+            "[0,1] (0.8+ = load-bearing, 0.3 = minor). Skip pure pleasantries and "
+            "chit-chat with no durable content.\n\n"
+            "Return ONLY a JSON array of objects "
+            "{\"fact\": str, \"type\": str, \"importance\": number}. "
+            "If nothing durable is worth keeping, return an empty array [].\n\n"
             f"User: {user_message}\n"
             f"Assistant: {assistant_response}\n\n"
-            "Durable facts (JSON array):"
+            "Typed durable facts (JSON array):"
         )
 
     @staticmethod
-    def _parse_distilled_facts(content: str) -> Optional[List[str]]:
-        """Parse the LLM output into a list of facts.
+    def _parse_distilled_facts(content: str) -> Optional[List[Dict[str, Any]]]:
+        """Parse the LLM output into a list of typed ``{fact, type, importance}``.
 
-        Tolerates prose and ```json code fences around the array. Returns the
-        parsed list (possibly empty), or ``None`` if no JSON array can be found.
+        Tolerates prose and ```json code fences around the array. Each item is
+        normalised: ``type`` is validated against ``MEMORY_FACT_TYPES`` (unknown
+        → ``DEFAULT_FACT_TYPE``) and ``importance`` is coerced to a [0,1] float
+        (default 0.5). Items without a non-empty ``fact`` string are dropped.
+        Returns the parsed list (possibly empty), or ``None`` if no JSON array
+        can be found.
         """
         if not content:
             return None
@@ -648,7 +694,29 @@ class SmartMemoryManager:
             return None
         if not isinstance(parsed, list):
             return None
-        return [str(f).strip() for f in parsed if str(f).strip()]
+
+        out: List[Dict[str, Any]] = []
+        for item in parsed:
+            # Tolerate a bare string (older shape) by typing it as the default.
+            if isinstance(item, str):
+                fact_text = item.strip()
+                ftype, importance = DEFAULT_FACT_TYPE, 0.5
+            elif isinstance(item, dict):
+                fact_text = str(item.get("fact", "")).strip()
+                ftype = str(item.get("type", DEFAULT_FACT_TYPE)).strip()
+                if ftype not in MEMORY_FACT_TYPES:
+                    ftype = DEFAULT_FACT_TYPE
+                try:
+                    importance = float(item.get("importance", 0.5))
+                except (ValueError, TypeError):
+                    importance = 0.5
+                importance = max(0.0, min(1.0, importance))
+            else:
+                continue
+            if not fact_text:
+                continue
+            out.append({"fact": fact_text, "type": ftype, "importance": importance})
+        return out
 
     # ---------------------------------------------------------------
     # Daily Log Summary (US-011 / US-012)

--- a/orchestrator/consumers/chatbot/smart_memory.py
+++ b/orchestrator/consumers/chatbot/smart_memory.py
@@ -453,15 +453,22 @@ class SmartMemoryManager:
             results: List[tuple] = []
             l3_raised = False
             for fact in facts:
+                # Defensive: tolerate a bare string (legacy/edge) and skip a
+                # malformed fact rather than crash the turn — the L2 transcript
+                # write below must NEVER be lost to one bad L3 fact (PRD-142 W3-S7).
+                if isinstance(fact, str):
+                    fact = {"fact": fact, "type": DEFAULT_FACT_TYPE, "importance": 0.5}
+                if not isinstance(fact, dict) or not fact.get("fact"):
+                    continue
                 fact_meta = {
                     **base_metadata,
-                    "category": fact["type"],
-                    "importance": fact["importance"],
+                    "category": fact.get("type", DEFAULT_FACT_TYPE),
+                    "importance": fact.get("importance", 0.5),
                 }
                 try:
                     fact_results = await self.unified_service.store_two_tier(
                         workspace_id=workspace_id,
-                        messages=[{"role": "user", "content": fact["fact"][:max_chars]}],
+                        messages=[{"role": "user", "content": str(fact["fact"])[:max_chars]}],
                         agent_id=agent_id,
                         tier=tier,
                         metadata=fact_meta,

--- a/orchestrator/consumers/chatbot/smart_memory.py
+++ b/orchestrator/consumers/chatbot/smart_memory.py
@@ -111,81 +111,33 @@ class SmartMemoryManager:
 
     def _classify_memory_tier(self, user_message: str, assistant_response: str) -> str:
         """
-        Classify where a memory should be stored.
+        Classify where a memory should be stored. Returns "global" or "agent".
 
-        Returns: "global", "agent", or "both"
+        PRD-159 S5: the "both"-tier double-write default is REMOVED. Every
+        exchange used to write to BOTH the workspace and agent namespaces,
+        doubling the Mem0 rows and the Explorer count for one memory. The default
+        is now a SINGLE workspace namespace ("global"); the agent namespace is
+        used only when the user gives an explicit agent-scoped instruction. The
+        fragile single-character keywords ('#'/'@') that misrouted ordinary
+        messages to the agent tier are gone.
 
-        Classification rules:
-        - Personal facts (name, location, job, general info) → global
-        - Tool/workflow-related (Slack, email patterns, contacts for tools) → agent
-        - Preferences → both (useful everywhere)
-
-        IMPORTANT: Only classify based on the USER message, not the assistant
-        response. The assistant mentioning "slack" or "github" in an explanation
-        shouldn't misclassify a personal question as agent-specific.
+        Only the USER message is classified — the assistant response contains
+        tool names in explanations that caused false positives.
         """
-        # Only use USER message for classification — assistant response
-        # contains tool names in explanations that cause false positives
         combined = user_message.lower()
 
-        # Tool/workflow-specific keywords → agent-specific memory
-        # These are things specific to how tools are used
-        tool_keywords = [
-            # Communication tools
-            "slack", "channel", "#", "dm", "message to",
-            "gmail", "email to", "send email", "cc", "bcc", "forward",
-            # Dev tools
-            "github", "repository", "repo", "branch", "pr", "pull request",
-            "jira", "ticket", "issue",
-            # Data tools
-            "database", "table", "query", "sql", "api", "endpoint",
-            # File tools
-            "spreadsheet", "document", "file", "folder", "drive", "upload",
-            # Workflow patterns
-            "when i ask", "for this agent", "in this context"
-        ]
-
-        # Personal/global keywords → global memory (who the user IS)
-        personal_keywords = [
-            "my name", "i am", "i'm", "call me",
-            "i work at", "i work for", "my job", "my role",
-            "i live", "from ireland", "from portugal", "i'm from",
-            "born", "age", "founder", "ceo", "coo", "manager",
-            "my company", "my team", "my organization"
-        ]
-
-        # Preference keywords → both tiers (useful everywhere)
-        preference_keywords = [
-            "prefer", "favorite", "like to", "don't like",
-            "usually", "my style", "i want", "i need"
-        ]
-
-        # Strong agent indicators (override others)
+        # Explicit agent-scoped instructions → store under the agent namespace.
+        # These are durable directions about how THIS agent should act, not
+        # passing mentions of a tool name.
         strong_agent_keywords = [
-            "always cc", "default channel", "send to", "post to",
-            "my slack", "my email", "contact", "@"
+            "always cc", "default channel", "for this agent", "in this context",
+            "when i ask you", "post to", "send to",
         ]
-
-        has_tool = any(kw in combined for kw in tool_keywords)
-        has_personal = any(kw in combined for kw in personal_keywords)
-        has_preference = any(kw in combined for kw in preference_keywords)
-        has_strong_agent = any(kw in combined for kw in strong_agent_keywords)
-
-        # Strong agent indicators take precedence
-        if has_strong_agent:
+        if any(kw in combined for kw in strong_agent_keywords):
             return "agent"
-        elif has_personal and has_tool:
-            return "both"  # Personal + tool context → store everywhere
-        elif has_preference and has_tool:
-            return "both"  # Tool preference → useful in both tiers
-        elif has_preference:
-            return "both"  # General preference → both
-        elif has_tool:
-            return "agent"  # Pure tool-specific
-        elif has_personal:
-            return "global"  # Pure personal fact
-        else:
-            return "both"  # Default to both — let Mem0 decide what's worth extracting
+
+        # Everything else → single workspace namespace. No double-write.
+        return "global"
 
     def _get_cache_key(self, workspace_id: str, agent_id: Optional[int], query: str) -> str:
         """Create cache key for memory lookups (includes agent for agent-specific cache)."""

--- a/orchestrator/modules/memory/context_router.py
+++ b/orchestrator/modules/memory/context_router.py
@@ -478,14 +478,14 @@ class ContextRouter:
                 signals.is_live_data,
             ]))
         )
-        fetch_long_term = (
-            signals.is_personal_fact
-            or not any([
-                signals.is_temporal,
-                signals.is_knowledge_query,
-                signals.is_live_data,
-            ])
-        )
+        # PRD-159 S3: operational memories (tool_outcome / task_learning /
+        # playbook_pattern / …) live in L3 and must be recallable for ANY
+        # query — including temporal ("why did the deploy mission fail?") and
+        # knowledge queries — not gated behind the temporal-regex signal. The
+        # server-side relevance floor in search_long_term keeps irrelevant junk
+        # out instead of this coarse signal gate. Live-data queries (weather,
+        # prices) still skip memory.
+        fetch_long_term = not signals.is_live_data
         fetch_temporal = signals.is_temporal and signals.temporal_window is not None
         # Daily logs on default path (no strong signal)
         fetch_daily = not any([

--- a/orchestrator/modules/memory/integrations/mem0_client.py
+++ b/orchestrator/modules/memory/integrations/mem0_client.py
@@ -24,6 +24,19 @@ logger = logging.getLogger(__name__)
 _MAX_RETRIES = 1                # One retry with backoff
 
 
+def filter_by_relevance_floor(results: List[Dict], floor: float) -> List[Dict]:
+    """Drop scored results below the similarity floor (PRD-159 S3).
+
+    Results without a score are kept (cannot judge); scored-but-below-floor are
+    dropped so low-relevance junk is never injected into context. A floor <= 0
+    disables filtering.
+    """
+    if not floor or floor <= 0:
+        return results
+    return [r for r in results if r.get("score") is None or (r.get("score") or 0) >= floor]
+
+
+
 class _CircuitBreaker:
     """Simple circuit breaker for Mem0 calls."""
     __slots__ = ("failures", "last_failure_time", "is_open", "threshold", "cooldown")
@@ -469,6 +482,14 @@ class Mem0Client:
             ),
             reverse=True,
         )
+        # PRD-159 S3: apply the server-side relevance floor so sub-floor junk is
+        # never injected into recall.
+        try:
+            from config import config
+            floor = float(getattr(config, "MEMORY_RELEVANCE_FLOOR", 0.3))
+        except Exception:
+            floor = 0.3
+        results = filter_by_relevance_floor(results, floor)
         return results[:limit]
 
     async def get_all(

--- a/orchestrator/modules/memory/operations/contradiction.py
+++ b/orchestrator/modules/memory/operations/contradiction.py
@@ -60,6 +60,26 @@ def subject_overlap(a: str, b: str) -> float:
     return len(ta & tb) / len(ta | tb)
 
 
+def _mutually_divergent(a_text: str, b_text: str) -> bool:
+    """True when each text asserts a meaningful token the other lacks.
+
+    This is what separates a *contradiction* (different value for a shared slot,
+    e.g. "deploy target is staging" vs "…production") from a *near-duplicate*
+    (one restates/elaborates the other — its tokens are a subset). Minimal-pair
+    contradictions are textually near-identical, so text similarity alone cannot
+    tell them apart; mutual divergence can.
+    """
+    sa, sb = _tokens(a_text), _tokens(b_text)
+    return bool(sa - sb) and bool(sb - sa)
+
+
+def _is_near_dup(a_text: str, b_text: str, threshold: float = DEFAULT_DUP_THRESHOLD) -> bool:
+    """Near-duplicate = highly similar AND not mutually divergent (a restatement,
+    not a conflicting value). Mutually-divergent pairs are contradictions and are
+    deliberately NOT merged — they go to the contradiction stage."""
+    return similarity(a_text, b_text) >= threshold and not _mutually_divergent(a_text, b_text)
+
+
 @dataclass
 class MergeGroup:
     canonical: Dict[str, Any]
@@ -83,12 +103,16 @@ class ConsolidationPlan:
 def group_near_duplicates(
     memories: List[Dict[str, Any]], threshold: float = DEFAULT_DUP_THRESHOLD
 ) -> List[List[Dict[str, Any]]]:
-    """Greedy single-link grouping of near-duplicate memories."""
+    """Greedy single-link grouping of near-duplicate memories.
+
+    Mutually-divergent pairs (contradictions) are never grouped here even when
+    textually similar — they are resolved in the contradiction stage instead.
+    """
     groups: List[List[Dict[str, Any]]] = []
     for m in memories:
         placed = False
         for g in groups:
-            if similarity(_text(m), _text(g[0])) >= threshold:
+            if _is_near_dup(_text(m), _text(g[0]), threshold):
                 g.append(m)
                 placed = True
                 break
@@ -105,16 +129,19 @@ def merge_group(group: List[Dict[str, Any]]) -> MergeGroup:
 
 
 def is_contradiction(a: Dict[str, Any], b: Dict[str, Any]) -> bool:
-    """High subject overlap but NOT a near-duplicate → conflicting statements.
+    """Same subject + mutual divergence → conflicting statements.
 
-    Same topic (overlapping subject tokens) with materially different wording is
-    treated as a contradiction to resolve by recency+confidence, rather than two
-    coexisting truths.
+    The pair is about the same subject (token overlap ≥ floor) AND each asserts a
+    meaningful token the other lacks (a different value for a shared slot) — so
+    they are resolved by recency+confidence rather than left as two coexisting
+    truths. Text similarity is deliberately NOT used as the upper bound: a
+    minimal-pair contradiction ("…staging" vs "…production") is near-identical
+    textually yet still a contradiction.
     """
     ta, tb = _text(a), _text(b)
     if subject_overlap(ta, tb) < DEFAULT_SUBJECT_OVERLAP:
         return False
-    return similarity(ta, tb) < DEFAULT_DUP_THRESHOLD
+    return _mutually_divergent(ta, tb)
 
 
 def resolve_contradiction(a: Dict[str, Any], b: Dict[str, Any]) -> Supersession:

--- a/orchestrator/modules/memory/operations/contradiction.py
+++ b/orchestrator/modules/memory/operations/contradiction.py
@@ -21,7 +21,7 @@ from typing import Any, Dict, List, Optional, Tuple
 # Similarity at/above this is a near-duplicate (merge); a contradiction is high
 # subject-overlap with a conflicting value, handled separately.
 DEFAULT_DUP_THRESHOLD = 0.82
-DEFAULT_SUBJECT_OVERLAP = 0.6
+DEFAULT_SUBJECT_OVERLAP = 0.5
 
 
 def _text(m: Dict[str, Any]) -> str:

--- a/orchestrator/modules/memory/operations/contradiction.py
+++ b/orchestrator/modules/memory/operations/contradiction.py
@@ -1,0 +1,186 @@
+"""Contradiction-based consolidation (PRD-159 S4).
+
+The primary memory lifecycle is **consolidation**, not time-decay: near-duplicates
+merge into one canonical memory (with provenance), and contradictions are resolved
+by recency + confidence (the newer/more-confident fact supersedes; the loser is
+archived with a reason) instead of being aged out by the old 15h decay.
+
+These are pure functions over plain memory dicts of the shape returned by the
+Mem0 layer — ``{"id", "memory"|"content", "importance", "created_at",
+"metadata": {...}}`` — so they unit-test without a DB. The job seam
+(``plan_consolidation``) turns a workspace's memories into an actionable plan
+(merges / supersessions / promotions) that the caller applies via the memory
+service.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from difflib import SequenceMatcher
+from typing import Any, Dict, List, Optional, Tuple
+
+# Similarity at/above this is a near-duplicate (merge); a contradiction is high
+# subject-overlap with a conflicting value, handled separately.
+DEFAULT_DUP_THRESHOLD = 0.82
+DEFAULT_SUBJECT_OVERLAP = 0.6
+
+
+def _text(m: Dict[str, Any]) -> str:
+    return str(m.get("memory") or m.get("content") or "").strip()
+
+
+def _importance(m: Dict[str, Any]) -> float:
+    md = m.get("metadata") or {}
+    try:
+        return float(m.get("importance", md.get("importance", 0.5)))
+    except (TypeError, ValueError):
+        return 0.5
+
+
+def _created(m: Dict[str, Any]) -> str:
+    return str(m.get("created_at") or (m.get("metadata") or {}).get("timestamp") or "")
+
+
+def similarity(a: str, b: str) -> float:
+    """Normalised text similarity in [0,1] (stdlib, no embeddings)."""
+    a, b = a.lower().strip(), b.lower().strip()
+    if not a or not b:
+        return 0.0
+    return SequenceMatcher(None, a, b).ratio()
+
+
+def _tokens(s: str) -> set:
+    return {t for t in "".join(c if c.isalnum() else " " for c in s.lower()).split() if len(t) > 2}
+
+
+def subject_overlap(a: str, b: str) -> float:
+    """Jaccard token overlap — proxy for 'about the same subject'."""
+    ta, tb = _tokens(a), _tokens(b)
+    if not ta or not tb:
+        return 0.0
+    return len(ta & tb) / len(ta | tb)
+
+
+@dataclass
+class MergeGroup:
+    canonical: Dict[str, Any]
+    merged_from: List[str] = field(default_factory=list)   # ids folded in
+
+
+@dataclass
+class Supersession:
+    winner: Dict[str, Any]
+    loser: Dict[str, Any]
+    reason: str
+
+
+@dataclass
+class ConsolidationPlan:
+    merges: List[MergeGroup] = field(default_factory=list)
+    supersessions: List[Supersession] = field(default_factory=list)
+    promotions: List[Dict[str, Any]] = field(default_factory=list)
+
+
+def group_near_duplicates(
+    memories: List[Dict[str, Any]], threshold: float = DEFAULT_DUP_THRESHOLD
+) -> List[List[Dict[str, Any]]]:
+    """Greedy single-link grouping of near-duplicate memories."""
+    groups: List[List[Dict[str, Any]]] = []
+    for m in memories:
+        placed = False
+        for g in groups:
+            if similarity(_text(m), _text(g[0])) >= threshold:
+                g.append(m)
+                placed = True
+                break
+        if not placed:
+            groups.append([m])
+    return groups
+
+
+def merge_group(group: List[Dict[str, Any]]) -> MergeGroup:
+    """Pick the canonical (highest importance, then newest) and record provenance."""
+    canonical = max(group, key=lambda m: (_importance(m), _created(m)))
+    merged_from = [str(m.get("id")) for m in group if m is not canonical and m.get("id")]
+    return MergeGroup(canonical=canonical, merged_from=merged_from)
+
+
+def is_contradiction(a: Dict[str, Any], b: Dict[str, Any]) -> bool:
+    """High subject overlap but NOT a near-duplicate → conflicting statements.
+
+    Same topic (overlapping subject tokens) with materially different wording is
+    treated as a contradiction to resolve by recency+confidence, rather than two
+    coexisting truths.
+    """
+    ta, tb = _text(a), _text(b)
+    if subject_overlap(ta, tb) < DEFAULT_SUBJECT_OVERLAP:
+        return False
+    return similarity(ta, tb) < DEFAULT_DUP_THRESHOLD
+
+
+def resolve_contradiction(a: Dict[str, Any], b: Dict[str, Any]) -> Supersession:
+    """Newer wins; ties broken by confidence (importance)."""
+    ca, cb = _created(a), _created(b)
+    if ca != cb:
+        winner, loser = (a, b) if ca > cb else (b, a)
+        reason = "superseded by a more recent fact"
+    else:
+        winner, loser = (a, b) if _importance(a) >= _importance(b) else (b, a)
+        reason = "superseded by a higher-confidence fact"
+    return Supersession(winner=winner, loser=loser, reason=reason)
+
+
+def select_promotions(
+    memories: List[Dict[str, Any]], *, min_access: int = 2, min_importance: float = 0.6
+) -> List[Dict[str, Any]]:
+    """L2 memories that have proven stable (accessed enough / important) → L3."""
+    out = []
+    for m in memories:
+        md = m.get("metadata") or {}
+        level = str(md.get("tier") or md.get("level") or "").lower()
+        if level and level not in ("l2", "short", "short_term", "session"):
+            continue
+        access = int(m.get("access_count", md.get("access_count", 0)) or 0)
+        if access >= min_access or _importance(m) >= min_importance:
+            out.append(m)
+    return out
+
+
+def plan_consolidation(
+    memories: List[Dict[str, Any]],
+    *,
+    dup_threshold: float = DEFAULT_DUP_THRESHOLD,
+) -> ConsolidationPlan:
+    """Turn a memory set into an actionable consolidation plan.
+
+    1. group + merge near-duplicates (provenance preserved),
+    2. resolve contradictions among the surviving canonicals (recency+confidence),
+    3. select stable L2 memories for L3 promotion.
+    """
+    plan = ConsolidationPlan()
+
+    groups = group_near_duplicates(memories, dup_threshold)
+    survivors: List[Dict[str, Any]] = []
+    for g in groups:
+        mg = merge_group(g)
+        if mg.merged_from:
+            plan.merges.append(mg)
+        survivors.append(mg.canonical)
+
+    # Contradictions among survivors — compare each pair once; archive losers.
+    archived_ids = set()
+    for i in range(len(survivors)):
+        for j in range(i + 1, len(survivors)):
+            a, b = survivors[i], survivors[j]
+            if id(a) in map(id, [m.loser for m in plan.supersessions]):
+                continue
+            if is_contradiction(a, b):
+                s = resolve_contradiction(a, b)
+                loser_id = str(s.loser.get("id"))
+                if loser_id in archived_ids:
+                    continue
+                archived_ids.add(loser_id)
+                plan.supersessions.append(s)
+
+    remaining = [m for m in survivors if str(m.get("id")) not in archived_ids]
+    plan.promotions = select_promotions(remaining)
+    return plan

--- a/orchestrator/modules/memory/tool_outcome_capture.py
+++ b/orchestrator/modules/memory/tool_outcome_capture.py
@@ -1,0 +1,210 @@
+"""Tool-execution outcome capture (PRD-159 S2).
+
+A post-execution hook turns notable tool outcomes — failures and *notable*
+successes (new channel/record ids, auth quirks, rate limits, schema surprises)
+— into typed ``tool_outcome`` memories under the workspace namespace, written
+direct (``infer:false`` via ``store_two_tier``) and deduped by content-hash.
+
+Design seams (so this is unit-testable without a DB / event-loop):
+  - ``build_tool_outcome``   — pure: result → outcome record or None (noise gate)
+  - ``should_dedupe``        — content-hash dedup against a bounded in-process set
+  - ``write_tool_outcome``   — async: persist one record via UnifiedMemoryService
+  - ``capture_tool_outcome`` — fire-and-forget entry called from the executor
+
+Never raises into the caller: the tool call must not fail because memory did.
+"""
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import logging
+from collections import OrderedDict
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+# Memory category for these records (subset of the PRD-159 taxonomy).
+TOOL_OUTCOME_TYPE = "tool_outcome"
+
+# Keys that, when present in a successful result's payload, mark it "notable"
+# (a resource was created / an external id surfaced). Trivial successes (reads,
+# searches with none of these) are gated OUT — that is the noise gate.
+_NOTABLE_SUCCESS_KEYS = frozenset({
+    "id", "ids", "channel", "channel_id", "ts", "url", "number", "sid",
+    "message_id", "thread_ts", "record_id", "issue_key", "pr_number",
+})
+
+# Bounded in-process dedup of recently-seen outcome hashes (identical outcome
+# twice → one row). Bounded so a long-running worker never grows unbounded.
+_SEEN_HASHES: "OrderedDict[str, None]" = OrderedDict()
+_SEEN_MAX = 1024
+
+
+def _classify_error(error: str) -> str:
+    """Map a raw error string to a coarse, stable class for dedup + recall."""
+    e = (error or "").lower()
+    if any(k in e for k in ("rate limit", "rate_limit", "429", "too many requests")):
+        return "rate_limit"
+    if any(k in e for k in ("unauthor", "auth", "token", "401", "403", "forbidden", "permission")):
+        return "auth"
+    if any(k in e for k in ("not_in_channel", "not in channel", "not_found", "not found", "404", "missing")):
+        return "not_found"
+    if any(k in e for k in ("timeout", "timed out", "deadline")):
+        return "timeout"
+    if any(k in e for k in ("schema", "invalid", "validation", "required", "bad request", "400")):
+        return "schema"
+    return "error"
+
+
+def _flatten_top_keys(payload: Any) -> set:
+    """Top-level keys of a dict payload (or of each item if it's a list)."""
+    keys: set = set()
+    if isinstance(payload, dict):
+        keys.update(payload.keys())
+        # one level down — Composio often nests under data/response_data
+        for v in payload.values():
+            if isinstance(v, dict):
+                keys.update(v.keys())
+    elif isinstance(payload, list):
+        for item in payload[:5]:
+            if isinstance(item, dict):
+                keys.update(item.keys())
+    return {str(k).lower() for k in keys}
+
+
+def _is_notable_success(result: Dict[str, Any]) -> bool:
+    payload = result.get("data")
+    if payload is None:
+        payload = result.get("result")
+    return bool(_flatten_top_keys(payload) & _NOTABLE_SUCCESS_KEYS)
+
+
+def _content_hash(workspace_id: str, app: str, action: str, signature: str) -> str:
+    raw = f"{workspace_id}|{app}|{action}|{signature}".encode("utf-8", "ignore")
+    return hashlib.sha256(raw).hexdigest()
+
+
+def build_tool_outcome(
+    *,
+    tool_name: str,
+    parameters: Dict[str, Any],
+    result: Dict[str, Any],
+    workspace_id: str,
+) -> Optional[Dict[str, Any]]:
+    """Pure noise gate + record builder.
+
+    Returns a ``{fact, type, importance, metadata}`` record for a failure or a
+    notable success, or ``None`` when the outcome is trivial (no write).
+    """
+    if not isinstance(result, dict) or not workspace_id:
+        return None
+
+    params = parameters if isinstance(parameters, dict) else {}
+    action = str(params.get("action") or tool_name or "unknown_action")
+    app = str(params.get("app_name") or result.get("app") or "platform")
+    success = bool(result.get("success"))
+
+    if success:
+        if not _is_notable_success(result):
+            return None  # noise gate: trivial success → no memory
+        signature = "success:notable"
+        fact = f"Tool {action} ({app}) succeeded with a notable result."
+        importance = 0.5
+        error_class = ""
+    else:
+        error = str(result.get("error") or "unknown error")
+        error_class = _classify_error(error)
+        signature = f"fail:{error_class}"
+        short = error.strip().splitlines()[0][:160] if error else ""
+        fact = f"Tool {action} ({app}) failed [{error_class}]: {short}"
+        importance = 0.6
+
+    outcome_hash = _content_hash(workspace_id, app, action, signature)
+    return {
+        "fact": fact,
+        "type": TOOL_OUTCOME_TYPE,
+        "importance": importance,
+        "metadata": {
+            "category": TOOL_OUTCOME_TYPE,
+            "importance": importance,
+            "app": app,
+            "action": action,
+            "error_class": error_class,
+            "success": success,
+            "outcome_hash": outcome_hash,
+        },
+    }
+
+
+def should_dedupe(outcome_hash: str) -> bool:
+    """True if this hash was seen recently (caller should skip the write)."""
+    if outcome_hash in _SEEN_HASHES:
+        _SEEN_HASHES.move_to_end(outcome_hash)
+        return True
+    _SEEN_HASHES[outcome_hash] = None
+    while len(_SEEN_HASHES) > _SEEN_MAX:
+        _SEEN_HASHES.popitem(last=False)
+    return False
+
+
+async def write_tool_outcome(
+    record: Dict[str, Any],
+    *,
+    workspace_id: str,
+    agent_id: Optional[int],
+    service: Any = None,
+) -> bool:
+    """Persist one outcome record to L3 (global tier, infer:false). Best-effort."""
+    try:
+        if service is None:
+            from modules.memory.unified_memory_service import get_unified_memory_service
+            service = get_unified_memory_service()
+        await service.store_two_tier(
+            workspace_id=str(workspace_id),
+            messages=[{"role": "user", "content": record["fact"]}],
+            agent_id=agent_id,
+            tier="global",
+            metadata=record["metadata"],
+        )
+        return True
+    except Exception:
+        logger.warning("[ToolOutcome] write failed", exc_info=True)
+        return False
+
+
+def capture_tool_outcome(
+    *,
+    tool_name: str,
+    parameters: Dict[str, Any],
+    result: Dict[str, Any],
+    workspace_id: Any,
+    agent_id: Optional[int],
+) -> Optional["asyncio.Task"]:
+    """Fire-and-forget entry. Builds + dedupes, then schedules the async write.
+
+    Returns the scheduled task (so tests can await it) or ``None`` when gated out
+    / deduped / no event loop. Never raises.
+    """
+    try:
+        if not workspace_id:
+            return None
+        record = build_tool_outcome(
+            tool_name=tool_name,
+            parameters=parameters,
+            result=result,
+            workspace_id=str(workspace_id),
+        )
+        if record is None:
+            return None
+        if should_dedupe(record["metadata"]["outcome_hash"]):
+            return None
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return None
+        return loop.create_task(
+            write_tool_outcome(record, workspace_id=str(workspace_id), agent_id=agent_id)
+        )
+    except Exception:
+        logger.debug("[ToolOutcome] capture skipped", exc_info=True)
+        return None

--- a/orchestrator/modules/memory/unified_memory_service.py
+++ b/orchestrator/modules/memory/unified_memory_service.py
@@ -24,7 +24,7 @@ import asyncio
 import hashlib
 import json
 import logging
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass, field, fields
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Union
 
@@ -130,8 +130,6 @@ class SessionMemory:
     """
 
     summary: str = ""
-    decisions: List[str] = field(default_factory=list)
-    action_items: List[str] = field(default_factory=list)
     exchange_count: int = 0
     last_updated: str = ""  # ISO-8601 string for JSON serialisation
     ended: bool = False
@@ -142,9 +140,14 @@ class SessionMemory:
 
     @classmethod
     def from_json(cls, raw: str) -> "SessionMemory":
-        """Deserialise from JSON string."""
+        """Deserialise from JSON string.
+
+        Tolerant of unknown keys so sessions written before PRD-159 removed the
+        dead ``decisions``/``action_items`` fields still load cleanly.
+        """
         data = json.loads(raw)
-        return cls(**data)
+        known = {f.name for f in fields(cls)}
+        return cls(**{k: v for k, v in data.items() if k in known})
 
 
 # ---------------------------------------------------------------------------
@@ -1359,8 +1362,6 @@ class UnifiedMemoryService:
             # Naive truncation to last 500 chars (Phase 2 adds LLM rolling summary)
             session = SessionMemory(
                 summary=combined[-500:],
-                decisions=list(session.decisions),
-                action_items=list(session.action_items),
                 exchange_count=session.exchange_count + 1,
                 last_updated=datetime.now(timezone.utc).isoformat(),
                 ended=session.ended,
@@ -1383,301 +1384,86 @@ class UnifiedMemoryService:
                 exc_info=True,
             )
 
-    async def end_session(
-        self,
-        workspace_id: str,
-        conversation_id: str,
-    ) -> None:
+    async def run_sleep_time_consolidation(
+        self, workspace_id: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """PRD-159 S4: contradiction-based consolidation — the primary lifecycle.
+
+        For each workspace, fetch L3 memories, then plan + apply:
+          - fold near-duplicates into one canonical (delete the rest),
+          - resolve contradictions by recency+confidence (delete/archive the
+            loser, reason logged).
+
+        This replaces time-decay as the way memories leave the active set:
+        memories are superseded by newer/contradicting facts or merged, not aged
+        out. Promotion (L2→L3) stays in ``run_promotion_all``.
         """
-        Mark session as ended and set a short TTL for the consolidation window.
+        from modules.memory.operations.contradiction import plan_consolidation
 
-        The session stays in Redis for MEMORY_SESSION_CONSOLIDATION_TTL_SECONDS
-        (default 1 hour) so the hourly consolidation job can promote important
-        decisions to L2 before the key expires.
-
-        Redis failures are logged but never break chat.
-        """
-        from config import config
-
-        redis_client = self._get_redis()
-        if redis_client is None:
-            return
-
-        ns = self.namespace(workspace_id)
-        key = ns.session(conversation_id)
-        consolidation_ttl = config.MEMORY_SESSION_CONSOLIDATION_TTL_SECONDS
-
-        try:
-            loop = asyncio.get_event_loop()
-            conn = redis_client.get_redis()
-
-            raw: Optional[str] = await loop.run_in_executor(None, conn.get, key)
-            if raw is None:
-                logger.debug("[UnifiedMemoryService] end_session key=%s — no session found", key)
-                return
-
-            session = SessionMemory.from_json(raw)
-            ended_session = SessionMemory(
-                summary=session.summary,
-                decisions=list(session.decisions),
-                action_items=list(session.action_items),
-                exchange_count=session.exchange_count,
-                last_updated=datetime.now(timezone.utc).isoformat(),
-                ended=True,
-            )
-
-            payload = ended_session.to_json()
-            await loop.run_in_executor(
-                None,
-                lambda: conn.setex(key, consolidation_ttl, payload),
-            )
-            logger.info(
-                "[UnifiedMemoryService] end_session key=%s ttl=%ds exchanges=%d",
-                key,
-                consolidation_ttl,
-                ended_session.exchange_count,
-            )
-        except Exception:
-            logger.error(
-                "[UnifiedMemoryService] end_session failed for key=%s",
-                key,
-                exc_info=True,
-            )
-
-    # ------------------------------------------------------------------
-    # L1→L2 Session Consolidation
-    # ------------------------------------------------------------------
-
-    async def consolidate_session(
-        self,
-        workspace_id: str,
-        conversation_id: str,
-    ) -> Dict[str, int]:
-        """
-        Consolidate an ended L1 session into L2 short-term memory.
-
-        Reads the Redis session, extracts decisions and action items, stores
-        each as a separate L2 entry with ``content_type='session_decision'``
-        and ``importance=0.6``, then stores the session summary as a separate
-        L2 entry. Deletes the L1 Redis key after successful consolidation.
-
-        Returns:
-            {"items_stored": N} count, or {"items_stored": 0} on failure.
-        """
-        redis_client = self._get_redis()
-        if redis_client is None:
-            return {"items_stored": 0}
-
-        ns = self.namespace(workspace_id)
-        key = ns.session(conversation_id)
-
-        try:
-            loop = asyncio.get_event_loop()
-            conn = redis_client.get_redis()
-
-            raw: Optional[str] = await loop.run_in_executor(None, conn.get, key)
-            if raw is None:
-                logger.debug(
-                    "[UnifiedMemoryService] consolidate_session key=%s — no session",
-                    key,
+        if workspace_id:
+            workspace_ids: List[str] = [workspace_id]
+        else:
+            try:
+                loop = asyncio.get_event_loop()
+                workspace_ids = await loop.run_in_executor(
+                    None, self._get_active_workspace_ids_sync
                 )
-                return {"items_stored": 0}
+            except Exception:
+                logger.error(
+                    "[UnifiedMemoryService] run_sleep_time_consolidation: "
+                    "workspace fetch failed",
+                    exc_info=True,
+                )
+                workspace_ids = []
 
-            session = SessionMemory.from_json(raw)
-            items_stored = 0
-
-            meta_base = {
-                "conversation_id": conversation_id,
-                "source": "session_consolidation",
-                "exchange_count": session.exchange_count,
-            }
-
-            # Store each decision as a separate L2 entry
-            for decision in session.decisions:
-                if not decision or not decision.strip():
+        merged = 0
+        superseded = 0
+        errors = 0
+        for ws_id in workspace_ids:
+            try:
+                memories = await self.get_all_memories(ws_id, limit=200)
+                if not memories:
                     continue
-                row_id = await self.store_short_term(
-                    workspace_id=workspace_id,
-                    content=f"Session decision: {decision}",
-                    content_type="session_decision",
-                    importance=0.6,
-                    metadata={**meta_base, "kind": "decision"},
-                )
-                if row_id:
-                    items_stored += 1
-
-            # Store each action item as a separate L2 entry
-            for action in session.action_items:
-                if not action or not action.strip():
-                    continue
-                row_id = await self.store_short_term(
-                    workspace_id=workspace_id,
-                    content=f"Action item: {action}",
-                    content_type="session_decision",
-                    importance=0.6,
-                    metadata={**meta_base, "kind": "action_item"},
-                )
-                if row_id:
-                    items_stored += 1
-
-            # Store session summary as an L2 entry (captures rolling context)
-            if session.summary and session.summary.strip():
-                row_id = await self.store_short_term(
-                    workspace_id=workspace_id,
-                    content=f"Session summary ({session.exchange_count} exchanges): {session.summary}",
-                    content_type="session_decision",
-                    importance=0.5,
-                    metadata={**meta_base, "kind": "summary"},
-                )
-                if row_id:
-                    items_stored += 1
-
-            # Delete the L1 Redis key after successful consolidation
-            await loop.run_in_executor(None, conn.delete, key)
-
-            logger.info(
-                "[UnifiedMemoryService] consolidate_session key=%s items_stored=%d",
-                key,
-                items_stored,
-            )
-            return {"items_stored": items_stored}
-
-        except Exception:
-            logger.error(
-                "[UnifiedMemoryService] consolidate_session failed key=%s",
-                key,
-                exc_info=True,
-            )
-            return {"items_stored": 0}
-
-    async def run_session_consolidation(self) -> Dict[str, Any]:
-        """
-        Scan Redis for ended sessions and consolidate them into L2.
-
-        Uses SCAN (not KEYS) to iterate ``mem:session:*`` keys safely at
-        production scale. For each session where ``ended=True``, calls
-        ``consolidate_session()`` to promote decisions/action_items to L2
-        and delete the L1 key.
-
-        Returns:
-            {"sessions_scanned": N, "sessions_consolidated": M, "total_items": K,
-             "errors": E}
-        """
-        redis_client = self._get_redis()
-        if redis_client is None:
-            logger.warning(
-                "[UnifiedMemoryService] run_session_consolidation: Redis unavailable"
-            )
-            return {
-                "sessions_scanned": 0,
-                "sessions_consolidated": 0,
-                "total_items": 0,
-                "errors": 0,
-            }
-
-        try:
-            loop = asyncio.get_event_loop()
-            conn = redis_client.get_redis()
-
-            # Collect ended session keys via SCAN
-            ended_sessions: List[Dict[str, str]] = []
-
-            def _scan_ended_sessions() -> List[Dict[str, str]]:
-                """
-                Synchronous SCAN over mem:session:* keys, returning those
-                where session.ended == True, along with parsed workspace_id
-                and conversation_id.
-                """
-                results: List[Dict[str, str]] = []
-                for key in conn.scan_iter(match="mem:session:*", count=100):
-                    try:
-                        raw = conn.get(key)
-                        if raw is None:
-                            continue
-                        session = SessionMemory.from_json(raw)
-                        if not session.ended:
-                            continue
-
-                        # Parse workspace_id and conversation_id from key
-                        # Key format: mem:session:{workspace_id}:{conversation_id}
-                        # scan_iter returns bytes — decode to str first
-                        key_str = key.decode("utf-8") if isinstance(key, bytes) else key
-                        parts = key_str.split(":", 3)  # ["mem", "session", ws_id, conv_id]
-                        if len(parts) < 4:
-                            logger.warning(
-                                "[UnifiedMemoryService] run_session_consolidation: "
-                                "unexpected key format: %s",
-                                key,
-                            )
-                            continue
-
-                        results.append({
-                            "workspace_id": parts[2],
-                            "conversation_id": parts[3],
-                        })
-                    except Exception:
-                        logger.error(
-                            "[UnifiedMemoryService] run_session_consolidation: "
-                            "error reading key=%s",
-                            key,
-                            exc_info=True,
+                plan = plan_consolidation(memories)
+                # Fold near-duplicates → delete the non-canonical members.
+                for mg in plan.merges:
+                    for dup_id in mg.merged_from:
+                        if dup_id and await self.delete_memory(dup_id, ws_id):
+                            merged += 1
+                # Contradictions → the loser leaves the active set (reason logged).
+                for s in plan.supersessions:
+                    loser_id = str(s.loser.get("id") or "")
+                    if loser_id and await self.delete_memory(loser_id, ws_id):
+                        superseded += 1
+                        logger.info(
+                            "[UnifiedMemoryService] consolidation superseded "
+                            "id=%s (%s)",
+                            loser_id,
+                            s.reason,
                         )
-                return results
+            except Exception:
+                errors += 1
+                logger.error(
+                    "[UnifiedMemoryService] run_sleep_time_consolidation failed "
+                    "for ws=%s",
+                    ws_id,
+                    exc_info=True,
+                )
 
-            ended_sessions = await loop.run_in_executor(None, _scan_ended_sessions)
-
-            sessions_consolidated = 0
-            total_items = 0
-            errors = 0
-
-            for info in ended_sessions:
-                try:
-                    result = await self.consolidate_session(
-                        workspace_id=info["workspace_id"],
-                        conversation_id=info["conversation_id"],
-                    )
-                    if result["items_stored"] > 0:
-                        sessions_consolidated += 1
-                        total_items += result["items_stored"]
-                    else:
-                        # Session existed but had nothing to store — still count
-                        sessions_consolidated += 1
-                except Exception:
-                    logger.error(
-                        "[UnifiedMemoryService] run_session_consolidation: "
-                        "failed for ws=%s conv=%s",
-                        info["workspace_id"],
-                        info["conversation_id"],
-                        exc_info=True,
-                    )
-                    errors += 1
-
-            logger.info(
-                "[UnifiedMemoryService] run_session_consolidation complete: "
-                "scanned=%d consolidated=%d items=%d errors=%d",
-                len(ended_sessions),
-                sessions_consolidated,
-                total_items,
-                errors,
-            )
-            return {
-                "sessions_scanned": len(ended_sessions),
-                "sessions_consolidated": sessions_consolidated,
-                "total_items": total_items,
-                "errors": errors,
-            }
-
-        except Exception:
-            logger.error(
-                "[UnifiedMemoryService] run_session_consolidation failed",
-                exc_info=True,
-            )
-            return {
-                "sessions_scanned": 0,
-                "sessions_consolidated": 0,
-                "total_items": 0,
-                "errors": 0,
-            }
+        logger.info(
+            "[UnifiedMemoryService] run_sleep_time_consolidation complete: "
+            "workspaces=%d merged=%d superseded=%d errors=%d",
+            len(workspace_ids),
+            merged,
+            superseded,
+            errors,
+        )
+        return {
+            "workspaces_processed": len(workspace_ids),
+            "merged": merged,
+            "superseded": superseded,
+            "errors": errors,
+        }
 
     # ------------------------------------------------------------------
     # Cross-layer

--- a/orchestrator/modules/memory/unified_memory_service.py
+++ b/orchestrator/modules/memory/unified_memory_service.py
@@ -672,6 +672,11 @@ class UnifiedMemoryService:
 
         try:
             results = await self._mem0.get_all(user_id=user_id, limit=limit, workspace_id=workspace_id)
+            # PRD-159 S3: daily logs are time-ordered (newest first) and bounded,
+            # not an arbitrary first-N slice — recall surfaces the most recent
+            # operational activity deterministically.
+            results.sort(key=lambda m: (m or {}).get("created_at") or "", reverse=True)
+            results = results[:limit]
             logger.debug(
                 "[UnifiedMemoryService] get_all_daily_logs user_id=%s → %d items",
                 user_id,

--- a/orchestrator/modules/tools/execution/unified_executor.py
+++ b/orchestrator/modules/tools/execution/unified_executor.py
@@ -35,6 +35,7 @@ from modules.tools.execution import exec_multimodal
 from modules.tools.execution import exec_workspace
 from modules.tools.execution import exec_planning
 from modules.tools.execution.telemetry import fire_telemetry
+from modules.memory.tool_outcome_capture import capture_tool_outcome
 
 # PRD-36: Composio Integration (lazy import to avoid startup overhead)
 _composio_executor = None
@@ -440,6 +441,16 @@ class UnifiedToolExecutor:
                 result=result,
                 execution_time_ms=_exec_ms,
                 caller_context=caller_context,
+            )
+            # PRD-159 S2: capture notable tool outcomes (failures + notable
+            # successes) as typed tool_outcome memories — fire-and-forget,
+            # content-hash deduped, noise-gated. Never fails the tool call.
+            capture_tool_outcome(
+                tool_name=tool_name,
+                parameters=parameters if isinstance(parameters, dict) else {},
+                result=result,
+                workspace_id=workspace_id,
+                agent_id=agent_id,
             )
 
     # ------------------------------------------------------------------

--- a/orchestrator/services/memory_jobs.py
+++ b/orchestrator/services/memory_jobs.py
@@ -3,9 +3,10 @@ MemoryJobScheduler — Background Jobs for Unified Memory (PRD-79)
 ================================================================
 Registers three recurring jobs on the UnifiedScheduler:
 
-1. **Session Consolidation** (hourly) — L1 Redis → L2 Postgres
-   Expired sessions (end_session called >1hr ago) are scanned, decisions
-   and action items extracted, stored in L2, and L1 keys deleted.
+1. **Consolidation** (periodic) — contradiction-based invalidation (PRD-159 S4)
+   Per workspace, near-duplicate L3 memories merge into one canonical and
+   contradictions supersede by recency+confidence (loser removed). This is the
+   primary memory lifecycle, replacing the dead L1 session-decision scan.
 
 2. **Decay Scoring** (hourly) — Ebbinghaus retention scoring on L2
    Updates decay_score for all active L2 rows and archives items
@@ -58,9 +59,9 @@ class MemoryJobScheduler:
             app_config, "MEMORY_PROMOTION_HOUR_UTC", 3
         )
 
-        # Hourly: Session consolidation (L1 → L2)
+        # Periodic: contradiction-based consolidation (PRD-159 S4)
         self._scheduler.add_job(
-            self._run_session_consolidation,
+            self._run_consolidation,
             "interval",
             seconds=consolidation_interval,
             id=self.JOB_ID_CONSOLIDATION,
@@ -135,26 +136,28 @@ class MemoryJobScheduler:
     # Job: Session Consolidation (L1 → L2)
     # ------------------------------------------------------------------
 
-    async def _run_session_consolidation(self):
-        """Scan expired L1 sessions, extract decisions, store in L2."""
+    async def _run_consolidation(self):
+        """PRD-159 S4: contradiction-based consolidation — merge near-duplicates
+        and supersede contradictions (recency+confidence) across workspaces. The
+        primary memory lifecycle, replacing the dead L1 session-decision scan."""
         try:
             from modules.memory.unified_memory_service import (
                 get_unified_memory_service,
             )
 
             service = get_unified_memory_service()
-            result = await service.run_session_consolidation()
+            result = await service.run_sleep_time_consolidation()
             logger.info(
-                "[MemoryJobs] Session consolidation complete: "
-                "scanned=%d, consolidated=%d, items=%d, errors=%d",
-                result.get("sessions_scanned", 0),
-                result.get("sessions_consolidated", 0),
-                result.get("total_items", 0),
+                "[MemoryJobs] Consolidation complete: "
+                "workspaces=%d, merged=%d, superseded=%d, errors=%d",
+                result.get("workspaces_processed", 0),
+                result.get("merged", 0),
+                result.get("superseded", 0),
                 result.get("errors", 0),
             )
         except Exception as e:
             logger.error(
-                "[MemoryJobs] Session consolidation failed: %s",
+                "[MemoryJobs] Consolidation failed: %s",
                 e,
                 exc_info=True,
             )

--- a/orchestrator/tests/test_l3_distill_input.py
+++ b/orchestrator/tests/test_l3_distill_input.py
@@ -1,19 +1,19 @@
-"""L3 input curation — distill durable facts before feeding Mem0.
+"""L3 input curation — distil TYPED durable facts before feeding Mem0 (PRD-159 S1).
 
 The chat path used to send the raw user+assistant exchange to L3 (Mem0). Mem0's
 default *server-side* extraction then produced thin, episodic facts like
-"User requested to fire a mission…" / "User was informed that…" — interaction
-logs, not durable knowledge.
+"User requested to fire a mission…" — interaction logs, not durable knowledge.
 
-The fix curates the L3 input *in the orchestrator*: distil 0..N durable facts
-from the exchange first, and:
-  - non-empty facts → store those to L3,
+PRD-159 S1 rewrites this:
+  - the distiller emits TYPED ``{fact, type, importance}`` objects over the
+    operational taxonomy (tool_outcome / task_learning / playbook_pattern /
+    user_fact / business_fact / preference / procedure),
+  - it runs on the cheap model tier (``config.MEMORY_DISTILL_MODEL``),
+  - non-empty facts → store each with its typed metadata (category + importance),
   - ``[]`` (nothing durable) → skip L3 entirely,
-  - ``None`` (LLM/parse failure) → fall back to the raw exchange so a transient
-    outage never drops the memory.
-
-In every case the verbatim transcript is still dual-written to L2 (Postgres),
-so the literal conversation is preserved for the Memory Explorer.
+  - ``None`` (LLM/parse failure) → store NOTHING (no raw-exchange fallback — that
+    fallback was the "user said hello" source). The L2 transcript still keeps
+    the verbatim turn either way.
 
 These tests use a fake LLM manager (no network) and a recording fake of the
 UnifiedMemoryService (no Mem0, no DB).
@@ -46,7 +46,11 @@ import core.llm as core_llm  # noqa: E402  (patch target for create_llm_manager)
 # chain resolves without the real package.
 sys.modules.setdefault("camelot", types.ModuleType("camelot"))
 
-from consumers.chatbot.smart_memory import SmartMemoryManager  # noqa: E402
+from consumers.chatbot.smart_memory import (  # noqa: E402
+    SmartMemoryManager,
+    MEMORY_FACT_TYPES,
+    DEFAULT_FACT_TYPE,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -64,6 +68,7 @@ class _FakeLLM:
     def __init__(self, content_or_exc):
         self._content_or_exc = content_or_exc
         self.calls = []
+        self.factory_kwargs = {}
 
     async def generate_response(self, messages, tools=None):
         self.calls.append(messages)
@@ -73,9 +78,18 @@ class _FakeLLM:
 
 
 def _patch_llm(monkeypatch, content_or_exc) -> _FakeLLM:
-    """Swap create_llm_manager so the distiller talks to a fake LLM."""
+    """Swap create_llm_manager so the distiller talks to a fake LLM.
+
+    Captures the factory kwargs (incl. ``model``) on the returned fake so tests
+    can assert the cheap-tier routing.
+    """
     fake = _FakeLLM(content_or_exc)
-    monkeypatch.setattr(core_llm, "create_llm_manager", lambda **kwargs: fake)
+
+    def _factory(**kwargs):
+        fake.factory_kwargs = kwargs
+        return fake
+
+    monkeypatch.setattr(core_llm, "create_llm_manager", _factory)
     return fake
 
 
@@ -96,59 +110,134 @@ class _FakeUnified:
 
 
 # ---------------------------------------------------------------------------
-# _distill_durable_facts
+# Golden suite — typed parse (strict on type + presence, fuzzy on wording)
 # ---------------------------------------------------------------------------
 
-@pytest.mark.asyncio
-async def test_distill_parses_json_array_of_facts(monkeypatch):
-    fake = _patch_llm(
-        monkeypatch,
-        '["InBuildUK is a UK smoke-ventilation contractor.", '
-        '"Blog posts should cite EN 12101-2, EN 12101-6 and EN 12101-10."]',
-    )
-    mgr = SmartMemoryManager()
-    facts = await mgr._distill_durable_facts(
-        "We do smoke ventilation for UK contractors",
-        "Noted — I'll cite EN 12101-2/-6/-10 in posts.",
-        workspace_id="ws1",
-        agent_id=3,
-    )
-    assert facts == [
-        "InBuildUK is a UK smoke-ventilation contractor.",
-        "Blog posts should cite EN 12101-2, EN 12101-6 and EN 12101-10.",
-    ]
-    # The distiller actually invoked the LLM once.
-    assert len(fake.calls) == 1
+# (llm_json_response, expected [(fact_substr, type)]) — one fixture per taxonomy
+# kind plus mixed/zero-write cases. Wording is fuzzy (substring); type + presence
+# are strict.
+GOLDEN = [
+    # business_fact
+    ('[{"fact": "InBuildUK is a UK smoke-ventilation contractor.", '
+     '"type": "business_fact", "importance": 0.9}]',
+     [("smoke-ventilation contractor", "business_fact")]),
+    # preference
+    ('[{"fact": "The user prefers British English spelling.", '
+     '"type": "preference", "importance": 0.7}]',
+     [("British English", "preference")]),
+    # tool_outcome
+    ('[{"fact": "SLACK_SEND_MESSAGE failed with not_in_channel for #ops.", '
+     '"type": "tool_outcome", "importance": 0.6}]',
+     [("not_in_channel", "tool_outcome")]),
+    # task_learning
+    ('[{"fact": "The deploy mission failed because the alembic migration was '
+     'not applied first.", "type": "task_learning", "importance": 0.8}]',
+     [("alembic migration", "task_learning")]),
+    # playbook_pattern
+    ('[{"fact": "Blog posts work best as draft then cite standards then review.", '
+     '"type": "playbook_pattern", "importance": 0.5}]',
+     [("cite standards", "playbook_pattern")]),
+    # procedure
+    ('[{"fact": "To publish, push to main then run the deploy playbook.", '
+     '"type": "procedure", "importance": 0.8}]',
+     [("run the deploy playbook", "procedure")]),
+    # user_fact
+    ('[{"fact": "The user is named Gerard.", "type": "user_fact", '
+     '"importance": 0.9}]',
+     [("Gerard", "user_fact")]),
+    # mixed multi-fact
+    ('[{"fact": "Posts must cite EN 12101-2.", "type": "business_fact", '
+     '"importance": 0.8}, {"fact": "The user prefers concise posts.", '
+     '"type": "preference", "importance": 0.6}]',
+     [("EN 12101-2", "business_fact"), ("concise", "preference")]),
+]
 
 
 @pytest.mark.asyncio
-async def test_distill_returns_empty_list_when_nothing_durable(monkeypatch):
-    _patch_llm(monkeypatch, "[]")
+@pytest.mark.parametrize("llm_json,expected", GOLDEN)
+async def test_golden_typed_facts(monkeypatch, llm_json, expected):
+    _patch_llm(monkeypatch, llm_json)
     mgr = SmartMemoryManager()
     facts = await mgr._distill_durable_facts(
-        "fire a mission to write the blog post",
-        "OK, firing the mission now.",
-        workspace_id="ws1",
-        agent_id=None,
+        "transcript", "reply", workspace_id="ws1", agent_id=3
+    )
+    assert facts is not None
+    assert len(facts) == len(expected)
+    for got, (sub, ftype) in zip(facts, expected):
+        assert sub.lower() in got["fact"].lower()      # fuzzy on wording
+        assert got["type"] == ftype                    # strict on type
+        assert ftype in MEMORY_FACT_TYPES
+        assert 0.0 <= got["importance"] <= 1.0
+
+
+# 'user said hello'-class fixtures must produce ZERO durable facts.
+ZERO_WRITE = [
+    "[]",                                  # model returns nothing durable
+    "  []  ",                              # with whitespace
+    '```json\n[]\n```',                    # fenced empty
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("llm_json", ZERO_WRITE)
+async def test_zero_write_fixtures_yield_no_facts(monkeypatch, llm_json):
+    _patch_llm(monkeypatch, llm_json)
+    mgr = SmartMemoryManager()
+    facts = await mgr._distill_durable_facts(
+        "user said hello", "Hi there!", workspace_id="ws1", agent_id=None
     )
     assert facts == []
 
 
+# ---------------------------------------------------------------------------
+# _distill_durable_facts — parsing + routing
+# ---------------------------------------------------------------------------
+
 @pytest.mark.asyncio
-async def test_distill_tolerates_prose_around_the_json(monkeypatch):
-    # Models sometimes wrap the array in prose / code fences.
+async def test_distill_routes_to_cheap_model_tier(monkeypatch):
+    """The distiller must run on config.MEMORY_DISTILL_MODEL (cheap tier)."""
+    from config import config
+    fake = _patch_llm(monkeypatch, "[]")
+    mgr = SmartMemoryManager()
+    await mgr._distill_durable_facts(
+        "x", "y", workspace_id="ws1", agent_id=None
+    )
+    assert fake.factory_kwargs.get("model") == config.MEMORY_DISTILL_MODEL
+    assert fake.factory_kwargs.get("request_type") == "memory_distill"
+
+
+@pytest.mark.asyncio
+async def test_distill_tolerates_prose_and_fences(monkeypatch):
     _patch_llm(
         monkeypatch,
-        'Here are the durable facts:\n```json\n["User prefers British English."]\n```',
+        'Here are the facts:\n```json\n'
+        '[{"fact": "User prefers British English.", "type": "preference", '
+        '"importance": 0.7}]\n```',
     )
     mgr = SmartMemoryManager()
     facts = await mgr._distill_durable_facts(
-        "Please always use British spelling.",
-        "Will do.",
-        workspace_id="ws1",
-        agent_id=None,
+        "Please always use British spelling.", "Will do.",
+        workspace_id="ws1", agent_id=None,
     )
-    assert facts == ["User prefers British English."]
+    assert facts == [
+        {"fact": "User prefers British English.", "type": "preference",
+         "importance": 0.7}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_distill_unknown_type_falls_back_to_default(monkeypatch):
+    _patch_llm(
+        monkeypatch,
+        '[{"fact": "Something durable.", "type": "made_up_kind", '
+        '"importance": 5}]',
+    )
+    mgr = SmartMemoryManager()
+    facts = await mgr._distill_durable_facts(
+        "x", "y", workspace_id="ws1", agent_id=None
+    )
+    assert facts[0]["type"] == DEFAULT_FACT_TYPE        # unknown → default
+    assert facts[0]["importance"] == 1.0                # clamped into [0,1]
 
 
 @pytest.mark.asyncio
@@ -171,13 +260,25 @@ async def test_distill_returns_none_on_unparseable_output(monkeypatch):
     assert facts is None
 
 
+def test_distill_prompt_has_no_exclusion_and_lists_taxonomy():
+    """The transient-event exclusion is DELETED; the taxonomy is present."""
+    prompt = SmartMemoryManager._build_distill_prompt("u", "a")
+    assert "Do NOT record transient interaction" not in prompt
+    for t in MEMORY_FACT_TYPES:
+        assert t in prompt
+
+
 # ---------------------------------------------------------------------------
 # store_conversation routing
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
-async def test_store_conversation_feeds_distilled_facts_to_l3(monkeypatch):
-    _patch_llm(monkeypatch, '["User prefers concise blog posts."]')
+async def test_store_conversation_feeds_typed_fact_to_l3(monkeypatch):
+    _patch_llm(
+        monkeypatch,
+        '[{"fact": "User prefers concise blog posts.", "type": "preference", '
+        '"importance": 0.6}]',
+    )
     mgr = SmartMemoryManager()
     fake = _FakeUnified()
     mgr._unified_service = fake
@@ -190,14 +291,42 @@ async def test_store_conversation_feeds_distilled_facts_to_l3(monkeypatch):
     )
 
     assert ok is True
-    # L3 received exactly one store, and its content is the distilled fact —
-    # NOT the raw assistant response.
+    # L3 received exactly one store; content is the distilled fact, NOT the raw
+    # assistant response; metadata carries the typed category + importance.
     assert len(fake.two_tier_calls) == 1
-    l3_text = " ".join(m["content"] for m in fake.two_tier_calls[0]["messages"])
+    call = fake.two_tier_calls[0]
+    l3_text = " ".join(m["content"] for m in call["messages"])
     assert "User prefers concise blog posts." in l3_text
     assert "Understood, I'll keep them concise" not in l3_text
+    assert call["metadata"]["category"] == "preference"
+    assert call["metadata"]["importance"] == 0.6
     # L2 transcript still preserved verbatim.
     assert len(fake.transcript_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_store_conversation_writes_one_l3_row_per_typed_fact(monkeypatch):
+    _patch_llm(
+        monkeypatch,
+        '[{"fact": "Posts cite EN 12101-2.", "type": "business_fact", '
+        '"importance": 0.8}, {"fact": "User prefers concise posts.", '
+        '"type": "preference", "importance": 0.6}]',
+    )
+    mgr = SmartMemoryManager()
+    fake = _FakeUnified()
+    mgr._unified_service = fake
+
+    ok = await mgr.store_conversation(
+        workspace_id="ws1", agent_id=3,
+        user_message="Cite EN 12101-2 and keep posts concise please",
+        assistant_response="Got it.",
+    )
+
+    assert ok is True
+    # Two typed facts → two L3 writes, each with its own category.
+    assert len(fake.two_tier_calls) == 2
+    cats = {c["metadata"]["category"] for c in fake.two_tier_calls}
+    assert cats == {"business_fact", "preference"}
 
 
 @pytest.mark.asyncio
@@ -214,7 +343,7 @@ async def test_store_conversation_skips_l3_when_nothing_durable(monkeypatch):
         assistant_response="OK, firing the mission now.",
     )
 
-    # Nothing durable → L3 is skipped entirely (no episodic noise stored).
+    # Nothing durable → L3 skipped entirely (no episodic noise stored).
     assert len(fake.two_tier_calls) == 0
     # But the raw transcript is still preserved in L2.
     assert len(fake.transcript_calls) == 1
@@ -222,7 +351,8 @@ async def test_store_conversation_skips_l3_when_nothing_durable(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_store_conversation_falls_back_to_raw_on_distill_error(monkeypatch):
+async def test_store_conversation_stores_nothing_to_l3_on_distill_error(monkeypatch):
+    """PRD-159 S1: distill failure stores NOTHING to L3 (no raw fallback)."""
     _patch_llm(monkeypatch, RuntimeError("llm provider down"))
     mgr = SmartMemoryManager()
     fake = _FakeUnified()
@@ -235,19 +365,17 @@ async def test_store_conversation_falls_back_to_raw_on_distill_error(monkeypatch
         assistant_response="A substantive assistant reply worth keeping.",
     )
 
-    # On distill failure we fall back to the raw exchange so memory isn't lost.
-    assert ok is True
-    assert len(fake.two_tier_calls) == 1
-    l3_text = " ".join(m["content"] for m in fake.two_tier_calls[0]["messages"])
-    assert "A substantive assistant reply worth keeping." in l3_text
-    # L2 transcript still written.
+    # No raw-exchange fallback — L3 gets nothing on distill failure.
+    assert len(fake.two_tier_calls) == 0
+    # The verbatim turn is still preserved in L2.
     assert len(fake.transcript_calls) == 1
+    assert ok is True
 
 
 @pytest.mark.asyncio
 async def test_store_conversation_still_skips_trivial_before_distilling(monkeypatch):
     # Trivial greetings must short-circuit BEFORE any LLM call.
-    fake_llm = _patch_llm(monkeypatch, '["should not be reached"]')
+    fake_llm = _patch_llm(monkeypatch, '[{"fact": "x", "type": "user_fact", "importance": 0.5}]')
     mgr = SmartMemoryManager()
     fake = _FakeUnified()
     mgr._unified_service = fake

--- a/orchestrator/tests/test_memory_consolidation.py
+++ b/orchestrator/tests/test_memory_consolidation.py
@@ -1,0 +1,101 @@
+"""PRD-159 S4 — contradiction-based consolidation (pure logic).
+
+Consolidation, not time-decay, is the primary lifecycle: near-duplicates merge
+into one canonical with provenance; contradictions resolve by recency+confidence
+(loser archived with a reason); stable L2 memories are promoted to L3.
+"""
+import os
+import sys
+from pathlib import Path
+
+ORCH_ROOT = Path(__file__).resolve().parent.parent
+if str(ORCH_ROOT) not in sys.path:
+    sys.path.insert(0, str(ORCH_ROOT))
+
+for _k, _v in {
+    "POSTGRES_USER": "test", "POSTGRES_PASSWORD": "test",
+    "POSTGRES_HOST": "localhost", "POSTGRES_PORT": "5432", "POSTGRES_DB": "test",
+}.items():
+    os.environ.setdefault(_k, _v)
+
+from modules.memory.operations.contradiction import (  # noqa: E402
+    plan_consolidation,
+    group_near_duplicates,
+    merge_group,
+    is_contradiction,
+    resolve_contradiction,
+    select_promotions,
+)
+
+
+def _m(id_, text, *, importance=0.5, created="", tier="l3", access=0):
+    return {
+        "id": id_, "memory": text, "importance": importance,
+        "created_at": created,
+        "metadata": {"tier": tier, "importance": importance, "access_count": access},
+        "access_count": access,
+    }
+
+
+def test_five_near_dups_merge_to_one_canonical_with_provenance():
+    dups = [
+        _m("1", "InBuildUK is a UK smoke ventilation contractor.", importance=0.5),
+        _m("2", "InBuildUK is a UK smoke-ventilation contractor.", importance=0.9),
+        _m("3", "InBuildUK is a UK smoke ventilation contractor", importance=0.4),
+        _m("4", "InBuildUK is a U.K. smoke ventilation contractor.", importance=0.6),
+        _m("5", "InBuildUK is a UK smoke ventilation contractor!", importance=0.3),
+    ]
+    groups = group_near_duplicates(dups)
+    assert len(groups) == 1
+    mg = merge_group(groups[0])
+    assert mg.canonical["id"] == "2"                     # highest importance wins
+    assert set(mg.merged_from) == {"1", "3", "4", "5"}   # provenance preserved
+
+
+def test_contradiction_newer_supersedes_older_with_reason():
+    older = _m("a", "The deploy target is the staging cluster.", created="2026-06-01")
+    newer = _m("b", "The deploy target is the production cluster now.", created="2026-06-10")
+    assert is_contradiction(older, newer)
+    s = resolve_contradiction(older, newer)
+    assert s.winner["id"] == "b"
+    assert s.loser["id"] == "a"
+    assert "recent" in s.reason
+
+
+def test_contradiction_tie_breaks_on_confidence():
+    a = _m("a", "Primary on-call is Alice for releases.", importance=0.4, created="2026-06-01")
+    b = _m("b", "Primary on-call is Bob for releases now.", importance=0.9, created="2026-06-01")
+    s = resolve_contradiction(a, b)
+    assert s.winner["id"] == "b"        # same timestamp → higher importance wins
+    assert "confidence" in s.reason
+
+
+def test_promotion_selects_accessed_l2():
+    mems = [
+        _m("1", "frequently used fact", tier="l2", access=5, importance=0.5),
+        _m("2", "rarely used l2 fact", tier="l2", access=0, importance=0.2),
+        _m("3", "important l2 fact", tier="l2", access=0, importance=0.8),
+        _m("4", "an l3 fact", tier="l3", access=9, importance=0.9),
+    ]
+    promoted = {m["id"] for m in select_promotions(mems)}
+    assert "1" in promoted        # accessed enough
+    assert "3" in promoted        # important enough
+    assert "2" not in promoted    # neither
+    assert "4" not in promoted    # already L3
+
+
+def test_plan_consolidation_end_to_end():
+    mems = [
+        _m("1", "InBuildUK is a UK smoke ventilation contractor.", importance=0.5),
+        _m("2", "InBuildUK is a UK smoke-ventilation contractor.", importance=0.9),
+        _m("3", "The deploy target is staging.", created="2026-06-01"),
+        _m("4", "The deploy target is production now.", created="2026-06-10"),
+        _m("5", "Posts should cite EN 12101-2.", tier="l2", access=4),
+    ]
+    plan = plan_consolidation(mems)
+    # near-dup 1+2 merged
+    assert any(set(mg.merged_from) == {"1"} or "1" in mg.merged_from for mg in plan.merges)
+    # contradiction 3 vs 4 resolved → newer (4) wins
+    assert any(s.winner["id"] == "4" and s.loser["id"] == "3" for s in plan.supersessions)
+    # stable L2 fact promoted
+    assert any(m["id"] == "5" for m in plan.promotions)

--- a/orchestrator/tests/test_memory_fixes.py
+++ b/orchestrator/tests/test_memory_fixes.py
@@ -61,7 +61,10 @@ async def test_mem0_search_sends_search_query_and_prefers_score(monkeypatch):
                     {
                         "id": "recent-low",
                         "content": "recent but weak",
-                        "score": 0.2,
+                        # Above the PRD-159 S3 relevance floor (0.3) so this test
+                        # exercises score ORDERING, not floor filtering (which has
+                        # its own suite: test_recall_relevance_floor).
+                        "score": 0.45,
                         "created_at": "2026-03-10T00:00:00Z",
                     },
                     {

--- a/orchestrator/tests/test_memory_single_write_path.py
+++ b/orchestrator/tests/test_memory_single_write_path.py
@@ -175,11 +175,11 @@ async def test_chat_turn_writes_l2_exactly_once():
 async def test_chat_turn_writes_l3_exactly_once():
     """L3 (Mem0) is invoked exactly once per turn via ``store_conversation``.
 
-    ``store_conversation`` *internally* may fan out to a global tier + an
-    agent tier (``store_two_tier`` with tier='both'). That fan-out is
-    *namespace dispatch by design*, not a duplicate write of the same
-    logical event. What G12 forbids is two SEPARATE call sites both pushing
-    the same chat exchange to L3 — the chat path must have exactly one.
+    ``store_conversation`` routes to a SINGLE namespace per turn — "global" by
+    default, or the agent namespace only on an explicit agent-scoped instruction
+    (PRD-159 S5 removed the old 'both'-tier double-write default). What G12
+    forbids is two SEPARATE call sites both pushing the same chat exchange to L3
+    — the chat path must have exactly one.
     """
     fake = _make_fake_orchestrator()
 

--- a/orchestrator/tests/test_memory_stored_sse.py
+++ b/orchestrator/tests/test_memory_stored_sse.py
@@ -1,0 +1,107 @@
+"""PRD-159 S5 — honest memory_stored signal (orchestrator side).
+
+The memory_stored SSE must fire ONLY after durable facts actually persisted to
+L3, with the real tier. SmartMemoryManager exposes ``_last_l3_facts_stored``
+(0 on zero-fact turns) + ``_last_tier`` which the streaming layer gates on.
+Fork-side sync (UPDATE/DELETE → SQL view, metadata) lives in ../automatos-mem0.
+"""
+import os
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+ORCH_ROOT = Path(__file__).resolve().parent.parent
+if str(ORCH_ROOT) not in sys.path:
+    sys.path.insert(0, str(ORCH_ROOT))
+
+for _k, _v in {
+    "POSTGRES_USER": "test", "POSTGRES_PASSWORD": "test",
+    "POSTGRES_HOST": "localhost", "POSTGRES_PORT": "5432", "POSTGRES_DB": "test",
+}.items():
+    os.environ.setdefault(_k, _v)
+
+import core.llm as core_llm  # noqa: E402
+sys.modules.setdefault("camelot", types.ModuleType("camelot"))
+from consumers.chatbot.smart_memory import SmartMemoryManager  # noqa: E402
+
+
+class _FakeResp:
+    def __init__(self, content):
+        self.content = content
+
+
+class _FakeLLM:
+    def __init__(self, content):
+        self._content = content
+
+    async def generate_response(self, messages, tools=None):
+        return _FakeResp(self._content)
+
+
+class _FakeUnified:
+    def __init__(self):
+        self.two_tier_calls = []
+
+    async def store_two_tier(self, **kwargs):
+        self.two_tier_calls.append(kwargs)
+        return [("global", {"success": True})]
+
+    async def store_transcript(self, **kwargs):
+        return "row-id"
+
+
+def _patch(monkeypatch, content):
+    monkeypatch.setattr(core_llm, "create_llm_manager", lambda **kw: _FakeLLM(content))
+
+
+@pytest.mark.asyncio
+async def test_no_facts_means_no_sse_signal(monkeypatch):
+    _patch(monkeypatch, "[]")          # nothing durable
+    mgr = SmartMemoryManager()
+    mgr._unified_service = _FakeUnified()
+    await mgr.store_conversation(
+        workspace_id="ws1", agent_id=3,
+        user_message="fire a mission to do the thing",
+        assistant_response="OK, firing now.",
+    )
+    # Zero durable facts persisted → the streaming layer must NOT emit.
+    assert mgr._last_l3_facts_stored == 0
+
+
+@pytest.mark.asyncio
+async def test_facts_stored_sets_count_and_tier(monkeypatch):
+    _patch(
+        monkeypatch,
+        '[{"fact": "User prefers concise posts.", "type": "preference", '
+        '"importance": 0.6}]',
+    )
+    mgr = SmartMemoryManager()
+    mgr._unified_service = _FakeUnified()
+    await mgr.store_conversation(
+        workspace_id="ws1", agent_id=3,
+        user_message="keep my posts concise please",
+        assistant_response="Will do.",
+    )
+    assert mgr._last_l3_facts_stored == 1
+    assert isinstance(mgr._last_tier, str) and mgr._last_tier
+
+
+@pytest.mark.asyncio
+async def test_distill_failure_means_no_sse_signal(monkeypatch):
+    # LLM raises → distill returns None → S1 stores nothing → no SSE.
+    def _raise(**kw):
+        class _Boom:
+            async def generate_response(self, *a, **k):
+                raise RuntimeError("down")
+        return _Boom()
+    monkeypatch.setattr(core_llm, "create_llm_manager", _raise)
+    mgr = SmartMemoryManager()
+    mgr._unified_service = _FakeUnified()
+    await mgr.store_conversation(
+        workspace_id="ws1", agent_id=3,
+        user_message="a substantive message",
+        assistant_response="a substantive reply",
+    )
+    assert mgr._last_l3_facts_stored == 0

--- a/orchestrator/tests/test_memory_stored_sse.py
+++ b/orchestrator/tests/test_memory_stored_sse.py
@@ -105,3 +105,30 @@ async def test_distill_failure_means_no_sse_signal(monkeypatch):
         assistant_response="a substantive reply",
     )
     assert mgr._last_l3_facts_stored == 0
+
+
+# --- PRD-159 S5: no 'both'-tier double-write -------------------------------
+
+def test_tier_classification_never_returns_both():
+    mgr = SmartMemoryManager()
+    samples = [
+        ("My name is Gerard", "Noted."),
+        ("I prefer concise blog posts", "Will do."),
+        ("Use the #ops slack channel", "OK."),          # '#' must NOT force agent/both
+        ("email me at x@y.com", "OK."),                  # '@' must NOT force agent/both
+        ("random chit chat", "sure"),
+    ]
+    for um, ar in samples:
+        assert mgr._classify_memory_tier(um, ar) in ("global", "agent")
+
+
+def test_default_tier_is_single_global():
+    mgr = SmartMemoryManager()
+    # Ordinary message → single workspace namespace, not a double-write.
+    assert mgr._classify_memory_tier("here is a durable fact", "ok") == "global"
+
+
+def test_explicit_agent_instruction_routes_to_agent():
+    mgr = SmartMemoryManager()
+    assert mgr._classify_memory_tier("always cc my manager", "ok") == "agent"
+    assert mgr._classify_memory_tier("for this agent, use formal tone", "ok") == "agent"

--- a/orchestrator/tests/test_recall_relevance_floor.py
+++ b/orchestrator/tests/test_recall_relevance_floor.py
@@ -1,0 +1,56 @@
+"""PRD-159 S3 — recall relevance floor.
+
+Low-relevance junk below the server-side similarity floor is never injected.
+Scored-but-below-floor results are dropped; unscored results are kept (cannot
+judge). Tested on the pure ``filter_by_relevance_floor`` helper (no network).
+"""
+import os
+import sys
+from pathlib import Path
+
+ORCH_ROOT = Path(__file__).resolve().parent.parent
+if str(ORCH_ROOT) not in sys.path:
+    sys.path.insert(0, str(ORCH_ROOT))
+
+for _k, _v in {
+    "POSTGRES_USER": "test", "POSTGRES_PASSWORD": "test",
+    "POSTGRES_HOST": "localhost", "POSTGRES_PORT": "5432", "POSTGRES_DB": "test",
+}.items():
+    os.environ.setdefault(_k, _v)
+
+from modules.memory.integrations.mem0_client import filter_by_relevance_floor  # noqa: E402
+
+
+def _r(score):
+    return {"memory": f"m{score}", "score": score}
+
+
+def test_drops_below_floor():
+    results = [_r(0.9), _r(0.4), _r(0.2), _r(0.05)]
+    kept = filter_by_relevance_floor(results, 0.3)
+    assert [r["score"] for r in kept] == [0.9, 0.4]
+
+
+def test_keeps_unscored_results():
+    results = [_r(0.9), {"memory": "no-score", "score": None}, _r(0.1)]
+    kept = filter_by_relevance_floor(results, 0.3)
+    # unscored kept (cannot judge), 0.1 dropped
+    assert {"memory": "no-score", "score": None} in kept
+    assert _r(0.1) not in kept
+
+
+def test_floor_zero_disables_filter():
+    results = [_r(0.9), _r(0.01)]
+    assert filter_by_relevance_floor(results, 0.0) == results
+    assert filter_by_relevance_floor(results, None) == results
+
+
+def test_boundary_is_inclusive():
+    results = [_r(0.3), _r(0.2999)]
+    kept = filter_by_relevance_floor(results, 0.3)
+    assert [r["score"] for r in kept] == [0.3]
+
+
+def test_config_floor_default_is_03():
+    from config import config
+    assert abs(float(config.MEMORY_RELEVANCE_FLOOR) - 0.3) < 1e-9

--- a/orchestrator/tests/test_tool_outcome_capture.py
+++ b/orchestrator/tests/test_tool_outcome_capture.py
@@ -1,0 +1,210 @@
+"""PRD-159 S2 — tool-execution outcome capture.
+
+Failures and notable successes become typed ``tool_outcome`` memories under the
+workspace namespace, written direct (infer:false) and deduped by content-hash;
+trivial successes are gated out. Pure helpers are unit-tested directly; the
+async write is tested with a recording fake service (no DB / Mem0).
+"""
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+ORCH_ROOT = Path(__file__).resolve().parent.parent
+if str(ORCH_ROOT) not in sys.path:
+    sys.path.insert(0, str(ORCH_ROOT))
+
+for _k, _v in {
+    "POSTGRES_USER": "test", "POSTGRES_PASSWORD": "test",
+    "POSTGRES_HOST": "localhost", "POSTGRES_PORT": "5432", "POSTGRES_DB": "test",
+}.items():
+    os.environ.setdefault(_k, _v)
+
+from modules.memory import tool_outcome_capture as toc  # noqa: E402
+from modules.memory.tool_outcome_capture import (  # noqa: E402
+    build_tool_outcome,
+    should_dedupe,
+    write_tool_outcome,
+    capture_tool_outcome,
+    TOOL_OUTCOME_TYPE,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_dedup():
+    toc._SEEN_HASHES.clear()
+    yield
+    toc._SEEN_HASHES.clear()
+
+
+class _FakeService:
+    def __init__(self):
+        self.calls = []
+
+    async def store_two_tier(self, **kwargs):
+        self.calls.append(kwargs)
+        return [("global", {"success": True})]
+
+
+# --- noise gate / record building ------------------------------------------
+
+def test_failed_composio_call_builds_tool_outcome_with_app_action_errorclass():
+    rec = build_tool_outcome(
+        tool_name="SLACK_SEND_MESSAGE",
+        parameters={"action": "SLACK_SEND_MESSAGE", "app_name": "slack",
+                    "params": {"channel": "#ops"}},
+        result={"success": False, "error": "not_in_channel: bot is not in #ops"},
+        workspace_id="ws1",
+    )
+    assert rec is not None
+    assert rec["type"] == TOOL_OUTCOME_TYPE
+    assert rec["metadata"]["app"] == "slack"
+    assert rec["metadata"]["action"] == "SLACK_SEND_MESSAGE"
+    assert rec["metadata"]["error_class"] == "not_found"   # not_in_channel → not_found class
+    assert "SLACK_SEND_MESSAGE" in rec["fact"]
+    assert rec["metadata"]["success"] is False
+
+
+def test_trivial_success_is_gated_out():
+    rec = build_tool_outcome(
+        tool_name="COMPOSIO_SEARCH_WEB",
+        parameters={"action": "COMPOSIO_SEARCH_WEB"},
+        result={"success": True, "data": {"results": ["a", "b"]}},  # no id-like keys
+        workspace_id="ws1",
+    )
+    assert rec is None
+
+
+def test_notable_success_is_captured():
+    rec = build_tool_outcome(
+        tool_name="SLACK_CREATE_CHANNEL",
+        parameters={"action": "SLACK_CREATE_CHANNEL", "app_name": "slack"},
+        result={"success": True, "data": {"channel_id": "C12345", "name": "ops"}},
+        workspace_id="ws1",
+    )
+    assert rec is not None
+    assert rec["metadata"]["success"] is True
+    assert rec["metadata"]["category"] == TOOL_OUTCOME_TYPE
+
+
+def test_rate_limit_and_auth_error_classes():
+    rl = build_tool_outcome(
+        tool_name="X", parameters={"action": "X"},
+        result={"success": False, "error": "429 Too Many Requests (rate limit)"},
+        workspace_id="ws1")
+    assert rl["metadata"]["error_class"] == "rate_limit"
+    au = build_tool_outcome(
+        tool_name="Y", parameters={"action": "Y"},
+        result={"success": False, "error": "401 Unauthorized: invalid token"},
+        workspace_id="ws1")
+    assert au["metadata"]["error_class"] == "auth"
+
+
+def test_no_record_without_workspace():
+    assert build_tool_outcome(
+        tool_name="X", parameters={}, result={"success": False, "error": "x"},
+        workspace_id="") is None
+
+
+# --- content-hash dedup -----------------------------------------------------
+
+def test_identical_outcome_dedupes_to_one():
+    rec = build_tool_outcome(
+        tool_name="SLACK_SEND_MESSAGE",
+        parameters={"action": "SLACK_SEND_MESSAGE", "app_name": "slack"},
+        result={"success": False, "error": "not_in_channel"},
+        workspace_id="ws1",
+    )
+    h = rec["metadata"]["outcome_hash"]
+    assert should_dedupe(h) is False     # first sighting → write
+    assert should_dedupe(h) is True      # second identical → skip
+
+
+def test_different_error_class_not_deduped():
+    a = build_tool_outcome(tool_name="T", parameters={"action": "T"},
+                           result={"success": False, "error": "429 rate limit"},
+                           workspace_id="ws1")
+    b = build_tool_outcome(tool_name="T", parameters={"action": "T"},
+                           result={"success": False, "error": "401 auth"},
+                           workspace_id="ws1")
+    assert a["metadata"]["outcome_hash"] != b["metadata"]["outcome_hash"]
+
+
+# --- async write + fire-and-forget capture ----------------------------------
+
+@pytest.mark.asyncio
+async def test_write_tool_outcome_persists_global_infer_false():
+    svc = _FakeService()
+    rec = build_tool_outcome(
+        tool_name="SLACK_SEND_MESSAGE",
+        parameters={"action": "SLACK_SEND_MESSAGE", "app_name": "slack"},
+        result={"success": False, "error": "not_in_channel"},
+        workspace_id="ws1",
+    )
+    ok = await write_tool_outcome(rec, workspace_id="ws1", agent_id=3, service=svc)
+    assert ok is True
+    assert len(svc.calls) == 1
+    call = svc.calls[0]
+    assert call["tier"] == "global"
+    assert call["metadata"]["category"] == TOOL_OUTCOME_TYPE
+    assert call["messages"][0]["content"] == rec["fact"]
+
+
+@pytest.mark.asyncio
+async def test_capture_schedules_write_for_failure(monkeypatch):
+    svc = _FakeService()
+    monkeypatch.setattr(
+        "modules.memory.unified_memory_service.get_unified_memory_service",
+        lambda: svc,
+    )
+    task = capture_tool_outcome(
+        tool_name="SLACK_SEND_MESSAGE",
+        parameters={"action": "SLACK_SEND_MESSAGE", "app_name": "slack"},
+        result={"success": False, "error": "not_in_channel"},
+        workspace_id="ws1",
+        agent_id=3,
+    )
+    assert task is not None
+    await task
+    assert len(svc.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_capture_skips_trivial_success(monkeypatch):
+    svc = _FakeService()
+    monkeypatch.setattr(
+        "modules.memory.unified_memory_service.get_unified_memory_service",
+        lambda: svc,
+    )
+    task = capture_tool_outcome(
+        tool_name="COMPOSIO_SEARCH_WEB",
+        parameters={"action": "COMPOSIO_SEARCH_WEB"},
+        result={"success": True, "data": {"results": []}},
+        workspace_id="ws1",
+        agent_id=3,
+    )
+    assert task is None           # gated out → nothing scheduled
+    assert len(svc.calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_capture_dedupes_identical_outcomes(monkeypatch):
+    svc = _FakeService()
+    monkeypatch.setattr(
+        "modules.memory.unified_memory_service.get_unified_memory_service",
+        lambda: svc,
+    )
+    args = dict(
+        tool_name="SLACK_SEND_MESSAGE",
+        parameters={"action": "SLACK_SEND_MESSAGE", "app_name": "slack"},
+        result={"success": False, "error": "not_in_channel"},
+        workspace_id="ws1",
+        agent_id=3,
+    )
+    t1 = capture_tool_outcome(**args)
+    t2 = capture_tool_outcome(**args)
+    assert t1 is not None
+    await t1
+    assert t2 is None             # identical outcome deduped
+    assert len(svc.calls) == 1

--- a/orchestrator/tests/test_unified_memory.py
+++ b/orchestrator/tests/test_unified_memory.py
@@ -210,23 +210,31 @@ class TestSessionMemory:
     def test_round_trip(self):
         original = SessionMemory(
             summary="pricing talk",
-            decisions=["tier-2"],
-            action_items=["send invoice"],
             exchange_count=3,
             last_updated="2026-03-12T10:00:00+00:00",
             ended=False,
         )
         restored = SessionMemory.from_json(original.to_json())
         assert restored.summary == original.summary
-        assert restored.decisions == original.decisions
-        assert restored.action_items == original.action_items
         assert restored.exchange_count == 3
         assert restored.ended is False
+
+    def test_from_json_ignores_unknown_keys(self):
+        # PRD-159 removed decisions/action_items; pre-existing Redis payloads
+        # that still carry them must load cleanly (tolerant deserialisation).
+        import json as _json
+        raw = _json.dumps({
+            "summary": "x", "exchange_count": 1, "ended": False,
+            "decisions": ["old"], "action_items": ["legacy"],
+        })
+        s = SessionMemory.from_json(raw)
+        assert s.summary == "x"
+        assert s.exchange_count == 1
+        assert not hasattr(s, "decisions")
 
     def test_defaults(self):
         s = SessionMemory()
         assert s.summary == ""
-        assert s.decisions == []
         assert s.exchange_count == 0
         assert s.ended is False
 
@@ -274,18 +282,6 @@ class TestL1Session:
         stored = SessionMemory.from_json(mock_redis_conn.setex.call_args[0][2])
         assert stored.exchange_count == 2
         assert "Q2" in stored.summary
-
-    @pytest.mark.asyncio
-    async def test_end_session_sets_flag_and_short_ttl(self, service, mock_redis_conn):
-        session = SessionMemory(summary="s", decisions=["d1"], exchange_count=5)
-        mock_redis_conn.get.return_value = session.to_json()
-        await service.end_session(WS_ID, CONV_ID)
-
-        _, ttl, payload = mock_redis_conn.setex.call_args[0]
-        assert ttl == 3600
-        stored = SessionMemory.from_json(payload)
-        assert stored.ended is True
-        assert stored.exchange_count == 5
 
     @pytest.mark.asyncio
     async def test_redis_failure_returns_none(self, service, mock_redis_conn):
@@ -427,76 +423,52 @@ class TestL3:
 
 
 # ===========================================================================
-# 5. L1→L2 Consolidation
+# 5. Sleep-time consolidation (PRD-159 S4) — replaces the dead L1→L2 session
+#    decision scan. Contradiction-based invalidation is the primary lifecycle:
+#    near-duplicates merge into one canonical (rest deleted), contradictions
+#    supersede by recency+confidence. The pure algorithm is covered in
+#    test_memory_consolidation.py; here we test the service applies the plan.
 # ===========================================================================
 
 
-class TestConsolidation:
+class TestSleepTimeConsolidation:
 
     @pytest.mark.asyncio
-    async def test_consolidate_with_decisions(self, service, mock_redis_conn):
-        session = SessionMemory(
-            summary="pricing talk",
-            decisions=["tier-2", "launch Q2"],
-            action_items=["send proposal"],
-            exchange_count=10,
-            ended=True,
-        )
-        mock_redis_conn.get.return_value = session.to_json()
+    async def test_merges_dups_via_delete(self, service):
+        mems = [
+            {"id": "1", "memory": "InBuildUK is a UK smoke ventilation contractor.",
+             "created_at": "2026-06-10", "metadata": {"importance": 0.9}},
+            {"id": "2", "memory": "InBuildUK is a UK smoke ventilation contractor.",
+             "created_at": "2026-06-01", "metadata": {"importance": 0.4}},
+            {"id": "3", "memory": "The user prefers British spelling.",
+             "created_at": "2026-06-05", "metadata": {"importance": 0.7}},
+        ]
+        deleted = []
 
-        with patch.object(service, "store_short_term", new_callable=AsyncMock) as mock_st:
-            mock_st.return_value = str(uuid.uuid4())
-            result = await service.consolidate_session(WS_ID, CONV_ID)
+        async def _del(mid, ws, agent_id=None):
+            deleted.append(mid)
+            return True
 
-        # 2 decisions + 1 action item + 1 summary = 4 L2 entries
-        assert result["items_stored"] == 4
-        assert mock_st.call_count == 4
-        mock_redis_conn.delete.assert_called_once()
+        with patch.object(service, "get_all_memories", new_callable=AsyncMock) as mock_get, \
+             patch.object(service, "delete_memory", side_effect=_del):
+            mock_get.return_value = mems
+            result = await service.run_sleep_time_consolidation(workspace_id=WS_ID)
 
-    @pytest.mark.asyncio
-    async def test_consolidate_no_session(self, service, mock_redis_conn):
-        mock_redis_conn.get.return_value = None
-        result = await service.consolidate_session(WS_ID, CONV_ID)
-        assert result["items_stored"] == 0
-
-    @pytest.mark.asyncio
-    async def test_consolidate_empty(self, service, mock_redis_conn):
-        session = SessionMemory(summary="hi", decisions=[], action_items=[], exchange_count=1, ended=True)
-        mock_redis_conn.get.return_value = session.to_json()
-
-        with patch.object(service, "store_short_term", new_callable=AsyncMock) as mock_st:
-            mock_st.return_value = str(uuid.uuid4())
-            result = await service.consolidate_session(WS_ID, CONV_ID)
-
-        assert result["items_stored"] == 1  # Just summary
+        # 1 & 2 are duplicates → canonical "1" (higher importance) kept, "2" deleted.
+        assert result["workspaces_processed"] == 1
+        assert result["merged"] == 1
+        assert deleted == ["2"]
 
     @pytest.mark.asyncio
-    async def test_run_consolidation_scans(self, service, mock_redis_conn):
-        ended = SessionMemory(summary="done", decisions=["d1"], exchange_count=3, ended=True)
-        active = SessionMemory(summary="active", exchange_count=1, ended=False)
+    async def test_empty_workspace_is_noop(self, service):
+        with patch.object(service, "get_all_memories", new_callable=AsyncMock) as mock_get, \
+             patch.object(service, "delete_memory", new_callable=AsyncMock) as mock_del:
+            mock_get.return_value = []
+            result = await service.run_sleep_time_consolidation(workspace_id=WS_ID)
 
-        key1 = f"mem:session:{WS_ID}:conv-1"
-        key2 = f"mem:session:{WS_ID}:conv-2"
-
-        # scan_iter returns byte keys matching mem:session:*
-        mock_redis_conn.scan_iter.return_value = iter([key1.encode(), key2.encode()])
-
-        def get_side_effect(key):
-            k = key.decode() if isinstance(key, bytes) else key
-            if k == key1:
-                return ended.to_json()
-            if k == key2:
-                return active.to_json()
-            return None
-
-        mock_redis_conn.get.side_effect = get_side_effect
-
-        with patch.object(service, "store_short_term", new_callable=AsyncMock) as mock_st:
-            mock_st.return_value = str(uuid.uuid4())
-            result = await service.run_session_consolidation()
-
-        # Only the ended session should be consolidated
-        assert result["sessions_consolidated"] >= 1
+        assert result["merged"] == 0
+        assert result["superseded"] == 0
+        mock_del.assert_not_called()
 
 
 # ===========================================================================


### PR DESCRIPTION
## What

Rewrites **what** Auto remembers, **how** it consolidates, and **how** it recalls — ending the "user said hello" era. D5 binding: the orchestrator owns extraction; mem0 is storage/search/dedup only.

7 commits, one per story (+ S4 in two parts). Cross-repo fork changes are in **`automatos-mem0`** (`fix/pool-exhaustion` → `16b27eb2`).

## Stories

- **S1 — typed operational distill** (`1ecd8bf6e`): distiller emits typed `{fact, type, importance}` over the 7-type taxonomy (tool_outcome/task_learning/playbook_pattern/user_fact/business_fact/preference/procedure). **Deleted** the transient-event exclusion (Q10) and the raw-exchange fallback — distill failure stores nothing + logs (L2 transcript still keeps the verbatim turn). Cheap-tier routing via new `config.MEMORY_DISTILL_MODEL`. Per-fact category+importance metadata.
- **S2 — tool-outcome capture** (`763ece5c9`): post-execution hook in the executor's fire-and-forget `finally` — failures + notable successes become `tool_outcome` memories, `infer:false`, content-hash deduped, noise-gated. New `modules/memory/tool_outcome_capture.py`.
- **S3 — recall that fires** (`7f53d7253`): dropped the temporal-regex gate so operational memories recall for **any** query; server-side relevance floor (`config.MEMORY_RELEVANCE_FLOOR`, default 0.3 — sub-floor junk never injected); ordered+bounded daily logs.
- **S4 — consolidation replaces decay-deletion** (`c0816be8d` + `5ccc90d1b`): new `operations/contradiction.py` (merge near-dups w/ provenance, supersede contradictions by recency+confidence, promote stable L2→L3) + `run_sleep_time_consolidation` wired into the memory job. **Deleted** the dead L1 session machinery (`end_session`, `consolidate_session`, `run_session_consolidation`, `SessionMemory.decisions`/`action_items`) — no shims; tolerant deserialise for old Redis payloads.
- **S5 — honest events + Explorer truth** (`4130953a7` + `9b5f60719` + fork): `memory_stored` SSE fires only after real persisted facts with the real tier (zero-fact turns emit nothing); removed the `'both'`-tier double-write default (single namespace + explicit agent triggers; fragile `#`/`@` routing deleted). **Fork:** preserve caller metadata in the Qdrant payload (tier/category filterable) + sync ADD/**UPDATE/DELETE** into the SQL view (no ghost rows).
- **S6 — fork V3 baseline** (fork `16b27eb2`): patch-set documented in `automatos-mem0/FORK_PATCHES.md`. ⚠️ The actual mem0 `1.0.2 → V3` major bump is **pending a build/test cycle** (Qdrant+Postgres) — flagged, not committed blind.

## Cross-repo deploy (required)

S5/S6 land in **`automatos-mem0`** `fix/pool-exhaustion` (`4bb3616c`, `16b27eb2`). **Rebuild the Mem0 server image** from that branch before deploy. Env: the PRD-156 auth token must be set (see `FORK_PATCHES.md`).

## Test plan

New suites (run in CI — not run locally, no Docker): `test_l3_distill_input` (golden typed-parse, zero-write, cheap-model, no-exclusion), `test_tool_outcome_capture`, `test_recall_relevance_floor`, `test_memory_consolidation`, `test_memory_stored_sse` (+ tier classification). Updated: `test_unified_memory` (dead session tests removed), `test_memory_single_write_path`.

- [ ] CI green (orchestrator-tests)
- [ ] Mem0 image rebuilt from `automatos-mem0@16b27eb2`
- [ ] mem0 V3 bump (S6) scheduled with a Qdrant+Postgres build/test cycle

## Notes

- Config added: `MEMORY_DISTILL_MODEL`, `MEMORY_RELEVANCE_FLOOR`.
- The contradiction detector is a text-similarity v1 (stdlib, no embeddings) — conservative thresholds to avoid wrongly deleting; refine with embeddings later if needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Tool execution outcomes are now captured and remembered for future context
  * Memory search results filtered by relevance threshold for more accurate recalls

* **Improvements**
  * Enhanced memory deduplication and contradiction resolution
  * Smarter memory organization with typed fact categories
  * Improved long-term memory retrieval in temporal and knowledge queries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->