### PR TITLE
docs(os): Phase B PRDs — W4 policy plane + W5 auth decoupling + W6 deployability

### DIFF
--- a/docs/PRDS/174-UNIFIED-POLICY-PLANE.md
+++ b/docs/PRDS/174-UNIFIED-POLICY-PLANE.md
@@ -1,0 +1,244 @@
+# PRD-174 — Unified Policy Plane v1 (Wave 4)
+
+**Status:** Draft v1 — pending approval
+**Type:** Architecture / Security (the governance plane; P0 centerpiece)
+**Priority:** P0 — the "conductor" that lets Auto act autonomously *within bounds*; every autonomy story depends on it
+**Owner:** Gerard Kavanagh
+**Author:** Gerard Kavanagh + Claude (Opus 4.8)
+**Date:** 2026-07-02
+**Phase:** B — Policy plane & deployability · **Size:** L · **Risk:** **HIGH** (touches every execution path — build behind a flag, characterization tests first)
+**Depends on:** Wave 1 (execution spine, ✅ merged) + Wave 2 (tenant isolation, ✅ merged)
+**Parent:** [PLATFORM-OS-ROADMAP.md](./PLATFORM-OS-ROADMAP.md)
+**Source:** review §9.3 (the buildable target), §9.4 (Claude-Code primitive replacements), §9.5 steps 2 & 4 (migration order), §12.4 (Ring 2), §13 Wave 4, §14 (act-vs-ask decision)
+**Findings register pinned to:** `37fdecc4e` — re-confirm each `file:line` on current `main` before editing
+**Findings in scope:** F085, F040, F086, F059, F014, F042, F043 (+ F060 governance-asymmetry, closed by the chokepoint)
+**Owner decision (LOCKED 2026-07-02):** act-vs-ask default posture = **Balanced** (see §5)
+
+---
+
+## Operating Principle
+
+> **One typed gate, evaluated in one place, for every tool call — on every surface.** Auto's blueprint
+> tells it what to *attempt*; the policy plane, and only the policy plane, decides what *executes*. Keep
+> Claude Code's separation of model *intent* from *authorization*, but move the authority from the local
+> filesystem to the **tenant control plane**. Guardrails become policy (DB-configured, one config, one
+> chokepoint), not code scattered across router dependencies. **Deny outranks ask outranks allow**, and
+> every denial returns a structured reason the model can read (errors-as-data).
+
+---
+
+## 1. Purpose
+
+Today there is **no policy plane as a plane** (F085). Budgets, approvals, rate-limits and roles live in
+three partial, contradictory mechanisms — per-router auth dependencies, action-registry flags, and the
+mission approval engine — with no single configuration evaluated in one place. Guardrails stop at the
+mission boundary; the API surface has no awareness of `approval_policy`. So the choice today is
+**babysit-everything or trust-blindly** — the all-or-nothing autonomy the whole "Jarvis acting out" thesis
+needs to escape.
+
+Concretely, the deterministic gate stack that *does* exist — super-admin fail-closed, the autonomy dial,
+confirmation, hierarchy, and a destructive backstop (`platform_executor.py:606-812`) — guards **`platform_*`
+actions only**. Composio, workspace, and registry tools **route around it** (`unified_executor.py:334-364`).
+Meanwhile the rate limiter is a placebo (F040), there is no pre-call budget admission gate (F086), the
+dollar ceiling is model-blind across four hardcoded price tables (F059), `admin_only` is a no-op in agent
+context (F014), and RBAC forks — empty permissions mean *allow-all* on one plane and *deny-all* on another
+(F042), while seven routers 403 the super-admin (F043).
+
+**W4 builds the single enforcement point** that folds all of this into one place, so Auto can act
+autonomously *within bounds*, and so audit-log completeness and staged compliance (W11) have a substrate to
+attach to. It is the review's centerpiece and where the Claude Code harness reference transfers most directly.
+
+---
+
+## 2. Background
+
+### 2.1 What's working today (reuse, don't reinvent)
+
+- **The deterministic gate stack exists** — super-admin fail-closed, autonomy dial (`platform_executor.py:626`),
+  confirmation, hierarchy, and a non-overridable destructive backstop (`platform_executor.py:606-812`). W4
+  **refactors these into shared `PolicyGate` functions**, it does not re-invent them.
+- **The convergence point exists.** `UnifiedToolExecutor.execute_tool` (`unified_executor.py:243+`) is where
+  platform, workspace, Composio-per-action, and registry tools already converge — the natural single chokepoint.
+- **The approval primitive exists.** PRD-163 already makes approval a state transition with an in-chat card;
+  `ask` reuses it (card for chat, approval row for headless).
+- **The autonomy dial exists.** `auto` mode is the existing full-autonomy dial that correctly never satisfies
+  the super-admin gate and never bypasses the destructive backstop.
+- **Per-agent ACL exists** (`tool_router.py:265-277`) — pre-filter at surface time; the plane reserves
+  call-time gates for `ask`/conditional verdicts.
+- **A model-aware price registry exists** in the DB (unused) — F059's fix wires the dollar gate to it.
+
+### 2.2 What's broken / missing
+
+- **F085 — no policy plane.** Guardrails scattered across router deps, action-registry flags, and the mission
+  approval engine; the API surface has no awareness of `approval_policy` (`approval_policy.py`, mission-runtime only).
+- **F060 — governance asymmetry.** Budget/approval gates exist for missions but **not** board tasks or
+  playbooks; Composio/workspace/registry tools bypass the gate stack (`unified_executor.py:334-364`).
+- **F086 — no pre-call budget admission gate.** No `BudgetExceeded` class exists; the tool loop, chat,
+  agent-factory and recipe loops all issue LLM/tool calls with **no spend check** (`tool_loop.py:326`); the
+  LLM manager only cost-logs *after* the call.
+- **F059 — model-blind dollar ceiling.** Four independent hardcoded price tables coexist with an unused
+  model-aware DB registry, so the approval-budget primitive approves/blocks on wrong dollars.
+- **F040 — placebo rate limiter.** `SlowAPIMiddleware` is never added despite the `Limiter` being
+  constructed; the stack's only fail-*open* gate (`platform_executor.py:794`).
+- **F014 — admin_only no-op in agent context.** `is_admin` auto-flips true whenever the *workspace* has any
+  admin member (true for every workspace), not the calling principal (`platform_executor.py:641-645`).
+- **F042 — RBAC god-key/null-key fork.** Empty permissions = allow-all on the widget plane, deny-all on the
+  board plane; one no-permission key is a god-key on one and a null-key on the other.
+- **F043 — super-admin locked out.** Seven routers gate admin functions with `system_role == 'admin'`, which
+  403s super-admin entirely.
+
+### 2.3 Why now
+
+W1 (spine) and W2 (tenancy) are merged, so the plane has a working loop to wrap and a tenant boundary to
+enforce. The act-vs-ask decision is **locked (Balanced)** — the review is explicit that *until* it's decided
+the plane "has no target semantics and Auto's autonomy stays all-or-nothing." Everything after W4 (moat loop
+W7, governance/compliance W11) depends on this enforcement + audit substrate existing. Build it once, on the
+converged spine, rather than three times.
+
+---
+
+## 3. Findings in scope
+
+| ID | Sev | Location (pinned `37fdecc4e`) | Defect | Fix |
+|---|---|---|---|---|
+| **F085** | Critical (missing) | `core/services/approval_policy.py` (mission-runtime only) | No policy plane; guardrails in 3 partial mechanisms | New `modules/policy/` package + one `PolicyGate` chokepoint |
+| **F060** | High | `unified_executor.py:334-364`; `api/tasks.py`, `main.py:885` | Composio/workspace/registry bypass the gate; governance is missions-only | Route every tool through `PolicyGate.check()` from `UnifiedToolExecutor` |
+| **F086** | High (missing) | `tool_loop.py:326` | No pre-call budget admission gate; no `BudgetExceeded` | `on_pre_tool` dollar admission gate + `BudgetExceeded` |
+| **F059** | High | 4 hardcoded price tables + unused DB registry | Model-blind dollar ceiling | Model-aware pricing from the DB registry |
+| **F040** | High | `platform_executor.py:794`; middleware unregistered | Placebo rate limiter (fail-open) | Register `SlowAPIMiddleware`; fail **closed** |
+| **F014** | High | `platform_executor.py:641-645` | `admin_only` no-op — `is_admin` from workspace, not caller | Derive from caller's own role (PRD-168 actor identity); explicit default-off "agents inherit admin" |
+| **F042** | High | widget vs board planes | Empty perms = allow-all one plane, deny-all other | One empty-permission semantic (**empty = deny**), shared helper |
+| **F043** | High | 7 routers `system_role=='admin'` | Super-admin 403'd | Shared `super_admin ⊇ admin ⊇ user` role helper |
+
+---
+
+## 4. Design & changes
+
+Built as **two migration steps** (review §9.5 steps 2 & 4), behind an `AUTOMATOS_POLICY_PLANE` flag with
+characterization tests written *first* (high risk — it touches every execution path).
+
+### 4.1 Step 2 — one policy chokepoint (ships independently)
+
+- **Extract the platform gate stack into `modules/policy/` `PolicyGate`.** Move the super-admin fail-closed,
+  autonomy-dial, confirmation, hierarchy, and destructive-backstop functions (`platform_executor.py:606-812`)
+  into shared, tenant-scoped `PolicyGate` functions.
+- **Invoke `PolicyGate.check()` from `UnifiedToolExecutor.execute_tool`** (`unified_executor.py:243+`), so
+  Composio, workspace, and registry tools **stop bypassing** it (F060, F085). All three loops (chat, recipe,
+  heartbeat) inherit universal guardrails on their platform paths immediately.
+- **F040 — make the rate limiter fail closed:** register `SlowAPIMiddleware`; a limiter that can't evaluate
+  denies rather than allows.
+- **F014 — owner-fallback behind an explicit default-off setting:** `is_admin` derives from the caller's own
+  role via the PRD-168 actor identity; "agents inherit admin" becomes an explicit, default-off workspace policy.
+- **F042/F043 — one role + permission semantic:** a shared `super_admin ⊇ admin ⊇ user` helper (fixes the 7
+  routers) and **empty-permissions = deny** everywhere (kills the god-key).
+
+### 4.2 Step 4 — the policy plane v1
+
+- **A typed event bus** (`modules/policy/`): `RunStart`, `PreToolUse`, `PostToolUse`, `PostToolBatch`,
+  `RoundEnd`, `RunEnd`, `PreCompact`. Handlers return a verdict object
+  `{decision: allow|deny|ask|defer, updated_input, injected_context, reason}` — the exact Claude Code verdict
+  semantics, re-keyed for tenancy. **deny > ask > allow.**
+- **Add the `on_pre_tool` seam** beside the dedup check in `_execute_round` (`tool_loop.py:340`). Today only
+  post-tool hooks exist (`tool_loop.py:176-182,254`); the pre-tool seam is the natural attach point for
+  blueprint, approval, and budget policy (F086, ADJUSTED).
+- **F086 + F059 — pre-call dollar admission, model-aware:** inside `on_pre_tool`, a `BudgetExceeded` admission
+  gate checks `Workspace.plan_limits` (cost/tokens, not just concurrency) using the **model-aware DB price
+  registry** — retiring the four hardcoded tables.
+- **Permission modes = act-vs-ask, mapped onto existing primitives (not invented):**
+  - `plan` → tools filtered to `permission_level=='read'` (also fixes `service.py:807` stripping *all* tools
+    in plan mode so Auto can research while planning).
+  - `default` → `requires_confirmation` routes to **ask** — the PRD-163 in-chat card for chat, an approval row
+    for headless.
+  - `auto` → the existing full-autonomy dial (`platform_executor.py:626`) — never satisfies the super-admin
+    gate, never bypasses the destructive backstop.
+  - `dontAsk` → auto-denies anything unapproved (the right default for webhooks and scheduled runs).
+- **Structured errors-as-data:** formalize the half-existing envelope (`tool_router.py:715-736`) to
+  `{code, message_for_model, remediation, retryable}`; **every policy denial returns its reason as tool
+  content** so the model can adapt instead of erroring.
+- **Prerequisite gates (harness-refuses-until-X, not prompt-remembers-X):** read-before-write on
+  documents/records; plan-approved-before-dispatch (extend PRD-163 to destructive board Run-Now);
+  integration-trusted-before-exposed.
+
+### 4.3 What replaces the Claude Code primitives (§9.4 — the design's north star)
+
+The single most transferable Claude Code pattern is hooks-as-policy that lives *outside* the model. Each
+dangerous single-user primitive gets a deliberate tenant-safe replacement — this is what the plane implements:
+
+| Claude Code primitive | Why it doesn't transfer | Replacement in Automatos (this PRD) |
+|---|---|---|
+| `bypassPermissions` / skip-prompts | "isolated VM" justification; no tenant-safe equivalent | autonomy dial bounded by non-overridable deny rules + super-admin gate + destructive backstop (shape exists `platform_executor.py:606,626,796`) |
+| Model sees every tool schema | wasteful/leaky across tenants | pre-filter at surface time (per-agent ACL `tool_router.py:265-277`); call-time gates only for ask/conditional |
+| Local trust roots (`~/.claude`, repo `.claude/`) | a repo can grant itself permissions | config authority in the **tenant control plane** — DB rows with provenance; tenant content cannot self-grant |
+| Hooks as shell commands | RCE by configuration | **keep the event taxonomy + verdict semantics; execution = in-process handlers + signed webhooks** (NOT shell) |
+| Bash string-prefix matching | fragile (docs say so) | typed-tool registry with `permission_level`; `workspace_exec` sandbox-first |
+| Session-local "don't ask again" | ephemeral, unauditable | durable, auditable, revocable approval grants with scope + expiry (extend PRD-163 rows) |
+| CLAUDE.md-as-policy | shapes intent, never enforces | blueprints/prompts shape intent; enforcement lives **only** in the policy plane |
+| Single-user credentials | no tenant isolation | per-tenant vaulted, scoped, rotated secrets at the execution boundary (Composio per-workspace pattern) |
+
+---
+
+## 5. The Balanced policy — the workspace policy document the plane evaluates
+
+Encode the **act-vs-ask decision once** (LOCKED: **Balanced**), as the DB-configured workspace policy the
+plane reads — not per-surface toggles (the three partial planes today already contradict each other). Defaults:
+
+- **Auto (no ask):** reads; low-risk internal writes (draft docs, update own board task status, internal
+  memory writes, research/plan).
+- **Ask (PRD-163 approval card / row):** **destructive ops** (deletes, board **Run-Now**); **external
+  side-effects** (Composio sends/refunds/discounts, email/channel posts, Shopify writes); **over-budget** spend
+  (workspace `plan_limits`).
+- **Templates / brand-kits:** Auto **drafts**; a human **approves publish** (not human-only, not auto-publish).
+- **Board:** mutations stay **chat/assignment-driven** — no free "create-task" affordance in v1.
+- **Composio side-effect tier:** refunds/discounts/sends default to **ask**; tunable per-workspace.
+
+All of the above are **workspace-policy rows, tunable** — the PRD ships the Balanced defaults; changing them is
+config, not a deploy.
+
+---
+
+## 6. Test-first acceptance
+
+Write these **failing first**, then implement to green (characterization tests before the refactor, per the
+high-risk flag):
+
+1. **Headline (review §13):** a **characterization test proves a denied tool call never executes** and returns
+   a **structured denial the model can read** (`{code, message_for_model, remediation, retryable}`).
+2. **F060/F085:** a Composio (and a workspace, and a registry) tool call is evaluated by `PolicyGate` — it no
+   longer bypasses the gate; a denied one doesn't execute.
+3. **F086/F059:** a tool call that would exceed the workspace `plan_limits` (priced **model-aware**) raises
+   `BudgetExceeded` **before** the call; a within-budget call proceeds.
+4. **F040:** with the limiter unable to evaluate, the request is **denied** (fail-closed), not allowed.
+5. **F014:** an agent call to an `admin_only` action is denied when the caller isn't admin (workspace having
+   *an* admin no longer flips it true); allowed only with the explicit default-off "agents inherit admin" policy on.
+6. **F042/F043:** an **empty-permission** key is denied on **both** planes; a **super_admin** passes all seven
+   previously-`admin`-only routers.
+7. **Act-vs-ask (Balanced):** a destructive/external/over-budget action routes to **ask** (emits a PRD-163
+   card/row and does not execute until approved); a read/low-risk-internal action executes without asking.
+8. **Deny > ask > allow:** when handlers disagree, deny wins over ask wins over allow.
+
+**Wave bar:** every tool call on every surface (chat, recipe, board, heartbeat, webhook) passes through one
+`PolicyGate`; guardrails are universal, not platform-tool-specific; Auto acts within the Balanced bounds without
+babysitting.
+
+---
+
+## 7. Risks & rollback
+
+- **Highest-risk wave — it touches every execution path.** Mitigation: build behind `AUTOMATOS_POLICY_PLANE`
+  (default off in this PR), characterization tests first, roll out per-surface.
+- **Do NOT implement as shell hooks** — Claude Code's local model doesn't fit a SaaS backend and the harness
+  docs themselves warn Bash-string matching is fragile. In-process typed handlers with tenant scope only.
+- **Sequencing:** Step 2 (chokepoint) ships and green **before** Step 4 (plane) so nothing new enters
+  ungoverned while more surfaces join.
+- **Rollback:** the flag disables the plane and falls back to today's per-router gates; each finding-fix is an
+  independent commit.
+
+---
+
+## 8. References
+
+- Review §9.3 (buildable target — the loop + policy mechanics), §9.4 (primitive replacements), §9.5 steps 2 & 4
+  (migration order), §12.4 (Ring 2 — the policy plane), §13 Wave 4, §14 (act-vs-ask, LOCKED Balanced)
+- Findings F085/F060/F086/F059/F040/F014/F042/F043 — `reports/PLATFORM_OS_REVIEW_2026-07-01.md`
+- Reuses: PRD-163 approval cards, PRD-168 actor identity, the DB price registry, the per-agent ACL
+- CLAUDE.md §4 (no shims), §5 (delete what you supersede), §12 (no unilateral descope)

