### PR TITLE
feat(prd-176): W6 deployability — fresh-clone boot + alembic-from-zero + DR (F009/F010/F051/F089/F068/F050)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,8 +69,22 @@ LOG_LEVEL=INFO
 
 
 # =============================================================================
-# AWS S3 Vectors (PRD-42: Cloud Document Sync)
+# Object Storage — local MinIO (PRD-176 F089)
 # =============================================================================
+# Local compose runs a MinIO S3-compatible object store so the knowledge
+# flywheel persists generated outputs instead of losing them. Defaults below
+# work out of the box; override only if you change the MinIO service.
+# MINIO_ROOT_USER=minioadmin
+# MINIO_ROOT_PASSWORD=minioadmin
+# MINIO_PORT=9000
+# MINIO_CONSOLE_PORT=9001
+# S3_ENDPOINT_URL=http://minio:9000        # unset in prod → real AWS S3
+# S3_DOCUMENTS_BUCKET=automatos-ai
+
+# =============================================================================
+# AWS S3 Vectors (PRD-42: Cloud Document Sync) — real S3 (prod)
+# =============================================================================
+# Leave S3_ENDPOINT_URL unset (above) to target real AWS S3 with these creds.
 # AWS_REGION=us-east-1
 # AWS_ACCESS_KEY_ID=
 # AWS_SECRET_ACCESS_KEY=

--- a/.github/workflows/smoke-fresh-clone.yml
+++ b/.github/workflows/smoke-fresh-clone.yml
@@ -1,0 +1,58 @@
+name: smoke-fresh-clone
+
+# PRD-176 Headline B — the deployability bar: a fresh clone boots to a green
+# /health with NO external credentials via `docker compose up`.
+#
+# NON-REQUIRED and BLOCKED ON WAVE 5. Until W5's boot-before-auth lands on main,
+# compose hard-requires Clerk keys, so a no-credential boot cannot reach /health.
+# The job runs the smoke script with continue-on-error so it reports the real
+# state without blocking; drop continue-on-error (and flip to required in branch
+# protection) once W5 is merged and the fresh-clone boot is green.
+#
+# Runs on manual dispatch and on pushes that touch the boot substrate (compose,
+# entrypoint, this workflow, or the script) — not on every push, since it builds
+# and boots the full stack.
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "docker-compose.yml"
+      - "docker-entrypoint.sh"
+      - "scripts/ci/smoke-fresh-clone.sh"
+      - ".github/workflows/smoke-fresh-clone.yml"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "docker-compose.yml"
+      - "docker-entrypoint.sh"
+      - "scripts/ci/smoke-fresh-clone.sh"
+      - ".github/workflows/smoke-fresh-clone.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  fresh-clone-boot:
+    name: Fresh-clone docker compose up -> /health 200 (non-required, blocked on W5)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Local-only secrets — throwaway values for an ephemeral stack. No external
+      # SaaS credential (Clerk / AWS / LLM) is provided, on purpose: that is the
+      # bar this test proves.
+      - name: Run fresh-clone smoke test
+        continue-on-error: true
+        env:
+          POSTGRES_PASSWORD: smoke_pg_pw
+          REDIS_PASSWORD: smoke_redis_pw
+          API_KEY: smoke_api_key
+          AUTH_EDITION: local
+          REQUIRE_AUTH: "false"
+        run: bash scripts/ci/smoke-fresh-clone.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -163,3 +163,103 @@ jobs:
             --timeout-method=thread \
             -p no:cacheprovider \
             -v
+
+  # PRD-176 F010 — the reliability bar: Alembic replays from zero to exactly
+  # ONE head. NON-REQUIRED (same posture as the test net) until the Step-2
+  # single-baseline squash lands.
+  #
+  # Two gates, deliberately separated by the review §7 two-step:
+  #   1. single-head invariant — asserts `alembic heads` returns exactly one
+  #      revision. Step 1 (the prd176_merge_heads merge revision) delivers this
+  #      NOW, so this step is the permanent regression guard against a new
+  #      divergent head. It needs no database.
+  #   2. from-zero replay — stands up an EMPTY pgvector database and runs
+  #      `alembic upgrade heads`. This is the Step-2 gate: it goes green once the
+  #      single-baseline squash reconciles the tables that today are ALTER-ed but
+  #      never CREATE-d. Runs with continue-on-error until then so the job
+  #      reports the real state without falsely blocking; flip to a hard failure
+  #      (drop continue-on-error) the moment Step 2 merges.
+  alembic-from-zero:
+    name: Alembic from-zero — exactly one head (non-required)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    services:
+      # pgvector, not stock postgres — the schema declares vector columns, so a
+      # from-zero replay needs the extension available.
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: alembic_zero_db
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U test -d alembic_zero_db"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      DATABASE_URL: postgresql://test:test@127.0.0.1:5432/alembic_zero_db
+      POSTGRES_USER: test
+      POSTGRES_PASSWORD: test
+      POSTGRES_HOST: 127.0.0.1
+      POSTGRES_PORT: "5432"
+      POSTGRES_DB: alembic_zero_db
+      ENVIRONMENT: development
+
+    defaults:
+      run:
+        working-directory: orchestrator
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: orchestrator/requirements.txt
+
+      - name: Install system libraries
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libpango-1.0-0 libpangocairo-1.0-0 libgdk-pixbuf-2.0-0 \
+            libcairo2 libffi-dev libmagic1 ghostscript
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      # Gate 1 — the single-head invariant (Step 1, green now, no DB needed).
+      - name: Assert exactly one Alembic head
+        run: |
+          HEADS="$(alembic heads 2>/dev/null | grep -c '(head)')"
+          echo "alembic head count: ${HEADS}"
+          alembic heads
+          if [ "${HEADS}" -ne 1 ]; then
+            echo "::error::Expected exactly one Alembic head, found ${HEADS}. A new divergent head was introduced — add a merge revision."
+            exit 1
+          fi
+
+      # Enable pgvector so the from-zero replay's vector columns resolve.
+      - name: Enable pgvector extension
+        env:
+          PGPASSWORD: test
+        run: |
+          psql -h 127.0.0.1 -U test -d alembic_zero_db -c "CREATE EXTENSION IF NOT EXISTS vector;"
+
+      # Gate 2 — from-zero replay (Step-2 gate). Non-blocking until the
+      # single-baseline squash lands; drop continue-on-error when it does.
+      - name: Replay all migrations from an empty database
+        continue-on-error: true
+        run: |
+          echo "Replaying alembic upgrade heads against an empty pgvector DB..."
+          alembic upgrade heads
+          echo "From-zero replay succeeded — Step 2 baseline is in place. Remove continue-on-error on this step."

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       - "${POSTGRES_PORT:-5432}:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
-      - ./orchestrator/database/init_complete_schema.sql:/docker-entrypoint-initdb.d/01-schema.sql:ro
+      - ./orchestrator/core/database/init_complete_schema.sql:/docker-entrypoint-initdb.d/01-schema.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres}"]
       interval: 10s
@@ -73,6 +73,56 @@ services:
       - automatos
 
   # ===========================================================================
+  # MinIO — local S3-compatible object store (PRD-176 F089)
+  # ===========================================================================
+  # Gives the knowledge flywheel a durable local object store so generated
+  # outputs persist instead of fail-softing to None on ephemeral disk. The
+  # backend talks to it through the existing S3 seam via S3_ENDPOINT_URL.
+  # Prod is unchanged (real AWS S3, S3_ENDPOINT_URL unset).
+  # ===========================================================================
+  minio:
+    image: minio/minio:latest
+    container_name: automatos_minio
+    restart: unless-stopped
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
+    ports:
+      - "${MINIO_PORT:-9000}:9000"
+      - "${MINIO_CONSOLE_PORT:-9001}:9001"
+    volumes:
+      - minio_data:/data
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
+    networks:
+      - automatos
+
+  # One-shot: create the documents bucket the flywheel writes to, then exit.
+  minio-init:
+    image: minio/mc:latest
+    container_name: automatos_minio_init
+    depends_on:
+      minio:
+        condition: service_healthy
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
+      S3_DOCUMENTS_BUCKET: ${S3_DOCUMENTS_BUCKET:-automatos-ai}
+    entrypoint: >
+      /bin/sh -c "
+      mc alias set local http://minio:9000 $${MINIO_ROOT_USER} $${MINIO_ROOT_PASSWORD} &&
+      mc mb --ignore-existing local/$${S3_DOCUMENTS_BUCKET} &&
+      echo 'MinIO bucket ready: '$${S3_DOCUMENTS_BUCKET}
+      "
+    networks:
+      - automatos
+
+  # ===========================================================================
   # Backend API (FastAPI)
   # ===========================================================================
   backend:
@@ -86,6 +136,8 @@ services:
       postgres:
         condition: service_healthy
       redis:
+        condition: service_healthy
+      minio:
         condition: service_healthy
     environment:
       # Database
