### PR TITLE
feat(prd-173): W3 hygiene — token encryption + CI lanes (code parts)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,50 @@
+# PRD-173 (F092, W3 slice) — dependency audit lane.
+#
+# Opens automated dependency-update PRs across the repo's three ecosystems.
+# These PRs are the "dependency audit" half of the F092 bar; each is triaged
+# as it arrives (not part of the W3 diff). Weekly cadence with a small open-PR
+# cap keeps the queue reviewable rather than a flood.
+
+version: 2
+updates:
+  # Python — the orchestrator backend.
+  - package-ecosystem: "pip"
+    directory: "/orchestrator"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "04:00"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+      - "python"
+
+  # JavaScript/TypeScript — the frontend (package.json + package-lock.json).
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "04:00"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+      - "javascript"
+
+  # GitHub Actions — keep the CI action versions patched.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "04:00"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(ci)"
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,64 @@
+name: CodeQL
+
+# PRD-173 (F092, W3 slice) — SAST lane.
+#
+# Static analysis (CodeQL) over the repo's two languages: the Python
+# orchestrator and the TypeScript/JavaScript frontend. Runs on PRs to main
+# (so new alerts surface before merge) and weekly (to catch newly-published
+# query updates against the existing tree).
+#
+# Interpreted languages use build-mode: none — no compile step. CodeQL's
+# default behaviour is to flag alerts without failing the check on the whole
+# backlog; alerts land in the repo's Security tab and PR checks. Tightening
+# to "fail on newly-introduced high-severity" is a branch-protection/Security
+# setting (default-setup style), not encoded here, so the lane does not red
+# the tree on day one against pre-existing findings (see PRD-173 §6).
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    # Mondays 03:17 UTC — off the hour to avoid the scheduling stampede.
+    - cron: "17 3 * * 1"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    permissions:
+      contents: read
+      security-events: write
+      # Needed for workflows in private repos / to fetch actions.
+      actions: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - python
+          - javascript-typescript
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,52 @@
+name: gitleaks
+
+# PRD-173 (F012 + F092, W3 slice) — secret-scanning lane.
+#
+# Scans the FULL git history for committed secrets on every PR to main (and on
+# push to main). fetch-depth: 0 pulls the entire history so the scan covers
+# every commit — which is what makes it (a) the enforcement that keeps the next
+# F012-class artifact out at the PR, and (b) the verification gate for the F012
+# history purge: once tests/e2e/.auth/user.json is purged, this job goes and
+# stays green. It runs on top of GitHub-native secret scanning (defence in
+# depth + history coverage), it does not replace it.
+#
+# License note: gitleaks-action needs GITLEAKS_LICENSE only for repos owned by
+# an ORGANISATION account. This repo is a personal account, so no license is
+# required. If it ever moves under an org, uncomment the GITLEAKS_LICENSE env
+# line below and add the secret.
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  # gitleaks-action posts a summary comment on PRs.
+  pull-requests: write
+
+jobs:
+  scan:
+    name: Scan history for secrets
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout (full history)
+        uses: actions/checkout@v4
+        with:
+          # Full history — the scan must see every commit, not just the tip.
+          fetch-depth: 0
+
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}  # org accounts only

--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,8 @@ scripts/vendor/
 # Graphify knowledge graph outputs (ignore contents, but keep snapshots/)
 graphify-out/*
 !graphify-out/snapshots/
+
+# E2E dev-browser auth fixtures — regenerated per run, NEVER commit (F012).
+# Holds live Clerk __session / __clerk_db_jwt material; must not be tracked.
+tests/e2e/.auth/
+**/tests/e2e/.auth/