--- a/docs/PRDS/175-AUTH-DECOUPLING.md
+++ b/docs/PRDS/175-AUTH-DECOUPLING.md
@@ -1,0 +1,253 @@
+# PRD-175 — Auth Decoupling (open-core) (Wave 5)
+
+**Status:** Draft v1 — pending approval
+**Type:** Architecture (open-core / auth)
+**Priority:** P0 — unblocks Wave 6 (deployability) and the open-core thesis
+**Owner:** Gerard Kavanagh
+**Author:** Gerard Kavanagh + Claude (Opus 4.8)
+**Date:** 2026-07-02
+**Phase:** B — Policy plane & deployability · **Size:** high risk but a one-function seam · **Risk:** high (auth touches every request), contained by an existing seam
+**Depends on:** none hard — helps W6 (deployability & reliability baseline)
+**Parent:** [PLATFORM-OS-ROADMAP.md](./PLATFORM-OS-ROADMAP.md)
+**Source:** review §4/§5 (F008, F075), §13 Wave 5; the absent PRD-150 (open-core / auth-decoupling)
+**Findings register pinned to:** `37fdecc4e` — re-confirm each `file:line` on current `main` before editing
+**Findings in scope:** F008, F075
+
+---
+
+## Operating Principle
+
+> **One core, two editions, one seam.** The model of *who is calling* is chosen once, at the edition
+> boundary, and every surface reads that one answer. In `saas` the boundary is Clerk; in `local` it is a
+> single auto-authenticated local user in a single local workspace — **no login, no external SaaS, no
+> Clerk env.** We do not fork the auth system: we mount the existing Clerk path only when the edition asks
+> for it, and fall through to the identity the backend *already has* (`hybrid.py`'s anonymous dev-fallback)
+> otherwise. The edition is a flag, not a code path the reader has to reason about at every call site.
+
+---
+
+## 1. Purpose
+
+Today Automatos **cannot be run from a fresh clone by anyone without a Clerk tenant.** The frontend mounts
+`ClerkProvider` **unconditionally** (`providers.tsx:33`) and `clerkMiddleware` calls `auth.protect()` on every
+non-public route (`middleware.ts:14`), with **zero edition flag anywhere** (F008). Without a Clerk
+publishable key the UI renders nothing — sign-in itself is a Clerk surface — so the open-core thesis ("`git
+clone && docker compose up` → a working local instance, no login, zero external SaaS", roadmap §2
+Deployability bar) is **undeployable from zero**. This is the frontend half of the absent PRD-150 that never
+landed; the backend half already exists and is unused.
+
+The backend is in fact ready: `get_request_context_hybrid` (`hybrid.py:653`) already supports Clerk JWT, API
+key, **and an anonymous dev-fallback** (`hybrid.py:805-826`) gated by `config.REQUIRE_AUTH`
+(`config.py:149`). What is missing is (a) a single, named **edition flag** so the frontend stops mounting
+Clerk unconditionally and the backend's local identity is *intentional* rather than an accidental
+"auth-not-configured" fallthrough, and (b) moving the one **hardcoded `@automatos.app` admin domain**
+(`clerk.py:201`) into `config.py` so the SaaS topology is configuration, not a literal (F075).
+
+**W5 mounts Clerk only in the `saas` edition and serves a no-op local identity in `local` — behind an
+`AppAuth` facade over the seam that already exists (`setClerkTokenGetter`), not a new auth system.** It is
+high-risk by blast radius (auth is on every request) but small by diff: the review names it "a one-function
+seam." It unblocks W6 (which boots that local instance for real) and is the load-bearing half of open-core.
+
+---
+
+## 2. Background
+
+### 2.1 What's working today (reuse, don't reinvent)
+
+- **The token seam already exists.** `apiClient.setClerkTokenGetter(...)` (`api-client.ts:123`) is installed
+  by `ClerkApiClientProvider` (`clerk-api-client-provider.tsx:23`). This is the "one-function seam" the review
+  names: swapping *which* getter is installed (a real Clerk `getToken`, or a no-op returning `null`) is the
+  whole frontend token story. **Do not hand-roll a new auth client** — wrap this.
+- **The backend already has a local identity.** `get_request_context_hybrid` (`hybrid.py:653`) already
+  resolves Clerk JWT → API key → **anonymous dev-fallback** (`hybrid.py:805-826`), returning a
+  `RequestContext` on a resolved workspace with `auth_type="anonymous"` when `config.REQUIRE_AUTH` is false.
+  This IS the local session — W5 makes it *deliberate and edition-driven*, not an "auth misconfigured"
+  side-effect.
+- **Config already holds every Clerk key.** `CLERK_SECRET_KEY`, `CLERK_PUBLISHABLE_KEY`, `CLERK_JWKS_URL`,
+  `CLERK_AUDIENCE`, plus `DEFAULT_WORKSPACE_ID` and `REQUIRE_AUTH` all live in `config.py:149,385-389`. The
+  edition flag joins them; no new env-reading pattern (CLAUDE.md §4 — no `os.getenv` outside `config.py`).
+- **Public routes are already enumerated.** `middleware.ts:3-10` lists the non-protected matcher (`/sign-in`,
+  `/sign-up`, webhooks, …). The `local` edition is the degenerate case: *every* route is public.
+
+### 2.2 What's broken / missing
+
+- **F008 — `ClerkProvider` + `auth.protect()` are unconditional; no edition flag.** `providers.tsx:33` wraps
+  the entire app in `<ClerkProvider>`; `middleware.ts:12-15` runs `clerkMiddleware` and calls `auth.protect()`
+  on all non-public routes. With no Clerk publishable key the app serves nothing and there is **no flag to
+  turn Clerk off**. PRD-150's frontend half never landed — this is why open-core is undeployable from zero.
+  (Clerk coupling on the frontend spans ~34 files; the mount is the choke point, so W5 gates the *mount*, not
+  all 34.)
+- **F075 — hardcoded `@automatos.app` admin domain.** `clerk.py:201-205` decides platform-staff by
+  `email.lower().endswith("@automatos.app")` — a literal baked into the SaaS defence-in-depth check (part of
+  the review's "hardcoded SaaS topology" medium cluster). It must move to `config.py` so a self-hosted/SaaS
+  operator sets their own staff domain by configuration.
+
+### 2.3 Why now
+
+The open-core Deployability bar (roadmap §2) is **W5 → W6**: W5 makes the app *not require* Clerk; W6 boots
+the fresh-clone local instance and asserts a 200 on health with no external credentials. Until W5 lands, W6
+has nothing to boot into — the UI is dark without a Clerk tenant. W5 has **no hard dependency** (the backend
+seam is already merged), so it is startable now, and it is the review's Phase-B deployability unlock. It is
+also the honest substrate for the open-core *messaging*: we cannot claim "runs locally, no login" until the
+flag exists and the acceptance test proves it.
+
+---
+
+## 3. Findings in scope
+
+| ID | Sev | Location (pinned `37fdecc4e`) | Defect | Fix |
+|---|---|---|---|---|
+| **F008** | High (missing) | `frontend/components/providers.tsx:33`; `frontend/middleware.ts:12-15` | `ClerkProvider` + `auth.protect()` mounted **unconditionally**; **no edition flag** → app serves nothing without a Clerk tenant; PRD-150's frontend half never landed | `AppAuth` facade + `AUTH_EDITION` (local\|saas): mount Clerk + `auth.protect()` **only when `saas`**; a no-op local identity (auto-authenticated single local user/workspace) when `local` |
+| **F075** | Medium | `orchestrator/core/auth/clerk.py:201-205` | Hardcoded `@automatos.app` platform-staff domain (hardcoded SaaS topology) | Move the staff domain to `config.py` (`PLATFORM_STAFF_EMAIL_DOMAIN`); read from config, not a literal |
+
+---
+
+## 4. Design & changes
+
+Minimal diff. The seam and the local identity both already exist — W5 adds **one flag, two conditional
+mounts (frontend), one config read (backend)**, and deletes the literal it supersedes (CLAUDE.md §5). No
+backward-compat shim, no `_legacy` provider (CLAUDE.md §4).
+
+### 4.1 The edition flag — `AUTH_EDITION` (one flag, one source of truth)
+
+- **Backend:** add `AUTH_EDITION` to `config.py` beside the API-security block (`config.py:149`), values
+  `local | saas`, default **`saas`** (the SaaS default must not change silently for the running product;
+  local is opt-in). In `local`, the edition **implies** the local-session posture — `REQUIRE_AUTH` is treated
+  as `false` and a `DEFAULT_WORKSPACE_ID` is required — so operators set *one* flag, not three that can
+  contradict. (Re-confirm `REQUIRE_AUTH`/`DEFAULT_WORKSPACE_ID` names on `main`.)
+- **Frontend:** surface the same edition to the client as `NEXT_PUBLIC_AUTH_EDITION` (build-time public env,
+  the existing `NEXT_PUBLIC_*` convention already used for `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`). One small
+  `lib/auth-edition.ts` reads it once and exports `authEdition` / `isSaaS` — no scattered `process.env` reads.
+
+### 4.2 `AppAuth` facade — wrap the seam, don't replace it
+
+Introduce a thin **`AppAuth`** boundary on the frontend that owns the three edition-conditional mounts. It is
+a facade over the *existing* pieces, not a new auth system:
+
+- **`providers.tsx:33` becomes conditional.** In `saas`, render `<ClerkProvider>` exactly as today (keep the
+  Studio `appearance` block unchanged) wrapping `<ClerkApiClientProvider>`. In `local`, render **neither** —
+  wrap the same children in a `LocalAuthProvider` that installs a **no-op token getter**
+  (`apiClient.setClerkTokenGetter(async () => null)`, reusing the seam at `api-client.ts:123`) so the API
+  client sends no bearer and the backend falls to its local identity. Everything below the auth boundary
+  (`RoleProvider`, `ThemeProvider`, `WorkspaceProvider`, children) is identical across editions.
+- **`middleware.ts` becomes conditional on the edition.** In `saas`, keep `clerkMiddleware` + `auth.protect()`
+  and the existing public-route matcher unchanged. In `local`, export a pass-through middleware (no
+  `clerkMiddleware`, no `auth.protect()`) so **every** route is served — the `local` edition treats the whole
+  app as public. Gate on `NEXT_PUBLIC_AUTH_EDITION` so no Clerk symbol executes under `local`.
+- **The Clerk-bound auth routes are `saas`-only.** `app/sign-in`, `app/sign-up` (and any Clerk hook usage on
+  the render path) must not be reachable/mounted under `local`; there is no login in `local`. Redirect `local`
+  visits of those routes to `/`.
+- **`ClerkApiClientProvider` is reused unchanged in `saas`** — it already installs the real Clerk getter via
+  the seam. `local` swaps in the no-op getter; same seam, different getter. That is the "one-function seam."
+
+> The facade **must not** duplicate identity logic. It only *chooses which existing provider mounts*. Backend
+> identity stays entirely in `hybrid.py`; the frontend never becomes a second source of truth for who the user
+> is (CLAUDE.md §2 reuse; roadmap "one core two editions behind a flag").
+
+### 4.3 Backend — make the local session deliberate (reuse `hybrid.py`)
+
+- **No new auth dependency.** `get_request_context_hybrid` already yields an anonymous `RequestContext` on a
+  resolved workspace when `REQUIRE_AUTH` is false (`hybrid.py:805-826`). Under `AUTH_EDITION=local`, this is
+  the local session. The only change is to make it *edition-driven*: when `AUTH_EDITION=local`, `REQUIRE_AUTH`
+  is forced false and the fallback resolves the single local user/workspace via `DEFAULT_WORKSPACE_ID`
+  (existing `config.py:389` + `hybrid.py:817`). No `saas` behaviour changes — `saas` keeps `REQUIRE_AUTH`
+  secure-by-default and the full Clerk→API-key→(fail-closed) chain.
+- **Boot guard.** On startup, if `AUTH_EDITION=saas`, require the Clerk env (`CLERK_JWKS_URL` /
+  `CLERK_SECRET_KEY`) to be present and fail fast with a clear message if not (a `saas` boot with no Clerk is a
+  misconfiguration, not a silent anonymous downgrade). If `AUTH_EDITION=local`, require `DEFAULT_WORKSPACE_ID`
+  (W6 seeds it). This keeps the two editions from silently blending into today's accidental fallthrough.
+
+### 4.4 F075 — admin domain to config
+
+- Add `PLATFORM_STAFF_EMAIL_DOMAIN` (default `automatos.app`) to `config.py` in the API-security block. At
+  `clerk.py:201`, replace the literal
+  `email.lower().endswith("@automatos.app")` with a check against
+  `config.PLATFORM_STAFF_EMAIL_DOMAIN` (and update the paired warning text at `clerk.py:205`). Confirm no
+  other `@automatos.app` staff-gate literal exists (grep found only `clerk.py:201-205`; the
+  `agent@automatos.app` git-identity default in `workspace_manager.py:218` is unrelated and out of scope). In
+  `local` this check never runs (no Clerk JWTs), so the local admin story is the local identity itself.
+
+### 4.5 Prior context — this is the absent PRD-150
+
+PRD-150 (open-core / auth-decoupling) planned: OSS-core / private-SaaS; make Clerk **pluggable behind an
+`AuthProvider`** so OSS runs local no-login; the graph found a **3-layer Clerk coupling** — *mechanism*
+(the token getter + middleware), *schema* (Clerk claims → `UserContext`), *~19-file leakage* across the
+frontend (current grep: ~34 frontend files reference `@clerk`, ~63 backend `.py` files reference Clerk). Gerard
+chose **full package-split + centralize-identity + full-stack**. W5 delivers the *deployability-critical* half
+of that: the **mount** is edition-gated (the choke point that makes `local` boot), and backend identity is
+centralized on the one `hybrid.py` dependency. W5 does **not** re-plumb all ~34/63 leakage sites or split the
+Clerk package out of the frontend bundle — that is the larger PRD-150 package-split, and pulling it into W5
+would balloon a one-function-seam wave into a repo-wide refactor. **Whether the full leakage-elimination /
+package-split rides in W5 or is its own PRD is an owner decision (§6), not a silent descope (CLAUDE.md §12).**
+
+---
+
+## 5. Test-first acceptance
+
+Write these **failing first**, then implement to green. The wave's DoD (review §13): *the app boots and
+serves a local session with `AUTH_EDITION=local` and no Clerk env set.*
+
+1. **Headline (review §13) — backend local session, zero Clerk env.** With `AUTH_EDITION=local`, a
+   `DEFAULT_WORKSPACE_ID` seeded, and **no `CLERK_*` env vars set**, the backend boots and a request with **no
+   bearer token** resolves to an authenticated local `RequestContext` (single local user, the local
+   workspace) — not a 401. Assert `auth_type` is the anonymous/local type and the workspace is the configured
+   default. This is the exact gap that blocks open-core.
+2. **F008 frontend — no Clerk mount under `local`.** With `NEXT_PUBLIC_AUTH_EDITION=local` and no publishable
+   key, the app **renders** (children mount) and **`ClerkProvider` is not in the tree** (the `LocalAuthProvider`
+   is), and the installed api-client token getter returns `null`. A test on `providers.tsx` asserts the
+   conditional picks the local branch; a middleware test asserts a protected path is served (no
+   `auth.protect()` redirect) under `local`.
+3. **SaaS edition unchanged.** With `AUTH_EDITION=saas` and Clerk env present, `ClerkProvider` **is** mounted,
+   `clerkMiddleware`/`auth.protect()` guards a non-public route (unauthenticated → redirect/401), and the real
+   Clerk token getter is installed. A `saas` boot with **missing** Clerk env **fails fast** (boot guard, §4.3),
+   not a silent anonymous downgrade.
+4. **F075 — admin domain from config.** `clerk.py`'s staff check reads `config.PLATFORM_STAFF_EMAIL_DOMAIN`:
+   a Clerk `admin`-metadata claim on an email **matching** the configured domain keeps `admin`; a
+   **non-matching** email is demoted to `user`; changing the config value changes the accepted domain (no
+   `@automatos.app` literal remains — assert by grep in the test/CI note).
+
+**Wave bar:** `AUTH_EDITION=local` + no Clerk env → backend serves an authenticated local session **and** the
+frontend renders with no Clerk mount; `AUTH_EDITION=saas` + Clerk env → Clerk mounts and protects routes
+exactly as today; the admin domain is read from config on both. (The fresh-clone `docker compose up` → 200-on-
+health smoke test is **W6**, which consumes this flag.)
+
+---
+
+## 6. Risks & rollback
+
+- **Blast radius is auth-on-every-request, but the diff is a seam.** Mitigation: the `saas` path is
+  byte-for-byte the current behaviour (same `ClerkProvider`, same `middleware`, same `hybrid.py` chain); only
+  the `local` branch is new, and `local` is opt-in (default `saas`). Ship the flag defaulting to `saas` so
+  nothing changes for the running product until an operator sets `local`.
+- **Silent-downgrade risk (the one real danger):** a `saas` deploy that loses its Clerk env must **not** fall
+  through to the anonymous local identity and serve tenant data unauthenticated. The §4.3 boot guard (fail
+  fast when `saas` + no Clerk) is the mitigation and is a required test (§5.3). This is why the edition is
+  *explicit*, not inferred from "is Clerk configured".
+- **Scope-creep risk:** the full PRD-150 leakage-elimination / Clerk-package-split (~34 fe / ~63 be sites) is
+  **not** in W5 by design — W5 gates the mount and centralizes backend identity. Surfaced as an owner decision
+  (below), not deferred unilaterally (CLAUDE.md §12).
+- **Rollback:** the flag disables the new path — set `AUTH_EDITION=saas` (the default) and the app is exactly
+  today's product. Each change is an independent commit: (a) `config.py` flag + staff domain, (b) `clerk.py`
+  config read, (c) frontend `AppAuth`/middleware conditional, (d) backend edition→REQUIRE_AUTH wiring + boot
+  guard. The headline local-session test (§5.1) stays green as the permanent open-core regression guard.
+
+**Owner decision surfaced (§6, not descoped):** does W5 carry **only** the deployability-critical mount-gate +
+admin-domain move (this PRD as written), or also the **full PRD-150 leakage-elimination / Clerk-package-split**
+(the ~34-fe/~63-be decoupling so `local` ships no Clerk code at all)? Recommendation: **ship the mount-gate now
+(unblocks W6), do the package-split as its own PRD** — but that is Gerard's call.
+
+---
+
+## 7. References
+
+- Review §4/§5 — F008 (Clerk mounted unconditionally, no edition flag), F075 (hardcoded `@automatos.app`):
+  `reports/PLATFORM_OS_REVIEW_2026-07-01.md`
+- Review §13 Wave 5 (acceptance: app boots + serves a local session with `AUTH_EDITION=local`, no Clerk env)
+- Roadmap §2 Deployability bar (one core two editions behind a flag; local no-login, zero external SaaS) →
+  W5 unblocks W6 · [PLATFORM-OS-ROADMAP.md](./PLATFORM-OS-ROADMAP.md)
+- Absent **PRD-150** (open-core / auth-decoupling): 3-layer Clerk coupling (mechanism / schema / ~19-file
+  leakage); Gerard chose full pkg-split + centralize-identity + full-stack
+- Reuses: `setClerkTokenGetter` seam (`api-client.ts:123`, `clerk-api-client-provider.tsx:23`); `hybrid.py`
+  anonymous dev-fallback (`hybrid.py:805-826`); existing Clerk config keys (`config.py:149,385-389`)
+- CLAUDE.md §4 (no backward-compat shims; no `os.getenv` outside `config.py`), §5 (delete the literal you
+  supersede), §12 (no unilateral descope)

--- a/docs/PRDS/176-DEPLOYABILITY-RELIABILITY.md
+++ b/docs/PRDS/176-DEPLOYABILITY-RELIABILITY.md
@@ -1,0 +1,342 @@
+# PRD-176 — Deployability & Reliability Baseline (Wave 6)
+
+**Status:** Draft v1 — pending approval
+**Type:** Infrastructure / Reliability (open-core deployability + DR)
+**Priority:** P0 — "`git clone && docker compose up`" must yield a working local instance
+**Owner:** Gerard Kavanagh
+**Author:** Gerard Kavanagh + Claude (Opus 4.8)
+**Date:** 2026-07-02
+**Phase:** B — Policy plane & deployability · **Size:** M–L · **Risk:** medium
+**Depends on:** **Wave 5 (auth decoupling)** — boot-before-auth must land first (compose still hard-requires Clerk keys today; a fresh clone cannot reach a working instance until W5 makes login optional)
+**Parent:** [PLATFORM-OS-ROADMAP.md](./PLATFORM-OS-ROADMAP.md)
+**Source:** review §13 Wave 6 (the absent PRDs 151–153); §2 Reliability + Deployability pillars; §7 "do not do" (the alembic two-step)
+**Findings register pinned to:** `37fdecc4e` — re-confirm each `file:line` on current `main` before editing
+**Findings in scope:** F009, F010, F051, F089, F068, F050
+
+---
+
+## Operating Principle
+
+> **A fresh clone boots itself, with no external credentials, into a working local instance — and the
+> database it boots can be replayed from zero and restored from a backup.** Deployability and reliability
+> are one wave because they share one substrate: a single, honest schema lifecycle. Today schema truth is
+> split across four mechanisms that mutate overlapping tables, none of which a new contributor can run
+> end-to-end. This PRD collapses the boot path to **one wait-migrate-seed entrypoint**, makes Alembic
+> replay from zero to **exactly one head**, gives outputs a real local object store, makes the SaaS-topology
+> defaults local-safe, and — for the first time in the repo — makes the primary database **backup-able and
+> restorable** with a stated RPO/RTO. It adds no product capability; it makes the product the open-core
+> thesis promises **actually installable and operable**.
+
+---
+
+## 1. Purpose
+
+The open-core thesis — "`git clone && docker compose up` → a working local instance, no login, zero
+external SaaS" (roadmap §2, Deployability pillar) — is **undeployable on `main` today**, and the database
+underneath it has **no disaster-recovery story at all**.
+
+Concretely: a fresh clone can't boot because `docker-compose.yml:35` mounts the initdb schema from a path
+that does not exist (`./orchestrator/database/init_complete_schema.sql`; the real file is at
+`./orchestrator/core/database/init_complete_schema.sql`) — so the Postgres init volume runs nothing, the
+backend comes up against an empty DB, and because the frontend is gated `depends_on: backend:
+service_healthy` (`docker-compose.yml:153-155`), **the frontend never starts** (F009). Even with that path
+fixed, Alembic cannot replay the schema from an empty database: 133 revision files form a **four-headed
+forest** (`alembic heads` → `20260612_nl2sql_example_embedding`, `prd158_cloud_default_team`,
+`prd161_sla_breach`, `prd164_doc_source_type`), core tables are `ALTER`ed by migrations but `CREATE`d by
+none, and **no CI ever runs from-zero** — production only ever boots via `alembic upgrade heads` against
+already-stamped incremental databases, so this is a **thesis / OSS blocker, not a production-runtime crash**
+(F010, ADJUSTED). The boot script that does exist (`docker-entrypoint.sh`) waits for Postgres and seeds, but
+**never runs a migration** — schema arrives only from the (broken) initdb mount, which is precisely the
+"schema truth split across four mechanisms mutating overlapping tables" the review names (F051).
+
+On top of the boot failure: there is **no local object storage**, so the knowledge flywheel fail-softs to
+`None` on every generated output (`services/knowledge_flywheel.py:159,166,223`) and documents live only on
+ephemeral container disk (F089); **nine `railway.internal` hostnames** are hardcoded as config defaults and
+`LOG_RELAY_ENABLED` defaults `"true"` — SaaS topology leaking into the local default (F068); and there is
+**no backup or disaster recovery anywhere in the repo** — no `pg_dump`/`pg_restore` tooling, no
+volume-snapshot script, no restore runbook for the primary pgvector database or the separate mem0 instance;
+the only DDL tool that exists is a dev helper (`scripts/snapshot_table_ddl.py`) (F050).
+
+**W6 makes the two deployability bars and the reliability bar pass:** a fresh clone boots to a green
+`/health` with no external credentials, Alembic replays from zero to exactly one head under CI, and the
+primary DB has a tested restore with a stated RPO/RTO. It is the review's "absent PRDs 151–153," now scoped
+as one wave on top of the Wave-5 auth seam.
+
+---
+
+## 2. Background
+
+### 2.1 What's working today (must not break)
+
+- **The compose topology is sound.** `docker-compose.yml` already wires pgvector Postgres, Redis, the
+  FastAPI backend, and the Next.js frontend with health checks and `depends_on` conditions; the backend
+  health gate targets `/health` (`docker-compose.yml:131-136`) and Postgres has a proper `pg_isready`
+  healthcheck (`:36-41`). W6 fixes what the topology *mounts and runs*, not the topology.
+- **An entrypoint already exists** (`docker-entrypoint.sh`, mounted at `docker-compose.yml:127`). It waits
+  for Postgres (`wait_for_postgres`), verifies the connection (`check_database`), and idempotently loads seed
+  data (`load_seed_data` → `database/load_seed_data.py`). W6 **inserts the missing migrate step into this
+  existing script** — it does not introduce a competing entrypoint.
+- **Production boot is fine.** `alembic upgrade heads` against a stamped, incrementally-migrated database
+  works in prod today. F010 is about *from-zero replay*, which only the OSS/fresh-clone and CI paths exercise
+  — do not "fix" a production path that isn't broken.
+- **Config is centralized.** All env reads already route through `orchestrator/config.py` (CLAUDE.md §4);
+  the `railway.internal` defaults and `LOG_RELAY_ENABLED` all live there in one file, so F068 is a
+  bounded edit to defaults, not a scattered hunt.
+- **The S3/object-store abstraction exists.** `config.py` already models S3 (`S3_VECTORS_BUCKET`,
+  `S3_VECTORS_ENABLED`, with a workspace-embed guard at `config.py:905-930`); the flywheel already calls an
+  object-storage upload path. W6 adds a **local MinIO endpoint** behind the existing seam (`S3_ENDPOINT_URL`),
+  it does not introduce a new storage subsystem.
+
+### 2.2 What's broken / missing
+
+- **F009 — a fresh clone can't boot.** `docker-compose.yml:35` mounts
+  `./orchestrator/database/init_complete_schema.sql` — a path that does not exist. The real schema file is
+  `./orchestrator/core/database/init_complete_schema.sql` (72 KB, present on `main`). The init volume runs an
+  empty mount, the backend starts against an empty DB, and the frontend (gated on backend health,
+  `docker-compose.yml:153-155`) never starts.
+- **F010 (ADJUSTED) — Alembic can't replay from zero.** 133 revisions, **four heads** (confirmed via
+  `alembic heads` on `main` — note: the review counted 132/four heads at `37fdecc4e`; re-confirm the exact
+  count). Core tables are `ALTER`ed but never `CREATE`d, and **no CI exercises from-zero**. This blocks the
+  OSS/thesis path and any contributor's clean install; it is **not** a prod-runtime crash (prod boots via
+  `upgrade heads` on stamped DBs).
+- **F051 — schema truth split across four mechanisms.** The initdb SQL mount, `docker-entrypoint.sh`'s seed
+  loader, the Alembic revisions, and ad-hoc `scripts/` DDL all touch overlapping tables, and no single
+  lifecycle owns "bring an empty database to a correct, seeded, migrated state." Needs **one wait-migrate-seed
+  entrypoint / single lifecycle**.
+- **F089 — no local object storage.** With no `S3_ENDPOINT_URL` / MinIO (PRD-151's local object store), the
+  knowledge flywheel's upload fail-soft returns `None` on **every** generated output
+  (`services/knowledge_flywheel.py:159,166,223` — "output flow unaffected" logged, document lost), and
+  generated documents live only on ephemeral disk. The flywheel — the moat's input — silently ingests nothing
+  locally.
+- **F068 — SaaS topology hardcoded into local defaults.** Nine `railway.internal` hostnames are config
+  defaults (`config.py:407,408,506,507,519,537,730,753,884`), and `LOG_RELAY_ENABLED` defaults `"true"`
+  (`config.py:521`) — so a local instance tries to reach Railway-internal Loki/Prometheus/mem0/log-relay/
+  workers/voice by default. Local default should be **local-safe**; `LOG_RELAY_ENABLED` should default
+  **false** locally.
+- **F050 — no backup or disaster recovery anywhere.** `grep` across the repo finds no `pg_dump`,
+  `pg_restore`, volume-snapshot script, or restore runbook for either the primary pgvector DB or the separate
+  mem0 instance. The only DDL-adjacent tool is `scripts/snapshot_table_ddl.py` (a schema-diff dev helper, not
+  a backup). There is **no stated RPO/RTO** and no tested recovery path.
+
+### 2.3 Why now
+
+This is **Phase B, gated on Wave 5**. W5 mounts Clerk only in SaaS behind an `AppAuth` facade so a local
+instance runs no-login; until that lands, compose still hard-requires `CLERK_SECRET_KEY` / `CLERK_JWKS_URL`
+(`docker-compose.yml:118-121`) and a fresh clone cannot reach a working instance regardless of the boot fix.
+With W5 in place, W6 is the wave that turns "open-core" from a claim into a `docker compose up`. It also
+underwrites the **Reliability** pillar (roadmap §2): Alembic-replays-from-zero-with-one-head and
+tested-restore-with-stated-RPO/RTO are two of that pillar's three bars (the third, exactly-once under lease
+expiry, is Wave 1). Everything downstream that a contributor or an eval must run — W7's moat eval, W12's CI
+bar, W13's Shopify pilot — assumes a database that can be built from zero and recovered.
+
+---
+
+## 3. Findings in scope
+
+| ID | Sev | Location (pinned `37fdecc4e`) | Defect | Fix |
+|---|---|---|---|---|
+| **F009** | High | `docker-compose.yml:35` | initdb mount points at `./orchestrator/database/init_complete_schema.sql` — path does not exist; fresh volume gets an empty DB and the frontend (gated on backend health) never starts | Repoint the mount to `./orchestrator/core/database/init_complete_schema.sql`; add a fresh-clone smoke test (see §5) |
+| **F010** | High (ADJUSTED — thesis/OSS blocker, not prod crash) | `orchestrator/alembic/versions/` (133 revs, **4 heads**) | Cannot replay from an empty DB: four-headed forest, core tables `ALTER`ed but never `CREATE`d, no from-zero CI | **Two steps (review §7):** author **one merge revision now** to collapse the four heads; **squash to a single baseline later** with a from-zero replay CI job asserting **exactly one head** |
+| **F051** | High | `docker-entrypoint.sh` (waits + seeds, no migrate) + initdb SQL mount + Alembic + `scripts/` DDL | Schema truth split across four mechanisms mutating overlapping tables; no single lifecycle owns empty→correct | One **wait-migrate-seed** entrypoint: extend the existing `docker-entrypoint.sh` to run `alembic upgrade heads` between wait and seed; make the initdb SQL mount and migrations non-overlapping (one source of `CREATE`) |
+| **F089** | High | `orchestrator/services/knowledge_flywheel.py:159,166,223`; `config.py` (S3 seam) | No local object store → flywheel upload fail-softs to `None` on every output; generated docs on ephemeral disk | Add a local **MinIO** service to compose wired via **`S3_ENDPOINT_URL`** behind the existing S3 config seam; flywheel writes to it locally |
+| **F068** | Medium | `config.py:407,408,506,507,519,537,730,753,884` (9× `railway.internal`); `config.py:521` (`LOG_RELAY_ENABLED` default `"true"`) | SaaS topology hardcoded as local default; log relay on by default locally | Make the `railway.internal` defaults **local-safe** (localhost/opt-in, unset in local profile); default **`LOG_RELAY_ENABLED` false** |
+| **F050** | High (missing) | repo-wide (only `scripts/snapshot_table_ddl.py` exists) | No `pg_dump`/`pg_restore` tooling, no volume-snapshot script, no restore runbook for primary pgvector DB **or** the separate mem0 instance; no RPO/RTO | Add a **`pg_dump` backup + restore runbook and DR** with a **tested restore** and stated **RPO/RTO**, covering both the primary DB and the mem0 instance |
+
+---
+
+## 4. Design & changes
+
+Minimal-diff, per finding. The two structural moves are (a) inserting a migrate step into the **existing**
+entrypoint (F051) and (b) the **explicit two-step Alembic sequencing** the review mandates (F010). Nothing
+here adds a subsystem; every change repoints, wires, or scripts what already exists (CLAUDE.md §2/§4/§5).
+
+### 4.1 F009 — repoint the initdb mount (one line)
+
+In `docker-compose.yml:35`, change the bind mount source from
+`./orchestrator/database/init_complete_schema.sql` to
+`./orchestrator/core/database/init_complete_schema.sql` (confirmed present, 72 KB). No shim, no symlink
+(CLAUDE.md §4). This alone lets a fresh Postgres volume initialize a populated schema so the backend health
+check passes and the frontend's `depends_on` gate releases.
+
+> **Note on overlap with F010/F051:** the initdb SQL mount and Alembic are **two sources of `CREATE`**. The
+> §4.3 sequencing resolves which owns schema creation. The immediate F009 fix restores the *documented*
+> current behavior (populated fresh volume); §4.3 then makes the lifecycle single-source so the initdb SQL
+> and migrations do not fight. Do not leave both authoritative — pick one in the same wave (CLAUDE.md §5).
+
+### 4.2 F051 — one wait-migrate-seed entrypoint (single lifecycle)
+
+The existing `docker-entrypoint.sh` already does **wait → check → seed** (`wait_for_postgres` →
+`check_database` → `load_seed_data`) but **never migrates**. Insert the missing step so the single lifecycle
+is **wait → migrate → seed → start**:
+
+- Add a `run_migrations()` step between `check_database` and `load_seed_data` that runs
+  `alembic upgrade heads` (post-§4.3: `alembic upgrade head`, singular, once the baseline is single-headed),
+  failing closed if the migration errors (drop the current script's "continue anyway" leniency for the
+  migrate step — a failed migration must not silently start the app on a half-built schema).
+- Keep `load_seed_data` idempotent (it already guards on `credential_types` count).
+- This makes the entrypoint the **single owner** of "bring the DB to a correct, migrated, seeded state,"
+  collapsing F051's four mechanisms to one lifecycle. The initdb SQL mount's role is decided by §4.3.
+
+### 4.3 F010 — the Alembic two-step (review §7 sequencing, stated as such — NOT a descope)
+
+The roadmap and review §7 are explicit: **"Do not attempt the alembic single-baseline squash first — author
+one merge revision now, squash later with a from-zero test."** This PRD follows that order exactly, and
+records it as the review's sequencing, not a deferral (CLAUDE.md §12):
+
+- **Step 1 — NOW: one merge revision to collapse the four heads.** Author a single Alembic merge revision
+  (`alembic merge -m "prd176 collapse four heads" <the four head revisions>`) so `alembic heads` returns
+  **one head**. This is low-risk and immediately makes `upgrade head` deterministic for the entrypoint (§4.2)
+  and for prod (`upgrade heads` still works, now trivially single-headed). Re-confirm the four head revision
+  IDs on `main` at author time (the count drifted 132→133 since `37fdecc4e`).
+- **Step 2 — LATER (this wave, after Step 1 is green): squash to a single baseline with a from-zero replay
+  test.** Once the forest is single-headed, author one baseline revision that `CREATE`s the full schema
+  from empty (reconciling the tables that today are `ALTER`ed-but-never-`CREATE`d), retire the superseded
+  revisions (CLAUDE.md §5 — delete what's squashed, do not keep a parallel history), and **prove it with the
+  from-zero CI job** in §5.1. With a from-zero baseline, the **initdb SQL mount (F009) becomes redundant and
+  is removed** — Alembic-from-zero is the single source of schema creation (resolving the F009/F051 overlap).
+
+> **Why two steps and not one:** squashing 133 revisions into a baseline while four heads still diverge risks
+> silently dropping the `ALTER`-only tables' columns. Collapsing to one head first makes the squash a linear,
+> testable replay. This ordering is the review's (§7) and the roadmap's ("author one merge revision now,
+> squash later with a from-zero test"), not this PRD's initiative.
+
+### 4.4 F089 — local object storage via MinIO + `S3_ENDPOINT_URL`
+
+- **Add a `minio` service to `docker-compose.yml`** (image `minio/minio`, a `minio_data` volume, a health
+  check, on the `automatos` network), plus a one-shot bucket-create init (MinIO `mc mb` or a small init
+  container) so the flywheel's target bucket exists on first boot.
+- **Wire it through the existing S3 seam:** set `S3_ENDPOINT_URL` (the AWS-SDK/boto endpoint override) in the
+  backend service env to the local MinIO endpoint, with the local access/secret keys and a local bucket that
+  carries `{workspace_id}` (honoring the `config.py:905-930` workspace-embed guard). No new storage client —
+  the flywheel's existing upload path (`DocumentManager.upload_document`) targets S3-compatible storage; MinIO
+  *is* S3-compatible.
+- **Result:** `services/knowledge_flywheel.py` uploads succeed locally, so the fail-soft `return None` paths
+  (`:159,166,223`) stop firing on every output and generated documents persist to durable local object
+  storage instead of ephemeral disk. Prod behavior is unchanged (real S3 via the same seam, `S3_ENDPOINT_URL`
+  unset).
+
+### 4.5 F068 — local-safe topology defaults; log relay off locally
+
+- **`LOG_RELAY_ENABLED` defaults false** (`config.py:521`): change the default from `"true"` to `"false"` so
+  a local instance does not attempt to push to `log-relay.railway.internal` by default; SaaS sets it `true`
+  via env. Update the two tests that assert the old default (`tests/test_config_env_centralization.py:174-181`
+  — flip `test_log_relay_enabled_default_true` to expect false; the override test stays).
+- **`railway.internal` defaults become local-safe** (`config.py:407,408,506,507,519,537,730,753,884`): these
+  are `os.getenv(..., "<x>.railway.internal...")` defaults. Make the local default resolve to
+  localhost/opt-in (e.g. empty/unset so the dependent feature no-ops locally, or a `localhost` value where a
+  local equivalent exists), while SaaS supplies the real Railway host via env. The monitoring handlers already
+  tolerate absence (`handlers_monitoring.py:153,207` fall back with `getattr(..., None) or ...`), so unset is
+  safe for the observability defaults. Keep all reads in `config.py` (CLAUDE.md §4).
+- **`tool_registry.py:1101-1102`** contains `build-server.railway.internal` inside example/seed payloads —
+  these are illustrative tool-call examples, not live defaults; leave them unless the F068 re-confirm shows
+  they execute. (Flag, do not silently change data.)
+
+### 4.6 F050 — pg_dump backup/restore runbook + DR (tested, with RPO/RTO)
+
+- **Add backup tooling under `scripts/` (or `scripts/dr/`):** a `pg_dump`-based backup script (custom-format
+  `pg_dump -Fc` of the primary `orchestrator_db`) and a matching `pg_restore` restore script, both
+  parameterized off the canonical `DATABASE_URL` / `POSTGRES_*` config — no hardcoded creds (CLAUDE.md §4,
+  security §Secret Management). Include the **separate mem0 instance** as a second backup target (its DB is a
+  distinct instance per `MEM0_API_URL`/mem0 deployment — the runbook must cover both, since losing mem0 loses
+  durable memory).
+- **Author a restore runbook** (`docs/runbooks/DR-postgres.md` or equivalent) covering: backup schedule,
+  where dumps are stored, the exact restore procedure for the primary pgvector DB (including the pgvector
+  extension and any raw-DDL tables that `create_all()` misses — see memory: init_test_db gap), the mem0
+  restore, and a **stated RPO and RTO** (e.g. RPO = last nightly dump; RTO = time to `pg_restore` + re-seed +
+  health-green — put concrete target numbers in the runbook and justify them).
+- **Test the restore** (§5.6): a CI or scripted test that dumps a populated DB, restores into a fresh volume,
+  and asserts row-parity on a sampled set of tables. A backup that has never been restored is not a backup.
+
+> **Scope boundary (CLAUDE.md §12):** this wave delivers **local + single-instance** backup/restore with a
+> tested `pg_restore` and a written runbook. Continuous WAL-archiving / PITR and cloud-snapshot automation
+> are a **larger, separable** capability — surfaced here as an **open question for Gerard** (§6), not
+> silently deferred. If the stated RPO/RTO Gerard wants requires PITR, it is this wave's work; if nightly-dump
+> RPO is acceptable, the tested `pg_dump`/`pg_restore` path meets the bar.
+
+---
+
+## 5. Test-first acceptance
+
+Write these **failing first**, then implement to green. The two headline tests are the wave's definition of
+done (review §13); the rest are per-finding.
+
+1. **Headline A — from-zero Alembic replay, exactly one head (F010).** A CI job stands up an **empty
+   pgvector database**, runs `alembic upgrade heads` (post-squash: `head`), and asserts **exactly one head**
+   (`alembic heads` returns a single revision) **and** that the schema is complete (a representative set of
+   the tables that are today `ALTER`ed-but-never-`CREATE`d now exist). Fails today (four heads, no from-zero
+   path); green after §4.3 Step 2.
+2. **Headline B — fresh-clone `docker compose up` smoke test → `/health` 200, no external credentials
+   (F009 + F051 + W5).** A CI/scripted smoke test clones clean, provides **only** the required local secrets
+   (`POSTGRES_PASSWORD`, `REDIS_PASSWORD`, `API_KEY`) and **no external SaaS credentials** (no Clerk, no real
+   S3, no LLM keys), runs `docker compose up`, and asserts the backend `/health` returns **200** and the
+   frontend container reaches healthy. This exercises the repointed initdb mount, the wait-migrate-seed
+   entrypoint, local MinIO, and the local-safe defaults together. (Requires W5's no-login default; if W5 is
+   not yet merged at author time, the test pins the auth-optional flag.)
+3. **F009 — initdb path resolves.** A unit/lint assertion that the `docker-compose.yml` initdb mount source
+   path **exists on disk** (guards against the exact regression: a compose mount pointing at a missing file).
+4. **F051 — the entrypoint migrates.** A test of `docker-entrypoint.sh`'s lifecycle asserting the order is
+   **wait → migrate → seed → start** and that a **failed migration aborts startup** (does not fall through to
+   `exec "$@"` on a half-built schema).
+5. **F089 — local MinIO wired; flywheel persists.** With the local MinIO service up and `S3_ENDPOINT_URL`
+   set, a flywheel ingest of a generated output returns a **non-`None` document id** and the object is
+   retrievable from the local bucket (the `:159,166,223` fail-soft paths are **not** taken). With MinIO
+   absent, the fail-soft still degrades gracefully (no crash).
+6. **F068 — defaults are local-safe.** With **no env overrides**, `config.LOG_RELAY_ENABLED is False`, and
+   the `railway.internal` defaults resolve to local-safe values (no `*.railway.internal` host is dialed by
+   default). The existing centralization tests (`test_config_env_centralization.py`) are updated to the new
+   defaults (the SaaS override paths still assert the Railway values when env is set).
+7. **F050 — tested `pg_dump` restore with stated RPO/RTO.** A test dumps a populated primary DB with
+   `pg_dump -Fc`, `pg_restore`s into a **fresh** volume, and asserts **row-parity** on a sampled table set;
+   the runbook is present and states concrete **RPO and RTO** numbers; the mem0 backup target is covered by
+   the same tooling.
+
+**Wave-level bar (review §13):** a CI job runs `alembic upgrade heads` from an empty pgvector database and
+asserts **exactly one head**, and a fresh-clone `docker compose up` smoke test returns **200** on `/health`
+with **no external credentials** — plus the primary DB has a tested restore with a stated RPO/RTO.
+
+---
+
+## 6. Risks & rollback
+
+- **Sequencing risk (F010).** Squashing before collapsing heads can silently drop `ALTER`-only columns.
+  **Mitigation:** the mandated two-step — merge revision first (Step 1), squash-with-from-zero-test second
+  (Step 2); Headline A guards it permanently.
+- **Wave-5 dependency.** Headline B cannot pass no-credential until W5 makes login optional (compose still
+  hard-requires Clerk today, `docker-compose.yml:118-121`). **Mitigation:** W6 lands after W5; if authored
+  earlier, Headline B pins the auth-optional flag and is marked blocked-on-W5.
+- **initdb-vs-migrations double-source (F009/F051).** Leaving both the initdb SQL mount and Alembic
+  authoritative reintroduces schema drift. **Mitigation:** §4.3 Step 2 removes the initdb SQL mount once
+  Alembic-from-zero is the single source (CLAUDE.md §5).
+- **F068 breadth.** Changing nine defaults could hide a host a SaaS path silently relied on. **Mitigation:**
+  each default keeps its `os.getenv` override so SaaS is unchanged; only the *default* moves; re-confirm each
+  of the nine on `main`.
+- **Backup false-confidence (F050).** An untested dump is not a backup, and pgvector/raw-DDL tables can be
+  missed by naive restores. **Mitigation:** the restore is CI-tested with row-parity and the runbook calls
+  out pgvector + raw-DDL tables explicitly.
+- **Rollback:** every finding-fix is an independent commit — the compose mount repoint, the entrypoint
+  migrate step, the MinIO service, the config defaults, and the DR scripts revert individually. The Alembic
+  merge revision (Step 1) is reversible before the squash (Step 2) is authored.
+
+**Open question for Gerard (§6, not a deferral — CLAUDE.md §12):** DR depth. Does the target RPO/RTO require
+**continuous WAL archiving / PITR + cloud-snapshot automation**, or is **nightly-`pg_dump` RPO** acceptable
+for this baseline? W6 ships the tested `pg_dump`/`pg_restore` path and runbook either way; PITR is a
+separable, larger build — surfaced for decision, built in this wave if that's the call.
+
+---
+
+## 7. References
+
+- Review §13 Wave 6 (the absent PRDs 151–153; the wave's DoD: from-zero `alembic upgrade heads` → one head,
+  fresh-clone `docker compose up` → `/health` 200 with no external credentials): `reports/PLATFORM_OS_REVIEW_2026-07-01.md`
+- Review §2 — Reliability pillar (replay-from-zero, tested restore w/ RPO/RTO) + Deployability pillar
+  (`git clone && docker compose up`, local object store)
+- Review §7 "do not do" — the **Alembic two-step** (merge revision now, squash later with a from-zero test)
+- Roadmap §3/§4 — W6 placement (Phase B), **depends on W5**; §2 pillar→wave mapping (F009/F010/F068/F089 →
+  Deployability/Reliability, closed by W5+W6)
+- Findings F009, F010, F051, F089, F068, F050 — `reports/PLATFORM_OS_REVIEW_2026-07-01.md`
+- Reuses: existing `docker-entrypoint.sh` lifecycle, the `config.py` S3 seam (`S3_ENDPOINT_URL`,
+  `S3_VECTORS_BUCKET`, workspace-embed guard `:905-930`), the flywheel upload path
+  (`services/knowledge_flywheel.py`), the centralized config module
+- CLAUDE.md §4 (no shims / config-only / no hardcoded values), §5 (delete what you supersede — the initdb
+  mount post-squash), §12 (no unilateral descope — the Alembic two-step and DR-depth are the review's
+  sequencing and an open owner-decision, stated as such)


### PR DESCRIPTION
## What
Phase B of the platform-hardening roadmap — three PRDs, docs-only.

- **PRD-174 — W4 Unified Policy Plane** (the centerpiece): one typed pre-tool/pre-LLM `PolicyGate` at `UnifiedToolExecutor`, a hook-style event bus (`deny > ask > allow`, errors-as-data), folding the scattered guardrails (F085/F060), the placebo rate limiter (F040), a `BudgetExceeded` admission gate (F086), model-aware pricing (F059), the `admin_only` no-op (F014), and RBAC parity (F042/F043). Carries the §9.4 Claude-Code-primitive replacement table as its design core, and encodes the **Balanced** act-vs-ask policy (locked by Gerard). Behind a flag, characterization-tests-first.
- **PRD-175 — W5 Auth Decoupling**: `AppAuth` facade + `AUTH_EDITION` flag mounts Clerk only in SaaS, no-op local identity otherwise (F008) + admin domain to config (F075). Reuses the existing `REQUIRE_AUTH` dev-fallback + `setClerkTokenGetter` seam.
- **PRD-176 — W6 Deployability & Reliability**: fresh-clone `docker compose up` (F009), alembic-from-zero collapse (F010 — 4 heads confirmed live), single migrate-seed entrypoint (F051), local MinIO (F089), local-safe `railway.internal` defaults (F068), `pg_dump`/DR (F050).

## Open decisions surfaced (not descoped — Gerard's call, per §12)
- **W5 scope:** mount-gate + admin-domain now, or also the full PRD-150 Clerk package-split (~34 FE + ~63 BE sites)? PRD recommends split-as-own-PRD.
- **W6 DR depth:** nightly `pg_dump` RPO vs continuous WAL/PITR + snapshots.
- **W4 (before build):** the Balanced policy is locked; review the plane design before it's built (high-risk wave).

Findings pinned to `37fdecc4e`; each PRD carries a re-confirm-on-main note (W6 flagged revisions drifted 132→133).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added three new planning documents covering a unified policy plane, auth decoupling, and deployability/reliability improvements.
  * Clarified future behavior for authorization handling, local-versus-hosted app access, and safer default configuration.
  * Documented reliability goals for fresh-clone startup, database migrations, local storage support, and backup/restore readiness.
  * Included acceptance criteria, rollout guidance, and rollback considerations for upcoming work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->