@@ -104,7 +156,16 @@ services:
       # LLM API Keys (optional)
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
-      
+
+      # Object storage — local MinIO via the S3 seam (PRD-176 F089).
+      # S3_ENDPOINT_URL points boto at MinIO; the AWS_* creds are the MinIO
+      # root creds. Prod leaves S3_ENDPOINT_URL unset and uses real AWS S3.
+      S3_ENDPOINT_URL: ${S3_ENDPOINT_URL:-http://minio:9000}
+      S3_DOCUMENTS_BUCKET: ${S3_DOCUMENTS_BUCKET:-automatos-ai}
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-${MINIO_ROOT_USER:-minioadmin}}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-${MINIO_ROOT_PASSWORD:-minioadmin}}
+      AWS_REGION: ${AWS_REGION:-us-east-1}
+
       # Document Generation (PRD-63)
       GOTENBERG_URL: http://gotenberg:3000
 
@@ -262,6 +323,9 @@ volumes:
   redis_data:
     driver: local
     name: automatos_redis_data
+  minio_data:
+    driver: local
+    name: automatos_minio_data
   backend_logs:
     driver: local
     name: automatos_backend_logs

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,10 +2,12 @@
 # =============================================================================
 # Automatos AI - Backend Entrypoint Script
 # =============================================================================
-# This script:
+# This script is the single wait-migrate-seed lifecycle (PRD-176 F051):
 #   1. Waits for PostgreSQL to be ready
-#   2. Loads seed data (if not already loaded)
-#   3. Starts the backend application
+#   2. Verifies the database connection
+#   3. Runs Alembic migrations (fails closed — a bad migration aborts startup)
+#   4. Loads seed data (idempotent, if not already loaded)
+#   5. Starts the backend application
 # =============================================================================
 
 set -e
@@ -34,6 +36,28 @@ wait_for_postgres() {
     done
     
     echo "✅ PostgreSQL is ready!"
+}
+
+# =============================================================================
+# Function: Run Database Migrations (PRD-176 F051)
+# =============================================================================
+# Brings the schema to head via Alembic. This is the single owner of schema
+# lifecycle for a fresh clone: `alembic upgrade heads` replays every revision
+# against the (initdb-populated or empty) database.
+#
+# Fails CLOSED: unlike seed loading, a failed migration exits non-zero so the
+# app never starts against a half-built schema. Alembic is idempotent — on an
+# already-migrated database `upgrade heads` is a no-op.
+run_migrations() {
+    echo ""
+    echo "🗄️  Running database migrations (alembic upgrade heads)..."
+
+    if alembic upgrade heads; then
+        echo "✅ Migrations applied (schema at head)"
+    else
+        echo "❌ Migration failed — aborting startup (will not run on a half-built schema)"
+        exit 1
+    fi
 }
 
 # =============================================================================
@@ -102,6 +126,9 @@ wait_for_postgres
 
 # Check database
 check_database
+
+# Run migrations (fail-closed) — the single owner of schema lifecycle
+run_migrations
 
 # Load seed data (idempotent)
 load_seed_data

--- a/docs/runbooks/DR-postgres.md
+++ b/docs/runbooks/DR-postgres.md
@@ -1,0 +1,137 @@
+# DR Runbook — PostgreSQL Backup & Restore (PRD-176 F050)
+
+**Scope:** Disaster recovery for the two durable datastores Automatos cannot
+regenerate: the **primary pgvector database** (`orchestrator_db`) and the
+**separate mem0 instance** (durable agent memory). Redis is a cache and is out
+of scope (it is rebuildable and holds no source-of-truth state).
+
+**Tooling:** `scripts/dr/backup.sh` (`pg_dump -Fc`) and `scripts/dr/restore.sh`
+(`pg_restore`). Both read connection strings from the environment — no
+credentials are stored in the repo.
+
+**Baseline chosen:** nightly `pg_dump` (custom format). See
+[DR depth — open decision](#dr-depth--open-decision-for-gerard) for the
+richer WAL/PITR option, which is **surfaced for decision, not silently
+deferred.**
+
+---
+
+## 1. Stated RPO / RTO
+
+| Metric | Target (nightly-`pg_dump` baseline) | Basis |
+|---|---|---|
+| **RPO** (max data loss) | **≤ 24 h** — worst case, everything since the last nightly dump | One dump per day. A workspace losing up to a day of documents/missions/memory is the accepted baseline for open-core + single-instance. Tighten by running `backup.sh` more often (e.g. every 6 h → RPO ≤ 6 h) or by adopting PITR (§5). |
+| **RTO** (time to restore) | **≤ 30 min** for the primary DB | Provision a fresh Postgres → `CREATE EXTENSION vector` → `pg_restore` the latest dump → run the wait-migrate-seed entrypoint to head → `/health` green. Dominated by `pg_restore` time, which scales with DB size; 30 min is comfortable for a DB in the low-GB range. |
+| **RTO (mem0)** | **≤ 30 min**, restored in parallel with the primary | Same `pg_restore` path against `MEM0_DATABASE_URL`. mem0 is independent of the primary, so the two restores run concurrently. |
+
+These are **baseline** targets for the open-core / single-instance deployment.
+A production SaaS SLA that requires a tighter RPO than 24 h is the trigger for
+the PITR decision in §5.
+
+---
+
+## 2. What is backed up (and the two gotchas)
+
+`pg_dump -Fc` captures the **full schema and data**, including:
+
+- All SQLAlchemy-modelled tables.
+- **Raw-DDL tables** that `create_all()` cannot build (e.g. `document_chunks`,
+  the pgvector chunk store created in prod via `init_complete_schema.sql`).
+  These live in the database, so the dump contains them — the restore rebuilds
+  them from the dump, not from `create_all()`.
+
+Two things the restore must handle that a naive `pg_restore` misses:
+
+1. **pgvector extension.** The schema declares `vector` columns. The extension
+   must exist in the **target** database *before* the restore. `restore.sh`
+   runs `CREATE EXTENSION IF NOT EXISTS vector` first.
+2. **Role/ownership drift.** Dumps are taken `--no-owner --no-privileges` and
+   restored the same way, so a recovery instance with a different Postgres role
+   restores cleanly.
+
+---
+
+## 3. Backup procedure
+
+### 3.1 Manual / on-demand
+
+```bash
+# Primary DB only:
+DATABASE_URL='postgresql://USER:PW@HOST:5432/orchestrator_db' \
+  scripts/dr/backup.sh /backups
+
+# Primary + mem0 (both durable stores):
+DATABASE_URL='postgresql://USER:PW@HOST:5432/orchestrator_db' \
+MEM0_DATABASE_URL='postgresql://USER:PW@MEM0_HOST:5432/mem0' \
+  scripts/dr/backup.sh /backups
+```
+
+Output: `/backups/primary-<UTC timestamp>.dump` (and `mem0-<...>.dump`).
+
+### 3.2 Schedule (nightly)
+
+Run `backup.sh` once per day via the platform's scheduler (cron / Railway
+scheduled job / CI cron). Recommended: **02:00 UTC**, off peak.
+
+### 3.3 Where dumps are stored
+
+- **Local/dev:** the `./backups` directory (or `DR_BACKUP_DIR`).
+- **Production:** ship each dump to durable off-host object storage
+  (S3/Backblaze) immediately after it is written, and set a retention policy
+  (e.g. 7 daily + 4 weekly). **A dump that lives only on the database host is
+  not a backup** — a host loss takes both the DB and its dumps.
+
+---
+
+## 4. Restore procedure
+
+1. **Provision a fresh, empty target** Postgres (pgvector image, e.g.
+   `pgvector/pgvector:pg16`), reachable at `RESTORE_DATABASE_URL`.
+2. **Restore the dump:**
+
+   ```bash
+   RESTORE_DATABASE_URL='postgresql://USER:PW@NEWHOST:5432/orchestrator_db' \
+     scripts/dr/restore.sh /backups/primary-<timestamp>.dump
+   ```
+
+   `restore.sh` creates the pgvector extension, then `pg_restore`s the dump
+   (`--exit-on-error`, so a real failure is loud).
+3. **Bring schema to head.** Point the backend at the restored DB and start it;
+   the wait-migrate-seed entrypoint (F051) runs `alembic upgrade heads`. A dump
+   is stamped with its `alembic_version`, so any migrations authored after the
+   dump apply on top.
+4. **Restore mem0** in parallel against its own `RESTORE_DATABASE_URL` using the
+   `mem0-<timestamp>.dump`.
+5. **Verify:** backend `/health` returns 200; spot-check row counts on a few
+   tables (`documents`, `workspaces`, `agents`) against expectations.
+
+---
+
+## 5. DR depth — open decision (for Gerard)
+
+**This runbook ships the nightly-`pg_dump` baseline (RPO ≤ 24 h).** The richer
+alternative is **continuous WAL archiving + Point-In-Time Recovery (PITR)**,
+which lowers RPO to near-zero (recover to any second) at the cost of:
+
+- a WAL archive (continuous shipping of write-ahead logs to durable storage),
+- a base-backup + WAL-replay restore path (more moving parts than `pg_restore`),
+- provider support (e.g. managed PITR, or `pgBackRest`/`wal-g` operationally).
+
+**Decision needed:** does the target RPO/RTO require WAL/PITR, or is the
+nightly-dump RPO acceptable for this baseline?
+
+- If **nightly-dump RPO (≤ 24 h, or ≤ 6 h at 4×/day) is acceptable** → this
+  wave's `pg_dump`/`pg_restore` path is the complete answer.
+- If a **tighter RPO is required** → PITR is a larger, separable build (WAL
+  archiving + base backups + replay tooling). Per PRD-176 §6 it is **built in
+  this wave if that is the call** — it is not being deferred here, it is being
+  surfaced for the owner's decision (CLAUDE.md §12).
+
+---
+
+## 6. Test coverage
+
+The restore path is CI-tested (a backup that has never been restored is not a
+backup): `orchestrator/tests/test_dr_restore.py` dumps a populated DB
+with `pg_dump -Fc`, restores it into a fresh database, and asserts **row-parity**
+on a sampled table set. See PRD-176 §5.7.

