### PR TITLE
fix(prd-172): W2 tenant isolation closure (F002-F007/F039/F045/F019)

### DIFF
--- a/orchestrator/api/context.py
+++ b/orchestrator/api/context.py
@@ -53,7 +53,10 @@ class ContextAddRequest(BaseModel):
 router = APIRouter(prefix="/api/context", tags=["Context Engineering"])
 
 @router.post("/add")
-async def add_to_context(request: ContextAddRequest):
+async def add_to_context(
+    request: ContextAddRequest,
+    ctx: RequestContext = Depends(get_request_context_hybrid),
+):
     """
     Add database query results to context system.
     Makes query results available for AI agent context and future retrieval.
@@ -83,14 +86,17 @@ async def add_to_context(request: ContextAddRequest):
 
 @router.get("/stats")
 async def get_context_stats(
+    ctx: RequestContext = Depends(get_request_context_hybrid),
     rag_service: RAGService = Depends(get_rag_service),
     db: Session = Depends(get_db)
 ):
-    """Get real-time context engineering statistics"""
+    """Get real-time context engineering statistics (workspace-scoped)"""
     try:
-        # Get retrieval stats from RAG service (now reads from database)
-        retrieval_stats = rag_service.get_retrieval_stats(db)
-        
+        # PRD-172 F045: scope the document counts to the caller's workspace.
+        # admin_all_workspaces → None → unfiltered admin aggregate.
+        ws = None if getattr(ctx, "admin_all_workspaces", False) else ctx.workspace_id
+        retrieval_stats = rag_service.get_retrieval_stats(db, workspace_id=ws)
+
         return {
             "contextQueries": retrieval_stats['total_queries'],
             "retrievalSuccess": retrieval_stats['success_rate'],
@@ -107,6 +113,7 @@ async def get_context_stats(
 @router.get("/performance")
 async def get_rag_performance_data(
     time_range: str = Query("24h", regex="^(1h|24h|7d|30d)$", description="Time range: 1h, 24h, 7d, or 30d"),
+    ctx: RequestContext = Depends(get_request_context_hybrid),
     rag_service: RAGService = Depends(get_rag_service),
     db: Session = Depends(get_db)
 ):
@@ -121,6 +128,7 @@ async def get_rag_performance_data(
 
 @router.get("/sources")
 async def get_context_sources(
+    ctx: RequestContext = Depends(get_request_context_hybrid),
     rag_service: RAGService = Depends(get_rag_service),
     db: Session = Depends(get_db)
 ):
@@ -135,6 +143,7 @@ async def get_context_sources(
 @router.get("/queries/recent")
 async def get_recent_queries(
     limit: int = Query(default=10, ge=1, le=50),
+    ctx: RequestContext = Depends(get_request_context_hybrid),
     rag_service: RAGService = Depends(get_rag_service),
     db: Session = Depends(get_db)
 ):
@@ -148,6 +157,7 @@ async def get_recent_queries(
 
 @router.get("/patterns")
 async def get_context_patterns(
+    ctx: RequestContext = Depends(get_request_context_hybrid),
     rag_service: RAGService = Depends(get_rag_service),
     db: Session = Depends(get_db)
 ):
@@ -163,6 +173,7 @@ async def get_context_patterns(
 async def test_rag_configuration(
     config_id: int,
     query: str = Query(..., description="Test query for RAG system"),
+    ctx: RequestContext = Depends(get_request_context_hybrid),
     rag_service: RAGService = Depends(get_rag_service),
     db: Session = Depends(get_db)
 ):
@@ -183,12 +194,14 @@ async def test_rag_configuration(
 
 @router.get("/system/health")
 async def get_context_system_health(
+    ctx: RequestContext = Depends(get_request_context_hybrid),
     rag_service: RAGService = Depends(get_rag_service),
     db: Session = Depends(get_db)
 ):
-    """Get context engineering system health"""
+    """Get context engineering system health (workspace-scoped)"""
     try:
-        stats = rag_service.get_retrieval_stats(db)
+        ws = None if getattr(ctx, "admin_all_workspaces", False) else ctx.workspace_id
+        stats = rag_service.get_retrieval_stats(db, workspace_id=ws)
         
         return {
             "status": "healthy" if stats['system_status'] == 'operational' else "degraded",
@@ -214,6 +227,7 @@ async def get_context_system_health(
 @router.post("/initialize")
 async def initialize_context_system(
     database_url: Optional[str] = None,
+    ctx: RequestContext = Depends(get_request_context_hybrid),
     rag_service: RAGService = Depends(get_rag_service)
 ):
     """Initialize or reinitialize the context engineering system"""

--- a/orchestrator/api/github_webhooks.py
+++ b/orchestrator/api/github_webhooks.py
@@ -15,7 +15,6 @@ from sqlalchemy.orm import Session
 
 from config import config
 from core.database.database import get_db
-from api.workflows import execute_workflow
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/github", tags=["github"])
@@ -127,28 +126,27 @@ async def github_webhook(
                 }
             }
             
-            try:
-                # Execute workflow asynchronously
-                execution = await execute_workflow(
-                    pr_workflow.id,
-                    execution_data,
-                    background_tasks,
-                    db
-                )
-                
-                logger.info(f"✅ Triggered PR review workflow for PR #{pr_number}")
-                
-                return {
-                    "status": "success",
-                    "message": f"PR review workflow triggered for PR #{pr_number}",
-                    "execution_id": execution.get("id"),
-                    "pr": pr_number,
-                    "workflow": pr_workflow.name
-                }
-                
-            except Exception as e:
-                logger.error(f"Failed to trigger PR review: {e}")
-                raise HTTPException(status_code=500, detail="Internal server error")
+            # PRD-172 F006 / PRD-125: the legacy workflow-execute path this
+            # webhook called was a disabled no-op stub reached via a broken
+            # argument list — it never actually ran a PR review. That dead
+            # trigger was removed with the legacy execute routes. Migrating the
+            # PR-review trigger onto the mission system is execution-spine work
+            # (out of this tenancy-closure PRD's scope). Acknowledge the webhook
+            # honestly instead of pretending to have started a run.
+            logger.info(
+                "PR #%s matched workflow %r, but legacy workflow execution is "
+                "disabled (PRD-125). PR-review auto-trigger awaits mission "
+                "migration.", pr_number, pr_workflow.name,
+            )
+            return {
+                "status": "workflow_execution_disabled",
+                "message": (
+                    "Legacy workflow execution is disabled (PRD-125). "
+                    "PR-review auto-trigger will move to the mission system."
+                ),
+                "pr": pr_number,
+                "workflow": pr_workflow.name,
+            }
     
     # Health check / ping event
     elif x_github_event == "ping":

--- a/orchestrator/api/memory.py
+++ b/orchestrator/api/memory.py
@@ -64,6 +64,22 @@ def get_memory_manager() -> AdvancedMemoryManager:
         )
     return memory_manager
 
+
+def _scoped_session(ctx: RequestContext, session_id: Optional[str]) -> Optional[str]:
+    """PRD-172 F039: namespace a caller-supplied session_id by workspace.
+
+    The AdvancedMemoryManager is a single process-global store shared by every
+    tenant, keyed on ``{session_id}_{timestamp}``. Passing the raw session_id
+    through lets workspace A read/write workspace B's memory simply by reusing a
+    session_id string. Prefixing every session_id that crosses into the store
+    with ``{workspace_id}::`` gives each workspace its own key space — A's
+    "abc" and B's "abc" become distinct keys — without changing the shared
+    store's internals. ``None`` (consolidate-all) is preserved as-is.
+    """
+    if session_id is None:
+        return None
+    return f"{ctx.workspace_id}::{session_id}"
+
 # Memory Storage Endpoints
 
 @router.post("/store", response_model=Dict[str, Any])
@@ -79,15 +95,17 @@ async def store_memory(
     try:
         manager = get_memory_manager()
         
+        # PRD-172 F039: namespace the session by workspace so tenant A cannot
+        # write into tenant B's memory by reusing a session_id.
         memory_id = await manager.store_memory(
-            session_id=memory_data.session_id,
+            session_id=_scoped_session(ctx, memory_data.session_id),
             content=memory_data.content,
             memory_type=MemoryType(memory_data.memory_type),
             importance=memory_data.importance,
             tags=memory_data.tags,
             auto_augment=auto_augment
         )
-        
+
         return {
             "memory_id": memory_id,
             "session_id": memory_data.session_id,

--- a/orchestrator/api/shopify.py
+++ b/orchestrator/api/shopify.py
@@ -13,6 +13,7 @@ Automatos app from the Shopify App Store:
 
 from __future__ import annotations
 
+import hmac
 import logging
 from typing import Any, Dict, List, Optional
 from uuid import UUID, uuid4
@@ -22,6 +23,8 @@ from pydantic import BaseModel, Field
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
+from core.auth.dependencies import RequestContext
+from core.auth.hybrid import get_request_context_hybrid
 from core.database.database import get_db
 from core.models.core import Agent, Skill
 from core.models.workspaces import Workspace
@@ -31,9 +34,6 @@ from config import config
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/shopify", tags=["Shopify Integration"])
-
-# Internal API key for Shopify app → Automatos server calls
-SHOPIFY_INTERNAL_KEY = config.SHOPIFY_INTERNAL_API_KEY if hasattr(config, "SHOPIFY_INTERNAL_API_KEY") else None
 
 
 # ── At-rest secret encryption (F058) ─────────────────────────────────
@@ -62,13 +62,46 @@ def _decrypt_secret(ciphertext: str) -> str:
 
 # ── Auth helper ──────────────────────────────────────────────────────
 
+def _resolve_sync_workspace(ctx: RequestContext, requested: Optional[str]) -> str:
+    """PRD-172 F003: resolve the workspace a Shopify sync route may act on.
+
+    The sync routes previously trusted a caller-supplied ``workspace_id`` query
+    param and ran with only ``db=Depends(get_db)`` — a guessed UUID triggered
+    costly Composio bulk-ops and overwrote another tenant's knowledge graph via
+    ``import_graph(merge=False)``. Now every sync route carries the shared
+    workspace-scoped auth dependency and derives its target from ``ctx``:
+
+    - A cross-workspace admin (``admin_all_workspaces``) may target any explicit
+      ``requested`` workspace (ops/backfill), else its own.
+    - Every other caller is pinned to ``ctx.workspace_id``; a mismatched
+      ``requested`` param is rejected 403 rather than silently honoured.
+    """
+    if getattr(ctx, "admin_all_workspaces", False):
+        return str(requested) if requested else str(ctx.workspace_id)
+    if requested and str(requested) != str(ctx.workspace_id):
+        raise HTTPException(
+            status_code=403,
+            detail="workspace_id does not match the authenticated workspace",
+        )
+    return str(ctx.workspace_id)
+
+
 def _verify_internal_key(authorization: str = Header(...)) -> None:
-    """Verify the internal API key from the Shopify app server."""
-    if not SHOPIFY_INTERNAL_KEY:
-        # No key configured — accept all (dev mode)
-        return
-    token = authorization.replace("Bearer ", "")
-    if token != SHOPIFY_INTERNAL_KEY:
+    """Verify the internal API key from the Shopify app server.
+
+    PRD-172 F004: fail-closed. There is NO "no key configured → accept all"
+    branch — an unset key is caught at boot by ``config.validate_security()``,
+    so by the time a request lands the key is guaranteed present and this only
+    ever compares against a real secret. A falsy configured key can no longer
+    wave through an arbitrary ``Authorization: Bearer x``.
+    """
+    expected = (config.SHOPIFY_INTERNAL_API_KEY or "").strip()
+    if not expected:
+        # Defence in depth: boot should already have failed. Refuse rather than
+        # fall open if this is somehow reached (e.g. key blanked at runtime).
+        raise HTTPException(status_code=503, detail="Shopify provisioning not configured")
+    token = authorization.replace("Bearer ", "").strip()
+    if not hmac.compare_digest(token, expected):
         raise HTTPException(status_code=401, detail="Invalid internal API key")
 
 
@@ -612,8 +645,22 @@ class SyncStartResponse(BaseModel):
 @router.post("/sync/products/start", response_model=SyncStartResponse)
 async def start_product_sync(
     workspace_id: Optional[str] = None,
+    ctx: RequestContext = Depends(get_request_context_hybrid),
     db: Session = Depends(get_db),
 ):
+    """HTTP entrypoint for the Shopify catalog sync (PRD-172 F003 authed).
+
+    The workspace-scoped auth dependency proves the tenant; the effective
+    workspace is derived from ``ctx`` (never a guessed query param). The heavy
+    lifting lives in ``_product_sync_impl`` so the internal auto-trigger
+    (``api/tools.py`` on SHOPIFY going active) can call it directly with an
+    already-trusted workspace_id.
+    """
+    effective_ws = _resolve_sync_workspace(ctx, workspace_id)
+    return await _product_sync_impl(effective_ws, db)
+
+
+async def _product_sync_impl(workspace_id: str, db: Session) -> "SyncStartResponse":
     """
     Run a full Shopify catalog sync → knowledge graph for a workspace.
 
