### PR TITLE
fix(frontend): restore 4 wrongly-deleted hooks + finish sonner codemod (fixes prod build)

### DIFF
--- a/frontend/hooks/use-analytics-api.ts
+++ b/frontend/hooks/use-analytics-api.ts
@@ -1,0 +1,146 @@
+import { useQuery, useMutation } from '@tanstack/react-query'
+import { apiClient } from '@/lib/api-client'
+import type {
+  ActivationMetric,
+  MissionSuccessRateMetric,
+  ErrorsBySubsystemMetric,
+  WidgetEngagementMetric,
+  PrimitiveHealthMetric,
+} from '@/lib/api-client'
+
+export const analyticsQueryKeys = {
+  successRate: ['analytics', 'success-rate'],
+  completionTime: ['analytics', 'completion-time'],
+  loadTrend: ['analytics', 'load-trend'],
+  errorRate: ['analytics', 'error-rate'],
+  queueDepth: ['analytics', 'queue-depth'],
+  efficiency: ['analytics', 'efficiency'],
+  costPerExecution: ['analytics', 'cost-per-execution'],
+  peakHours: ['analytics', 'peak-hours'],
+  bottlenecks: ['analytics', 'bottlenecks'],
+  alerts: ['analytics', 'alerts'],
+  ranking: ['analytics', 'ranking'],
+  sla: ['analytics', 'sla'],
+  allMetrics: ['analytics', 'all-metrics'],
+  allEnhancements: ['analytics', 'all-enhancements']
+}
+
+export function useAnalyticsSuccessRate() {
+  return useQuery({
+    queryKey: analyticsQueryKeys.successRate,
+    queryFn: () => apiClient.getAnalyticsSuccessRate()
+  })
+}
+
+export function useTaskCompletionTime() {
+  return useQuery({
+    queryKey: analyticsQueryKeys.completionTime,
+    queryFn: () => apiClient.getTaskCompletionTime()
+  })
+}
+
+export function useSystemLoadTrend() {
+  return useQuery({
+    queryKey: analyticsQueryKeys.loadTrend,
+    queryFn: () => apiClient.getSystemLoadTrend()
+  })
+}
+
+export function useErrorRateByType() {
+  return useQuery({
+    queryKey: analyticsQueryKeys.errorRate,
+    queryFn: () => apiClient.getErrorRateByType()
+  })
+}
+
+export function useAllMetrics() {
+  return useQuery({
+    queryKey: analyticsQueryKeys.allMetrics,
+    queryFn: () => apiClient.getAllMetrics()
+  })
+}
+
+// PRD-142 Wave 0 — "Is it working?" dashboard tiles
+export function useActivationMetrics() {
+  return useQuery<ActivationMetric>({
+    queryKey: ['analytics', 'activation'],
+    queryFn: () => apiClient.getActivationMetrics()
+  })
+}
+
+export function useMissionSuccessRate() {
+  return useQuery<MissionSuccessRateMetric>({
+    queryKey: ['analytics', 'mission-success-rate'],
+    queryFn: () => apiClient.getMissionSuccessRate()
+  })
+}
+
+export function useErrorsBySubsystem(window: string = '24h') {
+  return useQuery<ErrorsBySubsystemMetric>({
+    queryKey: ['analytics', 'errors-by-subsystem', window],
+    queryFn: () => apiClient.getErrorsBySubsystem(window)
+  })
+}
+
+export function useWidgetEngagement(window: string = '7d') {
+  return useQuery<WidgetEngagementMetric>({
+    queryKey: ['analytics', 'widget-engagement', window],
+    queryFn: () => apiClient.getWidgetEngagement(window)
+  })
+}
+
+export function usePrimitiveHealth() {
+  return useQuery<PrimitiveHealthMetric>({
+    queryKey: ['analytics', 'primitive-health'],
+    queryFn: () => apiClient.getPrimitiveHealth()
+  })
+}
+
+export function useCostAnalysis() {
+  return useQuery({
+    queryKey: ['analytics', 'cost-analysis'],
+    queryFn: () => apiClient.getCostAnalysis()
+  })
+}
+
+export function usePerformanceEnhancements() {
+  return useQuery({
+    queryKey: analyticsQueryKeys.allEnhancements,
+    queryFn: () => apiClient.getPerformanceEnhancements()
+  })
+}
+
+export function usePeakUsageAnalysis() {
+  return useQuery({
+    queryKey: analyticsQueryKeys.peakHours,
+    queryFn: () => apiClient.getPeakUsageAnalysis()
+  })
+}
+
+export function useBottleneckDetection() {
+  return useQuery({
+    queryKey: analyticsQueryKeys.bottlenecks,
+    queryFn: () => apiClient.getBottleneckDetection()
+  })
+}
+
+export function usePredictiveAlerts() {
+  return useQuery({
+    queryKey: analyticsQueryKeys.alerts,
+    queryFn: () => apiClient.getPredictiveAlerts()
+  })
+}
+
+export function useAgentRanking() {
+  return useQuery({
+    queryKey: analyticsQueryKeys.ranking,
+    queryFn: () => apiClient.getAgentRanking()
+  })
+}
+
+export function useSLACompliance() {
+  return useQuery({
+    queryKey: analyticsQueryKeys.sla,
+    queryFn: () => apiClient.getSLACompliance()
+  })
+}