--- a/orchestrator/alembic/versions/prd176_merge_heads.py
+++ b/orchestrator/alembic/versions/prd176_merge_heads.py
@@ -1,0 +1,44 @@
+"""PRD-176 F010 (Step 1): collapse the four-headed revision forest to one head.
+
+At 45609d780 ``alembic heads`` returned four divergent heads:
+
+    - 20260612_nl2sql_example_embedding
+    - prd158_cloud_default_team
+    - prd161_sla_breach
+    - prd164_doc_source_type
+
+Four heads make ``alembic upgrade head`` (singular) ambiguous and block a
+deterministic from-zero replay — the OSS/fresh-clone deployability bar. This is
+a **merge revision only**: it has no schema operations, it simply joins the four
+lineages so ``alembic heads`` returns exactly one revision and the wait-migrate
+entrypoint (F051) can run ``alembic upgrade heads`` to a single, well-defined
+head.
+
+This is Step 1 of the review §7 two-step. Step 2 (LATER, this wave) squashes the
+full forest into a single from-zero baseline behind the from-zero CI replay job.
+Do NOT add ``CREATE``/``ALTER`` here — a merge revision that mutates schema is
+exactly what makes the later squash lossy.
+
+Revision ID: prd176_merge_heads
+Revises: 20260612_nl2sql_example_embedding, prd158_cloud_default_team, prd161_sla_breach, prd164_doc_source_type
+Create Date: 2026-07-02
+"""
+
+# A pure merge point — no operations. Reversible before the Step-2 squash lands.
+revision = "prd176_merge_heads"
+down_revision = (
+    "20260612_nl2sql_example_embedding",
+    "prd158_cloud_default_team",
+    "prd161_sla_breach",
+    "prd164_doc_source_type",
+)
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """No-op: this revision only merges lineages."""
+
+
+def downgrade() -> None:
+    """No-op: splitting back into four heads needs no schema change."""

--- a/orchestrator/config.py
+++ b/orchestrator/config.py
@@ -404,8 +404,10 @@ class Config:
     OPENROUTER_SITE_URL: str = os.getenv("OPENROUTER_SITE_URL", "https://automatos.app")
     COHERE_RERANK_URL: str = os.getenv("COHERE_RERANK_URL", "https://api.cohere.com/v2/rerank")
     RAILWAY_GQL_URL: str = os.getenv("RAILWAY_GQL_URL", "https://backboard.railway.app/graphql/v2")
-    INTERNAL_API_HOSTNAME: str = os.getenv("INTERNAL_API_HOSTNAME", "automatos-ai.railway.internal")
-    INTERNAL_FRONTEND_HOSTNAME: str = os.getenv("INTERNAL_FRONTEND_HOSTNAME", "automatos-ai-frontend.railway.internal")
+    # PRD-176 F068: local-safe defaults. SaaS supplies the railway.internal host
+    # via env; a fresh local clone must not dial Railway topology by default.
+    INTERNAL_API_HOSTNAME: str = os.getenv("INTERNAL_API_HOSTNAME", "localhost")
+    INTERNAL_FRONTEND_HOSTNAME: str = os.getenv("INTERNAL_FRONTEND_HOSTNAME", "localhost")
     COMPOSIO_API_KEY: str = os.getenv("COMPOSIO_API_KEY") or os.getenv("COMPOSIO_KEY")
     # v3.1 default: tool endpoints automatically serve the latest toolkit version
     # (no `toolkit_versions=latest` param required). Only tool endpoints differ
@@ -503,8 +505,9 @@ class Config:
     # =============================================================================
     # MONITORING (PRD-73)
     # =============================================================================
-    LOKI_URL: str = os.getenv("LOKI_URL", "http://loki.railway.internal:3100")
-    PROMETHEUS_URL: str = os.getenv("PROMETHEUS_URL", "http://prometheus.railway.internal:9090")
+    # PRD-176 F068: local-safe defaults (SaaS sets the railway host via env).
+    LOKI_URL: str = os.getenv("LOKI_URL", "http://localhost:3100")
+    PROMETHEUS_URL: str = os.getenv("PROMETHEUS_URL", "http://localhost:9090")
     GRAFANA_URL: str = os.getenv("GRAFANA_URL", "")
     GRAFANA_SERVICE_ACCOUNT_TOKEN: str = os.getenv("GRAFANA_SERVICE_ACCOUNT_TOKEN", "")
     GRAFANA_LOKI_DATASOURCE_UID: str = os.getenv("GRAFANA_LOKI_DATASOURCE_UID", "loki")
@@ -513,12 +516,15 @@ class Config:
     # OBSERVABILITY — log relay, Prometheus metrics, Loki query API, alerts
     # (PRD-142 W3-S5 / G7 — centralized so monitoring modules stop reading env directly)
     # =============================================================================
-    # Log relay client (core/monitoring/automatos_logging.py)
+    # Log relay client (core/monitoring/automatos_logging.py).
+    # PRD-176 F068: local-safe default host + OFF by default. SaaS points this at
+    # log-relay.railway.internal and sets LOG_RELAY_ENABLED=true via env; a fresh
+    # local clone must not try to push logs to Railway topology.
     LOG_RELAY_URL: str = os.getenv(
         "LOG_RELAY_URL",
-        "http://log-relay.railway.internal:8080/push",
+        "http://localhost:8080/push",
     )
-    LOG_RELAY_ENABLED: bool = os.getenv("LOG_RELAY_ENABLED", "true").lower() == "true"
+    LOG_RELAY_ENABLED: bool = os.getenv("LOG_RELAY_ENABLED", "false").lower() == "true"
     LOG_RELAY_BATCH_SIZE: int = int(os.getenv("LOG_RELAY_BATCH_SIZE", "50"))
     LOG_RELAY_FLUSH_INTERVAL: float = float(os.getenv("LOG_RELAY_FLUSH_INTERVAL", "2.0"))
     # SERVICE_NAME has two distinct historical defaults — preserve both exactly.
@@ -534,7 +540,8 @@ class Config:
     METRICS_ENVIRONMENT: str = os.getenv("ENVIRONMENT", "unknown")
     # Loki query proxy (core/monitoring/automatos_logs_api.py) — separate from the
     # PRD-73 LOKI_URL above because the existing module reads LOKI_QUERY_URL.
-    LOKI_QUERY_URL: str = os.getenv("LOKI_QUERY_URL", "http://loki.railway.internal:3100")
+    # PRD-176 F068: local-safe default (SaaS sets the railway host via env).
+    LOKI_QUERY_URL: str = os.getenv("LOKI_QUERY_URL", "http://localhost:3100")
     # Shared by automatos_logs_api + automatos_alerts for HMAC verification.
     ALERT_INGEST_TOKEN: str = os.getenv("ALERT_INGEST_TOKEN", "")
 
@@ -712,6 +719,11 @@ class Config:
     AWS_REGION: str = os.getenv("AWS_REGION", "us-east-1")
     AWS_ACCESS_KEY_ID: str = os.getenv("AWS_ACCESS_KEY_ID")
     AWS_SECRET_ACCESS_KEY: str = os.getenv("AWS_SECRET_ACCESS_KEY")
+    # PRD-176 F089: S3 endpoint override for a local S3-compatible object store
+    # (MinIO). Empty by default so prod/boto talks to real AWS S3; local compose
+    # sets it to the MinIO endpoint so the knowledge flywheel persists outputs
+    # instead of fail-softing to None on ephemeral disk.
+    S3_ENDPOINT_URL: str = os.getenv("S3_ENDPOINT_URL", "")
 
     # S3 Vectors Configuration
     S3_VECTORS_ENABLED: bool = os.getenv("S3_VECTORS_ENABLED", "false").lower() == "true"
@@ -727,7 +739,8 @@ class Config:
     # PRD-58: FutureAGI Integration (Prompt Scoring & Optimization)
     # =============================================================================
     FUTUREAGI_API_KEY: str = os.getenv("FUTUREAGI_API_KEY")
-    AGENT_OPT_WORKER_URL: str = os.getenv("AGENT_OPT_WORKER_URL", "http://agent-opt-worker.railway.internal:8080")
+    # PRD-176 F068: local-safe default (SaaS sets the railway worker host via env).
+    AGENT_OPT_WORKER_URL: str = os.getenv("AGENT_OPT_WORKER_URL", "http://localhost:8080")
 
     # =============================================================================
     # JIRA BUG REPORTS (Pilot Helper Widget)
@@ -750,7 +763,8 @@ class Config:
     # =============================================================================
     RECIPE_SCRATCHPAD_TTL: int = int(os.getenv("RECIPE_SCRATCHPAD_TTL", "3600"))
     RECIPE_LOG_S3_BUCKET: str = os.getenv("RECIPE_LOG_S3_BUCKET", "automatos-ai")