--- a/docs/runbooks/W3-HUMAN-STEPS.md
+++ b/docs/runbooks/W3-HUMAN-STEPS.md
@@ -1,0 +1,208 @@
+# W3 (PRD-173) — Human-Only Steps
+
+**These steps are NOT automated and were deliberately left for a human to run.** They are
+destructive-history / live-credential / cross-repo-deploy operations that must not be run
+unattended by an agent. The **code parts** of W3 (Shopify token encryption, `.gitignore` entry,
+CodeQL + Dependabot + gitleaks CI lanes) landed in the PR that references this runbook; what
+remains below is the operational half.
+
+Findings pinned to `37fdecc4e` (current `main` at authoring); re-confirm before running.
+
+Order matters: **rotate credentials first** (so a leaked blob is already inert), then purge history,
+then the mem0 deploy.
+
+---
+
+## 1. F012 — untrack + purge the committed Clerk auth blob from history
+
+**What / why.** `tests/e2e/.auth/user.json` is git-tracked and lives in history (present since at
+least PR #303). It holds two `__session` JWTs + a `__clerk_db_jwt` dev-browser token. The JWTs are
+60-second tokens that **expired 2026-02-17**, so this is a re-commit hazard + hygiene failure, not a
+live breach — but a secret in history is still a secret, and the file re-stages every dev-browser
+run until it is untracked. The PR already added `tests/e2e/.auth/` to `.gitignore`; the steps below
+stop tracking it and rewrite it out of history.
+
+**Verification gate.** The new `.github/workflows/gitleaks.yml` scans full history. Before the purge
+it will flag the blob; after the purge it goes and stays green. Use it as the go/no-go.
+
+### 1a. Stop tracking (non-destructive — do this first, can go in a normal PR)
+
+```bash
+cd /path/to/automatos-ai
+# Remove from the index but KEEP the local file (the e2e fixture regenerates it per run).
+git rm --cached tests/e2e/.auth/user.json
+git commit -m "chore(security): stop tracking tests/e2e/.auth/user.json (F012)"
+# Confirm it is now ignored + untracked:
+git check-ignore tests/e2e/.auth/user.json   # should print the path
+git ls-files tests/e2e/.auth/                 # should print nothing
+```
+
+### 1b. Purge from ALL history (DESTRUCTIVE — coordinated force-push)
+
+> This rewrites every commit hash. It requires a force-push to protected `main` and every
+> collaborator to re-clone or hard-reset. Announce a freeze window first. Do it on a fresh mirror,
+> verify, then push.
+
+```bash
+# 0) Announce a freeze. Merge or close all open PRs first — the rewrite invalidates their bases.
+
+# 1) Tag a rollback point on the CURRENT main before touching anything.
+cd /path/to/automatos-ai
+git fetch origin
+git tag backup/pre-f012 origin/main
+git push origin backup/pre-f012        # keep until the team has re-synced
+
+# 2) Fresh mirror clone to do the rewrite in isolation.
+cd /tmp
+git clone --mirror git@github-automatos:AutomatosAI/automatos-ai.git automatos-ai-purge.git
+cd automatos-ai-purge.git
+
+# 3) Purge the blob from every commit. git-filter-repo is the maintained successor to
+#    BFG / filter-branch (install: `brew install git-filter-repo` or `pipx install git-filter-repo`).
+git filter-repo --path tests/e2e/.auth/user.json --invert-paths --force
+
+# 4) Verify the blob is gone from history BEFORE pushing.
+git log --oneline --all -- tests/e2e/.auth/user.json    # must print NOTHING
+#    Optional belt-and-braces: run gitleaks locally over the rewritten mirror.
+#    docker run -v "$(pwd):/repo" zricethezav/gitleaks:latest detect --source=/repo --log-opts="--all"
+
+# 5) Force-push the rewritten refs. (Temporarily lift branch protection / allow force-push on main,
+#    then restore it immediately after.)
+git push --force --mirror git@github-automatos:AutomatosAI/automatos-ai.git
+```
+
+### 1c. Every collaborator re-syncs (a plain `git pull` will diverge)
+
+```bash
+# Preferred: re-clone fresh.
+# Or hard-reset an existing clone (loses un-pushed local work — stash/branch it first):
+git fetch origin
+git reset --hard origin/main
+git for-each-ref --format="%(refname)" refs/original/ | xargs -n1 git update-ref -d 2>/dev/null || true
+```
+
+### 1d. Re-open any surviving PRs against the rewritten base, then remove the backup
+
+```bash
+# Once the team confirms everyone re-synced and CI (gitleaks) is green on the new main:
+git push origin :refs/tags/backup/pre-f012   # delete the rollback tag
+```
+
+**Rollback:** if anything goes wrong before collaborators rebase on the rewrite, restore with
+`git push --force origin backup/pre-f012:main`.
+
+---
+
+## 2. Credential rotation (live-cred ops — do BEFORE / alongside the purge)
+
+The review (§14) recommends rotating both regardless of the expired TTL; until done, treat them as
+live.
+
+### 2a. Revoke the Clerk dev-browser client (F012)
+
+The purged blob carries a `__clerk_db_jwt` dev-browser token that identifies a client. Revoke it so
+a replay of the historical blob is inert.
+
+- Clerk Dashboard → the relevant **application/instance** → **Sessions** (and **API Keys** if a dev
+  instance key is implicated) → revoke the dev-browser client / rotate the instance's dev keys.
+- Confirm the dev-browser suite still authenticates afterwards (it regenerates `user.json` on run).
+
+### 2b. Rotate the flagged AWS key (§14 production unknown)
+
+Access key `<FLAGGED_AWS_KEY_ID>` (the exact ID is in review §14 — do **not** re-commit the literal; it
+trips secret scanning) was flagged in the review. Rotate it regardless of whether it was ever committed here:
+
+```bash
+# Identify the IAM user the key belongs to.
+aws iam list-access-keys --output table   # or the console: IAM → Users → Security credentials
+
+# Create a NEW key, roll it into the deployment secret store (Railway/env), verify the app works,
+# THEN deactivate + delete the old one:
+aws iam create-access-key --user-name <USER>
+# ... update Railway/secret manager with the new key, redeploy, smoke-test ...
+aws iam update-access-key --user-name <USER> --access-key-id <FLAGGED_AWS_KEY_ID> --status Inactive
+aws iam delete-access-key --user-name <USER> --access-key-id <FLAGGED_AWS_KEY_ID>
+```
+
+---
+
+## 3. F011 — merge the mem0 auth/metadata patch, pin the deploy, add a boot probe
+
+**Repo:** `automatos-mem0` (the fork) — sibling checkout, remote
+`git@github-automatos:AutomatosAI/automatos-mem0.git`.
+
+**Confirmed state at authoring:** the PRD-156 router token auth + PRD-159 metadata preservation live
+only on branch `fix/pool-exhaustion` at tip **`16b27eb26ad267eed9b6eafbeb18e524547c6f0e`**, which is
+**NOT** an ancestor of `origin/main` (tip `5cbb4c1f8be921ce3b0f0e09df0fb11f4cbf8c31`). Re-verify:
+
+```bash
+cd /path/to/automatos-mem0
+git fetch origin
+git merge-base --is-ancestor 16b27eb26ad267eed9b6eafbeb18e524547c6f0e origin/main \
+  && echo "already merged (nothing to do)" || echo "NOT merged — proceed"
+```
+
+### 3a. Merge `fix/pool-exhaustion` → fork `main`
+
+```bash
+cd /path/to/automatos-mem0
+git checkout main
+git pull origin main
+git merge --no-ff fix/pool-exhaustion \
+  -m "merge(security): PRD-156 router token auth + PRD-159 metadata preservation (F011)"
+git push origin main
+# Record the merged SHA — you pin Railway to THIS exact commit, not a floating main.
+MEM0_PINNED_SHA=$(git rev-parse HEAD)
+echo "Pin Railway mem0 to: $MEM0_PINNED_SHA"
+```
+
+### 3b. Pin the Railway mem0 service to the verified SHA + rebuild
+
+- Railway → the **mem0 / OpenMemory** service → **Settings → Source**: pin the deploy to the exact
+  merged commit `$MEM0_PINNED_SHA` (a fixed commit, **not** the `main` branch tracker), so the image
+  cannot silently drift back to an unauthenticated build.
+- Ensure the OpenMemory API token env var is set on the service (the value the orchestrator sends).
+- Trigger a rebuild/redeploy from the pinned SHA.
+- **Record the pinned SHA** in the Railway service config / deploy notes.
+
+### 3c. Boot probe — assert 401-without-token
+
+Verify the deployed image is the authenticated build. The OpenMemory server is `server/main.py` in
+the fork. With a token configured, an **unauthenticated** request to a router must return **401**
+(not 200):
+
+```bash
+# Replace with the deployed OpenMemory base URL and a real memory router path.
+MEM0_URL="https://<your-mem0-service>.up.railway.app"
+code=$(curl -s -o /dev/null -w "%{http_code}" "$MEM0_URL/api/v1/memories/")
+echo "unauthenticated status: $code"
+test "$code" = "401" && echo "PASS — failing closed" || echo "FAIL — image may be the UNAUTHENTICATED build; do NOT keep it live"
+# Positive path: the same call WITH the token should succeed (200/2xx).
+curl -s -o /dev/null -w "authed: %{http_code}\n" -H "Authorization: Bearer $OPENMEMORY_TOKEN" "$MEM0_URL/api/v1/memories/"
+```
+
+If the unauthenticated call returns **200**, the running image is built from the pre-merge (fork-main)
+source — an open tenant-memory service. Do not serve it; re-pin to the merged SHA and rebuild.
+
+**Rollback:** un-pin to the prior known-good SHA (the merge stays on fork `main`).
+
+---
+
+## 4. F058 — migration of already-stored plaintext Shopify tokens (OWNER DECISION)
+
+The code fix encrypts the Shopify Admin token on write going forward and decrypts on read
+(`orchestrator/api/shopify.py`). **Existing `workspace.settings` rows may still hold plaintext tokens
+under the old path.** There is no runtime reader of `settings["shopify_access_token"]` in the
+orchestrator today (the Composio bridge reads the separate n8n credential store), so nothing breaks —
+but the stored plaintext should not linger.
+
+**Gerard's call — pick one (surfaced, NOT decided here):**
+
+- **(a) One-time re-encrypt migration:** a script/Alembic data migration that reads each
+  `workspace.settings.shopify_access_token`, and if it is *not* already Fernet ciphertext (i.e. it
+  still `startswith("shpat_")` or fails `decrypt`), re-writes it via the encryption service. Idempotent.
+- **(b) Documented "reconnect to re-store encrypted":** merchants re-run `POST /api/shopify/connect`
+  (which now encrypts), and any legacy plaintext value is treated as stale. Simpler, no migration, but
+  leaves plaintext in old rows until each merchant reconnects.
+
+Do not silently skip this — it is the one F058 open item that needs an owner decision.

--- a/orchestrator/api/shopify.py
+++ b/orchestrator/api/shopify.py
@@ -36,6 +36,30 @@ router = APIRouter(prefix="/api/shopify", tags=["Shopify Integration"])
 SHOPIFY_INTERNAL_KEY = config.SHOPIFY_INTERNAL_API_KEY if hasattr(config, "SHOPIFY_INTERNAL_API_KEY") else None
 
 
+# ── At-rest secret encryption (F058) ─────────────────────────────────
+#
+# The Shopify Admin access token is a 147-scope full-write credential. It is
+# encrypted at rest through the platform's canonical Fernet path
+# (``core.credentials.encryption`` — the same mechanism used for stored n8n
+# credentials and LLM API keys) before being written to
+# ``workspace.settings.shopify_access_token``, and decrypted at the point of
+# use. The key comes from ``config.CREDENTIAL_ENCRYPTION_KEY``; no key material
+# lives in this module.
+
+def _encrypt_secret(plaintext: str) -> str:
+    """Encrypt a secret for at-rest storage via the canonical Fernet service."""
+    from core.credentials.encryption import get_encryption_service
+
+    return get_encryption_service().encrypt(plaintext)
+
+
+def _decrypt_secret(ciphertext: str) -> str:
+    """Decrypt an at-rest secret written by :func:`_encrypt_secret`."""
+    from core.credentials.encryption import get_encryption_service
+
+    return get_encryption_service().decrypt(ciphertext)
+
+
 # ── Auth helper ──────────────────────────────────────────────────────
 
 def _verify_internal_key(authorization: str = Header(...)) -> None:
@@ -356,8 +380,11 @@ async def connect_shopify_store(
     """
     Store the Shopify access token for a workspace.
 
-    Saved in workspace.settings.shopify_access_token (encrypted at rest
-    via database-level encryption). Used by Composio for API calls.
+    The 147-scope Admin access token is encrypted at rest before storage
+    (application-level Fernet encryption via ``core.credentials.encryption``,
+    keyed by ``CREDENTIAL_ENCRYPTION_KEY``) and saved as ciphertext in
+    ``workspace.settings.shopify_access_token``. Read it back through
+    :func:`_decrypt_secret`. Used by Composio for API calls.
     """
     workspace = db.query(Workspace).get(request.workspace_id)
     if not workspace:
@@ -365,7 +392,8 @@ async def connect_shopify_store(
 
     settings = dict(workspace.settings or {})
     settings["shopify_domain"] = request.shop_domain
-    settings["shopify_access_token"] = request.access_token
+    # Encrypt at rest — never persist the raw Admin token (F058).
+    settings["shopify_access_token"] = _encrypt_secret(request.access_token)
     workspace.settings = settings
 
     from sqlalchemy.orm.attributes import flag_modified

--- a/orchestrator/tests/test_prd173_shopify_token_encryption.py
+++ b/orchestrator/tests/test_prd173_shopify_token_encryption.py
@@ -1,0 +1,104 @@
+"""
+PRD-173 (F058) — Shopify Admin token encrypted at rest
+=======================================================
+
+The ``POST /api/shopify/connect`` handler stores the merchant's 147-scope
+Shopify Admin access token in ``workspace.settings.shopify_access_token``.
+Previously it wrote the token verbatim while the docstring *claimed*
+encryption. These tests pin the real behaviour:
+
+  * the value written at rest is ciphertext, NOT the plaintext token;
+  * the decrypt path round-trips ciphertext back to the original token;
+  * the encryption goes through the platform's canonical Fernet service
+    (``core.credentials.encryption``), keyed from config — no hand-rolled
+    crypto, no key in source.
+
+Self-contained: generates a throwaway Fernet key and swaps the encryption
+singleton so it needs no configured ``CREDENTIAL_ENCRYPTION_KEY`` and no DB.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from cryptography.fernet import Fernet
+
+ORCH_ROOT = Path(__file__).resolve().parent.parent
+if str(ORCH_ROOT) not in sys.path:
+    sys.path.insert(0, str(ORCH_ROOT))
+
+# Triggers ``load_dotenv`` so imports that resolve config at import time work
+# regardless of test run order.
+import config  # noqa: E402,F401
+
+import core.credentials.encryption as encryption_module  # noqa: E402
+from core.credentials.encryption import EncryptionService  # noqa: E402
+from api import shopify  # noqa: E402
+
+# Built at runtime (not a literal) so secret scanners / push-protection don't
+# flag a shpat_-shaped constant in source. Shape mimics a real Admin token.
+PLAINTEXT_TOKEN = "shpat_" + ("0123456789abcdef" * 2)
+
+
+@pytest.fixture()
+def real_encryption(monkeypatch):
+    """Install a real (throwaway-key) Fernet encryption service as the singleton.
+
+    Uses the genuine :class:`EncryptionService` — not a mock — so the tests
+    exercise the actual encrypt/decrypt path, but with a key generated in the
+    test rather than read from the environment.
+    """
+    key = Fernet.generate_key()
+    monkeypatch.setattr(EncryptionService, "_load_or_generate_key", lambda self: key)
+    service = EncryptionService()
+    # Reset + pin the module-level singleton so ``get_encryption_service()``
+    # (used by shopify._encrypt_secret/_decrypt_secret) returns ours.
+    monkeypatch.setattr(encryption_module, "_encryption_service", service)
+    return service
+
+
+def test_encrypt_secret_produces_ciphertext_not_plaintext(real_encryption):
+    """The stored value must not be the raw token."""
+    stored = shopify._encrypt_secret(PLAINTEXT_TOKEN)
+
+    assert stored != PLAINTEXT_TOKEN
+    assert PLAINTEXT_TOKEN not in stored
+    # Fernet ciphertext is a non-empty base64 token, not the shpat_ prefix.
+    assert stored
+    assert not stored.startswith("shpat_")
+
+
+def test_decrypt_secret_round_trips(real_encryption):
+    """Ciphertext written at rest decrypts back to the original token."""
+    stored = shopify._encrypt_secret(PLAINTEXT_TOKEN)
+    recovered = shopify._decrypt_secret(stored)
+
+    assert recovered == PLAINTEXT_TOKEN
+
+
+def test_connect_settings_transform_stores_ciphertext(real_encryption):
+    """The exact settings mutation the /connect handler applies stores ciphertext.
+
+    Mirrors the handler's write without a DB session: the persisted
+    ``shopify_access_token`` is ciphertext and the raw token appears nowhere
+    under ``workspace.settings``.
+    """
+    settings: dict = {}
+    settings["shopify_domain"] = "example.myshopify.com"
+    settings["shopify_access_token"] = shopify._encrypt_secret(PLAINTEXT_TOKEN)
+
+    assert settings["shopify_access_token"] != PLAINTEXT_TOKEN
+    # Plaintext token must not leak into ANY settings value.
+    assert PLAINTEXT_TOKEN not in "".join(str(v) for v in settings.values())
+    # And it must round-trip for the reader.
+    assert shopify._decrypt_secret(settings["shopify_access_token"]) == PLAINTEXT_TOKEN
+
+
+def test_encryption_uses_canonical_fernet_service(real_encryption):
+    """Encryption is delegated to core.credentials.encryption (canonical path)."""
+    stored = shopify._encrypt_secret(PLAINTEXT_TOKEN)
+    # The canonical service must be able to decrypt what the helper produced,
+    # proving the helper used it rather than a parallel scheme.
+    assert real_encryption.decrypt(stored) == PLAINTEXT_TOKEN


### PR DESCRIPTION
Implements the **automatable parts of Wave 3 — Secret & Supply-Chain Hygiene (PRD-173)**. Closes the code half of F058, F012, and F092 (the SAST/dependabot/gitleaks slice). All refs re-confirmed on current `main` (`37fdecc4e`).

## What this PR does (code parts)

### F058 — Shopify Admin token encrypted at rest
`POST /api/shopify/connect` stored the merchant's 147-scope Shopify Admin token **verbatim** in `workspace.settings.shopify_access_token` while its docstring claimed encryption. Now:
- Encrypt on write / decrypt on read via the platform's **canonical Fernet path** (`core.credentials.encryption.get_encryption_service`, keyed from `config.CREDENTIAL_ENCRYPTION_KEY`) through two small helpers `_encrypt_secret` / `_decrypt_secret` in `orchestrator/api/shopify.py`. No hand-rolled crypto, no new dependency, no key in source.
- Docstring corrected to describe application-level encryption (no drift).
- `tests/test_prd173_shopify_token_encryption.py` (4 tests) asserts the stored value is ciphertext, not the plaintext token; round-trips; and delegates to the canonical service. Verified green locally with CI-equivalent env (`4 passed`).
- **Reader audit:** the only writer/reader of `settings["shopify_access_token"]` is this handler. The Composio bridge reads the separate n8n credential store (`ctx.decrypted_data`), so **no runtime reader breaks** — no reader migration needed.

### F012 — stop tracking the e2e auth fixture (gitignore only)
Added `tests/e2e/.auth/` to `.gitignore` so the Clerk dev-browser fixture (`__session` / `__clerk_db_jwt`) stops re-staging every run. **History purge is a human step (below).**

### F092 — standing supply-chain lanes
- `.github/workflows/codeql.yml` — CodeQL SAST over `python` + `javascript-typescript` (build-mode none), PRs to `main` + weekly.
- `.github/dependabot.yml` — `pip` (`/orchestrator`), `npm` (`/frontend`), `github-actions` (`/`), weekly.
- `.github/workflows/gitleaks.yml` — full-history (`fetch-depth: 0`) secret scan on PRs to `main`; doubles as the verification gate for the F012 purge.

Per PRD-173 §4.5, **migration-replay (W6)** and the **coverage ratchet (W12)** are explicitly *not* in this slice.

## Validation
- `python3 -m py_compile` on all changed `.py`: OK
- YAML well-formedness on all 3 new workflow/config files: OK
- F058 tests: `4 passed` (with CI-equivalent POSTGRES_* env; local import gate is the no-DB constraint, satisfied by CI's `test.yml`)
- **CI is the gate** for the new lanes (they run for the first time on this PR).

---

## ⚠️ PENDING HUMAN-ONLY STEPS — see [`docs/runbooks/W3-HUMAN-STEPS.md`](docs/runbooks/W3-HUMAN-STEPS.md)

These were deliberately **not** automated (destructive-history / live-cred / cross-repo-deploy). Exact copy-pasteable commands are in the runbook.

1. **F012 history purge (destructive).** `git rm --cached tests/e2e/.auth/user.json`, then `git filter-repo --path tests/e2e/.auth/user.json --invert-paths` on a mirror, coordinated force-push to protected `main`, collaborator re-clone/reset. Tagged rollback point `backup/pre-f012`. The gitleaks lane in this PR is the go/no-go verification.
2. **Credential rotation (live).** Revoke the Clerk dev-browser client; rotate AWS key `AKIA3ZLYFH2WTHW2CMN6`.
3. **F011 mem0 fork (cross-repo, `automatos-mem0`).** Confirmed on main: `fix/pool-exhaustion@16b27eb2` (PRD-156 token auth + PRD-159 metadata) is **NOT** an ancestor of fork `origin/main` (`5cbb4c1f`). Merge → fork main, pin the Railway service to the merged SHA, rebuild, run the **401-without-token boot probe** against `server/main.py`.
4. **F058 migration (owner decision).** Already-stored plaintext Shopify tokens: one-time re-encrypt migration **or** documented "reconnect to re-store encrypted". Surfaced, not decided (nothing breaks meanwhile — no runtime reader).

Draft until CI (test net + the 3 new lanes) is green and the human steps above are actioned.