--- a/frontend/hooks/use-context-management-api.ts
+++ b/frontend/hooks/use-context-management-api.ts
@@ -1,0 +1,195 @@
+/**
+ * Context Management API hooks
+ * Provides React Query integration for context management endpoints
+ */
+
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+import { apiClient } from '@/lib/api-client'
+
+// Query keys for React Query
+export const contextManagementQueryKeys = {
+  contextStats: ['context', 'stats'] as const,
+  contextPerformance: ['context', 'performance'] as const,
+  contextSources: ['context', 'sources'] as const,
+  recentQueries: ['context', 'queries', 'recent'] as const,
+  contextPatterns: ['context', 'patterns'] as const,
+  contextSystemHealth: ['context', 'system-health'] as const,
+}
+
+// ============= QUERY HOOKS =============
+
+// Get context stats
+export function useContextStats() {
+  return useQuery({
+    queryKey: contextManagementQueryKeys.contextStats,
+    queryFn: () => apiClient.getContextStats(),
+    refetchInterval: 30000,
+    staleTime: 15000,
+  })
+}
+
+// Get context performance
+export function useContextPerformance(timeRange: string = '24h') {
+  return useQuery({
+    queryKey: [...contextManagementQueryKeys.contextPerformance, timeRange],
+    queryFn: () => apiClient.getContextPerformance(timeRange),
+    refetchInterval: 30000,
+    staleTime: 15000,
+  })
+}
+
+// Get context sources
+export function useContextSources() {
+  return useQuery({
+    queryKey: contextManagementQueryKeys.contextSources,
+    queryFn: () => apiClient.getContextSources(),
+    refetchInterval: 60000,
+    staleTime: 30000,
+  })
+}
+
+// Get recent context queries
+export function useRecentContextQueries() {
+  return useQuery({
+    queryKey: contextManagementQueryKeys.recentQueries,
+    queryFn: () => apiClient.getRecentContextQueries(),
+    refetchInterval: 30000,
+    staleTime: 15000,
+  })
+}
+
+// Get context patterns
+export function useContextPatterns() {
+  return useQuery({
+    queryKey: contextManagementQueryKeys.contextPatterns,
+    queryFn: () => apiClient.getContextPatterns(),
+    refetchInterval: 60000,
+    staleTime: 30000,
+  })
+}
+
+// Get context system health
+export function useContextSystemHealth() {
+  return useQuery({
+    queryKey: contextManagementQueryKeys.contextSystemHealth,
+    queryFn: () => apiClient.getContextSystemHealth(),
+    refetchInterval: 30000,
+    staleTime: 15000,
+  })
+}
+
+// ============= MUTATION HOOKS =============
+
+// Initialize context
+export function useInitializeContext() {
+  const queryClient = useQueryClient()
+  
+  return useMutation({
+    mutationFn: (data: any) => apiClient.initializeContext(data),
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ['context'] })
+      toast.success('Context initialized successfully!')
+      return data
+    },
+    onError: (error) => {
+      toast.error(`Failed to initialize context: ${error.message}`)
+      throw error
+    },
+  })
+}
+
+// Test context RAG
+export function useTestContextRAG() {
+  return useMutation({
+    mutationFn: (configId: string) => apiClient.testContextRAG(configId),
+    onSuccess: (data) => {
+      toast.success('Context RAG test completed!')
+      return data
+    },
+    onError: (error) => {
+      toast.error(`Context RAG test failed: ${error.message}`)
+      throw error
+    },
+  })
+}
+
+// Update context performance
+export function useUpdateContextPerformance() {
+  const queryClient = useQueryClient()
+  
+  return useMutation({
+    mutationFn: (data: any) => apiClient.updateSystemLearningState(data),
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: contextManagementQueryKeys.contextPerformance })
+      toast.success('Context performance updated!')
+      return data
+    },
+    onError: (error) => {
+      toast.error(`Failed to update context performance: ${error.message}`)
+      throw error
+    },
+  })
+}
+
+// Get optimization recommendations (query)
+export function useOptimizationRecommendations() {
+  return useQuery({
+    queryKey: ['context', 'optimization'],
+    queryFn: () => apiClient.getOptimizationRecommendations(),
+    staleTime: 60000, // Cache for 1 minute
+    refetchInterval: false, // Don't auto-refetch
+  })
+}
+
+// Trigger optimization analysis (mutation for manual refresh)
+export function useOptimizeContext() {
+  const queryClient = useQueryClient()
+  
+  return useMutation({
+    mutationFn: () => apiClient.getOptimizationRecommendations(),
+    onSuccess: (data) => {
+      queryClient.setQueryData(['context', 'optimization'], data)
+      toast.success('Optimization analysis complete!')
+      return data
+    },
+    onError: (error) => {
+      toast.error(`Context optimization failed: ${error.message}`)
+      throw error
+    },
+  })
+}
+
+// Clear context cache
+export function useClearContextCache() {
+  const queryClient = useQueryClient()
+  
+  return useMutation({
+    mutationFn: () => Promise.resolve(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['context'] })
+      toast.success('Context cache cleared!')
+    },
+    onError: (error) => {
+      toast.error(`Failed to clear context cache: ${error.message}`)
+      throw error
+    },
+  })
+}
+
+// Refresh context data
+export function useRefreshContextData() {
+  const queryClient = useQueryClient()
+  
+  return useMutation({
+    mutationFn: () => Promise.resolve(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['context'] })
+      toast.success('Context data refreshed!')
+    },
+    onError: (error) => {
+      toast.error(`Failed to refresh context data: ${error.message}`)
+      throw error
+    },
+  })
+}

