### PR TITLE
fix(prd-158): teams backfill crash-loops deploy on null workspace_id

### DIFF
--- a/orchestrator/alembic/versions/prd158_teams_table.py
+++ b/orchestrator/alembic/versions/prd158_teams_table.py
@@ -42,6 +42,11 @@ def upgrade() -> None:
     # normalized_name is the lowercased/trimmed canonical form (one team per
     # workspace+normalized); MIN(name) picks a deterministic display name, so
     # 'Support'/'support' collapse to a single 'Support' team.
+    #
+    # `workspace_id IS NOT NULL` guards against orphaned rows: an agent/document can
+    # carry a team string while having a NULL workspace_id (e.g. a pre-tenancy 'Onboarding'
+    # agent). teams.workspace_id is NOT NULL, so such rows must be excluded or the whole
+    # transactional migration aborts and the deploy crash-loops.
     op.execute(
         """
         INSERT INTO teams (workspace_id, name, normalized_name)
@@ -49,11 +54,11 @@ def upgrade() -> None:
         FROM (
             SELECT workspace_id, TRIM(team) AS name, LOWER(TRIM(team)) AS normalized_name
             FROM agents
-            WHERE team IS NOT NULL AND TRIM(team) <> ''
+            WHERE team IS NOT NULL AND TRIM(team) <> '' AND workspace_id IS NOT NULL
             UNION ALL
             SELECT workspace_id, TRIM(t) AS name, LOWER(TRIM(t)) AS normalized_name
             FROM documents, unnest(team_access) AS t
-            WHERE team_access IS NOT NULL AND TRIM(t) <> ''
+            WHERE team_access IS NOT NULL AND TRIM(t) <> '' AND workspace_id IS NOT NULL
         ) src
         WHERE normalized_name <> ''
         GROUP BY workspace_id, normalized_name


### PR DESCRIPTION
## Problem (production deploy crash-loop)
Railway deploy fails in `prd158_teams_table` migration:

```
psycopg2.errors.NotNullViolation: null value in column "workspace_id" of relation "teams"
DETAIL: Failing row contains (9, null, Onboarding, onboarding, ...)
```

The teams backfill `SELECT`s `workspace_id` from `agents.team` and `documents.team_access` but only filters on the team string — **not** `workspace_id IS NOT NULL`. An orphaned row (a team string on a row with NULL `workspace_id`, e.g. a pre-tenancy `Onboarding` agent) yields a NULL `workspace_id`, which violates `teams.workspace_id NOT NULL`. The migration is transactional → it rolls back → the deploy retries → **infinite crash-loop**.

## Fix
Add `AND workspace_id IS NOT NULL` to both UNION branches of the backfill. Teams require a workspace, so team strings on workspace-less rows can't form a team anyway. Matches the existing pattern in `seed_auto_agents_existing_workspaces` and `add_workspace_id_to_chats`.

## Safety
Prod never applied this migration (it rolled back every time), so its `alembic_version` doesn't include `prd158_teams` — editing the migration in place is safe and the next deploy runs the fixed version cleanly. The sibling `prd158_cloud_default_team` is a server-default column add (no hazard).

## After merge
Merge → redeploy. The migration chain should pass `prd158_teams` and continue.

Note: the orphaned `agents`/`documents` rows with a team but NULL `workspace_id` are a separate data anomaly worth a later cleanup, but they no longer block the deploy.