### PR TITLE
fix(onboarding): blueprint rules optional — new users can create agents via Auto

### DIFF
--- a/orchestrator/modules/tools/discovery/actions_governance.py
+++ b/orchestrator/modules/tools/discovery/actions_governance.py
@@ -52,9 +52,11 @@ def register_governance_actions(registry: ActionRegistry) -> None:
     registry.register(ActionDefinition(
         name="platform_create_blueprint",
         description=(
-            "Create a new governance blueprint with rules for agent readiness. "
-            "Rules can include: min_tools, require_system_prompt, max_budget_per_run, "
-            "required_tags, allowed_models. Use when setting up new quality standards."
+            "Create a governance blueprint of OPTIONAL quality rules for agent readiness "
+            "(min_tools, require_system_prompt, max_budget_per_run, required_tags, allowed_models). "
+            "Only use this when the user explicitly asks for governance / quality standards. "
+            "Creating an agent does NOT require a blueprint — use platform_create_agent directly "
+            "for that. Rules are optional and default to no constraints."
         ),
         category="governance",
         parameters={
@@ -70,14 +72,18 @@ def register_governance_actions(registry: ActionRegistry) -> None:
                 },
                 "rules": {
                     "type": "object",
-                    "description": "Rule set: {min_tools, require_system_prompt, max_budget_per_run, required_tags, allowed_models}.",
+                    "description": (
+                        "Optional rule set: {min_tools, require_system_prompt, max_budget_per_run, "
+                        "required_tags, allowed_models}. Omit it for a permissive blueprint with no "
+                        "constraints (the default) — never ask the user to supply rules just to proceed."
+                    ),
                 },
                 "is_default": {
                     "type": "boolean",
                     "description": "Set as workspace default blueprint. Defaults to false.",
                 },
             },
-            "required": ["name", "rules"],
+            "required": ["name"],
         },
         permission_level="write",
         tags=["governance", "blueprints", "create"],


### PR DESCRIPTION
## Problem (new-user blocker, found testing on a fresh account)
A new user asks Auto: *"create me a new agent… give it a persona, select Claude Sonnet."* Auto detours into governance, calls `platform_create_blueprint`, and **dead-ends** asking the user to define `rules` (min_tools, allowed_models, required_tags, budget) — config a brand-new workspace has none of.

## Root cause
`platform_create_blueprint`'s **tool schema** marks `rules` as required (`actions_governance.py`), but the **handler already defaults it** (`handlers_governance.py:91` → `rules = params.get("rules", {})`). The requirement is spurious. Separately, `platform_create_agent` requires only `name`, so **agents never needed a blueprint at all**.

## Fix (one file, schema only)
- `required: ["name","rules"]` → `["name"]` — handler defaults `rules` to `{}` (permissive)
- `rules` marked optional in-schema; "never ask the user to supply rules just to proceed"
- description steers Auto to `platform_create_agent` for plain agent creation

## Verified
- `py_compile` clean; no test pins the old `required` array
- Adjacent new-user paths already work: `platform_create_agent` accepts `model_id` without pre-install; `platform_create_workspace_skill` exists for "build a new skill"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Governance rules are now optional when creating blueprints
  * Blueprint creation no longer requires specifying rules, only a name is mandatory

<!-- end of auto-generated comment: release notes by coderabbit.ai -->