--- a/frontend/hooks/use-notifications-api.ts
+++ b/frontend/hooks/use-notifications-api.ts
@@ -1,0 +1,186 @@
+/**
+ * Notifications API hooks (PRD-128 US-008)
+ * React Query v4 hooks backing the bell dropdown + settings page.
+ */
+
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { apiClient } from '@/lib/api-client'
+
+// ============= TYPES =============
+
+export interface NotificationRow {
+  id: string
+  workspace_id: string
+  user_id: number | null
+  event_type: string
+  title: string
+  message: string | null
+  link_type: string | null
+  link_id: string | null
+  agent_id: number | null
+  agent_name: string | null
+  status: string
+  read_at: string | null
+  dismissed_at: string | null
+  created_at: string
+}
+
+export interface NotificationListResponse {
+  success: boolean
+  notifications: NotificationRow[]
+  total: number
+  limit: number
+  offset: number
+}
+
+export interface UnreadCountResponse {
+  success: boolean
+  count: number
+}
+
+export interface PreferenceRow {
+  event_type: string
+  destination: string
+  enabled: boolean
+  channel_connection_id: string | null
+}
+
+export interface PreferenceListResponse {
+  success: boolean
+  preferences: PreferenceRow[]
+}
+
+export interface PreferenceBulkUpdateResponse {
+  success: boolean
+  updated_count: number
+}
+
+// ============= QUERY KEYS =============
+
+export const notificationQueryKeys = {
+  all: ['notifications'] as const,
+  list: (limit: number, offset: number, unreadOnly: boolean) =>
+    ['notifications', 'list', { limit, offset, unreadOnly }] as const,
+  unreadCount: ['notifications', 'unread-count'] as const,
+  preferences: ['notification-preferences'] as const,
+}
+
+// ============= QUERIES =============
+
+/**
+ * Polls /api/notifications/unread-count every 30s for the bell badge.
+ */
+export function useUnreadNotificationCount() {
+  return useQuery<UnreadCountResponse>({
+    queryKey: notificationQueryKeys.unreadCount,
+    queryFn: () =>
+      apiClient.request<UnreadCountResponse>('/api/notifications/unread-count'),
+    refetchInterval: 30000,
+    staleTime: 15000,
+  })
+}
+
+/**
+ * Fetches the most recent notifications. Only enabled when the caller opts in
+ * (e.g. when the popover is opened) to avoid wasted requests.
+ */
+export function useNotifications(
+  options: { limit?: number; offset?: number; unreadOnly?: boolean; enabled?: boolean } = {}
+) {
+  const { limit = 20, offset = 0, unreadOnly = false, enabled = true } = options
+
+  return useQuery<NotificationListResponse>({
+    queryKey: notificationQueryKeys.list(limit, offset, unreadOnly),
+    queryFn: () => {
+      const params = new URLSearchParams()
+      params.set('limit', String(limit))
+      params.set('offset', String(offset))
+      if (unreadOnly) params.set('unread_only', 'true')
+      return apiClient.request<NotificationListResponse>(
+        `/api/notifications?${params.toString()}`
+      )
+    },
+    enabled,
+    staleTime: 15000,
+  })
+}
+
+/**
+ * GET merged notification preferences for the settings page.
+ */
+export function useNotificationPreferences(enabled: boolean = true) {
+  return useQuery<PreferenceListResponse>({
+    queryKey: notificationQueryKeys.preferences,
+    queryFn: () =>
+      apiClient.request<PreferenceListResponse>('/api/notification-preferences'),
+    enabled,
+    staleTime: 30000,
+  })
+}
+
+// ============= MUTATIONS =============
+
+export function useMarkNotificationRead() {
+  const queryClient = useQueryClient()
+
+  return useMutation<{ success: boolean }, Error, string>({
+    mutationFn: (id: string) =>
+      apiClient.request<{ success: boolean }>(
+        `/api/notifications/${id}/read`,
+        { method: 'POST' }
+      ),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: notificationQueryKeys.all })
+    },
+  })
+}
+
+export function useMarkAllNotificationsRead() {
+  const queryClient = useQueryClient()
+
+  return useMutation<{ success: boolean; marked_count: number }, Error, void>({
+    mutationFn: () =>
+      apiClient.request<{ success: boolean; marked_count: number }>(
+        '/api/notifications/read-all',
+        { method: 'POST' }
+      ),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: notificationQueryKeys.all })
+    },
+  })
+}
+
+export function useDismissNotification() {
+  const queryClient = useQueryClient()
+
+  return useMutation<{ success: boolean }, Error, string>({
+    mutationFn: (id: string) =>
+      apiClient.request<{ success: boolean }>(
+        `/api/notifications/${id}/dismiss`,
+        { method: 'POST' }
+      ),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: notificationQueryKeys.all })
+    },
+  })
+}
+
+export function useUpdateNotificationPreferences() {
+  const queryClient = useQueryClient()
+
+  return useMutation<
+    PreferenceBulkUpdateResponse,
+    Error,
+    PreferenceRow[]
+  >({
+    mutationFn: (preferences: PreferenceRow[]) =>
+      apiClient.request<PreferenceBulkUpdateResponse>(
+        '/api/notification-preferences',
+        { method: 'PUT', body: JSON.stringify({ preferences }) }
+      ),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: notificationQueryKeys.preferences })
+      queryClient.invalidateQueries({ queryKey: notificationQueryKeys.all })
+    },
+  })
+}