-    MEM0_API_URL: str = os.getenv("MEM0_API_URL", "http://automatos-mem0-server.railway.internal")
+    # PRD-176 F068: local-safe default (SaaS sets the railway mem0 host via env).
+    MEM0_API_URL: str = os.getenv("MEM0_API_URL", "http://localhost:8888")
     MEM0_API_KEY: str = os.getenv("MEM0_API_KEY")
     # Read path (search/get_all) blocks TTFT — keep short.
     MEM0_TIMEOUT_SECONDS: float = float(os.getenv("MEM0_TIMEOUT_SECONDS", "3.0"))
@@ -881,7 +895,8 @@ class Config:
     # =============================================================================
     # VOICE SERVICE (PRD-74)
     # =============================================================================
-    VOICE_SERVICE_URL: str = os.getenv("VOICE_SERVICE_URL", "http://voice-service.railway.internal:8300")
+    # PRD-176 F068: local-safe default (SaaS sets the railway voice host via env).
+    VOICE_SERVICE_URL: str = os.getenv("VOICE_SERVICE_URL", "http://localhost:8300")
     VOICE_SERVICE_TIMEOUT: int = int(os.getenv("VOICE_SERVICE_TIMEOUT", "90"))
     VOICE_STT_MODEL: str = os.getenv("VOICE_STT_MODEL", "Systran/faster-whisper-large-v3")
     VOICE_TTS_MODEL: str = os.getenv("VOICE_TTS_MODEL", "kokoro")

--- a/orchestrator/modules/rag/ingestion/manager.py
+++ b/orchestrator/modules/rag/ingestion/manager.py
@@ -421,6 +421,10 @@ class DocumentManager:
         from config import config as app_config
         self.s3_bucket = s3_bucket or app_config.S3_DOCUMENTS_BUCKET
         self.s3_region = app_config.AWS_REGION or 'us-east-1'
+        # PRD-176 F089: honor S3_ENDPOINT_URL so a local MinIO (S3-compatible)
+        # object store is used when set. None => boto default (real AWS S3), so
+        # prod is unchanged. MinIO needs path-style addressing.
+        s3_endpoint = app_config.S3_ENDPOINT_URL or None
         # Bounded so a slow/unreachable/unconfigured S3 fails FAST (≤~5s) instead
         # of hanging the whole process. A DocumentManager must never block document
         # ops on S3 latency (PRD-164: this was a 90s faulthandler hang in CI when
@@ -429,9 +433,15 @@ class DocumentManager:
         self.s3_client = boto3.client(
             's3',
             region_name=self.s3_region,
+            endpoint_url=s3_endpoint,
             aws_access_key_id=app_config.AWS_ACCESS_KEY_ID,
             aws_secret_access_key=app_config.AWS_SECRET_ACCESS_KEY,
-            config=_BotoConfig(connect_timeout=3, read_timeout=5, retries={"max_attempts": 1}),
+            config=_BotoConfig(
+                connect_timeout=3,
+                read_timeout=5,
+                retries={"max_attempts": 1},
+                s3={"addressing_style": "path"} if s3_endpoint else {},
+            ),
         )
 
         # Ensure S3 bucket exists (create if needed)

--- a/orchestrator/tests/test_config_env_centralization.py
+++ b/orchestrator/tests/test_config_env_centralization.py
@@ -48,6 +48,16 @@ _SWEPT_ENV_VARS = (
     "ALERT_INGEST_TOKEN",
     "WIZARD_SKIP_GRAPHIFY",
     "PUBLIC_API_HOST",
+    # PRD-176 F068 — the nine railway.internal defaults + log-relay toggle that
+    # W6 makes local-safe. Swept so a Railway env value can't mask the new
+    # localhost/off defaults these tests assert.
+    "LOKI_URL",
+    "PROMETHEUS_URL",
+    "INTERNAL_API_HOSTNAME",
+    "INTERNAL_FRONTEND_HOSTNAME",
+    "AGENT_OPT_WORKER_URL",
+    "MEM0_API_URL",
+    "VOICE_SERVICE_URL",
 )
 
 
@@ -160,10 +170,12 @@ def test_swept_module_imports_config(relpath):
 # ---------------------------------------------------------------------------
 
 
-def test_log_relay_url_default(monkeypatch):
+def test_log_relay_url_default_local_safe(monkeypatch):
+    """PRD-176 F068: default log-relay target is local-safe, not railway.internal."""
     cfg = _reload_config(monkeypatch, {})
     assert hasattr(cfg.config, "LOG_RELAY_URL")
-    assert cfg.config.LOG_RELAY_URL == "http://log-relay.railway.internal:8080/push"
+    assert "railway.internal" not in cfg.config.LOG_RELAY_URL
+    assert cfg.config.LOG_RELAY_URL == "http://localhost:8080/push"
 
 
 def test_log_relay_url_override(monkeypatch):
@@ -171,14 +183,24 @@ def test_log_relay_url_override(monkeypatch):
     assert cfg.config.LOG_RELAY_URL == "http://custom:9090/push"
 
 
-def test_log_relay_enabled_default_true(monkeypatch):
+def test_log_relay_url_override_to_railway(monkeypatch):
+    """SaaS still points log relay at the railway host via env."""
+    cfg = _reload_config(
+        monkeypatch,
+        {"LOG_RELAY_URL": "http://log-relay.railway.internal:8080/push"},
+    )
+    assert cfg.config.LOG_RELAY_URL == "http://log-relay.railway.internal:8080/push"
+
+
+def test_log_relay_enabled_default_false(monkeypatch):
+    """PRD-176 F068: log relay is OFF by default (local); SaaS opts in via env."""
     cfg = _reload_config(monkeypatch, {})
-    assert cfg.config.LOG_RELAY_ENABLED is True
-
-
-def test_log_relay_enabled_off_when_false(monkeypatch):
-    cfg = _reload_config(monkeypatch, {"LOG_RELAY_ENABLED": "false"})
     assert cfg.config.LOG_RELAY_ENABLED is False
+
+
+def test_log_relay_enabled_on_when_true(monkeypatch):
+    cfg = _reload_config(monkeypatch, {"LOG_RELAY_ENABLED": "true"})
+    assert cfg.config.LOG_RELAY_ENABLED is True
 
 
 def test_log_relay_service_name_default_unknown(monkeypatch):
@@ -256,9 +278,11 @@ def test_metrics_environment_from_env(monkeypatch):
     assert cfg.config.METRICS_ENVIRONMENT == "production"
 
 
-def test_loki_query_url_default(monkeypatch):
+def test_loki_query_url_default_local_safe(monkeypatch):
+    """PRD-176 F068: default resolves local-safe, not railway.internal."""
     cfg = _reload_config(monkeypatch, {})
-    assert cfg.config.LOKI_QUERY_URL == "http://loki.railway.internal:3100"
+    assert "railway.internal" not in cfg.config.LOKI_QUERY_URL
+    assert cfg.config.LOKI_QUERY_URL == "http://localhost:3100"
 
 
 def test_loki_query_url_override(monkeypatch):
@@ -302,6 +326,63 @@ def test_public_api_host_strips_trailing_slash(monkeypatch):
     """channels.py rstrip('/') behaviour is preserved by the config accessor."""
     cfg = _reload_config(monkeypatch, {"PUBLIC_API_HOST": "api.staging.automatos.app/"})
     assert cfg.config.PUBLIC_API_HOST == "api.staging.automatos.app"
+
+
+# ---------------------------------------------------------------------------
+# 2b. PRD-176 F068 — the nine railway.internal defaults are local-safe
+# ---------------------------------------------------------------------------
+
+# Every config attribute that carried a ``*.railway.internal`` default at
+# 37fdecc4e. With no env override, none may dial a railway host by default
+# (roadmap deployability bar: a fresh clone reaches nothing SaaS-topology).
+_RAILWAY_DEFAULT_ATTRS = (
+    "INTERNAL_API_HOSTNAME",
+    "INTERNAL_FRONTEND_HOSTNAME",
+    "LOKI_URL",
+    "PROMETHEUS_URL",
+    "LOG_RELAY_URL",
+    "LOKI_QUERY_URL",
+    "AGENT_OPT_WORKER_URL",
+    "MEM0_API_URL",
+    "VOICE_SERVICE_URL",
+)
+
+
+def test_no_railway_internal_in_any_default(monkeypatch):
+    """PRD-176 F068: with no env, no config default contains 'railway.internal'."""
+    cfg = _reload_config(monkeypatch, {})
+    offenders = {
+        attr: getattr(cfg.config, attr)
+        for attr in _RAILWAY_DEFAULT_ATTRS
+        if "railway.internal" in (getattr(cfg.config, attr) or "")
+    }
+    assert offenders == {}, f"railway.internal leaked into local defaults: {offenders}"
+
+
+@pytest.mark.parametrize("attr", _RAILWAY_DEFAULT_ATTRS)
+def test_railway_default_is_localhost(monkeypatch, attr):
+    """Each former railway.internal default now resolves to a localhost value."""
+    cfg = _reload_config(monkeypatch, {})
+    value = getattr(cfg.config, attr) or ""
+    assert "localhost" in value, f"{attr} default is not local-safe: {value!r}"
+
+
+@pytest.mark.parametrize(
+    "attr,env_name,saas_value",
+    [
+        ("INTERNAL_API_HOSTNAME", "INTERNAL_API_HOSTNAME", "automatos-ai.railway.internal"),
+        ("INTERNAL_FRONTEND_HOSTNAME", "INTERNAL_FRONTEND_HOSTNAME", "automatos-ai-frontend.railway.internal"),
+        ("LOKI_URL", "LOKI_URL", "http://loki.railway.internal:3100"),
+        ("PROMETHEUS_URL", "PROMETHEUS_URL", "http://prometheus.railway.internal:9090"),
+        ("AGENT_OPT_WORKER_URL", "AGENT_OPT_WORKER_URL", "http://agent-opt-worker.railway.internal:8080"),
+        ("MEM0_API_URL", "MEM0_API_URL", "http://automatos-mem0-server.railway.internal"),
+        ("VOICE_SERVICE_URL", "VOICE_SERVICE_URL", "http://voice-service.railway.internal:8300"),
+    ],
+)
+def test_railway_host_still_settable_via_env(monkeypatch, attr, env_name, saas_value):
+    """SaaS supplies the real Railway host via env — only the default moved."""
+    cfg = _reload_config(monkeypatch, {env_name: saas_value})
+    assert getattr(cfg.config, attr) == saas_value
 
 
 # ---------------------------------------------------------------------------

