### PR TITLE
feat(prd-175): W5 auth decoupling — AppAuth facade + AUTH_EDITION (F008/F075)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,10 @@ jobs:
       POSTGRES_PORT: "5432"
       POSTGRES_DB: test_db
       ENVIRONMENT: development
+      # PRD-175: run the suite in the local edition so the anonymous dev-fallback
+      # is on (REQUIRE_AUTH=false). Without it, saas-default requires Clerk creds
+      # and every unauthenticated endpoint test 401s.
+      AUTH_EDITION: local
 
     defaults:
       run:
@@ -128,6 +132,10 @@ jobs:
       POSTGRES_PORT: "5432"
       POSTGRES_DB: test_db
       ENVIRONMENT: development
+      # PRD-175: run the suite in the local edition so the anonymous dev-fallback
+      # is on (REQUIRE_AUTH=false). Without it, saas-default requires Clerk creds
+      # and every unauthenticated endpoint test 401s.
+      AUTH_EDITION: local
 
     defaults:
       run:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,6 +68,12 @@ jobs:
       # is on (REQUIRE_AUTH=false). Without it, saas-default requires Clerk creds
       # and every unauthenticated endpoint test 401s.
       AUTH_EDITION: local
+      # AUTH_EDITION=local's boot guard (config.validate_auth_edition) requires
+      # DEFAULT_WORKSPACE_ID — the single local workspace the anonymous session
+      # resolves to. init_test_db.py seeds a workspaces row with this exact id so
+      # the anonymous-fallback resolution finds a real workspace. Fixed throwaway
+      # UUID for the ephemeral CI DB.
+      DEFAULT_WORKSPACE_ID: "00000000-0000-0000-0000-0000000000c1"
 
     defaults:
       run:
@@ -136,6 +142,11 @@ jobs:
       # is on (REQUIRE_AUTH=false). Without it, saas-default requires Clerk creds
       # and every unauthenticated endpoint test 401s.
       AUTH_EDITION: local
+      # AUTH_EDITION=local's boot guard requires DEFAULT_WORKSPACE_ID; set it so
+      # any config.validate_auth_edition() reached during the eval passes. The
+      # eval is SQLite-only and never resolves this workspace, but the flag must
+      # be internally consistent with AUTH_EDITION=local (mirrors the test job).
+      DEFAULT_WORKSPACE_ID: "00000000-0000-0000-0000-0000000000c1"
 
     defaults:
       run:

--- a/frontend/app/sign-in/[[...rest]]/page.tsx
+++ b/frontend/app/sign-in/[[...rest]]/page.tsx
@@ -1,8 +1,15 @@
 'use client'
 
 import { SignIn } from '@clerk/nextjs'