--- a/frontend/hooks/use-teams.ts
+++ b/frontend/hooks/use-teams.ts
@@ -6,7 +6,7 @@
  */
 
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { toast } from 'react-hot-toast'
+import { toast } from 'sonner'
 import apiClient from '../lib/api-client'
 
 export interface Team {

--- a/frontend/hooks/use-template-api.ts
+++ b/frontend/hooks/use-template-api.ts
@@ -1,0 +1,117 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { apiClient } from '@/lib/api-client'
+
+// Query key factory
+export const templateKeys = {
+  all: ['workflow-templates'] as const,
+  lists: () => [...templateKeys.all, 'list'] as const,
+  list: (params?: any) => [...templateKeys.lists(), params] as const,
+  details: () => [...templateKeys.all, 'detail'] as const,
+  detail: (id: string) => [...templateKeys.details(), id] as const,
+  featured: () => [...templateKeys.all, 'featured'] as const,
+  categories: () => [...templateKeys.all, 'categories'] as const,
+}
+
+// List templates with filtering
+export function useWorkflowTemplates(params?: {
+  category?: string
+  difficulty?: string
+  is_featured?: boolean
+  is_public?: boolean
+  search?: string
+  skip?: number
+  limit?: number
+  sort_by?: string
+}) {
+  return useQuery({
+    queryKey: templateKeys.list(params),
+    queryFn: () => apiClient.listWorkflowTemplates(params),
+    staleTime: 5 * 60 * 1000, // 5 minutes
+  })
+}
+
+// Get single template
+export function useWorkflowTemplate(templateId: string | undefined) {
+  return useQuery({
+    queryKey: templateKeys.detail(templateId || ''),
+    queryFn: () => apiClient.getWorkflowTemplateById(templateId!),
+    enabled: !!templateId,
+  })
+}
+
+// Get featured templates
+export function useFeaturedTemplates(limit?: number) {
+  return useQuery({
+    queryKey: templateKeys.featured(),
+    queryFn: () => apiClient.getFeaturedTemplates(limit),
+    staleTime: 10 * 60 * 1000, // 10 minutes
+  })
+}
+
+// Get template categories
+export function useTemplateCategories() {
+  return useQuery({
+    queryKey: templateKeys.categories(),
+    queryFn: () => apiClient.getTemplateCategories(),
+    staleTime: 30 * 60 * 1000, // 30 minutes
+  })
+}
+
+// Create template mutation
+export function useCreateTemplate() {
+  const queryClient = useQueryClient()
+  
+  return useMutation({
+    mutationFn: (templateData: any) => apiClient.createWorkflowTemplate(templateData),
+    onSuccess: () => {
+      // Invalidate all template lists
+      queryClient.invalidateQueries({ queryKey: templateKeys.lists() })
+      queryClient.invalidateQueries({ queryKey: templateKeys.featured() })
+    },
+  })
+}
+
+// Update template mutation
+export function useUpdateTemplate() {
+  const queryClient = useQueryClient()
+  
+  return useMutation({
+    mutationFn: ({ templateId, templateData }: { templateId: string; templateData: any }) =>
+      apiClient.updateWorkflowTemplate(templateId, templateData),
+    onSuccess: (_, variables) => {
+      // Invalidate the specific template and all lists
+      queryClient.invalidateQueries({ queryKey: templateKeys.detail(variables.templateId) })
+      queryClient.invalidateQueries({ queryKey: templateKeys.lists() })
+      queryClient.invalidateQueries({ queryKey: templateKeys.featured() })
+    },
+  })
+}
+
+// Delete template mutation
+export function useDeleteTemplate() {
+  const queryClient = useQueryClient()
+  
+  return useMutation({
+    mutationFn: (templateId: string) => apiClient.deleteWorkflowTemplate(templateId),
+    onSuccess: () => {
+      // Invalidate all template lists
+      queryClient.invalidateQueries({ queryKey: templateKeys.lists() })
+      queryClient.invalidateQueries({ queryKey: templateKeys.featured() })
+    },
+  })
+}
+
+// Record template usage mutation
+export function useRecordTemplateUsage() {
+  const queryClient = useQueryClient()
+  
+  return useMutation({
+    mutationFn: (templateId: string) => apiClient.recordTemplateUsage(templateId),
+    onSuccess: (_, templateId) => {
+      // Invalidate the specific template to refresh use_count
+      queryClient.invalidateQueries({ queryKey: templateKeys.detail(templateId) })
+      queryClient.invalidateQueries({ queryKey: templateKeys.lists() })
+    },
+  })
+}
+


### PR DESCRIPTION
## What broke
The frontend Docker build (Railway) failed with `Module not found` (webpack) errors — build-breaking regardless of `ignoreBuildErrors`. Undetected because the **frontend build is not in CI (F034)**.

Root cause = two incomplete prior refactors that left dangling imports:
- **PRD-168** (`5626c56ab`, "delete 26 dead api-era hooks") deleted 4 hooks that were **not** dead — they still have live callers: `use-analytics-api`, `use-notifications-api`, `use-context-management-api`, `use-template-api`.
- **PRD-154 S9** (one-toast-system → sonner) **missed `hooks/use-teams.ts`**, leaving a `react-hot-toast` import after the package was removed.

## Fix
- Restore the 4 hooks (their deps — `@/lib/api-client`, `@tanstack/react-query` — still exist).
- `use-teams.ts`: `react-hot-toast` → `sonner` (API-compatible `toast.success/error`).

## Verified
`next build` is **green** on Node 20 with a fresh `npm install --legacy-peer-deps` (matches the deploy). Backend untouched.

## Follow-up (F034)
Add the frontend build (`next build`) to CI so this class can't recur — belongs in W12 (CI enterprise bar).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reusable hooks for analytics, context management, notifications, and workflow templates.
  * Introduced notification inbox support, including unread counts, marking items read, dismissing alerts, and updating preferences.
  * Added template browsing and management actions, plus analytics and context-related data views.

* **Bug Fixes**
  * Improved cache updates so lists and detail views refresh correctly after changes.
  * Updated team-related toast notifications to use a new notification system.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->