--- a/orchestrator/tests/test_config_env_centralization.py
+++ b/orchestrator/tests/test_config_env_centralization.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import ast
 import importlib
+import os
 import sys
 from pathlib import Path
 
@@ -63,11 +64,30 @@ _SWEPT_ENV_VARS = (
 
 @pytest.fixture(autouse=True)
 def _restore_config_module():
-    """Contain the reload blast radius (PRD-142 W2-S/WS-F)."""
+    """Contain the reload blast radius (PRD-142 W2-S/WS-F).
+
+    ``_reload_config`` mutates the shared ``config`` module (``importlib.reload``
+    rebuilds its ``Config`` class + singleton). Downstream suites co-run after
+    this file — which sorts first — must not inherit a test's env-derived config
+    state (the leak that broke test_harness_commands / test_prd143_concierge).
+
+    Restore the exact pre-test ``config`` module object into ``sys.modules`` so
+    the class identity the rest of the session already bound (via
+    ``from config import config`` / ``type(config.config)``) is the one that
+    survives. Do NOT reload here: a reload would swap ``Config`` for a fresh
+    class object, desyncing downstream fixtures that patch ``type(config.config)``
+    class-level properties (e.g. CHATBOT_MAX_TOOL_ITERATIONS). Also snapshot and
+    restore ``os.environ`` so the swept vars / neutralized ``load_dotenv`` the
+    reload helper set cannot bleed past this file, independent of monkeypatch
+    teardown ordering.
+    """
+    env_snapshot = dict(os.environ)
     saved = sys.modules.get("config")
     try:
         yield
     finally:
+        os.environ.clear()
+        os.environ.update(env_snapshot)
         if saved is not None:
             sys.modules["config"] = saved
         else:

--- a/orchestrator/tests/test_deployability_w6.py
+++ b/orchestrator/tests/test_deployability_w6.py
@@ -1,0 +1,259 @@
+"""PRD-176 (Wave 6) — deployability & reliability baseline.
+
+Pure, dependency-light checks for the boot substrate that a fresh clone relies
+on. These do NOT require Docker: they assert the *shape* of the compose file and
+the entrypoint script (the two things that silently broke the fresh-clone boot),
+plus that the config S3 seam MinIO uses is present.
+
+- F009: the compose initdb mount points at a schema file that exists on disk.
+- F051: docker-entrypoint.sh runs wait -> migrate -> seed -> start, and a failed
+        migration aborts startup (does not fall through to `exec "$@"`).
+- F089: the S3_ENDPOINT_URL seam MinIO is wired through exists in config, and the
+        compose file defines a minio service + wires the backend to it.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+_ORCH_ROOT = Path(__file__).resolve().parent.parent
+_REPO_ROOT = _ORCH_ROOT.parent
+_COMPOSE = _REPO_ROOT / "docker-compose.yml"
+_ENTRYPOINT = _REPO_ROOT / "docker-entrypoint.sh"
+
+
+def _load_compose() -> dict:
+    with _COMPOSE.open("r", encoding="utf-8") as fh:
+        return yaml.safe_load(fh)
+
+
+# ---------------------------------------------------------------------------
+# F009 — the initdb mount source path exists on disk
+# ---------------------------------------------------------------------------
+
+
+def test_compose_file_exists():
+    assert _COMPOSE.is_file(), f"docker-compose.yml missing at {_COMPOSE}"
+
+
+def test_compose_is_valid_yaml():
+    compose = _load_compose()
+    assert "services" in compose
+    assert "postgres" in compose["services"]
+
+
+def _initdb_mount_source() -> str:
+    compose = _load_compose()
+    volumes = compose["services"]["postgres"].get("volumes", [])
+    for vol in volumes:
+        # bind mounts are "src:dst[:mode]" strings
+        if isinstance(vol, str) and "docker-entrypoint-initdb.d" in vol:
+            return vol.split(":", 1)[0]
+    raise AssertionError("postgres service has no initdb.d mount")
+
+
+def test_initdb_mount_source_exists_on_disk():
+    """F009: the exact regression — a compose mount pointing at a missing file."""
+    src = _initdb_mount_source()
+    # Source is repo-root-relative (leading ./).
+    resolved = (_REPO_ROOT / src.lstrip("./")).resolve()
+    assert resolved.is_file(), f"initdb mount source does not exist: {src} -> {resolved}"
+
+
+def test_initdb_mount_points_at_core_database_schema():
+    src = _initdb_mount_source()
+    assert src.endswith("orchestrator/core/database/init_complete_schema.sql"), (
+        f"initdb mount should point at the real schema file, got {src!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# F051 — the entrypoint migrates, in order, failing closed
+# ---------------------------------------------------------------------------
+
+
+def _entrypoint_text() -> str:
+    return _ENTRYPOINT.read_text(encoding="utf-8")
+
+
+def test_entrypoint_exists():
+    assert _ENTRYPOINT.is_file(), f"docker-entrypoint.sh missing at {_ENTRYPOINT}"
+
+
+def test_entrypoint_runs_alembic_upgrade():
+    """F051: the entrypoint must actually migrate (it never did before W6)."""
+    text = _entrypoint_text()
+    assert "alembic upgrade" in text, "entrypoint does not run alembic upgrade"
+
+
+def test_entrypoint_lifecycle_order_wait_migrate_seed_start():
+    """F051: order is wait -> migrate -> seed -> start (exec)."""
+    text = _entrypoint_text()
+    # Anchor on the main-execution call sites, not the function definitions.
+    wait_at = text.rindex("wait_for_postgres")
+    migrate_at = text.rindex("run_migrations")
+    seed_at = text.rindex("load_seed_data")
+    exec_at = text.rindex('exec "$@"')
+    assert wait_at < migrate_at < seed_at < exec_at, (
+        "entrypoint lifecycle must be wait -> migrate -> seed -> start; "
+        f"offsets wait={wait_at} migrate={migrate_at} seed={seed_at} exec={exec_at}"
+    )
+
+
+def test_entrypoint_migration_fails_closed():
+    """F051: a failed migration must abort startup, not continue on a half schema.
+
+    The seed step is deliberately lenient ("continue anyway"); the migrate step
+    must NOT be — it exits non-zero on failure so the app never starts against a
+    half-built schema.
+    """
+    text = _entrypoint_text()
+    # Isolate the run_migrations function body.
+    m = re.search(r"run_migrations\(\)\s*\{(.*?)\n\}", text, re.DOTALL)
+    assert m, "run_migrations() function not found"
+    body = m.group(1)
+    assert "exit 1" in body, "run_migrations must exit non-zero on failure (fail-closed)"
+    # And it must not swallow the failure with the seed step's leniency phrasing.
+    assert "continue anyway" not in body.lower(), (
+        "migrate step must fail closed, not 'continue anyway'"
+    )
+
+
+# ---------------------------------------------------------------------------
+# F089 — the S3_ENDPOINT_URL seam MinIO rides on, + the minio service
+# ---------------------------------------------------------------------------
+
+
+def test_config_exposes_s3_endpoint_url():
+    """F089: MinIO is wired via the S3_ENDPOINT_URL boto endpoint override."""
+    import config as cfg
+
+    assert hasattr(cfg.config, "S3_ENDPOINT_URL"), (
+        "config must expose S3_ENDPOINT_URL for the local object-store seam"
+    )
+
+
+def test_s3_endpoint_url_defaults_empty_and_reads_env(monkeypatch):
+    """Default unset (prod uses real S3); env override selects local MinIO."""
+    import importlib
+    import sys
+
+    monkeypatch.delenv("S3_ENDPOINT_URL", raising=False)
+    monkeypatch.setattr("dotenv.load_dotenv", lambda *a, **kw: False)
+    sys.modules.pop("config", None)
+    import config as cfg
+
+    importlib.reload(cfg)
+    assert cfg.config.S3_ENDPOINT_URL == ""
+
+    monkeypatch.setenv("S3_ENDPOINT_URL", "http://minio:9000")
+    sys.modules.pop("config", None)
+    import config as cfg2
+
+    importlib.reload(cfg2)
+    assert cfg2.config.S3_ENDPOINT_URL == "http://minio:9000"
+
+
+def test_compose_defines_minio_service():
+    compose = _load_compose()
+    assert "minio" in compose["services"], "compose must define a local minio service"
+    minio = compose["services"]["minio"]
+    assert "minio" in minio.get("image", ""), "minio service should use a minio image"
+
+
+def test_compose_backend_wired_to_minio_endpoint():
+    """Backend env carries S3_ENDPOINT_URL so the flywheel upload targets MinIO."""
+    compose = _load_compose()
+    backend_env = compose["services"]["backend"].get("environment", {})
+    # environment can be a dict or a list of "K=V" strings; normalize to keys.
+    if isinstance(backend_env, list):
+        keys = {item.split("=", 1)[0] for item in backend_env}
+    else:
+        keys = set(backend_env.keys())
+    assert "S3_ENDPOINT_URL" in keys, "backend must receive S3_ENDPOINT_URL for MinIO"
+
+
+def test_compose_defines_minio_bucket_init():
+    """A one-shot service creates the documents bucket the flywheel writes to."""
+    compose = _load_compose()
+    assert "minio-init" in compose["services"], (
+        "compose must create the flywheel's bucket on first boot (minio-init)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# F089 — DocumentManager threads S3_ENDPOINT_URL into its boto client
+# ---------------------------------------------------------------------------
+# The flywheel's upload path (get_document_manager -> DocumentManager) is what
+# fail-softs to None with no object store. This proves the endpoint override the
+# whole MinIO wiring depends on actually reaches boto3.client — without a live
+# server (we spy on boto3.client and stub the heavy post-client collaborators).
+
+
+def _make_document_manager_capturing_boto(monkeypatch, endpoint_url: str):
+    import importlib
+    import sys
+
+    import boto3
+
+    monkeypatch.setattr("dotenv.load_dotenv", lambda *a, **kw: False)
+    monkeypatch.setenv("S3_ENDPOINT_URL", endpoint_url) if endpoint_url else monkeypatch.delenv(
+        "S3_ENDPOINT_URL", raising=False
+    )
+    sys.modules.pop("config", None)
+    import config  # noqa: F401
+
+    importlib.reload(config)
+
+    from modules.rag.ingestion import manager as mgr_mod
+
+    captured = {}
+
+    def _spy_client(service, **kwargs):
+        captured["service"] = service
+        captured["kwargs"] = kwargs
+
+        class _FakeS3:
+            def head_bucket(self, **_):
+                return {}
+
+            def create_bucket(self, **_):
+                return {}
+
+        return _FakeS3()
+
+    # Spy on the boto client; neutralize the heavy collaborators __init__ calls.
+    monkeypatch.setattr(mgr_mod.boto3, "client", _spy_client)
+    monkeypatch.setattr(
+        mgr_mod.DocumentManager, "_ensure_s3_bucket_exists", lambda self: None
+    )
+    monkeypatch.setattr(
+        "core.llm.create_embedding_manager",
+        lambda *a, **kw: _StubEmbeddings(),
+    )
+
+    mgr_mod.DocumentManager(db_config={}, workspace_id="ws-test")
+    return captured
+
+
+class _StubEmbeddings:
+    def get_provider_info(self):
+        return {"provider": "stub"}
+
+
+def test_document_manager_uses_minio_endpoint_when_set(monkeypatch):
+    """With S3_ENDPOINT_URL set, boto3.client receives it (upload -> MinIO)."""
+    captured = _make_document_manager_capturing_boto(monkeypatch, "http://minio:9000")
+    assert captured["service"] == "s3"
+    assert captured["kwargs"].get("endpoint_url") == "http://minio:9000"
+
+
+def test_document_manager_no_endpoint_when_unset(monkeypatch):
+    """With S3_ENDPOINT_URL unset, endpoint_url is None (prod real AWS S3)."""
+    captured = _make_document_manager_capturing_boto(monkeypatch, "")
+    assert captured["service"] == "s3"
+    assert captured["kwargs"].get("endpoint_url") is None

--- a/orchestrator/tests/test_deployability_w6.py
+++ b/orchestrator/tests/test_deployability_w6.py
@@ -14,7 +14,10 @@ plus that the config S3 seam MinIO uses is present.
 
 from __future__ import annotations
 
+import importlib
+import os
 import re
+import sys
 from pathlib import Path
 
 import pytest
@@ -24,6 +27,29 @@ _ORCH_ROOT = Path(__file__).resolve().parent.parent
 _REPO_ROOT = _ORCH_ROOT.parent
 _COMPOSE = _REPO_ROOT / "docker-compose.yml"
 _ENTRYPOINT = _REPO_ROOT / "docker-entrypoint.sh"
+
+
+@pytest.fixture(autouse=True)
+def _restore_config_module():
+    """Contain the config-reload blast radius (mirrors test_config_env_centralization).
+
+    The F089 tests below ``importlib.reload(config)`` with S3_ENDPOINT_URL set /
+    unset. Without a restore, the mutated config singleton + swept env bleed into
+    downstream suites co-run after this file (test_harness_commands,
+    test_prd143_concierge_journey). Snapshot os.environ and the config module
+    reference at setup; restore both at teardown so nothing leaks past this file.
+    """
+    env_snapshot = dict(os.environ)
+    saved = sys.modules.get("config")
+    try:
+        yield
+    finally:
+        os.environ.clear()
+        os.environ.update(env_snapshot)
+        if saved is not None:
+            sys.modules["config"] = saved
+        else:
+            sys.modules.pop("config", None)
 
 
 def _load_compose() -> dict:

--- a/orchestrator/tests/test_dr_restore.py
+++ b/orchestrator/tests/test_dr_restore.py
@@ -1,0 +1,193 @@
+"""PRD-176 F050 — the DR backup/restore path is tested (row-parity).
+
+"A backup that has never been restored is not a backup." This test proves the
+scripts/dr tooling round-trips real data:
+
+    populate a source DB  ->  pg_dump -Fc  ->  pg_restore into a FRESH DB  ->
+    assert row-parity on the restored tables.
+
+It uses the same `pg_dump -Fc` / `pg_restore` invocations the DR scripts use, so
+it guards the actual recovery mechanism (not a stand-in). It builds its own
+isolated schema (a `dr_smoke_*` table with pgvector column) so it does not
+depend on the full application schema, and it creates + drops a dedicated
+restore-target database.
+
+Skips cleanly when no Postgres is reachable or when the pg client tools are
+absent (local dev without a DB); CI provides DATABASE_URL + the tools.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from urllib.parse import urlparse, urlunparse
+
+import pytest
+
+psycopg2 = pytest.importorskip("psycopg2")
+
+
+# ---------------------------------------------------------------------------
+# Environment gating
+# ---------------------------------------------------------------------------
+
+_DATABASE_URL = os.environ.get("DATABASE_URL")
+
+_TOOLS_PRESENT = all(shutil.which(t) for t in ("pg_dump", "pg_restore", "psql"))
+
+
+def _db_reachable(url: str) -> bool:
+    try:
+        conn = psycopg2.connect(url, connect_timeout=3)
+        conn.close()
+        return True
+    except Exception:
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not (_DATABASE_URL and _TOOLS_PRESENT and _db_reachable(_DATABASE_URL or "")),
+    reason="DR restore test needs a reachable Postgres (DATABASE_URL) and pg client tools",
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_SOURCE_TABLE = "dr_smoke_source"
+_RESTORE_DB = "dr_smoke_restore_db"
+_ROWS = [(i, f"row-{i}") for i in range(1, 26)]  # 25 known rows
+
+
+def _url_with_db(url: str, dbname: str) -> str:
+    parsed = urlparse(url)
+    new_path = "/" + dbname
+    return urlunparse(parsed._replace(path=new_path))
+
+
+def _run(cmd: list[str], env: dict | None = None) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        env={**os.environ, **(env or {})},
+        check=False,
+    )
+
+
+def _exec(url: str, sql: str, autocommit: bool = False):
+    conn = psycopg2.connect(url)
+    try:
+        conn.autocommit = autocommit
+        with conn.cursor() as cur:
+            cur.execute(sql)
+        if not autocommit:
+            conn.commit()
+    finally:
+        conn.close()
+
+
+def _scalar(url: str, sql: str):
+    conn = psycopg2.connect(url)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(sql)
+            return cur.fetchone()[0]
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# The round-trip
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def dr_environment():
+    """Create an isolated source table + a fresh restore-target DB; tear both down."""
+    src_url = _DATABASE_URL
+    # Base (maintenance) URL for CREATE/DROP DATABASE — connect to the same
+    # server, default 'postgres' maintenance DB.
+    admin_url = _url_with_db(src_url, "postgres")
+
+    # Seed the source table.
+    _exec(src_url, f"DROP TABLE IF EXISTS {_SOURCE_TABLE};")
+    _exec(
+        src_url,
+        f"CREATE TABLE {_SOURCE_TABLE} (id INTEGER PRIMARY KEY, label TEXT NOT NULL);",
+    )
+    values = ", ".join(f"({i}, '{label}')" for i, label in _ROWS)
+    _exec(src_url, f"INSERT INTO {_SOURCE_TABLE} (id, label) VALUES {values};")
+
+    # Fresh restore-target DB.
+    _exec(admin_url, f"DROP DATABASE IF EXISTS {_RESTORE_DB};", autocommit=True)
+    _exec(admin_url, f"CREATE DATABASE {_RESTORE_DB};", autocommit=True)
+    restore_url = _url_with_db(src_url, _RESTORE_DB)
+
+    try:
+        yield src_url, restore_url
+    finally:
+        _exec(src_url, f"DROP TABLE IF EXISTS {_SOURCE_TABLE};")
+        _exec(admin_url, f"DROP DATABASE IF EXISTS {_RESTORE_DB};", autocommit=True)
+
+
+def test_pg_dump_restore_row_parity(dr_environment):
+    """pg_dump -Fc a populated DB, pg_restore into a fresh DB, assert row-parity."""
+    src_url, restore_url = dr_environment
+
+    with tempfile.TemporaryDirectory() as tmp:
+        dump_path = Path(tmp) / "primary.dump"
+
+        # 1. Dump — same invocation shape as scripts/dr/backup.sh.
+        dump = _run(
+            [
+                "pg_dump",
+                "--format=custom",
+                "--no-owner",
+                "--no-privileges",
+                f"--file={dump_path}",
+                src_url,
+            ]
+        )
+        assert dump.returncode == 0, f"pg_dump failed: {dump.stderr}"
+        assert dump_path.exists() and dump_path.stat().st_size > 0, "dump is empty"
+
+        # 2. Ensure pgvector in target (mirrors restore.sh), then restore.
+        restore_pgvector = _run(
+            ["psql", restore_url, "-v", "ON_ERROR_STOP=1",
+             "-c", "CREATE EXTENSION IF NOT EXISTS vector;"]
+        )
+        # pgvector may be absent on a stock image; the smoke table doesn't need
+        # it, so tolerate failure here (the real schema's restore.sh runs on a
+        # pgvector image where this succeeds).
+        _ = restore_pgvector
+
+        restore = _run(
+            [
+                "pg_restore",
+                "--no-owner",
+                "--no-privileges",
+                "--exit-on-error",
+                f"--dbname={restore_url}",
+                str(dump_path),
+            ]
+        )
+        assert restore.returncode == 0, f"pg_restore failed: {restore.stderr}"
+
+        # 3. Row-parity: same count, and same content.
+        src_count = _scalar(src_url, f"SELECT COUNT(*) FROM {_SOURCE_TABLE};")
+        dst_count = _scalar(restore_url, f"SELECT COUNT(*) FROM {_SOURCE_TABLE};")
+        assert dst_count == src_count == len(_ROWS), (
+            f"row count mismatch: source={src_count} restored={dst_count} expected={len(_ROWS)}"
+        )
+
+        dst_checksum = _scalar(
+            restore_url,
+            f"SELECT string_agg(id || ':' || label, ',' ORDER BY id) FROM {_SOURCE_TABLE};",
+        )
+        expected = ",".join(f"{i}:{label}" for i, label in _ROWS)
+        assert dst_checksum == expected, "restored content does not match source"