@@ -623,8 +670,8 @@ async def start_product_sync(
       - modules.knowledge.graph_service.GraphifyService.import_graph
       - core.composio.entity_manager.EntityManager
 
-    Called manually (admin) or auto-triggered when a workspace's SHOPIFY
-    Composio connection flips pending → active (see consumer of this).
+    Callers MUST pass an already-authorised ``workspace_id`` (the HTTP route
+    resolves it from ``ctx``; the internal auto-trigger passes ``ctx.workspace_id``).
     """
     import time
     import httpx
@@ -764,12 +811,16 @@ async def start_product_sync(
 @router.get("/sync/status")
 async def get_product_sync_status(
     workspace_id: Optional[str] = None,
+    ctx: RequestContext = Depends(get_request_context_hybrid),
     db: Session = Depends(get_db),
 ):
-    """Return the current product_sync state stored on the workspace."""
-    if not workspace_id:
-        raise HTTPException(status_code=400, detail="workspace_id required")
-    workspace = db.query(Workspace).get(workspace_id)
+    """Return the current product_sync state stored on the workspace.
+
+    PRD-172 F003: scoped to the authenticated workspace — a guessed UUID can no
+    longer read another tenant's sync state.
+    """
+    effective_ws = _resolve_sync_workspace(ctx, workspace_id)
+    workspace = db.query(Workspace).get(effective_ws)
     if not workspace:
         raise HTTPException(status_code=404, detail="Workspace not found")
     return (workspace.settings or {}).get("product_sync") or {"status": "never_synced"}
@@ -832,13 +883,26 @@ async def start_orders_sync(
     workspace_id: Optional[str] = None,
     days: int = 90,
     min_support: int = 2,
+    ctx: RequestContext = Depends(get_request_context_hybrid),
     db: Session = Depends(get_db),
 ):
+    """HTTP entrypoint for the Shopify orders sync (PRD-172 F003 authed).
+
+    Proves the tenant via the shared auth dependency and derives the workspace
+    from ``ctx`` before running the (costly, graph-mutating) sync.
+    """
+    effective_ws = _resolve_sync_workspace(ctx, workspace_id)
+    return await _orders_sync_impl(effective_ws, days, min_support, db)
+
+
+async def _orders_sync_impl(
+    workspace_id: str, days: int, min_support: int, db: Session
+) -> "OrdersSyncResponse":
     """
     Run a Shopify orders sync → FBT edges merged into the workspace graph.
 
     Args:
-        workspace_id: target workspace.
+        workspace_id: target workspace (already authorised by the caller).
         days: time window for orders (default 90). Older orders less
               relevant for current customer co-purchase patterns.
         min_support: minimum number of orders a (Product A, Product B) pair
@@ -1016,12 +1080,15 @@ async def start_orders_sync(
 @router.get("/sync/orders/status")
 async def get_orders_sync_status(
     workspace_id: Optional[str] = None,
+    ctx: RequestContext = Depends(get_request_context_hybrid),
     db: Session = Depends(get_db),
 ):
-    """Return the current orders_sync state stored on the workspace."""
-    if not workspace_id:
-        raise HTTPException(status_code=400, detail="workspace_id required")
-    workspace = db.query(Workspace).get(workspace_id)
+    """Return the current orders_sync state stored on the workspace.
+
+    PRD-172 F003: scoped to the authenticated workspace.
+    """
+    effective_ws = _resolve_sync_workspace(ctx, workspace_id)
+    workspace = db.query(Workspace).get(effective_ws)
     if not workspace:
         raise HTTPException(status_code=404, detail="Workspace not found")
     return (workspace.settings or {}).get("orders_sync") or {"status": "never_synced"}

--- a/orchestrator/api/skills.py
+++ b/orchestrator/api/skills.py
@@ -136,6 +136,52 @@ def _assert_admin(ctx: RequestContext) -> None:
             raise HTTPException(status_code=403, detail="Admin access required")
 
 
+# ---------------------------------------------------------------------------
+# PRD-172 F002: tenant isolation for skills + agent-skill attach.
+#
+# A Skill with workspace_id IS NULL is a global/marketplace skill (readable by
+# every workspace, deletable only by super-admin). A Skill with a UUID belongs
+# to exactly one workspace. Agents are always workspace-scoped (non-nullable).
+# These helpers replace the previous "ctx is accepted but never used" pattern.
+# ---------------------------------------------------------------------------
+
+def _is_super_admin(ctx: RequestContext) -> bool:
+    """True for cross-workspace admins (mirrors core.auth.super_admin semantics).
+
+    An admin operating with the ``__all__`` sentinel (``admin_all_workspaces``)
+    or literally ``system_role == 'super_admin'`` may reach any workspace's
+    skills. Fail-closed: anything else is workspace-scoped.
+    """
+    if getattr(ctx, "admin_all_workspaces", False):
+        return True
+    return getattr(getattr(ctx, "user", None), "system_role", None) == "super_admin"
+
+
+def _skill_visible_to(skill: "Skill", ctx: RequestContext) -> bool:
+    """True if the caller may read/attach *skill*.
+
+    Global skills (``workspace_id IS NULL``) are visible to all workspaces;
+    workspace-owned skills only to their owning workspace (or a super-admin).
+    """
+    if _is_super_admin(ctx):
+        return True
+    if skill.workspace_id is None:
+        return True
+    return skill.workspace_id == ctx.workspace_id
+
+
+def _assert_agent_in_workspace(agent: "Agent", ctx: RequestContext) -> None:
+    """Raise 404 if *agent* is not owned by the caller's workspace.
+
+    404 (not 403) so the endpoint does not confirm the existence of another
+    workspace's agent — it looks identical to "no such agent".
+    """
+    if _is_super_admin(ctx):
+        return
+    if agent.workspace_id != ctx.workspace_id:
+        raise HTTPException(status_code=404, detail="Agent not found")
+
+
 # ----------------------------------------------------------------------------
 # PRD-22: Local skill recommendation helper
 # ----------------------------------------------------------------------------
@@ -561,10 +607,12 @@ async def get_skill_details(
     """
     try:
         skill = db.query(Skill).filter(Skill.id == skill_id).first()
-        
-        if not skill:
+
+        # PRD-172 F002: workspace-owned skills are invisible to other workspaces.
+        # 404 (not 403) so the endpoint doesn't confirm another tenant's skill exists.
+        if not skill or not _skill_visible_to(skill, ctx):
             raise HTTPException(status_code=404, detail="Skill not found")
-        
+
         return EnhancedSkillResponse(
             id=skill.id,
             name=skill.name,
@@ -619,10 +667,11 @@ async def get_skill_content(
     """
     try:
         skill = db.query(Skill).filter(Skill.id == skill_id).first()
-        
-        if not skill:
+
+        # PRD-172 F002: don't serve another workspace's private SKILL.md content.
+        if not skill or not _skill_visible_to(skill, ctx):
             raise HTTPException(status_code=404, detail="Skill not found")
-        
+
         skill_loader = get_skill_loader(db)
         content = ""
         estimated_tokens = 0
@@ -742,17 +791,31 @@ async def deactivate_skill(
     """
     try:
         skill = db.query(Skill).filter(Skill.id == skill_id).first()
-        
+
         if not skill:
             raise HTTPException(status_code=404, detail="Skill not found")
-        
+
+        # PRD-172 F002: a global builtin-core skill (workspace_id IS NULL) is
+        # shared by every tenant — deactivating it lobotomises every workspace's
+        # Auto. Only a super-admin may delete a global skill. A workspace-scoped
+        # caller may delete ONLY a skill its own workspace owns; another
+        # workspace's private skill is 404 (existence not confirmed).
+        if not _is_super_admin(ctx):
+            if skill.workspace_id is None:
+                raise HTTPException(
+                    status_code=403,
+                    detail="Global skills can only be deleted by a super-admin",
+                )
+            if skill.workspace_id != ctx.workspace_id:
+                raise HTTPException(status_code=404, detail="Skill not found")
+
         skill.is_active = False
-        
+
         # Remove from all agent assignments
         db.query(agent_skills).filter(agent_skills.c.skill_id == skill_id).delete()
-        
+
         db.commit()
-        
+
         return {"message": "Skill deactivated successfully"}
         
     except HTTPException:
@@ -784,6 +847,9 @@ async def get_agent_skills(
 
         if not agent:
             raise HTTPException(status_code=404, detail="Agent not found")
+
+        # PRD-172 F002: don't expose another workspace's agent-skill roster.
+        _assert_agent_in_workspace(agent, ctx)
 
         TOKEN_WARNING_THRESHOLD = 15_000
 
@@ -854,19 +920,35 @@ async def assign_skills_to_agent(
     """
     try:
         agent = db.query(Agent).filter(Agent.id == agent_id).first()
-        
+
         if not agent:
             raise HTTPException(status_code=404, detail="Agent not found")
-        
-        # Verify skills exist
-        skills = db.query(Skill).filter(
+
+        # PRD-172 F002: the caller may only attach skills to an agent its own
+        # workspace owns — otherwise a workspace could graft its skills onto
+        # another tenant's agent.
+        _assert_agent_in_workspace(agent, ctx)
+
+        # Verify skills exist. PRD-172 F002: only global skills (workspace_id
+        # IS NULL) or skills owned by the caller's workspace are attachable —
+        # never another workspace's private SKILL.md (prompt-injection /
+        # exfiltration vector). Super-admins may attach any skill.
+        skill_query = db.query(Skill).filter(
             Skill.id.in_(skill_ids),
             Skill.is_active == True
-        ).all()
-        
+        )
+        if not _is_super_admin(ctx):
+            skill_query = skill_query.filter(
+                or_(
+                    Skill.workspace_id.is_(None),
+                    Skill.workspace_id == ctx.workspace_id,
+                )
+            )
+        skills = skill_query.all()
+
         if len(skills) != len(skill_ids):
             raise HTTPException(status_code=400, detail="One or more skills not found or inactive")
-        
+
         # Assign skills
         if replace:
             agent.skills = skills
@@ -925,7 +1007,10 @@ async def remove_skills_from_agent(
         
         if not agent:
             raise HTTPException(status_code=404, detail="Agent not found")
-        
+
+        # PRD-172 F002: only mutate skills on an agent the caller's workspace owns.
+        _assert_agent_in_workspace(agent, ctx)
+
         # Remove skills
         agent.skills = [s for s in agent.skills if s.id not in skill_ids]
         

--- a/orchestrator/api/tools.py
+++ b/orchestrator/api/tools.py
@@ -269,13 +269,14 @@ async def connected(
                     # background task so we don't block this listing endpoint.
                     if (conn.get("app_name") or "").upper() == "SHOPIFY":
                         try:
-                            from api.shopify import start_product_sync
+                            # PRD-172 F003: call the impl directly with the
+                            # already-trusted ctx.workspace_id — the HTTP route's
+                            # auth wrapper is for external callers, not this
+                            # in-process auto-trigger.
+                            from api.shopify import _product_sync_impl
                             import asyncio as _asyncio
                             _asyncio.create_task(
-                                start_product_sync(
-                                    workspace_id=str(ctx.workspace_id),
-                                    db=db,
-                                )
+                                _product_sync_impl(str(ctx.workspace_id), db)
                             )
                             logger.info(
                                 "[PRD-009] Auto-fired Shopify product sync for workspace %s",

--- a/orchestrator/api/workflows.py
+++ b/orchestrator/api/workflows.py
@@ -1045,130 +1045,17 @@ async def execute_workflow_advanced(
         logger.error(f"Error executing workflow {workflow_id}: {e}")
         raise HTTPException(status_code=500, detail="Internal server error")
 
-# Additional endpoints for user journey tests
-@router.post("/{workflow_id}/execute")
-async def execute_workflow(
-    workflow_id: int,
-    execution_data: Dict[str, Any],
-    ctx: RequestContext = Depends(get_request_context_hybrid),
-    db: Session = Depends(get_db)
-):
-    """Execute workflow (simplified version for journey tests)"""
-    try:
-        # Validate workflow exists with proper loading
-        workflow = db.query(Workflow).options(
-            joinedload(Workflow.agents)
-        ).filter(Workflow.id == workflow_id).first()
-
-        if not workflow:
-            raise HTTPException(status_code=404, detail="Workflow not found")
-
-        if not workflow.id:
-            raise HTTPException(status_code=400, detail="Invalid workflow data")
-
-        # Get agent with skills loaded
-        agent = db.query(Agent).options(
-            joinedload(Agent.skills)
-        ).filter(Agent.status == 'active').first()
-
-        if not agent:
-            raise HTTPException(status_code=400, detail="No active agents available")
-
-        if not agent.id:
-            logger.error(f"❌ Agent object missing ID: {agent}")
-            raise HTTPException(status_code=500, detail="Agent data corruption - missing ID")
-
-        # Validate input_data
-        input_data = execution_data.get('input_data')
-        if not input_data:
-            logger.warning("⚠️  No input_data provided, using empty dict")
-            input_data = {}
-
-        if not isinstance(input_data, dict):
-            raise HTTPException(
-                status_code=400,
-                detail=f"input_data must be a dictionary, got {type(input_data).__name__}"
-            )
-
-        logger.info(f"🚀 Creating execution for workflow {workflow_id} with agent {agent.id}")
-        logger.info(f"   Agent skills: {len(agent.skills) if agent.skills else 0}")
-
-        # Create execution record
-        execution = WorkflowExecution(
-            workflow_id=workflow_id,
-            agent_id=agent.id,
-            workspace_id=ctx.workspace_id,
-            input_data=input_data,
-            status=ExecutionStatus.PENDING.value
-        )
-        
-        db.add(execution)
-        db.commit()
-        db.refresh(execution)
-        
-        # PRD-56: Dispatch through TaskRunner abstraction
-        runner = get_task_runner()
-
-        if runner.backend_name == "queued":
-            # Phase 2: Enqueue to workspace worker
-            task = AgentTask(
-                task_type=TaskType.WORKFLOW_SUBTASK,
-                workspace_id=ctx.workspace_id,
-                agent_id=agent.id,
-                prompt=json.dumps(input_data),
-                context={
-                    "execution_id": execution.id,
-                    "workflow_id": workflow_id,
-                    "options": execution_data.get('options', {}),
-                },
-                priority=TaskPriority.NORMAL,
-                timeout_seconds=600,
-            )
-            handle = await runner.submit_task(task)
-            logger.info(f"Workflow {workflow_id} execution {execution.id} queued (task={handle.task_id[:8]})")
-        else:
-            # Phase 1 / Local: Run in-process (existing behavior), guarded so a
-            # GC'd loop can't silently cancel it and an uncaught crash is recorded.
-            launch_guarded(
-                execute_workflow_with_progress(
-                    execution.id,
-                    execution_data.get('options', {})
-                ),
-                subsystem="workflow",
-                operation="execute",
-                workspace_id=ctx.workspace_id,
-                extra={"execution_id": execution.id, "workflow_id": workflow_id},
-            )
-
-        logger.info(f"Workflow {workflow_id} execution {execution.id} started")
-        
-        return {
-            "id": execution.id,
-            "execution_id": execution.id,
-            "workflow_id": workflow_id,
-            "status": "started",
-            "message": "Workflow execution started"
-        }
-        
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error(f"Error executing workflow {workflow_id}: {e}")
-        raise HTTPException(status_code=500, detail="Internal server error")
-
-@router.post("/execute")
-async def execute_workflow_general(execution_data: Dict[str, Any], ctx: RequestContext = Depends(get_request_context_hybrid), db: Session = Depends(get_db)):
-    """General workflow execution endpoint"""
-    try:
-        workflow_id = execution_data.get('workflow_id')
-        if not workflow_id:
-            raise HTTPException(status_code=400, detail="workflow_id required")
-
-        return await execute_workflow(workflow_id, execution_data, ctx, db)
-        
-    except Exception as e:
-        logger.error(f"Error in general workflow execution: {e}")
-        raise HTTPException(status_code=500, detail="Internal server error")
+# PRD-172 F006: the legacy PRD-125 workflow-execute surface was DELETED here.
+#
+# `POST /{workflow_id}/execute` (execute_workflow), `POST /execute`
+# (execute_workflow_general) and `POST /executions/` (create_execution) formed
+# a cross-tenant existence oracle: they fetched the Workflow with NO workspace
+# filter and selected "the first active agent from ANY workspace", then handed
+# off to `execute_workflow_with_progress` — a disabled no-op stub (PRD-125).
+# Both surviving callers (github_webhooks, create_execution) already passed a
+# broken argument list, so nothing functional was lost. Missions are the
+# canonical execution path (CLAUDE.md §5/§10). The workspace-scoped
+# `POST /{workflow_id}/execute-advanced` (execute_workflow_advanced) remains.
 
 @router.get("/executions/")
 async def list_executions(
@@ -1213,15 +1100,9 @@ async def list_executions(
         logger.error(f"Error listing executions: {e}")
         raise HTTPException(status_code=500, detail="Internal server error")
 
-@router.post("/executions/")
-async def create_execution(execution_data: Dict[str, Any], db: Session = Depends(get_db)):
-    """Create workflow execution"""
-    try:
-        workflow_id = execution_data.get('workflow_id')
-        return await execute_workflow(workflow_id, execution_data, db)
-    except Exception as e:
-        logger.error(f"Error creating execution: {e}")
-        raise HTTPException(status_code=500, detail="Internal server error")
+# PRD-172 F006: `POST /executions/` (create_execution) deleted — it delegated
+# to the removed legacy execute_workflow with a broken argument list (see the
+# deletion note above). Executions are created inside execute_workflow_advanced.
 
 @router.get("/executions/{execution_id}")
 async def get_execution_status(execution_id: int, db: Session = Depends(get_db)):

--- a/orchestrator/config.py
+++ b/orchestrator/config.py
@@ -890,6 +890,56 @@ class Config:
     VOICE_MAX_AUDIO_SIZE_MB: int = int(os.getenv("VOICE_MAX_AUDIO_SIZE_MB", "25"))
     AUTO_VOICE_PROVIDER: str = os.getenv("AUTO_VOICE_PROVIDER", "chatterbox")
 
+    def validate_security(self) -> None:
+        """PRD-172: fail-closed validation of tenant-isolation secrets.
+
+        Called from the hard-fail boot phase (``main._boot_phase_1_core``) so a
+        misconfigured multi-tenant secret turns a silent cross-tenant leak into a
+        loud boot failure rather than shipping fail-open.
+
+        Raises ``RuntimeError`` (which aborts boot) when:
+
+        - F004: ``SHOPIFY_INTERNAL_API_KEY`` is unset while the Shopify
+          provisioning surface is reachable — an empty key previously made
+          ``_verify_internal_key`` accept any ``Authorization`` header.
+        - F005: S3 Vectors is enabled but ``S3_VECTORS_BUCKET`` does not embed
+          the ``{workspace_id}`` placeholder — a shared bucket with no
+          placeholder is a cross-tenant leak by construction, since every
+          workspace would resolve to the same physical bucket.
+        """
+        errors: list[str] = []
+
+        # F004 — Shopify provisioning must not be fail-open.
+        if not (self.SHOPIFY_INTERNAL_API_KEY or "").strip():
+            errors.append(
+                "SHOPIFY_INTERNAL_API_KEY is unset — the Shopify provisioning "
+                "surface (/api/shopify/provision|connect|deactivate) would accept "
+                "any Authorization header (fail-open). Set SHOPIFY_INTERNAL_API_KEY."
+            )
+
+        # F005 — a shared S3 Vectors bucket with no per-workspace placeholder
+        # leaks chunks across tenants. Only assert when the feature is enabled.
+        if self.S3_VECTORS_ENABLED:
+            bucket = (self.S3_VECTORS_BUCKET or "").strip()
+            if not bucket:
+                errors.append(
+                    "S3_VECTORS_ENABLED=true but S3_VECTORS_BUCKET is unset."
+                )
+            elif "{workspace_id}" not in bucket:
+                errors.append(
+                    "S3_VECTORS_ENABLED=true but S3_VECTORS_BUCKET "
+                    f"({bucket!r}) does not contain the '{{workspace_id}}' "
+                    "placeholder — every workspace would share one bucket "
+                    "(cross-tenant vector leak). Use e.g. "
+                    "'automatos-vectors-{workspace_id}'."
+                )
+
+        if errors:
+            raise RuntimeError(
+                "Tenant-isolation security config invalid (PRD-172):\n  - "
+                + "\n  - ".join(errors)
+            )
+
     def validate(self) -> bool:
         """
         Validate required configuration

--- a/orchestrator/core/monitoring/automatos_alerts.py
+++ b/orchestrator/core/monitoring/automatos_alerts.py
@@ -19,6 +19,7 @@ from fastapi import APIRouter, Depends, Header, HTTPException, Request
 from pydantic import BaseModel
 
 from config import config
+from core.auth.super_admin import require_super_admin
 
 logger = logging.getLogger(__name__)
 
@@ -208,13 +209,16 @@ def create_alerts_router(get_db_dependency) -> APIRouter:
             "errors": errors,
         }
 
-    @router.get("/alerts")
+    @router.get("/alerts", dependencies=[Depends(require_super_admin)])
     async def list_alerts(
         status: Optional[str] = None,
         severity: Optional[str] = None,
         limit: int = 50,
         db=Depends(get_db_dependency),
     ):
+        # PRD-172 F007: the alert read surface is the obs tier (PRD-143) —
+        # super-admin only. The ALERT_INGEST_TOKEN bearer check stays on the
+        # ingest POST above (AlertManager is machine-to-machine, no user session).
         from sqlalchemy import text
         conditions = []
         params = {"limit": limit}

--- a/orchestrator/core/monitoring/automatos_logs_api.py
+++ b/orchestrator/core/monitoring/automatos_logs_api.py
@@ -16,15 +16,15 @@ from datetime import datetime, timezone, timedelta
 from typing import Optional
 from urllib.parse import urlencode
 
-from fastapi import APIRouter, Header, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 
 from config import config
+from core.auth.super_admin import require_super_admin
 
 logger = logging.getLogger(__name__)
 
 # PRD-142 W3-S5 / G7 — env reads routed through config.
 LOKI_URL = config.LOKI_QUERY_URL
-ALERT_INGEST_TOKEN = config.ALERT_INGEST_TOKEN
 
 
 def _build_logql(
@@ -83,8 +83,16 @@ def _parse_iso_or_relative(value: Optional[str], default_delta: timedelta) -> st
 
 
 def create_logs_router() -> APIRouter:
-    """Create the logs query router."""
-    router = APIRouter(tags=["logs"])
+    """Create the logs query router.
+
+    PRD-172 F007: the Loki log-query surface is the obs tier (PRD-143) — every
+    route is super-admin only. A caller-supplied ``workspace_id`` filter made
+    this a cross-workspace log-read oracle; ``require_super_admin`` at the router
+    level closes it. The old per-route ALERT_INGEST_TOKEN checks (a
+    machine-to-machine control misapplied to a human read surface) are removed
+    in favour of the canonical role gate.
+    """
+    router = APIRouter(tags=["logs"], dependencies=[Depends(require_super_admin)])
 
     @router.get("/logs/query")
     async def query_logs(
@@ -99,19 +107,11 @@ def create_logs_router() -> APIRouter:
         end: Optional[str] = Query(None, description="End time (ISO8601 or relative)"),
         limit: int = Query(100, ge=1, le=1000, description="Max entries to return"),
         direction: str = Query("backward", description="Sort direction: backward or forward"),
-        authorization: Optional[str] = Header(None),
     ):
-        """Query logs from Loki.
+        """Query logs from Loki (super-admin only — see router dependency).
 
         Supports raw LogQL or convenience parameters that auto-build the query.
-        Requires Bearer token authentication (same as alert ingest).
         """
-        # Auth
-        if ALERT_INGEST_TOKEN:
-            expected = f"Bearer {ALERT_INGEST_TOKEN}"
-            if authorization != expected:
-                raise HTTPException(status_code=401, detail="Invalid token")
-
         # Build LogQL
         logql = _build_logql(query, service, level, workspace_id, error_fingerprint, request_id, module)
 
@@ -183,15 +183,8 @@ def create_logs_router() -> APIRouter:
         }
 
     @router.get("/logs/labels")
-    async def list_labels(
-        authorization: Optional[str] = Header(None),
-    ):
-        """List available Loki label names."""
-        if ALERT_INGEST_TOKEN:
-            expected = f"Bearer {ALERT_INGEST_TOKEN}"
-            if authorization != expected:
-                raise HTTPException(status_code=401, detail="Invalid token")
-
+    async def list_labels():
+        """List available Loki label names (super-admin only)."""
         import asyncio
         from urllib.request import Request, urlopen
 
@@ -207,16 +200,8 @@ def create_logs_router() -> APIRouter:
             raise HTTPException(status_code=502, detail=f"Loki labels query failed: {e}")
 
     @router.get("/logs/label/{label_name}/values")
-    async def label_values(
-        label_name: str,
-        authorization: Optional[str] = Header(None),
-    ):
-        """List values for a specific Loki label."""
-        if ALERT_INGEST_TOKEN:
-            expected = f"Bearer {ALERT_INGEST_TOKEN}"
-            if authorization != expected:
-                raise HTTPException(status_code=401, detail="Invalid token")
-
+    async def label_values(label_name: str):
+        """List values for a specific Loki label (super-admin only)."""
         import asyncio
         from urllib.request import Request, urlopen
 

--- a/orchestrator/main.py
+++ b/orchestrator/main.py
@@ -171,6 +171,12 @@ async def _boot_phase_1_core():
     from core.database.database import create_tables, get_db_session, engine
     from core.database.boot_lock import boot_leader_lock
 
+    # PRD-172 F004/F005: fail-closed on tenant-isolation secrets BEFORE any
+    # traffic is served. Raises RuntimeError (aborting boot) if the Shopify
+    # internal key is unset or the S3 Vectors bucket lacks the {workspace_id}
+    # placeholder — a loud boot failure beats a silent cross-tenant leak.
+    config.validate_security()
+
     # DDL — safe for all workers (idempotent, fast no-op when tables exist)
     create_tables()
 

--- a/orchestrator/modules/nl2sql/query/validator.py
+++ b/orchestrator/modules/nl2sql/query/validator.py
@@ -35,9 +35,74 @@ _FORBIDDEN_NODES = (
 # Roots that are read-only result expressions.
 _READ_ONLY_ROOTS = (exp.Select, exp.Union, exp.Intersect, exp.Except)
 
+# PRD-172 F019: side-effecting / dangerous SQL functions that MUST NOT appear
+# inside a nominally read-only SELECT. The DML/DDL node walk above cannot see
+# these — they are function calls, not statement nodes — so a payload like
+# ``SELECT query_to_xml('UPDATE users SET is_admin=true', true, true, '')`` (or
+# ``dblink_exec``, ``lo_export``, ``pg_read_file`` …) previously passed the
+# SELECT-only check and still mutated data / touched the filesystem / opened a
+# network connection. Names are matched case-insensitively against every
+# function node in the parsed tree (see ``_forbidden_function_in``). Postgres is
+# the primary target (it is what the platform runs) but common cross-engine
+# offenders are included for defence-in-depth.
+_FORBIDDEN_FUNCTIONS = frozenset({
+    # Postgres: run arbitrary SQL (incl. writes) from inside a SELECT.
+    "query_to_xml", "query_to_xmlschema", "query_to_xml_and_xmlschema",
+    "table_to_xml", "cursor_to_xml",
+    # Postgres dblink: execute statements on another (or the same) DB.
+    "dblink", "dblink_exec", "dblink_open", "dblink_send_query", "dblink_connect",
+    # Server-side filesystem / large objects.
+    "pg_read_file", "pg_read_binary_file", "pg_ls_dir", "pg_stat_file",
+    "lo_import", "lo_export", "lo_put", "lo_get",
+    # Availability / side-effect timing.
+    "pg_sleep", "pg_sleep_for", "pg_sleep_until",
+    # Config / session mutation and privilege probing.
+    "set_config", "pg_reload_conf", "pg_rotate_logfile",
+    "pg_terminate_backend", "pg_cancel_backend",
+    # Advisory locks hold server-side state.
+    "pg_advisory_lock", "pg_advisory_unlock", "pg_advisory_xact_lock",
+    # Generic cross-engine offenders.
+    "copy", "system", "load_file", "sys_exec", "sys_eval", "xp_cmdshell",
+})
+
 
 class SQLValidationError(Exception):
     pass
+
+
+def _function_names(node: "exp.Expression") -> Set[str]:
+    """Return the lower-cased name(s) a function-call node is known by.
+
+    PRD-172 F019. sqlglot models a call two ways:
+      * ``exp.Anonymous`` — an unknown/user function; its ``.name`` (or the
+        ``this`` token) is the identifier as written (e.g. ``query_to_xml``).
+      * ``exp.Func`` subclasses — recognised builtins; ``sql_names()`` yields the
+        canonical spelling(s) and ``.name`` is often empty. Some Postgres funcs
+        (e.g. ``pg_sleep``) parse as ``exp.Anonymous``, others as typed nodes,
+        so we check both spellings.
+    """
+    names: Set[str] = set()
+    raw_name = getattr(node, "name", None)
+    if raw_name:
+        names.add(str(raw_name).lower())
+    try:
+        if isinstance(node, exp.Func):
+            for n in node.sql_names():  # class-level canonical names
+                if n:
+                    names.add(str(n).lower())
+    except Exception:  # noqa: BLE001 — never let name extraction break validation
+        pass
+    return names
+
+
+def _forbidden_function_in(tree: "exp.Expression") -> Optional[str]:
+    """Return the first denylisted function name found anywhere in *tree*, else None."""
+    for node in tree.walk():
+        if isinstance(node, (exp.Func, exp.Anonymous)):
+            hit = _FORBIDDEN_FUNCTIONS & _function_names(node)
+            if hit:
+                return sorted(hit)[0]
+    return None
 
 
 class SQLValidator:
@@ -212,6 +277,17 @@ class SQLValidator:
         for node in tree.walk():
             if isinstance(node, _FORBIDDEN_NODES):
                 raise SQLValidationError("Only SELECT statements are allowed")
+
+        # PRD-172 F019: a SELECT can still mutate via a side-effecting function
+        # (e.g. ``SELECT query_to_xml('UPDATE …', …)`` / ``dblink_exec`` /
+        # ``lo_export``). The DML-node walk above cannot see those — they are
+        # function calls, not statement nodes — so reject any denylisted
+        # function found anywhere in the tree.
+        forbidden_fn = _forbidden_function_in(tree)
+        if forbidden_fn is not None:
+            raise SQLValidationError(
+                f"Side-effecting function not allowed: {forbidden_fn}"
+            )
 
         if schema_metadata:
             self._check_tables(tree, schema_metadata)

--- a/orchestrator/modules/rag/service.py
+++ b/orchestrator/modules/rag/service.py
@@ -328,8 +328,10 @@ class RAGService:
         if self.config.enable_reranking:
             candidates = await self._rerank_candidates(query, candidates)
 
-        # Parent-child context expansion
-        candidates = await self._expand_to_parent_context(candidates, self.config.expansion_window)
+        # Parent-child context expansion (PRD-172 F005: scoped to workspace).
+        candidates = await self._expand_to_parent_context(
+            candidates, self.config.expansion_window, workspace_id=workspace_id
+        )
 
         # Use existing ContextOptimizer if available
         if self._context_optimizer:
@@ -820,10 +822,15 @@ class RAGService:
 
             logger.info(f"🔎 S3 Vectors search: workspace={effective_workspace_id}, min_similarity={min_similarity}, limit={limit}")
 
+            # PRD-172 F005: pass an explicit workspace_id filter so the backend
+            # drops any hit not scoped to this workspace (defence-in-depth over
+            # the per-workspace bucket; a shared/mis-templated bucket no longer
+            # leaks cross-workspace chunks into LLM context).
             results = vector_store.search(
                 query_embedding=query_embedding.tolist() if hasattr(query_embedding, 'tolist') else list(query_embedding),
                 limit=limit,
                 min_score=min_similarity,
+                filters={"workspace_id": str(effective_workspace_id)},
             )
 
             candidates = []
@@ -871,14 +878,22 @@ class RAGService:
     async def _expand_to_parent_context(
         self,
         candidates: List[Dict],
-        expand_window: int = 1
+        expand_window: int = 1,
+        workspace_id: str = None,
     ) -> List[Dict]:
         """
         For each retrieved chunk, fetch surrounding chunks from the same document.
         Uses chunk_index from metadata to find neighbors.
+
+        PRD-172 F005: ``workspace_id`` scopes the document_chunks hydration to
+        the caller's workspace. Previously this joined document_chunks by
+        (document_id, chunk_index) alone with NO workspace predicate, so on a
+        shared store it could hydrate another tenant's chunk text into context.
         """
         if not candidates or not self.config.parent_child_expansion:
             return candidates
+
+        effective_workspace_id = workspace_id or self._workspace_id
 
         window = expand_window or self.config.expansion_window
 
@@ -924,13 +939,22 @@ class RAGService:
                 chunk_idxs = [p[1] for p in pairs]
                 # ONE round-trip: join the requested (doc_id, chunk_index) keys
                 # against document_chunks via unnest of two parallel arrays.
+                # PRD-172 F005: additionally join documents and pin
+                # documents.workspace_id so a chunk is hydrated ONLY when its
+                # parent document belongs to this workspace. When workspace_id
+                # is unavailable ($3 IS NULL) the predicate is a no-op (only
+                # reachable for a non-multi-tenant / self._workspace_id-less
+                # caller), preserving prior behaviour without widening a
+                # tenant's scope.
                 rows = await conn.fetch("""
                     SELECT dc.document_id, dc.chunk_index, dc.content
                     FROM document_chunks dc
                     JOIN unnest($1::int[], $2::int[]) AS k(document_id, chunk_index)
                       ON dc.document_id = k.document_id
                      AND dc.chunk_index = k.chunk_index
-                """, doc_ids, chunk_idxs)
+                    JOIN documents d ON d.id = dc.document_id
+                    WHERE ($3::uuid IS NULL OR d.workspace_id = $3::uuid)
+                """, doc_ids, chunk_idxs, str(effective_workspace_id) if effective_workspace_id else None)
             finally:
                 await conn.close()
 
@@ -1037,19 +1061,28 @@ class RAGService:
     # Stats & Analytics Methods (for api/context.py)
     # =========================================================================
     
-    def get_retrieval_stats(self, db) -> Dict[str, Any]:
-        """Get retrieval statistics from database"""
+    def get_retrieval_stats(self, db, workspace_id=None) -> Dict[str, Any]:
+        """Get retrieval statistics from database.
+
+        PRD-172 F045: ``workspace_id`` scopes the document counts to the caller's
+        workspace. Previously the ``documents`` COUNT(*) was unscoped, so every
+        caller saw a platform-wide total (cross-tenant count). When
+        ``workspace_id`` is None the caller is an unfiltered admin aggregate.
+        """
         try:
             from sqlalchemy import text
-            
-            # Count total RAG queries from documents table
-            result = db.execute(text("""
+
+            # Count total RAG queries from documents table, scoped to workspace.
+            ws = str(workspace_id) if workspace_id is not None else None
+            where = "WHERE workspace_id = :workspace_id" if ws else ""
+            result = db.execute(text(f"""
                 SELECT
                     COUNT(*) as total_docs,
                     SUM(chunk_count) as total_chunks,
                     COUNT(CASE WHEN status = 'completed' THEN 1 END) as completed_docs
                 FROM documents
-            """)).fetchone()
+                {where}
+            """), ({"workspace_id": ws} if ws else {})).fetchone()
 
             total_docs = result.total_docs or 0
             total_chunks = result.total_chunks or 0

--- a/orchestrator/modules/rag/service.py
+++ b/orchestrator/modules/rag/service.py
@@ -808,7 +808,7 @@ class RAGService:
             logger.error("Embedding manager not initialized — cannot search")
             return []
 
-        effective_workspace_id = workspace_id or self._workspace_id
+        effective_workspace_id = workspace_id or getattr(self, "_workspace_id", None)
         if not effective_workspace_id:
             logger.error("No workspace_id available — cannot search S3 Vectors")
             return []
@@ -893,7 +893,7 @@ class RAGService:
         if not candidates or not self.config.parent_child_expansion:
             return candidates
 
-        effective_workspace_id = workspace_id or self._workspace_id
+        effective_workspace_id = workspace_id or getattr(self, "_workspace_id", None)
 
         window = expand_window or self.config.expansion_window
 

--- a/orchestrator/modules/search/vector_store/backends/s3_vectors_backend.py
+++ b/orchestrator/modules/search/vector_store/backends/s3_vectors_backend.py
@@ -43,6 +43,16 @@ class S3VectorsBackend:
         bucket_template = config.S3_VECTORS_BUCKET
         if not bucket_template:
             raise ValueError("S3_VECTORS_BUCKET not configured in .env")
+        # PRD-172 F005: a bucket template with NO {workspace_id} placeholder
+        # means every workspace resolves to the same physical bucket — a
+        # cross-tenant vector leak by construction. Boot already asserts this
+        # (config.validate_security), but fail-closed here too so a backend can
+        # never be instantiated against a shared bucket.
+        if "{workspace_id}" not in bucket_template:
+            raise ValueError(
+                "S3_VECTORS_BUCKET must contain the '{workspace_id}' placeholder "
+                f"for per-workspace isolation (got {bucket_template!r})."
+            )
         self.bucket_name = bucket_template.replace("{workspace_id}", self.workspace_id)
 
         # Get index configuration from config
@@ -131,8 +141,32 @@ class S3VectorsBackend:
         Search vectors by cosine similarity.
 
         Returns list of dicts with keys: key, score, metadata.
+
+        PRD-172 F005: the ``filters`` param is now enforced. Isolation on S3
+        Vectors previously rested entirely on a per-workspace bucket name; if a
+        deploy ever pointed multiple workspaces at one bucket (no
+        ``{workspace_id}`` placeholder), search leaked cross-workspace chunk
+        text into LLM context. We ALWAYS post-filter on the backend's own
+        ``workspace_id`` and, when a ``workspace_id`` filter is supplied, on that
+        too — dropping any hit whose metadata ``workspace_id`` does not match.
         """
         self._ensure_setup()
+
+        # Fail-closed workspace scope: the backend is bound to exactly one
+        # workspace at construction; every hit must carry that workspace_id.
+        # An explicit filters['workspace_id'] must agree with it.
+        required_ws = str(self.workspace_id)
+        if filters:
+            filter_ws = filters.get("workspace_id")
+            if filter_ws is not None and str(filter_ws) != required_ws:
+                # A caller asked to search a different workspace through a
+                # workspace-bound backend — refuse rather than silently widen.
+                logger.warning(
+                    "S3 Vectors search: filter workspace_id=%s != backend "
+                    "workspace_id=%s — returning no results",
+                    filter_ws, required_ws,
+                )
+                return []
 
         try:
             response = self.client.query_vectors(
@@ -153,6 +187,14 @@ class S3VectorsBackend:
                     continue
 
                 metadata = match.get("metadata", {})
+                # PRD-172 F005: drop any hit not scoped to this workspace. On a
+                # correctly-templated per-workspace bucket every hit already
+                # matches; on a mis-configured shared bucket this is the last
+                # line of defence against a cross-tenant chunk leak.
+                hit_ws = metadata.get("workspace_id")
+                if hit_ws is not None and str(hit_ws) != required_ws:
+                    continue
+
                 results.append({
                     "key": match.get("key", ""),
                     "score": similarity,

--- a/orchestrator/tests/security/test_nl2sql_validator.py
+++ b/orchestrator/tests/security/test_nl2sql_validator.py
@@ -249,3 +249,71 @@ class TestStatementStructure:
     def test_rejects_non_select(self, validator):
         with pytest.raises(SQLValidationError, match="SELECT"):
             validator.validate_and_rewrite("SHOW TABLES")
+
+
+# ============================================================================
+# PRD-172 F019 — side-effecting functions inside a nominal SELECT
+# ============================================================================
+
+class TestSideEffectingFunctionsF019:
+    """The SELECT-only validator must reject side-effecting SQL functions.
+
+    Before PRD-172 the AST walk only looked for DML/DDL *statement* nodes, so a
+    payload that wraps a mutation in a function call
+    (``SELECT query_to_xml('UPDATE …', …)``) had a SELECT root, no INTO, and no
+    Insert/Update/Delete node — it passed and still mutated. These tests pin the
+    function denylist. The exact same schema_metadata allowlist is provided so
+    the rejection is on the FUNCTION, not on an unlisted table.
+    """
+
+    _META = {"tables": [{"name": "users", "columns": [{"name": "id"}, {"name": "email"}]}]}
+
+    @pytest.mark.parametrize(
+        "sql",
+        [
+            # The canonical review payload: a write smuggled through query_to_xml.
+            "SELECT query_to_xml('UPDATE users SET email=''x''', true, true, '')",
+            # dblink executes arbitrary statements on a (possibly the same) DB.
+            "SELECT dblink_exec('DELETE FROM users')",
+            "SELECT * FROM users WHERE id IN (SELECT dblink('host=x', 'DROP TABLE users'))",
+            # Server-side filesystem read/write.
+            "SELECT pg_read_file('/etc/passwd')",
+            "SELECT lo_export(1234, '/tmp/x')",
+            # Availability / timing side effect.
+            "SELECT pg_sleep(10)",
+            # Session/config mutation.
+            "SELECT set_config('search_path', 'evil', false)",
+            # Hidden deep in the tree: inside a CTE.
+            "WITH t AS (SELECT query_to_xml('UPDATE users SET id=1', true, true, '')) "
+            "SELECT * FROM t",
+            # Hidden in a UNION branch.
+            "SELECT id FROM users UNION SELECT pg_sleep(5)",
+        ],
+    )
+    def test_rejects_side_effecting_functions(self, validator, sql):
+        with pytest.raises(SQLValidationError, match="Side-effecting function not allowed"):
+            validator.validate_and_rewrite(sql, schema_metadata=self._META)
+
+    @pytest.mark.parametrize(
+        "sql",
+        [
+            # Legitimate read-only scalar/aggregate functions must still pass.
+            "SELECT upper(email) FROM users",
+            "SELECT count(*) FROM users",
+            "SELECT id, lower(email) AS e FROM users WHERE email LIKE '%@x.com'",
+            "SELECT coalesce(email, 'none') FROM users",
+        ],
+    )
+    def test_allows_safe_read_only_functions(self, validator, sql):
+        safe_sql, _ = validator.validate_and_rewrite(sql, schema_metadata=self._META)
+        assert "SELECT" in safe_sql.upper()
+        # LIMIT is injected by the validator — proves it reached the rewrite path
+        # (i.e. it did NOT reject the query).
+        assert "LIMIT" in safe_sql.upper()
+
+    def test_denylist_is_case_insensitive(self, validator):
+        with pytest.raises(SQLValidationError, match="Side-effecting function not allowed"):
+            validator.validate_and_rewrite(
+                "SELECT QUERY_TO_XML('UPDATE users SET id=1', true, true, '')",
+                schema_metadata=self._META,
+            )

--- a/orchestrator/tests/security/test_prd172_tenant_isolation.py
+++ b/orchestrator/tests/security/test_prd172_tenant_isolation.py
@@ -1,0 +1,586 @@
+"""PRD-172 — Tenant Isolation Closure (Wave 2).
+
+The headline acceptance (spec §5.0) is the **cross-tenant matrix**: workspace A
+cannot read, write, or delete any of workspace B's data across every in-scope
+domain — skills, documents/vectors, workflows, memory, and context. Each finding
+adds a focused test underneath the matrix.
+
+These are pure/behavioural tests: the DB is mocked (query-chain / execute-capture
+stubs) and auth is injected via ``app.dependency_overrides`` — the blessed pattern
+from ``tests/test_prd143_obs_routers_batch1.py`` and ``tests/security/
+test_tenancy_matrix.py``. No live Postgres is needed; the end-to-end DB matrix
+runs in CI. The point of each test is to prove the *actual* scope decision the
+handler/helper makes, which is stronger than asserting a clause in isolation.
+
+Findings covered: F002, F003, F004, F005, F006, F007, F039, F045.
+(F019 — the NL2SQL side-effecting-function denylist — lives in
+``tests/security/test_nl2sql_validator.py`` next to the validator's other cases.)
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from unittest.mock import MagicMock
+
+import pytest
+
+# Dummy POSTGRES_* satisfies the config import chain; the port points at nothing
+# so any fail-soft connect refuses instantly. CI exports real vars (setdefault
+# no-ops). Blessed pattern — see test_prd143_obs_routers_batch1.py.
+os.environ.setdefault("POSTGRES_USER", "test")
+os.environ.setdefault("POSTGRES_PASSWORD", "test")
+os.environ.setdefault("POSTGRES_HOST", "127.0.0.1")
+os.environ.setdefault("POSTGRES_PORT", "59432")
+os.environ.setdefault("POSTGRES_DB", "test")
+
+from core.auth.dependencies import RequestContext, UserContext
+
+WS_A = uuid.uuid4()
+WS_B = uuid.uuid4()
+
+# Principals. system_role drives the super-admin gate (core/auth/super_admin.py).
+USER_A = UserContext(id="u-a", role="member", system_role="user")
+USER_B = UserContext(id="u-b", role="member", system_role="user")
+SUPER_ADMIN = UserContext(id="u-gerard", role="admin", system_role="super_admin")
+
+
+def _ctx(ws=WS_A, user=USER_A, *, admin_all=False, auth_type="clerk") -> RequestContext:
+    return RequestContext(
+        workspace_id=ws, user=user, auth_type=auth_type, admin_all_workspaces=admin_all
+    )
+
+
+# ===========================================================================
+# F002 — skills: cross-workspace attach/read denied; global-skill delete gated
+# ===========================================================================
+
+class _FakeSkill:
+    def __init__(self, id, workspace_id, is_active=True):
+        self.id = id
+        self.workspace_id = workspace_id
+        self.is_active = is_active
+        self.name = f"skill-{id}"
+
+
+class _FakeAgent:
+    def __init__(self, id, workspace_id):
+        self.id = id
+        self.workspace_id = workspace_id
+
+
+class TestF002SkillsIsolation:
+    """The skills router took ``ctx`` and never used it. These pin the helpers
+    that now gate read/attach/delete (api/skills.py)."""
+
+    def _helpers(self):
+        import api.skills as s
+        return s
+
+    def test_workspace_cannot_see_other_workspaces_private_skill(self):
+        s = self._helpers()
+        b_skill = _FakeSkill(1, WS_B)
+        # A caller in workspace A: B's private skill is NOT visible.
+        assert s._skill_visible_to(b_skill, _ctx(ws=WS_A)) is False
+
+    def test_workspace_can_see_global_skill(self):
+        s = self._helpers()
+        global_skill = _FakeSkill(2, None)  # workspace_id IS NULL == global
+        assert s._skill_visible_to(global_skill, _ctx(ws=WS_A)) is True
+
+    def test_workspace_can_see_own_skill(self):
+        s = self._helpers()
+        own = _FakeSkill(3, WS_A)
+        assert s._skill_visible_to(own, _ctx(ws=WS_A)) is True
+
+    def test_super_admin_sees_any_skill(self):
+        s = self._helpers()
+        b_skill = _FakeSkill(4, WS_B)
+        assert s._skill_visible_to(b_skill, _ctx(ws=WS_A, user=SUPER_ADMIN)) is True
+
+    def test_attach_to_other_workspaces_agent_is_404(self):
+        s = self._helpers()
+        b_agent = _FakeAgent(10, WS_B)
+        from fastapi import HTTPException
+        with pytest.raises(HTTPException) as ei:
+            s._assert_agent_in_workspace(b_agent, _ctx(ws=WS_A))
+        assert ei.value.status_code == 404
+
+    def test_attach_to_own_agent_allowed(self):
+        s = self._helpers()
+        a_agent = _FakeAgent(11, WS_A)
+        # No raise == allowed.
+        s._assert_agent_in_workspace(a_agent, _ctx(ws=WS_A))
+
+    def test_super_admin_flag_recognised(self):
+        s = self._helpers()
+        # admin_all_workspaces sentinel OR literal super_admin role.
+        assert s._is_super_admin(_ctx(ws=WS_A, admin_all=True)) is True
+        assert s._is_super_admin(_ctx(ws=WS_A, user=SUPER_ADMIN)) is True
+        assert s._is_super_admin(_ctx(ws=WS_A, user=USER_A)) is False
+
+
+class TestF002GlobalSkillDelete:
+    """DELETE /{skill_id}: a global builtin-core skill is deletable ONLY by a
+    super-admin (deleting it lobotomises every tenant's Auto). A workspace caller
+    deleting another workspace's private skill gets 404."""
+
+    def _client_and_skill(self, ctx, skill):
+        import importlib
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+        from core.auth.hybrid import get_request_context_hybrid
+        from core.database.database import get_db
+
+        skills = importlib.import_module("api.skills")
+
+        # DB stub: query(Skill).filter(...).first() -> the skill under test;
+        # the agent_skills delete chain is a harmless no-op.
+        db = MagicMock()
+        q = MagicMock()
+        q.filter.return_value = q
+        q.first.return_value = skill
+        q.delete.return_value = 0
+        db.query.return_value = q
+
+        app = FastAPI()
+        app.include_router(skills.router)
+        app.dependency_overrides[get_request_context_hybrid] = lambda: ctx
+        app.dependency_overrides[get_db] = lambda: db
+        return TestClient(app, raise_server_exceptions=False), skill
+
+    def test_workspace_caller_cannot_delete_global_skill(self):
+        skill = _FakeSkill(100, None)  # global
+        client, _ = self._client_and_skill(_ctx(ws=WS_A, user=USER_A), skill)
+        resp = client.delete("/api/v1/skills/100")
+        assert resp.status_code == 403, resp.text
+        # The skill was NOT deactivated by the denied attempt.
+        assert skill.is_active is True
+
+    def test_workspace_caller_cannot_delete_other_workspace_skill(self):
+        skill = _FakeSkill(101, WS_B)
+        client, _ = self._client_and_skill(_ctx(ws=WS_A, user=USER_A), skill)
+        resp = client.delete("/api/v1/skills/101")
+        assert resp.status_code == 404, resp.text
+        assert skill.is_active is True
+
+    def test_super_admin_can_delete_global_skill(self):
+        skill = _FakeSkill(102, None)
+        client, _ = self._client_and_skill(
+            _ctx(ws=WS_A, user=SUPER_ADMIN, admin_all=True), skill
+        )
+        resp = client.delete("/api/v1/skills/102")
+        assert resp.status_code == 200, resp.text
+        assert skill.is_active is False
+
+    def test_workspace_caller_can_delete_own_skill(self):
+        skill = _FakeSkill(103, WS_A)
+        client, _ = self._client_and_skill(_ctx(ws=WS_A, user=USER_A), skill)
+        resp = client.delete("/api/v1/skills/103")
+        assert resp.status_code == 200, resp.text
+        assert skill.is_active is False
+
+
+# ===========================================================================
+# F003 — Shopify sync routes: a guessed workspace UUID is rejected
+# ===========================================================================
+
+class TestF003ShopifySyncScope:
+    """The four sync routes derive their target from ``ctx``; a caller-supplied
+    workspace_id that is not the caller's own is refused (api/shopify.py
+    ``_resolve_sync_workspace``)."""
+
+    def _resolve(self):
+        import api.shopify as sh
+        return sh._resolve_sync_workspace
+
+    def test_no_param_uses_own_workspace(self):
+        resolve = self._resolve()
+        assert resolve(_ctx(ws=WS_A), None) == str(WS_A)
+
+    def test_matching_param_allowed(self):
+        resolve = self._resolve()
+        assert resolve(_ctx(ws=WS_A), str(WS_A)) == str(WS_A)
+
+    def test_guessed_other_workspace_rejected(self):
+        resolve = self._resolve()
+        from fastapi import HTTPException
+        with pytest.raises(HTTPException) as ei:
+            resolve(_ctx(ws=WS_A), str(WS_B))  # guessed B's UUID
+        assert ei.value.status_code == 403
+
+    def test_admin_all_may_target_any_workspace(self):
+        resolve = self._resolve()
+        # Cross-workspace admin (ops backfill) may target B explicitly.
+        assert resolve(_ctx(ws=WS_A, admin_all=True), str(WS_B)) == str(WS_B)
+
+
+# ===========================================================================
+# F004 — Shopify provisioning is fail-closed
+# ===========================================================================
+
+class TestF004ShopifyFailClosed:
+    """Unset SHOPIFY_INTERNAL_API_KEY must fail at boot; a falsy key can no
+    longer wave through an arbitrary Authorization header."""
+
+    def test_boot_fails_when_shopify_key_unset(self, monkeypatch):
+        from config import Config
+        cfg = Config()
+        monkeypatch.setattr(cfg, "SHOPIFY_INTERNAL_API_KEY", "", raising=False)
+        monkeypatch.setattr(cfg, "S3_VECTORS_ENABLED", False, raising=False)
+        with pytest.raises(RuntimeError, match="SHOPIFY_INTERNAL_API_KEY"):
+            cfg.validate_security()
+
+    def test_boot_passes_when_shopify_key_set(self, monkeypatch):
+        from config import Config
+        cfg = Config()
+        monkeypatch.setattr(cfg, "SHOPIFY_INTERNAL_API_KEY", "real-secret", raising=False)
+        monkeypatch.setattr(cfg, "S3_VECTORS_ENABLED", False, raising=False)
+        cfg.validate_security()  # no raise
+
+    def test_verify_internal_key_rejects_arbitrary_header(self, monkeypatch):
+        import api.shopify as sh
+        from fastapi import HTTPException
+        monkeypatch.setattr(sh.config, "SHOPIFY_INTERNAL_API_KEY", "real-secret", raising=False)
+        # An arbitrary bearer value is rejected — no fail-open branch remains.
+        with pytest.raises(HTTPException) as ei:
+            sh._verify_internal_key("Bearer x")
+        assert ei.value.status_code == 401
+
+    def test_verify_internal_key_accepts_correct_key(self, monkeypatch):
+        import api.shopify as sh
+        monkeypatch.setattr(sh.config, "SHOPIFY_INTERNAL_API_KEY", "real-secret", raising=False)
+        # Correct key: no raise.
+        sh._verify_internal_key("Bearer real-secret")
+
+
+# ===========================================================================
+# F005 — S3 vector search drops cross-workspace hits; bucket placeholder required
+# ===========================================================================
+
+class TestF005VectorIsolation:
+    """S3VectorsBackend.search() now enforces its workspace filter, and a bucket
+    template without {workspace_id} is refused."""
+
+    def _backend_cls(self):
+        from modules.search.vector_store.backends.s3_vectors_backend import S3VectorsBackend
+        return S3VectorsBackend
+
+    def _make_backend(self, monkeypatch, ws):
+        from config import config as app_config
+        monkeypatch.setattr(
+            app_config, "S3_VECTORS_BUCKET", "automatos-vectors-{workspace_id}", raising=False
+        )
+        cls = self._backend_cls()
+        b = cls.__new__(cls)  # bypass __init__/AWS client
+        b.workspace_id = str(ws)
+        b.bucket_name = f"automatos-vectors-{ws}"
+        b.index_name = "documents-index"
+        b.index_dimension = 2048
+        b.distance_metric = "cosine"
+        b._setup_complete = True
+        b.client = MagicMock()
+        # search() calls _ensure_setup(); it's a no-op here (no live AWS).
+        b._ensure_setup = lambda: None
+        return b
+
+    def test_search_drops_foreign_workspace_hits(self, monkeypatch):
+        b = self._make_backend(monkeypatch, WS_A)
+        # The store returns one A-owned and one B-owned chunk (shared-bucket
+        # worst case). B's chunk MUST be dropped.
+        b.client.query_vectors.return_value = {
+            "vectors": [
+                {"key": "a1", "distance": 0.1, "metadata": {"workspace_id": str(WS_A), "chunk_text": "A secret"}},
+                {"key": "b1", "distance": 0.1, "metadata": {"workspace_id": str(WS_B), "chunk_text": "B secret"}},
+            ]
+        }
+        results = b.search([0.1, 0.2, 0.3], limit=10, min_score=0.0,
+                            filters={"workspace_id": str(WS_A)})
+        keys = {r["key"] for r in results}
+        assert keys == {"a1"}, f"leaked cross-workspace chunk: {keys}"
+        assert all("B secret" not in r["content"] for r in results)
+
+    def test_search_refuses_mismatched_filter(self, monkeypatch):
+        b = self._make_backend(monkeypatch, WS_A)
+        b.client.query_vectors.return_value = {"vectors": []}
+        # Asking an A-bound backend to search B → empty, and the store is never
+        # even queried with B's scope.
+        results = b.search([0.1], filters={"workspace_id": str(WS_B)})
+        assert results == []
+
+    def test_init_rejects_bucket_without_placeholder(self, monkeypatch):
+        from config import config as app_config
+        monkeypatch.setattr(app_config, "S3_VECTORS_BUCKET", "one-shared-bucket", raising=False)
+        cls = self._backend_cls()
+        with pytest.raises(ValueError, match="workspace_id"):
+            cls(workspace_id=str(WS_A))
+
+    def test_config_boot_asserts_bucket_placeholder(self, monkeypatch):
+        from config import Config
+        cfg = Config()
+        monkeypatch.setattr(cfg, "SHOPIFY_INTERNAL_API_KEY", "x", raising=False)
+        monkeypatch.setattr(cfg, "S3_VECTORS_ENABLED", True, raising=False)
+        monkeypatch.setattr(cfg, "S3_VECTORS_BUCKET", "shared-no-placeholder", raising=False)
+        with pytest.raises(RuntimeError, match="workspace_id"):
+            cfg.validate_security()
+
+
+# ===========================================================================
+# F006 — legacy PRD-125 workflow execute surface deleted (no cross-tenant oracle)
+# ===========================================================================
+
+class TestF006LegacyExecuteDeleted:
+    """The unscoped legacy execute routes were deleted. Deleting removes the
+    existence oracle and the cross-workspace AgentTask enqueue entirely."""
+
+    def test_execute_workflow_symbol_removed(self):
+        import api.workflows as wf
+        assert not hasattr(wf, "execute_workflow"), (
+            "legacy unscoped execute_workflow must be deleted"
+        )
+        assert not hasattr(wf, "execute_workflow_general"), (
+            "legacy /execute wrapper must be deleted"
+        )
+        assert not hasattr(wf, "create_execution"), (
+            "legacy /executions POST (broken caller of execute_workflow) must be deleted"
+        )
+
+    def test_legacy_execute_routes_not_registered(self):
+        import api.workflows as wf
+        # (method, path) pairs still registered.
+        registered = set()
+        for r in wf.router.routes:
+            path = getattr(r, "path", None)
+            for m in (getattr(r, "methods", None) or set()):
+                registered.add((m, path))
+        # The unscoped legacy execute routes must be gone…
+        assert ("POST", "/api/workflows/{workflow_id}/execute") not in registered
+        assert ("POST", "/api/workflows/execute") not in registered
+        # …including the POST create-execution that called the deleted function.
+        assert ("POST", "/api/workflows/executions/") not in registered
+        # The scoped advanced-execute path stays.
+        assert ("POST", "/api/workflows/{workflow_id}/execute-advanced") in registered
+
+    def test_workspace_scoped_advanced_execute_survives(self):
+        import api.workflows as wf
+        # The correct, workspace-scoped path stays.
+        assert hasattr(wf, "execute_workflow_advanced")
+
+    def test_github_webhook_no_longer_imports_deleted_symbol(self):
+        import api.github_webhooks as gh
+        # The broken import was removed; module still loads.
+        assert not hasattr(gh, "execute_workflow")
+
+
+# ===========================================================================
+# F039 — memory: session_id is namespaced by workspace
+# ===========================================================================
+
+class TestF039MemoryScope:
+    """A caller-supplied session_id is prefixed with the workspace so tenant A's
+    "abc" and tenant B's "abc" are distinct keys (api/memory.py)."""
+
+    def _scoped(self):
+        import api.memory as m
+        return m._scoped_session
+
+    def test_same_session_id_differs_across_workspaces(self):
+        scoped = self._scoped()
+        a = scoped(_ctx(ws=WS_A), "abc")
+        b = scoped(_ctx(ws=WS_B), "abc")
+        assert a != b, "same session_id must not collide across workspaces"
+        assert a.startswith(f"{WS_A}::")
+        assert b.startswith(f"{WS_B}::")
+
+    def test_none_session_preserved(self):
+        scoped = self._scoped()
+        assert scoped(_ctx(ws=WS_A), None) is None
+
+
+# ===========================================================================
+# F007 — monitoring alert/log read surfaces are super-admin only
+# ===========================================================================
+
+class TestF007MonitoringGate:
+    """GET /api/alerts and the Loki log routes are the obs tier; ingest POST
+    keeps only its bearer token."""
+
+    def _alerts_client(self, ctx):
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+        from core.monitoring.automatos_alerts import create_alerts_router
+        from core.auth.hybrid import get_request_context_hybrid
+
+        def _db():
+            db = MagicMock()
+            res = MagicMock()
+            res.fetchall.return_value = []
+            db.execute.return_value = res
+            yield db
+
+        router = create_alerts_router(_db)
+        app = FastAPI()
+        app.include_router(router, prefix="/api")
+        if ctx is not None:
+            app.dependency_overrides[get_request_context_hybrid] = lambda: ctx
+        return TestClient(app, raise_server_exceptions=False)
+
+    def test_alerts_read_403_for_non_super_admin(self):
+        resp = self._alerts_client(_ctx(user=USER_A)).get("/api/alerts")
+        assert resp.status_code == 403, resp.text
+        assert resp.json()["detail"] == "Super admin only"
+
+    def test_alerts_read_ok_for_super_admin(self):
+        resp = self._alerts_client(_ctx(user=SUPER_ADMIN)).get("/api/alerts")
+        assert resp.status_code not in (401, 403), resp.text
+
+    def test_logs_router_is_super_admin_gated(self):
+        # The logs router carries a router-level require_super_admin dependency.
+        from core.monitoring.automatos_logs_api import create_logs_router
+        from core.auth.super_admin import require_super_admin
+
+        router = create_logs_router()
+        dep_calls = [d.dependency for d in getattr(router, "dependencies", [])]
+        assert require_super_admin in dep_calls, (
+            "logs router must be wrapped in require_super_admin"
+        )
+
+
+# ===========================================================================
+# F045 — context.py: no unauthenticated tenant-data endpoints; count is scoped
+# ===========================================================================
+
+class TestF045ContextAuth:
+    """Every context.py route now carries the workspace-scoped auth dependency,
+    and the stats count is scoped to the caller's workspace."""
+
+    def test_all_context_routes_require_auth(self):
+        import api.context as ctx_mod
+        from core.auth.hybrid import get_request_context_hybrid
+
+        # Every route's dependant tree must reference the shared auth dependency.
+        offenders = []
+        for route in ctx_mod.router.routes:
+            dependant = getattr(route, "dependant", None)
+            if dependant is None:
+                continue
+            calls = _collect_dependency_calls(dependant)
+            if get_request_context_hybrid not in calls:
+                offenders.append(getattr(route, "path", "?"))
+        assert not offenders, f"unauthenticated context routes remain: {offenders}"
+
+    def test_retrieval_stats_count_is_workspace_scoped(self):
+        # The RAG service count query is filtered by workspace_id when supplied.
+        from modules.rag.service import RAGService
+        svc = RAGService.__new__(RAGService)  # bypass heavy __init__
+        svc._workspace_id = str(WS_A)
+
+        captured = {}
+
+        db = MagicMock()
+
+        def _execute(stmt, params=None):
+            captured["sql"] = str(stmt)
+            captured["params"] = params
+            res = MagicMock()
+            row = MagicMock()
+            row.total_docs = 0
+            row.total_chunks = 0
+            row.completed_docs = 0
+            res.fetchone.return_value = row
+            return res
+
+        db.execute.side_effect = _execute
+        svc.get_retrieval_stats(db, workspace_id=WS_A)
+        assert "workspace_id" in captured["sql"], "documents count is not workspace-scoped"
+        assert captured["params"] and str(captured["params"].get("workspace_id")) == str(WS_A)
+
+
+def _collect_dependency_calls(dependant):
+    """Flatten a FastAPI Dependant tree into the set of its ``.call`` callables."""
+    calls = set()
+    stack = [dependant]
+    while stack:
+        d = stack.pop()
+        if getattr(d, "call", None) is not None:
+            calls.add(d.call)
+        stack.extend(getattr(d, "dependencies", []) or [])
+    return calls
+
+
+# ===========================================================================
+# 5.0 Cross-tenant matrix (headline) — A cannot reach B across every domain
+# ===========================================================================
+
+class TestCrossTenantMatrix:
+    """The wave's definition of done: for every in-scope domain, a workspace-A
+    principal is denied (or own-only) against a workspace-B resource — read,
+    write, and delete. Each cell delegates to the same scope decision the live
+    handler makes, proven per-finding above; this class asserts the matrix
+    *as a whole* stays closed (a permanent regression guard).
+    """
+
+    # (domain, callable(ctx_A) -> "denied"|"own_only") — each returns whether an
+    # A-principal is blocked from B's resource.
+    def _skill_read_denied(self):
+        import api.skills as s
+        return s._skill_visible_to(_FakeSkill(1, WS_B), _ctx(ws=WS_A)) is False
+
+    def _skill_delete_denied(self):
+        # A workspace caller cannot delete a global (NULL) skill.
+        import api.skills as s
+        return s._is_super_admin(_ctx(ws=WS_A, user=USER_A)) is False
+
+    def _vectors_read_denied(self, monkeypatch):
+        from config import config as app_config
+        monkeypatch.setattr(
+            app_config, "S3_VECTORS_BUCKET", "automatos-vectors-{workspace_id}", raising=False
+        )
+        from modules.search.vector_store.backends.s3_vectors_backend import S3VectorsBackend
+        b = S3VectorsBackend.__new__(S3VectorsBackend)
+        b.workspace_id = str(WS_A)
+        b.bucket_name = f"automatos-vectors-{WS_A}"
+        b.index_name = "i"
+        b.index_dimension = 2048
+        b.distance_metric = "cosine"
+        b._setup_complete = True
+        b._ensure_setup = lambda: None
+        b.client = MagicMock()
+        b.client.query_vectors.return_value = {
+            "vectors": [{"key": "b", "distance": 0.0, "metadata": {"workspace_id": str(WS_B)}}]
+        }
+        hits = b.search([0.1], min_score=0.0, filters={"workspace_id": str(WS_A)})
+        return hits == []
+
+    def _workflow_execute_denied(self):
+        # The unscoped cross-tenant execute route no longer exists at all.
+        import api.workflows as wf
+        return not hasattr(wf, "execute_workflow")
+
+    def _memory_write_denied(self):
+        import api.memory as m
+        return m._scoped_session(_ctx(ws=WS_A), "shared") != m._scoped_session(_ctx(ws=WS_B), "shared")
+
+    def _shopify_sync_denied(self):
+        import api.shopify as sh
+        from fastapi import HTTPException
+        try:
+            sh._resolve_sync_workspace(_ctx(ws=WS_A), str(WS_B))
+            return False
+        except HTTPException as e:
+            return e.status_code == 403
+
+    def test_matrix_all_domains_denied(self, monkeypatch):
+        cells = {
+            "skills:read": self._skill_read_denied(),
+            "skills:delete-global": self._skill_delete_denied(),
+            "vectors:read": self._vectors_read_denied(monkeypatch),
+            "workflows:execute": self._workflow_execute_denied(),
+            "memory:write": self._memory_write_denied(),
+            "shopify-graph:write": self._shopify_sync_denied(),
+        }
+        failed = [domain for domain, denied in cells.items() if not denied]
+        assert not failed, f"cross-tenant leak — A reached B on: {failed}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Wave 2 — Tenant Isolation Closure (PRD-172)

Closes the nine surfaces that touch tenant data without proving the tenant. **Per-router dependency additions + `ctx.workspace_id` filters — the shared 657-site hybrid auth dependency is NOT modified** (memory: `prd09-board-sdk-auth-unlock`).

### Findings implemented

| ID | Fix |
|---|---|
| **F002** `api/skills.py` | Filter `Skill`/`Agent` by `ctx.workspace_id` on read/attach/remove. A global builtin-core skill (`workspace_id IS NULL`) is deletable **only** by super-admin — a workspace caller can no longer deactivate it and lobotomise every tenant's Auto; another workspace's private skill → 404. New helpers `_is_super_admin` / `_skill_visible_to` / `_assert_agent_in_workspace`. |
| **F003** `api/shopify.py` | The four sync routes (`/sync/products/start`, `/sync/status`, `/sync/orders/start`, `/sync/orders/status`) now carry the workspace-scoped auth dependency and derive the target from `ctx` via `_resolve_sync_workspace` (a guessed UUID → 403). Heavy bodies extracted to `_product_sync_impl` / `_orders_sync_impl` so the in-process auto-trigger (`api/tools.py`, SHOPIFY→active) calls them with an already-trusted `workspace_id`. |
| **F004** `config.py` + `api/shopify.py` | **Fail-closed.** New `config.validate_security()` runs in the hard-fail boot phase (`main._boot_phase_1_core`) and aborts boot if `SHOPIFY_INTERNAL_API_KEY` is unset. `_verify_internal_key` drops the fail-open "no key → accept all" branch and uses `hmac.compare_digest`. |
| **F005** `s3_vectors_backend.py` + `rag/service.py` | `S3VectorsBackend.search()` now enforces its `workspace_id` filter (drops non-matching hits) and refuses a bucket template with no `{workspace_id}` placeholder. The RAG choke point passes the filter; `_expand_to_parent_context` joins `documents` and pins `documents.workspace_id` (was an **unscoped** `document_chunks` hydration). Gated by `S3_VECTORS_ENABLED`. |
| **F006** `api/workflows.py` + `api/github_webhooks.py` | **DELETE chosen** (see below). |
| **F007** `core/monitoring/automatos_alerts.py` + `automatos_logs_api.py` | `GET /api/alerts` and the 3 Loki log routes are now `require_super_admin` (obs tier, PRD-143). `ALERT_INGEST_TOKEN` stays **only** on the AlertManager ingest `POST`. |
| **F039** `api/memory.py` | `session_id` is namespaced by workspace (`{ws}::{session_id}`) before it reaches the process-global store — A's `"abc"` ≠ B's `"abc"`. |
| **F045** `api/context.py` + `rag/service.py` | Added the workspace-scoped auth dependency to every previously-unauthenticated endpoint (`/add`, `/stats`, `/performance`, `/sources`, `/queries/recent`, `/patterns`, `/rag/{id}/test`, `/system/health`, `/initialize`); `get_retrieval_stats` scopes its `documents` `COUNT(*)` to the caller's workspace. |
| **F019** `modules/nl2sql/query/validator.py` | **Real validator = `SQLValidator.validate_and_rewrite` (sqlglot AST)** — the review's `query_to_xml` was the *attack payload*, not the fn name. Added a side-effecting-function denylist walked over the whole AST: `SELECT query_to_xml('UPDATE …')`, `dblink`/`dblink_exec`, `lo_import`/`lo_export`, `pg_read_file`, `pg_sleep`, `set_config`, … are rejected; safe read functions (`upper`, `count`, …) pass. |

### F006 — DELETE vs scope: **DELETE chosen**
The legacy PRD-125 execute surface was an unscoped cross-tenant existence oracle: it fetched the `Workflow` with no workspace filter and picked "the first active agent from **any** workspace." Its engine (`execute_workflow_with_progress`) is a disabled no-op stub, and its two callers (`create_execution`, `github_webhooks`) already passed a **broken argument list** — nothing functional was lost. Deleted `execute_workflow` (`POST /{workflow_id}/execute`), `execute_workflow_general` (`POST /execute`), and `create_execution` (`POST /executions/`). `github_webhooks` drops the dead import and acknowledges honestly (`workflow_execution_disabled`). The **workspace-scoped** `execute_workflow_advanced` (`/execute-advanced`) and the stub (still used by that live path + `composio.py`) are untouched — re-wiring the PR-review trigger onto missions is execution-spine work (W1), out of this PRD's tenancy scope.

### Cross-tenant matrix (§5.0 — headline acceptance)
`tests/security/test_prd172_tenant_isolation.py::TestCrossTenantMatrix` asserts a workspace-A principal is denied against a workspace-B resource across **every** in-scope domain — skills (read + global-delete), documents/vectors, workflows, memory, and shopify-graph write — as a permanent regression guard. Per-finding tests (F002–F007/F039/F045) sit underneath it; F019's cases live in `tests/security/test_nl2sql_validator.py`.

- Local: `py_compile` clean on all 14 changed `.py`; **74 tests pass** (35 PRD-172 matrix/per-finding + 39 validator) with a fake DB. **CI (`orchestrator-tests`) is the gate** — the live-Postgres integration matrix runs there (no DB locally).

### ⚠️ Owner-config flags required before deploy (fail-closed can fail a deploy — this is intended)
- **`SHOPIFY_INTERNAL_API_KEY` must be set in Railway** (F004). If currently unset, this change will (correctly) fail boot until it is set.
- **Every deploy's `S3_VECTORS_BUCKET` must contain `{workspace_id}`** when `S3_VECTORS_ENABLED=true` (F005). A shared bucket with no placeholder now fails boot instead of leaking cross-tenant vectors.
- **Owner policy calls surfaced, not taken** (CLAUDE.md §12): F019's read-only DB role at provisioning (defence-in-depth on top of the validator); F039's fix-or-delete of `/api/v1/memory` as a possible "placebo" (the tenancy fix applies regardless while the route exists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)