+import { redirect } from 'next/navigation'
+import { isSaaS } from '@/lib/auth-edition'
 
 export default function SignInPage() {
+  // PRD-175 (F008): there is no login in the `local` edition — send visitors home.
+  if (!isSaaS) {
+    redirect('/')
+  }
+
   return (
     <div className="min-h-screen flex items-center justify-center bg-background px-6 py-12">
       <div className="relative z-10 w-full max-w-md">
@@ -19,4 +26,3 @@ export default function SignInPage() {
     </div>
   )
 }
-

--- a/frontend/app/sign-up/[[...rest]]/page.tsx
+++ b/frontend/app/sign-up/[[...rest]]/page.tsx
@@ -1,8 +1,15 @@
 'use client'
 
+import { redirect } from 'next/navigation'
 import { SignUpForm } from '@/components/auth/sign-up-form'
+import { isSaaS } from '@/lib/auth-edition'
 
 export default function SignUpPage() {
+  // PRD-175 (F008): there is no signup in the `local` edition — send visitors home.
+  if (!isSaaS) {
+    redirect('/')
+  }
+
   return (
     <div className="min-h-screen flex items-center justify-center bg-background px-6 py-12">
       <div className="relative z-10 w-full max-w-md">

--- a/frontend/components/__tests__/prd175-auth-edition.test.tsx
+++ b/frontend/components/__tests__/prd175-auth-edition.test.tsx
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { readFileSync } from 'fs'
+import path from 'path'
+import { render } from '@testing-library/react'
+
+// PRD-175 W5 (F008) — the frontend half of the absent PRD-150. The app must
+// render with NO ClerkProvider mount under AUTH_EDITION=local (git clone &&
+// docker compose up, no Clerk tenant), while saas keeps Clerk mounted and
+// protecting routes exactly as today. The choke point is the *mount*: one flag,
+// two conditional mounts (providers + middleware), the existing token seam reused.
+
+const PROVIDERS = path.resolve(__dirname, '..', 'providers.tsx')
+const MIDDLEWARE = path.resolve(__dirname, '..', '..', 'middleware.ts')
+const SIGN_IN = path.resolve(
+  __dirname, '..', '..', 'app', 'sign-in', '[[...rest]]', 'page.tsx',
+)
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  vi.resetModules()
+})
+
+// ---------------------------------------------------------------------------
+// lib/auth-edition.ts — one source of truth for the client edition
+// ---------------------------------------------------------------------------
+
+describe('PRD-175 — lib/auth-edition', () => {
+  it('defaults to saas when the flag is unset (running product unchanged)', async () => {
+    vi.stubEnv('NEXT_PUBLIC_AUTH_EDITION', '')
+    const mod = await import('@/lib/auth-edition')
+    expect(mod.authEdition).toBe('saas')
+    expect(mod.isSaaS).toBe(true)
+    expect(mod.isLocal).toBe(false)
+  })
+
+  it('is local when the flag is local', async () => {
+    vi.stubEnv('NEXT_PUBLIC_AUTH_EDITION', 'local')
+    const mod = await import('@/lib/auth-edition')
+    expect(mod.authEdition).toBe('local')
+    expect(mod.isSaaS).toBe(false)
+    expect(mod.isLocal).toBe(true)
+  })
+
+  it('falls back to saas for an unknown value (never silently un-guard)', async () => {
+    vi.stubEnv('NEXT_PUBLIC_AUTH_EDITION', 'banana')
+    const mod = await import('@/lib/auth-edition')
+    expect(mod.authEdition).toBe('saas')
+    expect(mod.isSaaS).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// LocalAuthProvider — installs a no-op token getter via the existing seam
+// ---------------------------------------------------------------------------
+
+describe('PRD-175 — LocalAuthProvider', () => {
+  it('installs a null token getter (no bearer → backend local identity) and renders children', async () => {
+    vi.stubEnv('NEXT_PUBLIC_AUTH_EDITION', 'local')
+    const { apiClient } = await import('@/lib/api-client')
+    const spy = vi.spyOn(apiClient, 'setClerkTokenGetter')
+
+    const { LocalAuthProvider } = await import('@/components/local-auth-provider')
+    const { getByText } = render(<LocalAuthProvider><span>child-ok</span></LocalAuthProvider>)
+
+    expect(getByText('child-ok')).toBeInTheDocument()
+    expect(spy).toHaveBeenCalledTimes(1)
+    const getter = spy.mock.calls[0][0]
+    await expect(getter()).resolves.toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// providers.tsx — the mount is conditional on the edition (F008 choke point)
+// ---------------------------------------------------------------------------
+
+describe('PRD-175 — providers.tsx mount gate', () => {
+  const src = readFileSync(PROVIDERS, 'utf8')
+
+  it('branches the mount on the edition flag, not an unconditional ClerkProvider', () => {
+    // isSaaS decides which auth boundary mounts.
+    expect(src).toMatch(/isSaaS/)
+    // The local branch mounts LocalAuthProvider instead of ClerkProvider.
+    expect(src).toContain('LocalAuthProvider')
+    // The `Providers` component itself must NOT return ClerkProvider directly —
+    // its top-level element is the edition-aware AuthBoundary, so no Clerk symbol
+    // is reached in `local`.
+    expect(src).toMatch(/export function Providers[\s\S]*?return\s*\(\s*<AuthBoundary/)
+    // And the `local` branch short-circuits before any ClerkProvider is rendered.
+    expect(src).toMatch(/if\s*\(\s*!isSaaS\s*\)[\s\S]*?LocalAuthProvider/)
+  })
+
+  it('keeps the shared providers identical across editions (single children tree)', () => {
+    // RoleProvider / ThemeProvider / WorkspaceProvider are below the auth boundary.
+    expect(src).toContain('RoleProvider')
+    expect(src).toContain('WorkspaceProvider')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// middleware.ts — auth.protect() only runs under saas
+// ---------------------------------------------------------------------------
+
+describe('PRD-175 — middleware edition gate', () => {
+  const src = readFileSync(MIDDLEWARE, 'utf8')
+
+  it('gates clerkMiddleware / auth.protect() on the edition flag', () => {
+    expect(src).toMatch(/NEXT_PUBLIC_AUTH_EDITION|isSaaS|authEdition/)
+    // A local pass-through exists so every route is served with no auth.protect().
+  })
+
+  it('does not call auth.protect() unconditionally at module top level', () => {
+    // The default export must be edition-aware, not a bare clerkMiddleware(protect).
+    // (Presence of a local pass-through branch is the assertion.)
+    expect(src).toMatch(/local/i)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// sign-in is saas-only — local redirects to '/'
+// ---------------------------------------------------------------------------
+
+describe('PRD-175 — sign-in is saas-only', () => {
+  const src = readFileSync(SIGN_IN, 'utf8')
+  it('redirects to / under the local edition (no login in local)', () => {
+    expect(src).toMatch(/isSaaS|authEdition|NEXT_PUBLIC_AUTH_EDITION/)
+    expect(src).toMatch(/redirect|'\/'/)
+  })
+})

--- a/frontend/components/local-auth-provider.tsx
+++ b/frontend/components/local-auth-provider.tsx
@@ -1,0 +1,29 @@
+'use client'
+
+import { useRef } from 'react'
+import { apiClient } from '@/lib/api-client'
+
+/**
+ * PRD-175 (F008) — the `local` edition counterpart to ClerkApiClientProvider.
+ *
+ * It reuses the *same* token seam (`apiClient.setClerkTokenGetter`, api-client.ts)
+ * — the "one-function seam" — but installs a NO-OP getter that always resolves
+ * `null`. With no bearer on the wire, the backend falls through to its single
+ * local identity (`hybrid.py` anonymous dev-fallback, gated by REQUIRE_AUTH which
+ * `AUTH_EDITION=local` forces false). No Clerk symbol is imported here, so `local`
+ * mounts and renders with zero Clerk env / no publishable key.
+ *
+ * This is a *facade over the existing seam*, not a second source of truth for
+ * identity — the backend remains the only authority for who the user is.
+ */
+export function LocalAuthProvider({ children }: { children: React.ReactNode }) {
+  // Install synchronously during render (mirrors ClerkApiClientProvider) so
+  // React Query can't fire a request before the getter is set.
+  const configuredRef = useRef(false)
+  if (!configuredRef.current) {
+    apiClient.setClerkTokenGetter(async () => null)
+    configuredRef.current = true
+  }
+
+  return <>{children}</>
+}

--- a/frontend/components/providers.tsx
+++ b/frontend/components/providers.tsx
@@ -7,11 +7,13 @@ import { Suspense, useState } from 'react'
 import { ThemeProvider } from './theme-provider'
 import { WorkspaceProvider } from './workspace-provider'
 import { ClerkApiClientProvider } from './clerk-api-client-provider'
+import { LocalAuthProvider } from './local-auth-provider'
 import { RoleProvider } from '../contexts/role-context'
 import { FirstLoginGuard } from './onboarding/first-login-guard'
 import { Toaster } from './ui/sonner'
 import { GlobalSearch } from './shared/global-search'
 import { useStudioThemeFlag } from '../hooks/use-studio-theme'
+import { isSaaS } from '@/lib/auth-edition'
 
 // Inline child so we can read useSearchParams (needs a Suspense boundary in Next).
 function StudioThemeFlag() {
@@ -19,16 +21,15 @@ function StudioThemeFlag() {
   return null
 }
 
-export function Providers({ children }: { children: React.ReactNode }) {
-  const [queryClient] = useState(() => new QueryClient({
-    defaultOptions: {
-      queries: {
-        staleTime: 60 * 1000, // 1 minute
-        retry: 1,
-      },
-    },
-  }))
-
+// PRD-175 (F008): the auth boundary is edition-conditional and is the ONLY thing
+// that differs between editions — everything below it (RoleProvider, ThemeProvider,
+// WorkspaceProvider, children) is identical. In `saas` the boundary is Clerk +
+// ClerkApiClientProvider (the real token getter); in `local` it is LocalAuthProvider
+// (a no-op token getter over the same seam), and NO Clerk symbol executes.
+function AuthBoundary({ children }: { children: React.ReactNode }) {
+  if (!isSaaS) {
+    return <LocalAuthProvider>{children}</LocalAuthProvider>
+  }
   return (
     <ClerkProvider
       signInFallbackRedirectUrl="/"
@@ -68,30 +69,45 @@ export function Providers({ children }: { children: React.ReactNode }) {
         },
       }}
     >
-      <ClerkApiClientProvider>
-        <RoleProvider>
-          <ThemeProvider
-            attribute="class"
-            defaultTheme="system"
-            enableSystem
-            themes={['light', 'dark', 'matte', 'studio']}
-            storageKey="automatos-theme"
-            disableTransitionOnChange
-          >
-            <QueryClientProvider client={queryClient}>
-              <WorkspaceProvider>
-                <Suspense fallback={null}>
-                  <StudioThemeFlag />
-                </Suspense>
-                <FirstLoginGuard />
-                {children}
-                <GlobalSearch />
-                <Toaster position="top-right" richColors closeButton />
-              </WorkspaceProvider>
-            </QueryClientProvider>
-          </ThemeProvider>
-        </RoleProvider>
-      </ClerkApiClientProvider>
+      <ClerkApiClientProvider>{children}</ClerkApiClientProvider>
     </ClerkProvider>
+  )
+}
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  const [queryClient] = useState(() => new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 60 * 1000, // 1 minute
+        retry: 1,
+      },
+    },
+  }))
+
+  return (
+    <AuthBoundary>
+      <RoleProvider>
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="system"
+          enableSystem
+          themes={['light', 'dark', 'matte', 'studio']}
+          storageKey="automatos-theme"
+          disableTransitionOnChange
+        >
+          <QueryClientProvider client={queryClient}>
+            <WorkspaceProvider>
+              <Suspense fallback={null}>
+                <StudioThemeFlag />
+              </Suspense>
+              <FirstLoginGuard />
+              {children}
+              <GlobalSearch />
+              <Toaster position="top-right" richColors closeButton />
+            </WorkspaceProvider>
+          </QueryClientProvider>
+        </ThemeProvider>
+      </RoleProvider>
+    </AuthBoundary>
   )
 }

--- a/frontend/lib/auth-edition.ts
+++ b/frontend/lib/auth-edition.ts
@@ -1,0 +1,27 @@
+/**
+ * PRD-175 (F008) — the open-core edition, read once for the client.
+ *
+ * One core, two editions, one seam. This is the frontend mirror of the backend
+ * `config.AUTH_EDITION`, surfaced as the build-time public env
+ * `NEXT_PUBLIC_AUTH_EDITION` (the existing `NEXT_PUBLIC_*` convention already
+ * used for `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`).
+ *
+ *   saas  → Clerk is the identity boundary (the running product; the default).
+ *   local → no login, no Clerk mount, no external SaaS — every route is public
+ *           and the API client sends no bearer, so the backend falls to its
+ *           single local identity (`hybrid.py` anonymous dev-fallback).
+ *
+ * An unknown value falls back to `saas` so a typo never silently un-guards the
+ * app. Nothing else in the frontend should read `process.env.NEXT_PUBLIC_AUTH_EDITION`
+ * directly — import `isSaaS` / `isLocal` / `authEdition` from here.
+ */
+export type AuthEdition = 'local' | 'saas'
+
+function resolveEdition(): AuthEdition {
+  const raw = (process.env.NEXT_PUBLIC_AUTH_EDITION || '').trim().toLowerCase()
+  return raw === 'local' ? 'local' : 'saas'
+}
+
+export const authEdition: AuthEdition = resolveEdition()
+export const isSaaS: boolean = authEdition === 'saas'
+export const isLocal: boolean = authEdition === 'local'

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -1,4 +1,12 @@
+import { NextResponse } from "next/server";
 import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
+import { isSaaS } from "@/lib/auth-edition";
+
+// PRD-175 (F008): the middleware is edition-conditional.
+//   saas  → clerkMiddleware + auth.protect() on every non-public route (unchanged).
+//   local → a pass-through: NO clerkMiddleware, NO auth.protect(), so EVERY route
+//           is served. `local` treats the whole app as public — there is no login.
+// Gated on the build-time edition flag so no Clerk symbol executes under `local`.
 
 const isPublicRoute = createRouteMatcher([
   "/sign-in(.*)",
@@ -9,11 +17,16 @@ const isPublicRoute = createRouteMatcher([
   "/api/webhooks(.*)",
 ]);
 
-export default clerkMiddleware(async (auth, request) => {
+const saasMiddleware = clerkMiddleware(async (auth, request) => {
   if (!isPublicRoute(request)) {
     await auth.protect();
   }
 });
+
+// In `local`, serve everything untouched — the app is fully public with no auth.
+const localMiddleware = () => NextResponse.next();
+
+export default isSaaS ? saasMiddleware : localMiddleware;
 
 export const config = {
   matcher: ["/((?!.+\\.[\\w]+$|_next).*)", "/", "/(api|trpc)(.*)"],

--- a/orchestrator/config.py
+++ b/orchestrator/config.py
@@ -146,8 +146,32 @@ class Config:
     # API SECURITY
     # =============================================================================
     ORCHESTRATOR_API_KEY: str = os.getenv("ORCHESTRATOR_API_KEY") or os.getenv("AUTOMATOS_API_KEY") or os.getenv("API_KEY")
-    REQUIRE_AUTH: bool = os.getenv("REQUIRE_AUTH", "true").strip().lower() in ("true", "1", "yes")
+
+    # PRD-175 (F008) — the open-core edition flag. One core, two editions, one seam.
+    #   saas  → Clerk is the identity boundary (the running product; the default).
+    #   local → a single auto-authenticated local user in a single local workspace;
+    #           no login, no external SaaS, no Clerk env (git clone && docker up).
+    # An unknown value falls back to `saas` so a typo never silently un-guards auth.
+    # This is the ONE flag the frontend mount-gate and the backend local-session
+    # posture both read (mirrored to the client as NEXT_PUBLIC_AUTH_EDITION).
+    _AUTH_EDITION_RAW = (os.getenv("AUTH_EDITION", "saas") or "saas").strip().lower()
+    AUTH_EDITION: str = _AUTH_EDITION_RAW if _AUTH_EDITION_RAW in ("local", "saas") else "saas"
+
+    # The `local` edition *implies* the no-login posture: REQUIRE_AUTH is forced
+    # false so operators set ONE flag, not three that can silently contradict
+    # (PRD §4.1/§4.3). In `saas`, REQUIRE_AUTH stays secure-by-default from env.
+    REQUIRE_AUTH: bool = (
+        False if AUTH_EDITION == "local"
+        else os.getenv("REQUIRE_AUTH", "true").strip().lower() in ("true", "1", "yes")
+    )
     AUTH_DEBUG: bool = os.getenv("AUTH_DEBUG", "").strip().lower() in ("1", "true", "yes", "on")
+
+    # PRD-175 (F075) — the platform-staff email domain used by the Clerk
+    # defence-in-depth admin gate (core/auth/clerk.py). Configuration, not a
+    # baked-in literal, so a self-hosted/SaaS operator sets their own staff domain.
+    PLATFORM_STAFF_EMAIL_DOMAIN: str = (
+        os.getenv("PLATFORM_STAFF_EMAIL_DOMAIN", "automatos.app") or "automatos.app"
+    ).strip().lstrip("@").lower()
     
     # =============================================================================
     # CORS (Frontend origins)
@@ -376,7 +400,16 @@ class Config:
     @property
     def IS_DEVELOPMENT(self) -> bool:
         return self.ENVIRONMENT.lower() == "development"
-    
+
+    # PRD-175 (F008) — edition helpers (read the one AUTH_EDITION flag).
+    @property
+    def IS_LOCAL_EDITION(self) -> bool:
+        return self.AUTH_EDITION == "local"
+
+    @property
+    def IS_SAAS_EDITION(self) -> bool:
+        return self.AUTH_EDITION == "saas"
+
     NEXT_PUBLIC_API_URL: str = os.getenv("NEXT_PUBLIC_API_URL")
     
     # =============================================================================
@@ -939,6 +972,51 @@ class Config:
                 "Tenant-isolation security config invalid (PRD-172):\n  - "
                 + "\n  - ".join(errors)
             )
+
+        # PRD-175 (F008) — the edition boot guard runs in the same hard-fail phase
+        # so a saas deploy that lost its Clerk env aborts boot rather than silently
+        # downgrading to the anonymous local identity and serving tenant data.
+        self.validate_auth_edition()
+
+    def validate_auth_edition(self) -> None:
+        """PRD-175 (F008): fail-closed boot guard for the open-core edition flag.
+
+        Keeps the two editions from silently blending into the accidental
+        "auth-not-configured" fallthrough that made local undeployable:
+
+        - ``saas``  requires the Clerk env (``CLERK_JWKS_URL`` +
+          ``CLERK_SECRET_KEY``). A saas boot with no Clerk is a misconfiguration,
+          not a silent anonymous downgrade (the one real danger, review §5.3) —
+          it must be a loud boot failure.
+        - ``local`` requires a ``DEFAULT_WORKSPACE_ID`` — the single local
+          workspace the auto-authenticated local session resolves to (W6 seeds it).
+          It requires NO Clerk env.
+
+        Raises ``RuntimeError`` (aborting boot) on a contradiction.
+        """
+        errors: list[str] = []
+
+        if self.AUTH_EDITION == "saas":
+            if not (self.CLERK_JWKS_URL or "").strip():
+                errors.append("CLERK_JWKS_URL is unset")
+            if not (self.CLERK_SECRET_KEY or "").strip():
+                errors.append("CLERK_SECRET_KEY is unset")
+            if errors:
+                raise RuntimeError(
+                    "AUTH_EDITION=saas requires Clerk to be configured, but "
+                    + " and ".join(errors)
+                    + ". A saas boot with no Clerk must fail fast, not fall through "
+                    "to the anonymous local identity (which would serve tenant data "
+                    "unauthenticated). Set the Clerk env, or set AUTH_EDITION=local "
+                    "for a no-login local instance."
+                )
+        elif self.AUTH_EDITION == "local":
+            if not (self.DEFAULT_WORKSPACE_ID or "").strip():
+                raise RuntimeError(
+                    "AUTH_EDITION=local requires DEFAULT_WORKSPACE_ID (the single "
+                    "local workspace the auto-authenticated local session resolves "
+                    "to). Set DEFAULT_WORKSPACE_ID to the seeded local workspace."
+                )
 
     def validate(self) -> bool:
         """

--- a/orchestrator/core/auth/clerk.py
+++ b/orchestrator/core/auth/clerk.py
@@ -197,13 +197,17 @@ class ClerkAuth:
         
         # Defence-in-depth: Clerk publicMetadata is the source of truth, but a
         # tenant user with stray admin metadata must NEVER be promoted to
-        # platform admin. Require an Automatos-staff email domain on top.
-        is_automatos_staff = bool(email) and email.lower().endswith("@automatos.app")
-        if system_role == "admin" and not is_automatos_staff:
+        # platform admin. Require the configured platform-staff email domain on
+        # top. PRD-175 (F075): the domain is configuration (PLATFORM_STAFF_EMAIL_DOMAIN),
+        # not a baked-in literal, so a self-hosted/SaaS operator sets their own.
+        staff_domain = config.PLATFORM_STAFF_EMAIL_DOMAIN
+        is_platform_staff = bool(email) and email.lower().endswith("@" + staff_domain)
+        if system_role == "admin" and not is_platform_staff:
             logger.warning(
-                "Refusing platform-admin role for non-Automatos email %s — "
-                "Clerk publicMetadata says admin but email domain is not @automatos.app",
+                "Refusing platform-admin role for %s — Clerk publicMetadata says "
+                "admin but email domain is not @%s",
                 email,
+                staff_domain,
             )
             system_role = "user"
             role = system_role

--- a/orchestrator/scripts/init_test_db.py
+++ b/orchestrator/scripts/init_test_db.py
@@ -46,6 +46,29 @@ def init_db():
             )
         """))
 
+    # PRD-175: seed the single local workspace that the AUTH_EDITION=local
+    # anonymous session resolves to. The CI test job runs the suite under
+    # AUTH_EDITION=local + DEFAULT_WORKSPACE_ID (config.py:422); the endpoint
+    # tests that fall through to the anonymous dev-fallback
+    # (core/auth/hybrid.py) resolve to config.DEFAULT_WORKSPACE_ID and then
+    # assert the workspace exists. Read the id from the canonical config (no
+    # os.getenv here — CLAUDE.md §4) and seed it idempotently so the row is
+    # present whatever DEFAULT_WORKSPACE_ID the environment sets.
+    from config import config as _app_config
+
+    _default_ws_id = (_app_config.DEFAULT_WORKSPACE_ID or "").strip()
+    if _default_ws_id:
+        with engine.begin() as conn:
+            conn.execute(
+                _raw_sql(
+                    "INSERT INTO workspaces (id, name, slug, is_personal, is_active) "
+                    "VALUES (:id, 'Local Workspace', 'local', TRUE, TRUE) "
+                    "ON CONFLICT (id) DO NOTHING"
+                ),
+                {"id": _default_ws_id},
+            )
+        print(f"   ✅ seeded local workspace {_default_ws_id}")
+
     print("✅ Database initialized successfully!")
     print(f"   Tables created: {len(Base.metadata.tables)}")
 

--- a/orchestrator/tests/test_prd175_auth_edition.py
+++ b/orchestrator/tests/test_prd175_auth_edition.py
@@ -40,6 +40,55 @@ os.environ.setdefault("POSTGRES_DB", "test")
 LOCAL_WS = UUID("00000000-0000-0000-0000-0000000000aa")
 
 
+@pytest.fixture(autouse=True)
+def _contain_reload_blast_radius():
+    """Snapshot + restore the *attributes* of the two modules these tests reload.
+
+    This file deliberately reloads ``config`` (``_fresh_config`` — to re-run the
+    class-body edition resolution under a mutated env) and ``core.auth.hybrid``
+    (the local-session test — to re-bind its module-level ``from config import
+    config``).
+
+    CRITICAL: ``importlib.reload`` re-executes the module body into the SAME
+    module object (``sys.modules[name]`` identity is preserved) but REPLACES every
+    attribute — it mints a brand-new ``config.config`` singleton and a brand-new
+    ``hybrid.get_request_context_hybrid`` function object. So snapshotting
+    ``sys.modules[name]`` is a no-op; the leak is at the attribute level.
+
+    Left un-restored, that leaks two ways into sibling test files:
+
+    * ``config``: later ``from config import config`` (e.g. ``tool_router``'s lazy
+      read) binds this reloaded singleton with env defaults, silently defeating
+      ``test_tool_router_semantic``'s ``_FAKE_CONFIG`` (SEMANTIC_TOOL_ROUTING back
+      to its ``true`` default → ``assert True is False``).
+    * ``core.auth.hybrid``: the endpoint suites override ``get_request_context_hybrid``
+      via ``app.dependency_overrides``. FastAPI keys that override by function
+      identity. After a reload, the routers still hold the ORIGINAL function
+      (captured at their import) while the test imports the NEW one, so the
+      override silently misses and the request falls through to the real
+      anonymous resolver ("Workspace not resolved").
+
+    Snapshot each module's ``__dict__`` before the test and restore it verbatim
+    after (put original attributes back, drop any the reload added), so the reload
+    can never escape this module. Mirrors ``test_config.py``'s
+    ``_restore_config_module`` intent, corrected to operate at attribute level and
+    extended to ``core.auth.hybrid``.
+    """
+    import config as _config_mod
+    import core.auth.hybrid as _hybrid_mod
+
+    snapshots = {
+        _config_mod: dict(_config_mod.__dict__),
+        _hybrid_mod: dict(_hybrid_mod.__dict__),
+    }
+    try:
+        yield
+    finally:
+        for mod, saved_dict in snapshots.items():
+            mod.__dict__.clear()
+            mod.__dict__.update(saved_dict)
+
+
 def _fresh_config(**env):
     """Reimport config.py under a controlled environment and return its singleton.
 

--- a/orchestrator/tests/test_prd175_auth_edition.py
+++ b/orchestrator/tests/test_prd175_auth_edition.py
@@ -1,0 +1,235 @@
+"""PRD-175 W5 — Auth decoupling: AUTH_EDITION flag + local session + F075 staff domain.
+
+These pin the *deployability-critical* half of the absent PRD-150 (F008/F075):
+
+  1. Headline (review §13): with ``AUTH_EDITION=local`` and NO ``CLERK_*`` env, the
+     backend resolves a request with no bearer to an authenticated *local*
+     ``RequestContext`` (anonymous auth_type, the configured default workspace) —
+     not a 401. This is the exact gap that blocks ``git clone && docker compose up``.
+  2. ``local`` edition *implies* ``REQUIRE_AUTH=false`` — one flag, not three that
+     can contradict (PRD §4.1/§4.3).
+  3. Boot guard (PRD §4.3, review §5.3): a ``saas`` boot with no Clerk env fails
+     fast (RuntimeError), never a silent anonymous downgrade; a ``local`` boot
+     with no ``DEFAULT_WORKSPACE_ID`` fails fast.
+  4. F075: the platform-staff check reads ``config.PLATFORM_STAFF_EMAIL_DOMAIN``,
+     not a ``@automatos.app`` literal — changing the config changes the accepted
+     domain, and no literal remains in ``clerk.py``.
+
+All tests here are pure/DB-free: the local-session test stubs the DB seam
+(``SessionLocal`` + workspace helpers) so it runs without Postgres, matching the
+lean-venv idiom used across the suite. CI runs the full DB-backed path.
+"""
+from __future__ import annotations
+
+import importlib
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+from uuid import UUID
+
+import pytest
+
+# Dummy POSTGRES_* satisfies the config import chain without a live DB (blessed
+# pattern; a closed port refuses instantly, nothing here touches a real DB).
+os.environ.setdefault("POSTGRES_USER", "test")
+os.environ.setdefault("POSTGRES_PASSWORD", "test")
+os.environ.setdefault("POSTGRES_HOST", "127.0.0.1")
+os.environ.setdefault("POSTGRES_PORT", "59432")
+os.environ.setdefault("POSTGRES_DB", "test")
+
+LOCAL_WS = UUID("00000000-0000-0000-0000-0000000000aa")
+
+
+def _fresh_config(**env):
+    """Reimport config.py under a controlled environment and return its singleton.
+
+    ``AUTH_EDITION``/``REQUIRE_AUTH`` are resolved at class-definition time, so the
+    module must be reloaded to pick up a changed edition. We snapshot/restore the
+    relevant env keys so tests don't leak into each other.
+    """
+    keys = [
+        "AUTH_EDITION", "REQUIRE_AUTH", "DEFAULT_WORKSPACE_ID",
+        "CLERK_JWKS_URL", "CLERK_SECRET_KEY", "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY",
+        "PLATFORM_STAFF_EMAIL_DOMAIN",
+    ]
+    saved = {k: os.environ.get(k) for k in keys}
+    for k in keys:
+        os.environ.pop(k, None)
+    os.environ.update({k: v for k, v in env.items() if v is not None})
+    try:
+        import config as config_mod
+        importlib.reload(config_mod)
+        return config_mod.config
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+# ---------------------------------------------------------------------------
+# §5.2 (backend) / §4.1 — the edition flag & its implications
+# ---------------------------------------------------------------------------
+
+def test_default_edition_is_saas_and_require_auth_stays_secure():
+    """Default (no flag) must remain the SaaS product: edition=saas, auth on."""
+    cfg = _fresh_config()  # no AUTH_EDITION, no REQUIRE_AUTH override
+    assert cfg.AUTH_EDITION == "saas"
+    assert cfg.IS_SAAS_EDITION is True
+    assert cfg.IS_LOCAL_EDITION is False
+    # REQUIRE_AUTH secure-by-default in saas (unset env → true).
+    assert cfg.REQUIRE_AUTH is True
+
+
+def test_local_edition_forces_require_auth_false():
+    """PRD §4.1: local *implies* the no-login posture; REQUIRE_AUTH is forced false
+    even if the raw env says true, so operators set one flag, not three."""
+    cfg = _fresh_config(AUTH_EDITION="local", DEFAULT_WORKSPACE_ID=str(LOCAL_WS),
+                        REQUIRE_AUTH="true")
+    assert cfg.AUTH_EDITION == "local"
+    assert cfg.IS_LOCAL_EDITION is True
+    assert cfg.REQUIRE_AUTH is False
+
+
+def test_saas_edition_respects_require_auth_env():
+    cfg = _fresh_config(AUTH_EDITION="saas", REQUIRE_AUTH="false",
+                        CLERK_JWKS_URL="https://x/.well-known/jwks.json",
+                        CLERK_SECRET_KEY="sk_test")
+    assert cfg.REQUIRE_AUTH is False
+
+
+def test_unknown_edition_falls_back_to_saas():
+    """An invalid value must not silently disable auth — fail safe to saas."""
+    cfg = _fresh_config(AUTH_EDITION="banana")
+    assert cfg.AUTH_EDITION == "saas"
+    assert cfg.REQUIRE_AUTH is True
+
+
+# ---------------------------------------------------------------------------
+# §4.3 — boot guard (the silent-downgrade mitigation)
+# ---------------------------------------------------------------------------
+
+def test_boot_guard_saas_without_clerk_fails_fast():
+    """review §5.3: a saas boot that lost its Clerk env must abort boot, NOT fall
+    through to the anonymous local identity and serve tenant data unauthenticated."""
+    cfg = _fresh_config(AUTH_EDITION="saas")  # no CLERK_* set
+    with pytest.raises(RuntimeError) as exc:
+        cfg.validate_auth_edition()
+    assert "CLERK" in str(exc.value).upper()
+
+
+def test_boot_guard_saas_with_clerk_passes():
+    cfg = _fresh_config(AUTH_EDITION="saas",
+                        CLERK_JWKS_URL="https://x/.well-known/jwks.json",
+                        CLERK_SECRET_KEY="sk_test")
+    cfg.validate_auth_edition()  # must not raise
+
+
+def test_boot_guard_local_requires_default_workspace():
+    cfg = _fresh_config(AUTH_EDITION="local")  # no DEFAULT_WORKSPACE_ID
+    with pytest.raises(RuntimeError) as exc:
+        cfg.validate_auth_edition()
+    assert "DEFAULT_WORKSPACE_ID" in str(exc.value)
+
+
+def test_boot_guard_local_with_workspace_passes_without_clerk():
+    """The headline: local needs a workspace, needs NO Clerk env."""
+    cfg = _fresh_config(AUTH_EDITION="local", DEFAULT_WORKSPACE_ID=str(LOCAL_WS))
+    cfg.validate_auth_edition()  # must not raise even with zero CLERK_* env
+
+
+def test_validate_auth_edition_is_wired_into_validate_security():
+    """The guard runs at the same hard-fail boot phase as PRD-172 (main.py:178)."""
+    cfg = _fresh_config(AUTH_EDITION="saas")  # no clerk → must fail via validate_security
+    with pytest.raises(RuntimeError):
+        cfg.validate_security()
+
+
+# ---------------------------------------------------------------------------
+# §5.1 headline — backend serves a local session with zero Clerk env
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_local_session_no_bearer_no_clerk_resolves_authenticated():
+    """With AUTH_EDITION=local, DEFAULT_WORKSPACE_ID seeded, and NO CLERK_* env, a
+    request with no bearer resolves to an authenticated anonymous/local context on
+    the configured workspace — not a 401."""
+    import config as config_mod
+    importlib.reload(config_mod)
+    import core.auth.hybrid as hybrid
+    importlib.reload(hybrid)
+
+    # Drive the module's live config into the local posture.
+    with patch.object(hybrid.config, "AUTH_EDITION", "local"), \
+         patch.object(hybrid.config, "REQUIRE_AUTH", False), \
+         patch.object(hybrid.config, "DEFAULT_WORKSPACE_ID", str(LOCAL_WS)), \
+         patch.object(hybrid.config, "WORKSPACE_ID", None), \
+         patch.object(hybrid.config, "AUTH_DEBUG", False), \
+         patch.object(hybrid, "SessionLocal", MagicMock(return_value=MagicMock())), \
+         patch.object(hybrid, "_workspace_exists", return_value=True), \
+         patch.object(hybrid, "_assert_workspace_usable", return_value=None), \
+         patch.object(hybrid, "_enrich_log_context", return_value=None):
+
+        request = MagicMock()
+        request.method = "GET"
+        request.headers = {}
+        request.query_params = {}
+        request.state = MagicMock(spec=[])  # no pre-resolved workspace
+
+        ctx = await hybrid.get_request_context_hybrid(request)
+
+    assert ctx.auth_type == "anonymous"
+    assert ctx.workspace_id == LOCAL_WS
+
+
+# ---------------------------------------------------------------------------
+# §5.4 — F075: staff domain comes from config, not a literal
+# ---------------------------------------------------------------------------
+
+def _make_clerk_auth():
+    import core.auth.clerk as clerk_mod
+    importlib.reload(clerk_mod)
+    return clerk_mod, clerk_mod.ClerkAuth()
+
+
+def test_admin_kept_for_configured_staff_domain():
+    clerk_mod, auth = _make_clerk_auth()
+    with patch.object(clerk_mod.config, "PLATFORM_STAFF_EMAIL_DOMAIN", "automatos.app"):
+        info = auth.extract_user_info(
+            {"sub": "u1", "email": "gerard@automatos.app", "metadata": {"role": "admin"}}
+        )
+    assert info["system_role"] == "admin"
+
+
+def test_admin_demoted_for_non_staff_domain():
+    clerk_mod, auth = _make_clerk_auth()
+    with patch.object(clerk_mod.config, "PLATFORM_STAFF_EMAIL_DOMAIN", "automatos.app"):
+        info = auth.extract_user_info(
+            {"sub": "u2", "email": "attacker@evil.com", "metadata": {"role": "admin"}}
+        )
+    assert info["system_role"] == "user"
+
+
+def test_staff_domain_is_configurable():
+    """Changing config value changes the accepted domain (self-host operator sets
+    their own staff domain) — proves it's config, not a baked-in literal."""
+    clerk_mod, auth = _make_clerk_auth()
+    with patch.object(clerk_mod.config, "PLATFORM_STAFF_EMAIL_DOMAIN", "acme.example"):
+        kept = auth.extract_user_info(
+            {"sub": "u3", "email": "ops@acme.example", "metadata": {"role": "admin"}}
+        )
+        demoted = auth.extract_user_info(
+            {"sub": "u4", "email": "x@automatos.app", "metadata": {"role": "admin"}}
+        )
+    assert kept["system_role"] == "admin"
+    assert demoted["system_role"] == "user"
+
+
+def test_no_automatos_literal_remains_in_clerk_py():
+    """review §5.4: assert by grep that the hardcoded @automatos.app staff-gate
+    literal is gone from clerk.py (the git-identity default lives elsewhere)."""
+    clerk_py = Path(__file__).resolve().parents[1] / "core" / "auth" / "clerk.py"
+    src = clerk_py.read_text()
+    assert "@automatos.app" not in src
+    assert "PLATFORM_STAFF_EMAIL_DOMAIN" in src


### PR DESCRIPTION
## PRD-175 W5 — Auth Decoupling (open-core)

**Deployability-critical mount-gate + admin-domain move only** (PRD-175 as written). *One core, two editions, one seam.* The running SaaS product is **byte-for-byte unchanged** — default `AUTH_EDITION=saas`; only the opt-in `local` branch is new. This is the load-bearing half of open-core: it makes the app *not require* Clerk, unblocking W6 (which boots the fresh-clone local instance).

Findings register re-confirmed on current `main` (`45609d78`); all pinned `file:line` matched.

### F008 — `AppAuth` facade + `AUTH_EDITION` (local|saas)
**Backend**
- `AUTH_EDITION` flag in `config.py` (default `saas`; unknown value → `saas` so a typo never un-guards auth). `local` **implies** `REQUIRE_AUTH=false` (one flag, not three that contradict), so `get_request_context_hybrid`'s **existing** anonymous dev-fallback becomes the *deliberate* local session — no new auth code.
- Boot guard `validate_auth_edition()` (wired into `validate_security`, the same hard-fail phase as PRD-172): a `saas` boot with no Clerk env **fails fast** (never a silent anonymous downgrade — the one real danger); `local` requires `DEFAULT_WORKSPACE_ID`. `IS_LOCAL_EDITION`/`IS_SAAS_EDITION` helpers.

**Frontend**
- `lib/auth-edition.ts` reads `NEXT_PUBLIC_AUTH_EDITION` once → `isSaaS`/`isLocal`/`authEdition` (no scattered `process.env` reads).
- `providers.tsx`: an `AuthBoundary` mounts `ClerkProvider` + `ClerkApiClientProvider` (the Studio `appearance` block unchanged) **only in `saas`**; a new `LocalAuthProvider` installs a **no-op token getter over the same `setClerkTokenGetter` seam** in `local`. Everything below the boundary (`RoleProvider`/`ThemeProvider`/`WorkspaceProvider`/children) is identical across editions.
- `middleware.ts`: `saas` keeps `clerkMiddleware` + `auth.protect()` unchanged; `local` exports a pass-through (`NextResponse.next()`) so every route is served.
- `sign-in` / `sign-up` redirect to `/` under `local` (no login in local).

### F075 — admin domain to config
- The hardcoded `@automatos.app` platform-staff gate in `clerk.py` now reads `config.PLATFORM_STAFF_EMAIL_DOMAIN` (default `automatos.app`) — a self-hosted/SaaS operator sets their own. **No `@automatos.app` literal remains** in `clerk.py` (asserted by a test).

## Test-first (failing → green)
**Backend — `orchestrator/tests/test_prd175_auth_edition.py` (14, all pass locally):**
- `test_default_edition_is_saas_and_require_auth_stays_secure`
- `test_local_edition_forces_require_auth_false`
- `test_saas_edition_respects_require_auth_env`
- `test_unknown_edition_falls_back_to_saas`
- `test_boot_guard_saas_without_clerk_fails_fast`
- `test_boot_guard_saas_with_clerk_passes`
- `test_boot_guard_local_requires_default_workspace`
- `test_boot_guard_local_with_workspace_passes_without_clerk`
- `test_validate_auth_edition_is_wired_into_validate_security`
- `test_local_session_no_bearer_no_clerk_resolves_authenticated` ← **headline (review §13)**
- `test_admin_kept_for_configured_staff_domain`
- `test_admin_demoted_for_non_staff_domain`
- `test_staff_domain_is_configurable`
- `test_no_automatos_literal_remains_in_clerk_py`

**Frontend — `frontend/components/__tests__/prd175-auth-edition.test.tsx` (9, all pass locally):**
- auth-edition resolution: defaults saas / is local / unknown→saas
- `LocalAuthProvider` installs a null getter + renders children
- `providers.tsx` mount gate (top-level `AuthBoundary`; `!isSaaS`→`LocalAuthProvider`)
- middleware edition gate; sign-in saas-only redirect

## Local verification (no DB/Docker locally; CI is the full gate)
- `python3 -m py_compile` on all changed `.py` — OK
- Backend PRD-175 tests: **14 passed**
- Frontend PRD-175 tests: **9 passed**; full existing `__tests__` suite: **90 passed, 0 regressions**
- `tsc --noEmit`: **0 errors in the 6 touched frontend files** (the pre-existing ~554-error backlog is unchanged)
- ESLint on touched files: **clean**

## Package-split boundary left (owner decision, PRD §6 — NOT a silent descope)
The full PRD-150 Clerk **leakage-elimination / package-split** (~34 FE / ~63 BE sites so `local` ships *no Clerk code at all*) is **not** in this PR by design. W5 gates the **mount** (the choke point that makes `local` boot) and centralizes backend identity on the one `hybrid.py` dependency. Recommendation (PRD §6): ship the mount-gate now (unblocks W6), do the package-split as its own PRD — **Gerard's call.**

## Rollback
Set `AUTH_EDITION=saas` (the default) → the app is exactly today's product.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for two app editions, enabling a local mode that works without full authentication setup.
  * Sign-in and sign-up pages now redirect away when those pages aren’t available in the current edition.

* **Bug Fixes**
  * Improved startup checks so misconfigured authentication setups fail early instead of causing runtime issues.
  * Updated staff access handling to use a configurable email domain.
  * Local test and evaluation environments now include the required defaults to run reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->