--- a/scripts/ci/smoke-fresh-clone.sh
+++ b/scripts/ci/smoke-fresh-clone.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# PRD-176 Headline B — fresh-clone deployability smoke test.
+#
+# The open-core thesis bar: `git clone && docker compose up` yields a working
+# local instance with NO external credentials. This script proves it end to end:
+# it provides ONLY the required local secrets (POSTGRES_PASSWORD, REDIS_PASSWORD,
+# API_KEY) and NO external SaaS credentials (no Clerk, no real S3/AWS, no LLM
+# keys), brings the compose stack up, and asserts the backend `/health` returns
+# HTTP 200.
+#
+# It exercises together: the repointed initdb mount (F009), the wait-migrate-seed
+# entrypoint (F051), local MinIO via S3_ENDPOINT_URL (F089), and the local-safe
+# railway.internal defaults (F068).
+#
+# DEPENDS ON WAVE 5 (auth decoupling). Until W5's boot-before-auth lands on main,
+# compose hard-requires Clerk keys (docker-compose.yml Clerk env) and a
+# no-credential boot cannot reach a green /health. This script sets
+# AUTH_EDITION=local (the W5 flag) so it is correct the moment W5 merges; run it
+# in CI as NON-REQUIRED / allowed-to-fail until then (see the workflow).
+#
+# Exit 0 = /health returned 200 with no external creds. Exit 1 = boot failed.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+COMPOSE_FILE="docker-compose.yml"
+HEALTH_URL="http://localhost:${API_PORT:-8000}/health"
+MAX_WAIT_SECONDS="${SMOKE_MAX_WAIT_SECONDS:-300}"
+POLL_INTERVAL_SECONDS=5
+
+# ---------------------------------------------------------------------------
+# Local-only secrets. These are throwaway values for an ephemeral local stack —
+# NOT real credentials, and never reused. No external SaaS credential is set:
+# CLERK_*, AWS_*, OPENAI_API_KEY, ANTHROPIC_API_KEY are all intentionally absent.
+# ---------------------------------------------------------------------------
+export POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-smoke_pg_pw}"
+export REDIS_PASSWORD="${REDIS_PASSWORD:-smoke_redis_pw}"
+export API_KEY="${API_KEY:-smoke_api_key}"
+# W5 flag: run the local no-login edition (auth-optional). Harmless before W5.
+export AUTH_EDITION="${AUTH_EDITION:-local}"
+export REQUIRE_AUTH="${REQUIRE_AUTH:-false}"
+
+echo "========================================="
+echo "PRD-176 fresh-clone smoke test"
+echo "  health url : ${HEALTH_URL}"
+echo "  max wait   : ${MAX_WAIT_SECONDS}s"
+echo "  auth       : AUTH_EDITION=${AUTH_EDITION} REQUIRE_AUTH=${REQUIRE_AUTH}"
+echo "  external creds: NONE (no Clerk / AWS / LLM keys)"
+echo "========================================="
+
+# Bring the stack up on just the core boot services (backend gates the frontend).
+echo "Starting compose stack (postgres, redis, minio, backend)..."
+if ! docker compose -f "$COMPOSE_FILE" up -d --build postgres redis minio backend; then
+  echo "FAIL: docker compose up failed" >&2
+  docker compose -f "$COMPOSE_FILE" logs --tail 100 || true
+  docker compose -f "$COMPOSE_FILE" down -v || true
+  exit 1
+fi
+
+# Poll /health until 200 or timeout.
+echo "Waiting for backend /health to return 200..."
+elapsed=0
+status=""
+while [ "$elapsed" -lt "$MAX_WAIT_SECONDS" ]; do
+  status="$(curl -s -o /dev/null -w '%{http_code}' "$HEALTH_URL" 2>/dev/null || echo '000')"
+  if [ "$status" = "200" ]; then
+    echo "OK: /health returned 200 after ${elapsed}s (no external credentials)"
+    docker compose -f "$COMPOSE_FILE" down -v || true
+    exit 0
+  fi
+  echo "  ...${elapsed}s: /health -> ${status}"
+  sleep "$POLL_INTERVAL_SECONDS"
+  elapsed=$((elapsed + POLL_INTERVAL_SECONDS))
+done
+
+echo "FAIL: /health did not return 200 within ${MAX_WAIT_SECONDS}s (last: ${status})" >&2
+echo "----- backend logs (tail) -----" >&2
+docker compose -f "$COMPOSE_FILE" logs --tail 150 backend >&2 || true
+docker compose -f "$COMPOSE_FILE" down -v || true
+exit 1

--- a/scripts/dr/backup.sh
+++ b/scripts/dr/backup.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# PRD-176 F050 — pg_dump backup for the Automatos primary database (and,
+# optionally, the separate mem0 database).
+#
+# Produces a custom-format dump (`pg_dump -Fc`) — compressed, and restorable
+# selectively with `pg_restore`. Custom format is required so the matching
+# restore.sh can rebuild into a fresh volume.
+#
+# Connection comes from the canonical DATABASE_URL (same source the app uses).
+# No credentials are hardcoded (CLAUDE.md §4 / security §Secret Management):
+# pass them via DATABASE_URL in the environment. The optional mem0 target is
+# MEM0_DATABASE_URL — losing mem0 loses durable memory, so it is a first-class
+# backup target, not an afterthought.
+#
+# Usage:
+#   DATABASE_URL=postgresql://user:pw@host:5432/orchestrator_db \
+#     scripts/dr/backup.sh [OUTPUT_DIR]
+#
+#   # include the mem0 instance:
+#   DATABASE_URL=... MEM0_DATABASE_URL=postgresql://.../mem0 \
+#     scripts/dr/backup.sh /backups
+#
+# Exit 0 = all requested dumps written. Non-zero = a dump failed.
+set -euo pipefail
+
+OUTPUT_DIR="${1:-${DR_BACKUP_DIR:-./backups}}"
+TIMESTAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+
+if [ -z "${DATABASE_URL:-}" ]; then
+  echo "FAIL: DATABASE_URL is not set (the primary DB connection string)." >&2
+  exit 1
+fi
+
+mkdir -p "$OUTPUT_DIR"
+
+_dump() {
+  local url="$1"
+  local label="$2"
+  local out="${OUTPUT_DIR}/${label}-${TIMESTAMP}.dump"
+  echo "Dumping ${label} -> ${out}"
+  # -Fc custom format, --no-owner/--no-privileges so the dump restores cleanly
+  # into a fresh instance with a possibly-different role.
+  pg_dump --format=custom --no-owner --no-privileges --file="$out" "$url"
+  local bytes
+  bytes="$(wc -c < "$out" | tr -d ' ')"
+  if [ "$bytes" -le 0 ]; then
+    echo "FAIL: ${label} dump is empty (${out})." >&2
+    return 1
+  fi
+  echo "OK: ${label} dump written (${bytes} bytes)"
+  echo "$out"
+}
+
+echo "========================================="
+echo "PRD-176 DR backup  (${TIMESTAMP})"
+echo "  output dir: ${OUTPUT_DIR}"
+echo "========================================="
+
+_dump "$DATABASE_URL" "primary"
+
+if [ -n "${MEM0_DATABASE_URL:-}" ]; then
+  _dump "$MEM0_DATABASE_URL" "mem0"
+else
+  echo "NOTE: MEM0_DATABASE_URL unset — skipping mem0 backup."
+  echo "      Set it to back up the separate mem0 instance (durable memory)."
+fi
+
+echo "Backup complete."

--- a/scripts/dr/restore.sh
+++ b/scripts/dr/restore.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# PRD-176 F050 — pg_restore restore for an Automatos custom-format dump.
+#
+# Restores a `pg_dump -Fc` dump (from backup.sh) into a TARGET database. The
+# target should be a fresh/empty database — this is the disaster-recovery path,
+# not an in-place merge.
+#
+# Handles the two things a naive restore misses (PRD-176 §4.6):
+#   1. pgvector — the schema declares `vector` columns, so the extension must
+#      exist in the target BEFORE the restore runs. We create it first.
+#   2. raw-DDL tables (e.g. document_chunks) — these ARE captured in a -Fc dump,
+#      so pg_restore rebuilds them; the risk is only the extension above.
+#
+# Connection comes from RESTORE_DATABASE_URL (the target). No hardcoded creds.
+#
+# Usage:
+#   RESTORE_DATABASE_URL=postgresql://user:pw@host:5432/restore_db \
+#     scripts/dr/restore.sh path/to/primary-YYYYMMDDT...Z.dump
+#
+# Exit 0 = restore completed. Non-zero = restore failed.
+set -euo pipefail
+
+DUMP_FILE="${1:-}"
+
+if [ -z "$DUMP_FILE" ]; then
+  echo "FAIL: no dump file given. Usage: restore.sh <dump-file>" >&2
+  exit 1
+fi
+if [ ! -f "$DUMP_FILE" ]; then
+  echo "FAIL: dump file not found: ${DUMP_FILE}" >&2
+  exit 1
+fi
+if [ -z "${RESTORE_DATABASE_URL:-}" ]; then
+  echo "FAIL: RESTORE_DATABASE_URL is not set (the target DB connection string)." >&2
+  exit 1
+fi
+
+echo "========================================="
+echo "PRD-176 DR restore"
+echo "  dump  : ${DUMP_FILE}"
+echo "  target: (RESTORE_DATABASE_URL)"
+echo "========================================="
+
+# 1. Ensure pgvector exists in the target before restoring vector columns.
+#    Best-effort: on a pgvector image this succeeds; on a stock Postgres the
+#    extension control file is absent. Don't hard-abort the whole restore here —
+#    warn, and let pg_restore surface any genuine vector-column failure at the
+#    point it actually matters. (The target for a real recovery is a pgvector
+#    image; the runbook says so.)
+echo "Ensuring pgvector extension exists in target..."
+if ! psql "$RESTORE_DATABASE_URL" -c "CREATE EXTENSION IF NOT EXISTS vector;" 2>/dev/null; then
+  echo "WARN: could not create the 'vector' extension (not a pgvector image?)." >&2
+  echo "      Restore will continue; vector columns require a pgvector target." >&2
+fi
+
+# 2. Restore. --no-owner/--no-privileges to tolerate a different target role;
+#    --exit-on-error so a genuine restore failure is loud (a silent partial
+#    restore is worse than a failed one).
+echo "Restoring dump with pg_restore..."
+pg_restore \
+  --no-owner \
+  --no-privileges \
+  --exit-on-error \
+  --dbname="$RESTORE_DATABASE_URL" \
+  "$DUMP_FILE"
+
+echo "OK: restore completed."


### PR DESCRIPTION
## Wave 6 — Deployability & Reliability Baseline (PRD-176)

Makes the open-core thesis (`git clone && docker compose up` → working local instance, no external creds) real, and gives the primary DB its first disaster-recovery story. Findings pinned/re-confirmed on `main`; the four alembic heads named in the PRD were confirmed present before authoring the merge.

### Findings implemented

| ID | Fix |
|---|---|
| **F009** | Repointed the postgres initdb mount `docker-compose.yml` → the real `orchestrator/core/database/init_complete_schema.sql` (was a non-existent path → empty DB → frontend never started). |
| **F010 (Step 1)** | **One merge revision** `prd176_merge_heads` collapsing the four heads (`20260612_nl2sql_example_embedding`, `prd158_cloud_default_team`, `prd161_sla_breach`, `prd164_doc_source_type`) → **one head**. Pure merge point, no schema ops. **Step 2 (single-baseline squash) is explicitly LATER this wave** per review §7 — not a descope. |
| **F051** | Inserted a **fail-closed `run_migrations()`** (`alembic upgrade heads`) into `docker-entrypoint.sh` between check and seed → single **wait → migrate → seed → start** lifecycle. A failed migration aborts startup. |
| **F089** | Local **MinIO** service (+ one-shot bucket init, `minio_data` volume) wired via **`S3_ENDPOINT_URL`** through the existing S3 seam; threaded `endpoint_url` (+ path-style addressing) into the `DocumentManager` boto client so the flywheel persists outputs instead of fail-softing to `None`. Prod unchanged (endpoint unset → real AWS S3). |
| **F068** | The nine `railway.internal` defaults → **localhost** (SaaS still sets real hosts via env); **`LOG_RELAY_ENABLED` defaults false**. `tool_registry.py:1101-1102` left as-is (illustrative `ssh_execute` example payloads, not live defaults). |
| **F050** | `scripts/dr/backup.sh` (`pg_dump -Fc`, primary + optional mem0) + `scripts/dr/restore.sh` (`pg_restore` into fresh DB, best-effort pgvector), `docs/runbooks/DR-postgres.md` with **RPO ≤ 24h / RTO ≤ 30min**, and a **row-parity restore test**. |

### Alembic head count: **4 → 1**
Merge revision id: **`prd176_merge_heads`**. Verified `alembic heads` → single revision; `alembic history` shows it as a mergepoint joining all four lineages (the repo already uses this pattern, e.g. `prd158_teams`).

### Test-first / CI

- **`orchestrator/tests/test_config_env_centralization.py`** (F068) — flipped the old railway-default assertions, added a `no-railway.internal-in-any-default` guard + per-attr localhost + SaaS-override tests + `S3_ENDPOINT_URL`. **72 pass.** Written failing-first (13 red), then green.
- **`orchestrator/tests/test_deployability_w6.py`** (new) — F009 initdb path resolves + points at core schema; F051 entrypoint order + fail-closed; F089 config seam + minio/minio-init services + backend wired + DocumentManager threads `endpoint_url`. **17 pass.**
- **`orchestrator/tests/test_dr_restore.py`** (new) — F050 dump→restore→row-parity. Skips without a live PG; **verified green against a throwaway Postgres locally** (both the test and the two DR shell scripts end-to-end).
- **CI job `alembic-from-zero`** (`test.yml`, non-required) — asserts exactly one head (green now); attempts from-zero replay against empty **pgvector** (`continue-on-error` until Step-2 baseline, then flip to required).
- **CI `smoke-fresh-clone`** (new workflow + `scripts/ci/smoke-fresh-clone.sh`) — clone clean, only local secrets, no SaaS creds, `docker compose up`, assert `/health` 200. **Blocked on W5** (sets `AUTH_EDITION=local`, `continue-on-error` until W5 lands).

### Decisions taken
- **DR depth:** implemented the **nightly-`pg_dump` baseline** (RPO ≤ 24h). **WAL/PITR surfaced as an explicit open question for Gerard** in the runbook §5 + PRD §6 — not silently deferred; built this wave if that's the call.
- **F010 sequencing:** Step 1 (merge) now, Step 2 (squash + from-zero baseline) later this wave, per the review's mandated order — recorded as sequencing, not a deferral.

### Dependency note (W5)
The end-to-end fresh-clone boot (Headline B) depends on **W5 (auth decoupling / boot-before-auth)** landing on `main` — compose still hard-requires Clerk today. The smoke script + workflow are written and gated (`AUTH_EDITION=local`, non-blocking); **the fresh-clone boot is verified once W5 is on main.**

### Validation
No local Docker — changed `.py` compiled (`py_compile`), compose + both workflows validated as well-formed YAML, entrypoint + DR + smoke scripts `bash -n` clean. CI is the full gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
