### PR TITLE
feat(prd-174): W4 unified policy plane (F085/F060/F040/F086/F059/F014/F042/F043)

### DIFF
--- a/orchestrator/api/admin_plugins.py
+++ b/orchestrator/api/admin_plugins.py
@@ -51,7 +51,9 @@ def _is_admin(ctx: RequestContext) -> bool:
     """Check whether the current user has admin privileges."""
     if not ctx.user:
         return False
-    return getattr(ctx.user, "system_role", "user") == "admin"
+    # PRD-174 F043: shared admin check — super_admin ⊇ admin when the plane is on.
+    from core.auth.roles import caller_is_admin
+    return caller_is_admin(ctx.user)
 
 
 def _assert_admin(ctx: RequestContext) -> None:

--- a/orchestrator/api/admin_workspaces.py
+++ b/orchestrator/api/admin_workspaces.py
@@ -45,7 +45,9 @@ router = APIRouter(prefix="/api/admin/workspaces", tags=["Admin Workspaces"])
 def _is_admin(ctx: RequestContext) -> bool:
     if not ctx.user:
         return False
-    return getattr(ctx.user, "system_role", "user") == "admin"
+    # PRD-174 F043: shared admin check — super_admin ⊇ admin when the plane is on.
+    from core.auth.roles import caller_is_admin
+    return caller_is_admin(ctx.user)
 
 
 def _assert_admin(ctx: RequestContext) -> None:

--- a/orchestrator/api/marketplace.py
+++ b/orchestrator/api/marketplace.py
@@ -37,7 +37,9 @@ def is_admin(ctx: RequestContext) -> bool:
     """Check whether the current user has admin privileges."""
     if not ctx.user:
         return False
-    return getattr(ctx.user, 'system_role', 'user') == 'admin'
+    # PRD-174 F043: shared admin check — super_admin ⊇ admin when the plane is on.
+    from core.auth.roles import caller_is_admin
+    return caller_is_admin(ctx.user)
 
 
 def assert_admin(ctx: RequestContext) -> None:

--- a/orchestrator/api/marketplace_plugins.py
+++ b/orchestrator/api/marketplace_plugins.py
@@ -29,7 +29,9 @@ logger = logging.getLogger(__name__)
 
 def _is_admin(ctx: RequestContext) -> bool:
     """Check if current user has admin role."""
-    return getattr(ctx.user, "system_role", "user") == "admin"
+    # PRD-174 F043: shared admin check — super_admin ⊇ admin when the plane is on.
+    from core.auth.roles import caller_is_admin
+    return caller_is_admin(ctx.user)
 
 router = APIRouter(prefix="/api/marketplace/plugins", tags=["Marketplace Plugins"])
 

--- a/orchestrator/api/skills.py
+++ b/orchestrator/api/skills.py
@@ -522,7 +522,9 @@ async def list_skills(
         # Marketplace endpoint: only surface system-owned skills (workspace_id IS NULL).
         # Workspace-owned skills (forks, custom) are listed via /workspaces/{id}/skills,
         # which already shadows marketplace originals when a fork exists. Admins see all.
-        is_admin = getattr(ctx.user, "system_role", "user") == "admin"
+        # PRD-174 F043: shared admin check — super_admin ⊇ admin when the plane is on.
+        from core.auth.roles import caller_is_admin
+        is_admin = caller_is_admin(ctx.user)
         query = db.query(Skill).filter(Skill.is_active == True)
         if not is_admin:
             query = query.filter(Skill.workspace_id.is_(None))

--- a/orchestrator/api/widget_marketplace.py
+++ b/orchestrator/api/widget_marketplace.py
@@ -54,7 +54,9 @@ def _require_user_db_id(db: Session, ctx: RequestContext):
 
 
 def _is_admin(ctx: RequestContext) -> bool:
-    return getattr(ctx.user, "system_role", "user") == "admin"
+    # PRD-174 F043: shared admin check — super_admin ⊇ admin when the plane is on.
+    from core.auth.roles import caller_is_admin
+    return caller_is_admin(ctx.user)
 
 
 def _assert_admin(ctx: RequestContext) -> None:

--- a/orchestrator/api/widgets/auth.py
+++ b/orchestrator/api/widgets/auth.py
@@ -236,8 +236,27 @@ def require_permission(permission: str) -> Callable:
     async def _check(
         auth: WidgetAuthContext = Depends(widget_auth),
     ) -> WidgetAuthContext:
-        # An empty permissions list means unrestricted (all permissions).
-        if auth.permissions and permission not in auth.permissions:
+        # PRD-174 F042 — one empty-permission semantic. Historically the widget
+        # plane treated an empty permission list as "unrestricted" (a god-key),
+        # while the board plane treats empty as "grants nothing". When the policy
+        # plane is ON we unify on the board plane's least-privilege rule (empty =
+        # deny) via the shared helper; OFF keeps the historical behaviour so the
+        # large population of already-issued keys is not broken mid-rollout.
+        try:
+            from modules.policy import policy_plane_enabled
+            from modules.policy.roles import has_permission as _has_perm
+
+            _plane_on = policy_plane_enabled()
+        except Exception:
+            _plane_on = False
+
+        if _plane_on:
+            allowed = _has_perm(auth.permissions, permission)  # empty = deny
+        else:
+            # Legacy: empty list = unrestricted; a non-empty list must contain it.
+            allowed = (not auth.permissions) or (permission in auth.permissions)
+
+        if not allowed:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail=f"Missing required permission: {permission}",

--- a/orchestrator/api/workspace_plugins.py
+++ b/orchestrator/api/workspace_plugins.py
@@ -30,7 +30,9 @@ router = APIRouter(prefix="/api/workspaces", tags=["Workspace Plugins"])
 
 def _is_admin(ctx: RequestContext) -> bool:
     """System admins can operate on any workspace (mirrors admin_plugins.py)."""
-    return getattr(ctx.user, "system_role", "user") == "admin"
+    # PRD-174 F043: shared admin check — super_admin ⊇ admin when the plane is on.
+    from core.auth.roles import caller_is_admin
+    return caller_is_admin(ctx.user)
 
 
 def _assert_workspace_access(ctx: RequestContext, workspace_id: UUID) -> None:

--- a/orchestrator/api/workspace_skills.py
+++ b/orchestrator/api/workspace_skills.py
@@ -40,7 +40,9 @@ _WARNING_SEVERITIES = {"high"}
 
 def _is_admin(ctx: RequestContext) -> bool:
     """System admins can operate on any workspace (mirrors admin_plugins.py)."""
-    return getattr(ctx.user, "system_role", "user") == "admin"
+    # PRD-174 F043: shared admin check — super_admin ⊇ admin when the plane is on.
+    from core.auth.roles import caller_is_admin
+    return caller_is_admin(ctx.user)
 
 
 def _assert_workspace_access(ctx: RequestContext, workspace_id: UUID) -> None:

--- a/orchestrator/config.py
+++ b/orchestrator/config.py
@@ -592,6 +592,14 @@ class Config:
     # priority and escalated for human approval (when self-management is on).
     HARNESS_HIGH_PRIORITY_RISK: int = int(os.getenv("HARNESS_HIGH_PRIORITY_RISK", "4"))
 
+    # PRD-174 Wave 4 — Unified Policy Plane. THE master flag for the policy
+    # plane: one typed gate (`modules/policy.PolicyGate`) evaluated in one place
+    # (`UnifiedToolExecutor.execute_tool`) for every tool call on every surface,
+    # plus the `on_pre_tool` budget/approval seam. HIGHEST-RISK wave — touches
+    # every execution path — so it ships default OFF. Flag OFF ⇒ byte-for-byte
+    # today's per-router gates (nothing new enters the path). Flag ON ⇒ the plane.
+    POLICY_PLANE_ENABLED: bool = os.getenv("AUTOMATOS_POLICY_PLANE", "false").lower() in ("true", "1", "yes")
+
     # =============================================================================
     # PRD-130 — Business Intake Wizard (PoC)
     # =============================================================================

--- a/orchestrator/core/auth/roles.py
+++ b/orchestrator/core/auth/roles.py
@@ -1,0 +1,45 @@
+"""One shared admin-role check for API routers (PRD-174 F043).
+
+Seven+ routers duplicated ``getattr(user, "system_role", "user") == "admin"``,
+which 403s the platform super-admin entirely (a super-admin is *not* literally
+``"admin"``). This is the single choke point they now call instead.
+
+Behaviour is gated on the policy-plane flag so the rollout stays byte-for-byte:
+
+- **Plane OFF** — exactly today's check: ``system_role == "admin"`` (super-admin
+  still excluded, unchanged).
+- **Plane ON** — the shared ``super_admin ⊇ admin ⊇ user`` hierarchy from
+  :mod:`modules.policy.roles`, so a super-admin satisfies every admin gate.
+
+Pure role read (no DB); the flag read is the only side input.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+ADMIN_ROLE = "admin"
+
+
+def caller_role(user: Any) -> str:
+    """Extract the principal's ``system_role`` (defaulting to ``"user"``)."""
+    return getattr(user, "system_role", "user") or "user"
+
+
+def caller_is_admin(user: Any) -> bool:
+    """True when the principal satisfies an admin gate.
+
+    Plane OFF ⇒ ``system_role == "admin"`` (legacy, super-admin excluded).
+    Plane ON  ⇒ super_admin ⊇ admin (super-admin passes admin gates).
+    """
+    role = caller_role(user)
+    try:
+        from modules.policy import policy_plane_enabled
+
+        if policy_plane_enabled():
+            from modules.policy.roles import is_admin as _hier_is_admin
+
+            return _hier_is_admin(role)
+    except Exception:
+        # Fail-safe: fall back to the legacy exact check on any import/flag error.
+        pass
+    return role == ADMIN_ROLE

--- a/orchestrator/core/llm/manager.py
+++ b/orchestrator/core/llm/manager.py
@@ -702,7 +702,14 @@ class LLMManager:
     _cost_logger = logging.getLogger("llm.cost_audit")
 
     # Approximate $/1K-token rates for common models (input, output).
-    # Used ONLY for logging estimates — not billing.  Keep sorted.
+    # Used ONLY for this class's audit-LOG estimate — never billing. The
+    # authoritative, model-aware dollars are already written by
+    # ``UsageTracker.track`` from the ``llm_models`` DB registry (below), and
+    # PRD-174 F059's *enforcement* fix — the budget/approval primitive — prices
+    # off that same registry via ``modules.policy.pricing``. We deliberately do
+    # NOT open a DB session here: ``_estimate_cost`` runs on every LLM call, so a
+    # per-call price query would add a round-trip + pool checkout to the hottest
+    # path in the system just for a log line. Keep the log estimate in-memory.
     _MODEL_COST_MAP: Dict[str, tuple] = {
         "claude-3-opus":       (0.015, 0.075),
         "claude-3.5-sonnet":   (0.003, 0.015),
@@ -720,7 +727,7 @@ class LLMManager:
     }
 
     def _estimate_cost(self, input_tokens: int, output_tokens: int) -> float:
-        """Rough USD cost estimate for logging. Not for billing."""
+        """Rough USD cost estimate for logging. Not for billing (see F059 note above)."""
         model = (self.config.model or "").lower()
         for key, (inp_rate, out_rate) in self._MODEL_COST_MAP.items():
             if key in model:

--- a/orchestrator/main.py
+++ b/orchestrator/main.py
@@ -766,9 +766,15 @@ app.add_middleware(WidgetCORSMiddleware)
 app.add_middleware(WidgetRateLimitMiddleware)
 
 # Rate limiting (US-017)
+# PRD-174 F040 — the limiter was constructed but SlowAPIMiddleware was never
+# registered, so the default_limits never applied to any route: a placebo, and
+# the stack's only fail-OPEN gate. Fix: register the middleware AND fail closed —
+# swallow_errors=False means a limiter that can't evaluate (storage error) raises
+# instead of waving the request through. A gate that can't decide must deny.
 from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.util import get_remote_address
 from slowapi.errors import RateLimitExceeded
+from slowapi.middleware import SlowAPIMiddleware
 
 def _get_real_client_ip(request) -> str:
     """Extract real client IP, respecting X-Forwarded-For behind reverse proxy."""
@@ -777,9 +783,24 @@ def _get_real_client_ip(request) -> str:
         return forwarded.split(",")[0].strip()
     return get_remote_address(request)
 
-limiter = Limiter(key_func=_get_real_client_ip, default_limits=["60/minute"])
+# F040 fix is gated on the policy-plane flag so flag-OFF is byte-for-byte today's
+# behaviour (limiter constructed but inert). swallow_errors follows the flag:
+# fail-CLOSED only when the plane is on, else the historical fail-open default.
+from config import config as _app_config
+_policy_plane_on = bool(getattr(_app_config, "POLICY_PLANE_ENABLED", False))
+
+limiter = Limiter(
+    key_func=_get_real_client_ip,
+    default_limits=["60/minute"],
+    swallow_errors=not _policy_plane_on,  # F040: fail CLOSED when the plane is on
+)
 app.state.limiter = limiter
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+# F040: actually enforce the limits — without this middleware the limiter above
+# is inert on every route. Registered ONLY under the policy-plane flag; OFF keeps
+# today's (placebo) behaviour so the rollout stays byte-for-byte reversible.
+if _policy_plane_on:
+    app.add_middleware(SlowAPIMiddleware)
 
 # Request body size limit middleware (10MB default, 50MB for uploads)
 MAX_BODY_SIZE = 10 * 1024 * 1024  # 10MB

--- a/orchestrator/modules/policy/__init__.py
+++ b/orchestrator/modules/policy/__init__.py
@@ -1,0 +1,81 @@
+"""Unified Policy Plane (PRD-174 Wave 4).
+
+One typed gate, evaluated in one place, for every tool call — on every surface.
+Auto's blueprint says what to *attempt*; this plane, and only this plane,
+decides what *executes*. Guardrails become policy (DB-configured, one config,
+one chokepoint), not code scattered across router dependencies.
+
+Public surface:
+
+- Flag: :func:`policy_plane_enabled` (``AUTOMATOS_POLICY_PLANE``, default OFF).
+- Verdict vocabulary: :class:`Verdict`, :class:`Decision`, :class:`PolicyError`,
+  :func:`merge_verdicts` (deny > ask > allow).
+- Chokepoint: :class:`PolicyGate` + :class:`ToolCall` — invoked from
+  ``UnifiedToolExecutor.execute_tool``.
+- Event bus: :class:`PolicyBus`, :class:`Event`, :class:`EventContext`,
+  :func:`get_policy_bus` — the ``on_pre_tool`` seam.
+- Budget: :class:`BudgetExceeded`, :func:`check_budget`.
+- Policy document: :func:`load_policy_document` (the Balanced defaults).
+- Errors-as-data: :func:`verdict_to_result`, :func:`ensure_error_envelope`.
+
+Everything is stdlib-only at import time (DB/registry imports are lazy) so the
+tool loop and unit tests can import it without the heavy ``modules.tools`` init.
+"""
+from __future__ import annotations
+
+from modules.policy.budget import BudgetDecision, BudgetExceeded, check_budget
+from modules.policy.bus import (
+    EventContext,
+    Handler,
+    PolicyBus,
+    get_policy_bus,
+    reset_policy_bus,
+)
+from modules.policy.errors import ensure_error_envelope, verdict_to_result
+from modules.policy.flag import policy_plane_enabled
+from modules.policy.gate import PolicyGate, ToolCall
+from modules.policy.policy_document import (
+    PolicyDocument,
+    classify_action,
+    load_policy_document,
+    set_policy_document,
+)
+from modules.policy.types import (
+    Decision,
+    Event,
+    PolicyError,
+    Verdict,
+    merge_verdicts,
+)
+
+__all__ = [
+    # flag
+    "policy_plane_enabled",
+    # verdict vocabulary
+    "Decision",
+    "Event",
+    "PolicyError",
+    "Verdict",
+    "merge_verdicts",
+    # chokepoint
+    "PolicyGate",
+    "ToolCall",
+    # bus
+    "PolicyBus",
+    "EventContext",
+    "Handler",
+    "get_policy_bus",
+    "reset_policy_bus",
+    # budget
+    "BudgetDecision",
+    "BudgetExceeded",
+    "check_budget",
+    # policy document
+    "PolicyDocument",
+    "classify_action",
+    "load_policy_document",
+    "set_policy_document",
+    # errors-as-data
+    "verdict_to_result",
+    "ensure_error_envelope",
+]

--- a/orchestrator/modules/policy/budget.py
+++ b/orchestrator/modules/policy/budget.py
@@ -1,0 +1,216 @@
+"""Policy plane — pre-call budget admission (PRD-174 F086 + F059).
+
+Today no ``BudgetExceeded`` exists and no loop checks spend *before* issuing a
+call — the LLM manager only cost-logs *after*. This adds the admission gate the
+``on_pre_tool`` seam calls: it reads the workspace's cost/token budget from
+``Workspace.plan_limits`` and compares it to spend-to-date (summed from
+``llm_usage``, which the manager already writes model-aware dollars into). Over
+budget → :class:`BudgetExceeded`, surfaced to the model as errors-as-data.
+
+Budget lives on ``plan_limits`` (JSONB, already present — holds concurrency
+caps) under a ``budget`` key, so no new column:
+
+    workspace.plan_limits = {
+        "max_agents": 10, ...,                # existing concurrency caps
+        "budget": {                            # NEW (this PRD) — all optional
+            "max_cost_usd": 25.0,             # spend ceiling for the window
+            "max_total_tokens": 5_000_000,    # token ceiling for the window
+            "window": "day" | "month" | "all" # rolling window (default "day")
+        }
+    }
+
+No budget key ⇒ no ceiling ⇒ the gate is inert (allow). Pricing for the pending
+call is model-aware via :mod:`modules.policy.pricing`. SQLAlchemy is imported
+lazily so this module loads in the stdlib-only unit-test env.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+_VALID_WINDOWS = frozenset({"day", "month", "all"})
+_DEFAULT_WINDOW = "day"
+
+
+class BudgetExceeded(Exception):
+    """Raised (or returned as a deny) when a call would breach the workspace budget.
+
+    Carries the numbers so the caller can build errors-as-data the model reads.
+    """
+
+    def __init__(
+        self,
+        *,
+        reason: str,
+        limit: float,
+        spent: float,
+        projected: float,
+        dimension: str,
+    ) -> None:
+        self.reason = reason
+        self.limit = limit
+        self.spent = spent
+        self.projected = projected
+        self.dimension = dimension  # "cost_usd" | "total_tokens"
+        super().__init__(reason)
+
+
+@dataclass(frozen=True)
+class BudgetDecision:
+    """Outcome of a budget admission check."""
+
+    allowed: bool
+    reason: str
+    dimension: Optional[str] = None  # which ceiling bound (cost/tokens), if any
+    limit: Optional[float] = None
+    spent: Optional[float] = None
+    projected: Optional[float] = None
+
+    def audit_snapshot(self) -> Dict[str, Any]:
+        return {
+            "allowed": self.allowed,
+            "reason": self.reason,
+            "dimension": self.dimension,
+            "limit": self.limit,
+            "spent": round(self.spent, 6) if self.spent is not None else None,
+            "projected": round(self.projected, 6) if self.projected is not None else None,
+        }
+
+
+def load_budget(db: Any, workspace_id: Any) -> Dict[str, Any]:
+    """Return the workspace's ``plan_limits.budget`` merged onto defaults.
+
+    Empty/missing ⇒ ``{}`` (no ceiling). Fail-safe: an unreadable row returns
+    ``{}`` (no ceiling — the gate is a *cost* control, not a correctness gate;
+    it must not wedge execution if the settings read fails).
+    """
+    if db is None or workspace_id is None:
+        return {}
+    try:
+        from core.models.workspaces import Workspace
+
+        ws = db.query(Workspace).filter(Workspace.id == workspace_id).first()
+        if ws is None:
+            return {}
+        budget = (ws.plan_limits or {}).get("budget") or {}
+        if not isinstance(budget, dict):
+            return {}
+        window = budget.get("window")
+        if window not in _VALID_WINDOWS:
+            window = _DEFAULT_WINDOW
+        out: Dict[str, Any] = {"window": window}
+        if isinstance(budget.get("max_cost_usd"), (int, float)):
+            out["max_cost_usd"] = float(budget["max_cost_usd"])
+        if isinstance(budget.get("max_total_tokens"), (int, float)):
+            out["max_total_tokens"] = int(budget["max_total_tokens"])
+        return out
+    except Exception:
+        logger.warning(
+            "[policy.budget] budget read failed for workspace=%s", workspace_id,
+            exc_info=True,
+        )
+        return {}
+
+
+def _window_start(window: str, now: Optional[datetime] = None) -> Optional[datetime]:
+    now = now or datetime.now(timezone.utc)
+    if window == "day":
+        return now - timedelta(days=1)
+    if window == "month":
+        return now - timedelta(days=30)
+    return None  # "all" — no lower bound
+
+
+def spend_to_date(db: Any, workspace_id: Any, window: str) -> Dict[str, float]:
+    """Sum this workspace's spend + tokens over the window from ``llm_usage``.
+
+    Returns ``{"cost_usd": float, "total_tokens": float}``. Fail-safe: a read
+    error returns zeros — an unreadable ledger must not block work, only the
+    ceilings do, and they only bind when a spend number actually clears them.
+    """
+    zero = {"cost_usd": 0.0, "total_tokens": 0.0}
+    if db is None or workspace_id is None:
+        return dict(zero)
+    try:
+        from sqlalchemy import func as _func
+        from core.models.core import LLMUsage
+
+        start = _window_start(window)
+        q = db.query(
+            _func.coalesce(_func.sum(LLMUsage.total_cost), 0.0),
+            _func.coalesce(_func.sum(LLMUsage.total_tokens), 0.0),
+        ).filter(LLMUsage.workspace_id == workspace_id)
+        if start is not None:
+            q = q.filter(LLMUsage.created_at >= start)
+        cost, tokens = q.one()
+        return {"cost_usd": float(cost or 0.0), "total_tokens": float(tokens or 0.0)}
+    except Exception:
+        logger.warning(
+            "[policy.budget] spend-to-date read failed for workspace=%s", workspace_id,
+            exc_info=True,
+        )
+        return dict(zero)
+
+
+def check_budget(
+    db: Any,
+    workspace_id: Any,
+    *,
+    projected_cost_usd: float = 0.0,
+    projected_tokens: int = 0,
+) -> BudgetDecision:
+    """Admission check: would this call breach the workspace budget?
+
+    ``projected_*`` is the pending call's estimate (model-aware, from
+    :mod:`modules.policy.pricing`). We compare *spend-to-date + projected*
+    against each configured ceiling. First ceiling crossed denies; if no ceiling
+    is configured the call is allowed (the gate is inert).
+    """
+    budget = load_budget(db, workspace_id)
+    if not budget or ("max_cost_usd" not in budget and "max_total_tokens" not in budget):
+        return BudgetDecision(True, "no budget ceiling configured")
+
+    window = budget.get("window", _DEFAULT_WINDOW)
+    spent = spend_to_date(db, workspace_id, window)
+
+    max_cost = budget.get("max_cost_usd")
+    if max_cost is not None:
+        projected_total = spent["cost_usd"] + max(0.0, float(projected_cost_usd))
+        if projected_total > max_cost:
+            return BudgetDecision(
+                False,
+                (
+                    f"cost ${projected_total:.4f} (spent ${spent['cost_usd']:.4f} + "
+                    f"call ${max(0.0, float(projected_cost_usd)):.4f}) over "
+                    f"{window} ceiling ${max_cost:.2f}"
+                ),
+                dimension="cost_usd",
+                limit=max_cost,
+                spent=spent["cost_usd"],
+                projected=projected_total,
+            )
+
+    max_tokens = budget.get("max_total_tokens")
+    if max_tokens is not None:
+        projected_total_tok = spent["total_tokens"] + max(0, int(projected_tokens))
+        if projected_total_tok > max_tokens:
+            return BudgetDecision(
+                False,
+                (
+                    f"tokens {projected_total_tok:.0f} over {window} ceiling "
+                    f"{max_tokens}"
+                ),
+                dimension="total_tokens",
+                limit=float(max_tokens),
+                spent=spent["total_tokens"],
+                projected=projected_total_tok,
+            )
+
+    return BudgetDecision(
+        True, f"within {window} budget", dimension="cost_usd",
+        limit=max_cost, spent=spent["cost_usd"],
+    )

--- a/orchestrator/modules/policy/bus.py
+++ b/orchestrator/modules/policy/bus.py
@@ -1,0 +1,109 @@
+"""Policy plane — the typed event bus (PRD-174 Step 4, §4.2).
+
+Keeps Claude Code's hook *taxonomy* and *verdict semantics*, but execution is
+**in-process typed handlers with tenant scope only** — NOT shell commands (the
+review is explicit: Bash-string hooks are RCE-by-configuration and don't fit a
+SaaS backend). Handlers are plain callables:
+
+    handler(event: Event, ctx: EventContext) -> Optional[Verdict]
+
+registered against an :class:`Event`. On each fire the bus runs every handler
+for that event and merges their verdicts under **deny > ask > allow**
+(:func:`~modules.policy.types.merge_verdicts`). A handler returning ``None`` (or
+a ``defer`` verdict) is "no opinion".
+
+The `PreToolUse` seam is the natural attach point for budget (F086), approval
+routing (act-vs-ask), and prerequisite (read-before-write) policy — it sits
+beside the dedup check in the tool loop. Post-tool / round / run events exist so
+audit + compaction policy can attach later without re-opening the loop.
+
+Stdlib-only: no DB, no config. The bus itself is a thin dispatcher; handlers
+bring their own dependencies.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional
+
+from modules.policy.types import Event, Verdict, merge_verdicts
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class EventContext:
+    """Everything a handler needs to decide, tenant-scoped.
+
+    Deliberately loose (``dict`` payload) so new events don't force a type
+    change, but the common fields are named for the hot path (PreToolUse).
+    """
+
+    workspace_id: Any = None
+    agent_id: Optional[int] = None
+    tool_name: Optional[str] = None
+    tool_input: Optional[Dict[str, Any]] = None
+    caller_context: Optional[Dict[str, Any]] = None
+    # Free-form extras (result payloads for post events, round state, etc.).
+    data: Dict[str, Any] = field(default_factory=dict)
+
+
+# handler signature: (event, ctx) -> Optional[Verdict]
+Handler = Callable[[Event, EventContext], Optional[Verdict]]
+
+
+class PolicyBus:
+    """In-process typed event bus with deny > ask > allow merge."""
+
+    def __init__(self) -> None:
+        self._handlers: Dict[Event, List[Handler]] = {}
+
+    def register(self, event: Event, handler: Handler) -> None:
+        """Attach a handler to an event. Order of registration is preserved but
+        does not affect the outcome — the merge is rank-based, not first-wins."""
+        self._handlers.setdefault(event, []).append(handler)
+
+    def clear(self) -> None:
+        """Drop all handlers (test isolation)."""
+        self._handlers.clear()
+
+    def fire(self, event: Event, ctx: EventContext) -> Verdict:
+        """Run every handler for ``event`` and merge verdicts (deny > ask > allow).
+
+        A handler that raises is treated as **no opinion** (logged), never as a
+        silent allow *or* a hard failure — one bad handler must not take the
+        loop down, nor must it wave a call through by crashing.
+        """
+        verdicts: List[Optional[Verdict]] = []
+        for handler in self._handlers.get(event, ()):  # empty when unregistered
+            try:
+                verdicts.append(handler(event, ctx))
+            except Exception:
+                logger.warning(
+                    "[policy.bus] handler raised on %s (treated as no-opinion)",
+                    event.value, exc_info=True,
+                )
+                verdicts.append(None)
+        return merge_verdicts(*verdicts)
+
+
+# ---------------------------------------------------------------------------
+# Process-wide singleton. Handlers are registered once at startup (or lazily in
+# the tool loop). Kept module-level so the stdlib-only tool_loop can reach it
+# without constructing anything.
+# ---------------------------------------------------------------------------
+
+_BUS: Optional[PolicyBus] = None
+
+
+def get_policy_bus() -> PolicyBus:
+    global _BUS
+    if _BUS is None:
+        _BUS = PolicyBus()
+    return _BUS
+
+
+def reset_policy_bus() -> None:
+    """Test hook: drop the singleton so a test starts from a clean bus."""
+    global _BUS
+    _BUS = None

--- a/orchestrator/modules/policy/errors.py
+++ b/orchestrator/modules/policy/errors.py
@@ -1,0 +1,91 @@
+"""Policy plane — errors-as-data envelope (PRD-174 §4.2).
+
+Formalises the half-existing failure envelope (`tool_router.execute_and_format`
+returned an ad-hoc `{success, llm_context, error_type, fatal_error}` shape) into
+the typed `{code, message_for_model, remediation, retryable}` the *model* reads.
+Every policy denial returns its reason as tool content so Auto can adapt
+(escalate, ask, drop a field) instead of emitting "Unknown error".
+
+Two directions:
+
+- :func:`verdict_to_result` — turn a blocking :class:`Verdict` (deny/ask) into
+  the executor result dict a tool call returns, carrying the structured error so
+  the loop surfaces it to the LLM.
+- :func:`ensure_error_envelope` — normalise any failing tool result so it always
+  exposes a `policy_error` block, giving the model a stable shape to reason over.
+
+Stdlib-only.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from modules.policy.types import Decision, PolicyError, Verdict
+
+
+def verdict_to_result(verdict: Verdict, tool_name: str) -> Dict[str, Any]:
+    """Render a blocking verdict as a tool-execution result dict.
+
+    The result is shaped so both the tool loop and `tool_router` treat it as a
+    non-success outcome, while `policy_error` + `llm_context` carry the
+    model-readable reason. A denial is NOT an exception here — it is data.
+    """
+    err = verdict.error or PolicyError(
+        code="policy_denied",
+        message_for_model=verdict.reason or f"Action '{tool_name}' was blocked by policy.",
+    )
+    blocked = verdict.decision is Decision.DENY
+    return {
+        "success": False,
+        "tool": tool_name,
+        # Legacy-compatible keys the existing formatter/loop already read, so a
+        # policy block flows through the same non-success path as any tool error
+        # (the loop surfaces `error`/`llm_context` to the model).
+        "error": err.message_for_model,
+        "llm_context": err.message_for_model,
+        "permission_denied": blocked,
+        "requires_approval": verdict.decision is Decision.ASK,
+        # The formalised errors-as-data payload (the new contract).
+        "policy_error": err.to_dict(),
+        "policy_decision": verdict.decision.value,
+        "fatal_error": False,
+        "error_type": err.code,
+    }
+
+
+def ensure_error_envelope(result: Dict[str, Any]) -> Dict[str, Any]:
+    """Guarantee a failing result carries a `policy_error` block.
+
+    Non-blocking success results pass through untouched. A failure that already
+    has `policy_error` is left alone; otherwise we synthesise one from the
+    result's own `error`/`error_type` so every denial the model sees has the
+    same `{code, message_for_model, remediation, retryable}` shape.
+    """
+    if not isinstance(result, dict):
+        return result
+    if result.get("success"):
+        return result
+    if result.get("policy_error"):
+        return result
+
+    message = (
+        result.get("error")
+        or result.get("message")
+        or result.get("llm_context")
+        or "Tool call failed."
+    )
+    code = result.get("error_type") or (
+        "rate_limited" if result.get("rate_limited")
+        else "permission_denied" if result.get("permission_denied")
+        else "requires_confirmation" if result.get("requires_confirmation")
+        else "tool_error"
+    )
+    retryable = bool(result.get("rate_limited")) or code == "requires_confirmation"
+    enriched = dict(result)
+    enriched["policy_error"] = PolicyError(
+        code=code,
+        message_for_model=str(message),
+        remediation=result.get("remediation"),
+        retryable=retryable,
+    ).to_dict()
+    return enriched

--- a/orchestrator/modules/policy/flag.py
+++ b/orchestrator/modules/policy/flag.py
@@ -1,0 +1,32 @@
+"""Policy plane — the master feature flag (PRD-174 W4).
+
+``AUTOMATOS_POLICY_PLANE`` (read once in ``config.py``, per the no-``os.getenv``-
+outside-config rule) gates the entire plane. OFF ⇒ byte-for-byte today's
+per-router gates; ON ⇒ the plane (one chokepoint + the on_pre_tool seam).
+
+Isolated in its own module so the stdlib-only call sites (``tool_loop``) and the
+unit tests can flip it without importing the heavy config graph directly — and
+so a config-import failure fails *safe* (plane OFF), never wedges execution.
+"""
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def policy_plane_enabled() -> bool:
+    """True when the unified policy plane is switched on for this deployment.
+
+    Fail-safe: if config can't be read the plane is OFF (falls back to today's
+    per-router gates) — the flag never fails *into* the new path.
+    """
+    try:
+        from config import config
+
+        return bool(config.POLICY_PLANE_ENABLED)
+    except Exception:
+        logger.warning(
+            "[policy.flag] config read failed — policy plane treated OFF", exc_info=True
+        )
+        return False

--- a/orchestrator/modules/policy/gate.py
+++ b/orchestrator/modules/policy/gate.py
@@ -1,0 +1,279 @@
+"""Policy plane — the one typed chokepoint (PRD-174 Step 2, F085/F060).
+
+`PolicyGate.check()` is the single enforcement point every tool call on every
+surface passes through when the plane is on. It folds together, for *all* tools
+(not just `platform_*`), the guardrails that today are scattered across router
+deps, action-registry flags and the mission approval engine — and that
+Composio / workspace / registry tools bypass entirely (`unified_executor`
+routes them around the gate stack).
+
+What the gate evaluates, in order (deny > ask > allow — first blocking wins):
+
+1. **Super-admin gate** (fail-closed) — `super_admin_only` actions: only a
+   literal ``system_role == 'super_admin'`` caller passes. (F043 helper.)
+2. **Admin gate** — `admin_only` actions require the *caller's own* admin role
+   (F014); the "agents inherit admin from the workspace owner" fallback is an
+   explicit, default-OFF workspace policy, not an implicit workspace-has-an-
+   admin flip.
+3. **Budget admission** (F086 + F059) — model-aware pre-call spend check against
+   the workspace budget; over budget ⇒ ask/deny with errors-as-data.
+4. **Act-vs-ask routing** (Balanced, §5) — destructive / external side-effect /
+   publish ⇒ ask (PRD-163 card/row); read / low-risk-internal ⇒ auto. Skipped
+   when the workspace is dialled to full autonomy (the auto dial) — that path
+   still can't satisfy the super-admin gate or the destructive backstop, both
+   of which live in `platform_executor` downstream.
+
+The gate does NOT re-implement the PRD-140 hierarchy check or the per-(workspace,
+agent) rate limiter — those stay in `platform_executor` for platform actions and
+remain authoritative. The gate is the *universal* layer on top, so external
+tools stop being ungoverned.
+
+Returns a :class:`~modules.policy.types.Verdict`. Callers execute only on
+allow; deny/ask stop the call and surface `verdict.error` (errors-as-data) as
+tool content the model reads.
+
+SQLAlchemy / registry imports are lazy so this loads stdlib-only for unit tests;
+`check()` needs a live `db` only to price budgets and read the workspace policy.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+from modules.policy import budget as _budget
+from modules.policy import policy_document as _policy_doc
+from modules.policy import pricing as _pricing
+from modules.policy import roles as _roles
+from modules.policy.types import Decision, PolicyError, Verdict
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ToolCall:
+    """The subject of a policy decision — one tool call, tenant-scoped.
+
+    Deliberately small and typed so the gate has no dependency on the caller's
+    request shape.
+    """
+
+    tool_name: str
+    parameters: Dict[str, Any]
+    workspace_id: Any
+    agent_id: Optional[int] = None
+    caller_context: Optional[Dict[str, Any]] = None
+    # Optional model-aware budget inputs for the pending call (F086/F059). When
+    # a caller knows the model + token estimate it passes them; otherwise the
+    # budget check uses spend-to-date only (still catches an already-over budget).
+    model_id: Optional[str] = None
+    est_input_tokens: int = 0
+    est_output_tokens: int = 0
+
+
+class PolicyGate:
+    """Stateless evaluator. Construct per-request with the live `db` session."""
+
+    def __init__(self, db: Any) -> None:
+        self.db = db
+
+    # -- public API --------------------------------------------------------
+
+    def check(self, call: ToolCall) -> Verdict:
+        """Evaluate one tool call. Returns the merged verdict (deny > ask > allow)."""
+        doc = _policy_doc.load_policy_document(self.db, call.workspace_id)
+        action_def = self._lookup_action(call.tool_name)
+        is_composio = self._is_composio(call.tool_name)
+
+        # 1) super-admin gate (fail-closed) — highest precedence.
+        if action_def is not None and getattr(action_def, "super_admin_only", False):
+            role = (call.caller_context or {}).get("system_role")
+            if not _roles.is_super_admin(role):
+                return Verdict.deny(
+                    PolicyError(
+                        code="super_admin_required",
+                        message_for_model=(
+                            f"Action '{call.tool_name}' is restricted to the platform "
+                            "super admin (observability tier)."
+                        ),
+                        remediation="This action cannot be taken by an agent or workspace user.",
+                        retryable=False,
+                    )
+                )
+
+        # 2) admin gate — caller's own role (F014). The workspace-owner fallback
+        #    is gated behind the explicit, default-OFF `agents_inherit_admin`.
+        if action_def is not None and getattr(action_def, "admin_only", False):
+            admin_verdict = self._admin_gate(call, doc)
+            if admin_verdict.decision is Decision.DENY:
+                return admin_verdict
+
+        # 3) budget admission (model-aware). May deny (hard ceiling breach).
+        budget_verdict = self._budget_gate(call)
+        if budget_verdict.decision is not Decision.ALLOW:
+            return budget_verdict
+
+        # 4) act-vs-ask routing under the workspace posture (Balanced by default).
+        route_verdict = self._route_gate(call, doc, action_def, is_composio)
+        return route_verdict
+
+    # -- gate stages -------------------------------------------------------
+
+    def _admin_gate(self, call: ToolCall, doc: _policy_doc.PolicyDocument) -> Verdict:
+        ctx = call.caller_context
+        # Full autonomy: Auto runs as admin (the existing dial). Kept here so the
+        # gate matches platform_executor's admin path when the flag is on.
+        if self._full_autonomy(call.workspace_id):
+            return Verdict.allow("full-autonomy: agent runs as admin")
+
+        if ctx is not None:
+            role = ctx.get("system_role")
+            ws_role = ctx.get("workspace_role")
+            if _roles.is_admin(role) or ws_role in ("owner", "admin"):
+                return Verdict.allow("caller has admin/owner role")
+            # Explicit non-admin caller — deny (F014: no workspace-has-an-admin flip).
+            return Verdict.deny(
+                PolicyError(
+                    code="admin_required",
+                    message_for_model=(
+                        f"Action '{call.tool_name}' requires workspace admin or owner role."
+                    ),
+                    remediation="Ask a workspace admin to perform this, or escalate.",
+                    retryable=False,
+                )
+            )
+
+        # No caller identity (heartbeat / agent factory). Only the explicit,
+        # default-OFF workspace policy lets an agent inherit admin here (F014).
+        if doc.agents_inherit_admin and self._workspace_has_admin_owner(call.workspace_id):
+            return Verdict.allow("agents_inherit_admin policy on + workspace has admin owner")
+        return Verdict.deny(
+            PolicyError(
+                code="admin_required",
+                message_for_model=(
+                    f"Action '{call.tool_name}' requires admin. No admin caller identity "
+                    "and this workspace does not grant agents inherited admin."
+                ),
+                remediation="Enable the 'agents inherit admin' workspace policy, or run as an admin.",
+                retryable=False,
+            )
+        )
+
+    def _budget_gate(self, call: ToolCall) -> Verdict:
+        projected_cost = 0.0
+        if call.model_id and (call.est_input_tokens or call.est_output_tokens):
+            priced = _pricing.estimate_cost_usd(
+                self.db, call.model_id, call.est_input_tokens, call.est_output_tokens
+            )
+            projected_cost = priced or 0.0
+        decision = _budget.check_budget(
+            self.db,
+            call.workspace_id,
+            projected_cost_usd=projected_cost,
+            projected_tokens=call.est_input_tokens + call.est_output_tokens,
+        )
+        if decision.allowed:
+            return Verdict.allow(decision.reason)
+        return Verdict.deny(
+            PolicyError(
+                code="budget_exceeded",
+                message_for_model=(
+                    f"This call would exceed the workspace budget: {decision.reason}."
+                ),
+                remediation=(
+                    "Raise the workspace budget ceiling, wait for the window to roll "
+                    "over, or ask a human to approve the overage."
+                ),
+                retryable=False,
+            ),
+            reason=decision.reason,
+        )
+
+    def _route_gate(
+        self,
+        call: ToolCall,
+        doc: _policy_doc.PolicyDocument,
+        action_def: Any,
+        is_composio: bool,
+    ) -> Verdict:
+        # Full autonomy short-circuits the ask routing (auto dial). The
+        # destructive backstop + super-admin gate are unaffected (they ran
+        # above / run downstream in platform_executor).
+        if self._full_autonomy(call.workspace_id):
+            return Verdict.allow("full-autonomy: act without asking")
+
+        permission_level = getattr(action_def, "permission_level", None)
+        risk = _policy_doc.classify_action(
+            call.tool_name, permission_level=permission_level, is_composio=is_composio
+        )
+        route = doc.route_for(risk)
+        if route == "auto":
+            return Verdict.allow(f"posture={doc.posture} routes {risk} to auto")
+        return Verdict.ask(
+            PolicyError(
+                code="approval_required",
+                message_for_model=(
+                    f"Action '{call.tool_name}' ({risk}) requires human approval under "
+                    f"the workspace's {doc.posture} policy. It has NOT been executed."
+                ),
+                remediation=(
+                    "A human must approve this in the approval card/queue before it runs."
+                ),
+                retryable=True,
+            ),
+            reason=f"posture={doc.posture} routes {risk} to ask",
+        )
+
+    # -- lazy lookups (DB / registry) --------------------------------------
+
+    def _lookup_action(self, tool_name: str) -> Any:
+        """Resolve the ActionDefinition for a platform action, or None.
+
+        Handles both the ``platform_execute`` meta-tool (action nested in
+        params) — not seen here, callers pass the resolved action name — and
+        direct ``platform_*`` names. Non-platform tools return None.
+        """
+        try:
+            from modules.tools.discovery import get_action_registry
+
+            return get_action_registry().get(tool_name)
+        except Exception:
+            return None
+
+    @staticmethod
+    def _is_composio(tool_name: str) -> bool:
+        name = (tool_name or "")
+        return name.startswith("composio_") or name == "composio_execute"
+
+    def _full_autonomy(self, workspace_id: Any) -> bool:
+        try:
+            from core.services.auto_autonomy import is_full_autonomy
+
+            return bool(is_full_autonomy(self.db, workspace_id))
+        except Exception:
+            logger.warning(
+                "[policy.gate] autonomy read failed for workspace=%s — supervised",
+                workspace_id, exc_info=True,
+            )
+            return False
+
+    def _workspace_has_admin_owner(self, workspace_id: Any) -> bool:
+        try:
+            from core.workspaces.models import WorkspaceMember
+
+            member = (
+                self.db.query(WorkspaceMember)
+                .filter(
+                    WorkspaceMember.workspace_id == workspace_id,
+                    WorkspaceMember.role.in_(("owner", "admin")),
+                    WorkspaceMember.is_active.is_(True),
+                )
+                .first()
+            )
+            return member is not None
+        except Exception:
+            logger.warning(
+                "[policy.gate] workspace-admin-owner read failed for %s",
+                workspace_id, exc_info=True,
+            )
+            return False

--- a/orchestrator/modules/policy/policy_document.py
+++ b/orchestrator/modules/policy/policy_document.py
@@ -1,0 +1,256 @@
+"""Policy plane — the Balanced workspace policy document (PRD-174 §5).
+
+Encodes the act-vs-ask decision **once**, as the DB-configured workspace policy
+the plane reads — not per-surface toggles (the three partial planes today
+already contradict each other). Owner decision LOCKED 2026-07-02: **Balanced**.
+
+Balanced defaults (all tunable per-workspace — config, not a deploy):
+
+- **Auto (no ask):** reads; low-risk internal writes (draft docs, update own
+  board-task status, internal memory writes, research/plan).
+- **Ask (PRD-163 card / row):** destructive ops (deletes, board Run-Now);
+  external side-effects (Composio sends/refunds/discounts, email/channel posts,
+  Shopify writes); over-budget spend.
+- **Templates / brand-kits:** Auto drafts; a human approves publish.
+- **Board:** mutations stay chat/assignment-driven — no free create-task in v1.
+
+Single canonical reader/writer for ``workspace.settings.policy_plane``, mirroring
+the ``auto_autonomy`` / ``approval_policy`` services (settings live on the
+Workspace JSON column; the caller owns the transaction). Fail-safe: an
+unreadable / corrupt setting falls back to the Balanced defaults.
+
+SQLAlchemy is imported lazily so this module loads stdlib-only for unit tests;
+the *classifier* (:func:`classify_action`) is pure and needs no DB at all.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+from uuid import UUID
+
+logger = logging.getLogger(__name__)
+
+# Posture names. Balanced is the locked default; the others exist so the same
+# document can express "supervise everything" or "trust within the autonomy
+# dial" without inventing new mechanisms.
+BALANCED = "balanced"
+STRICT = "strict"      # ask for every write + external + destructive
+PERMISSIVE = "permissive"  # ask only for destructive + over-budget
+VALID_POSTURES = frozenset({BALANCED, STRICT, PERMISSIVE})
+
+# Risk classes an action can fall into (pure, tool-name + permission derived).
+RISK_READ = "read"
+RISK_INTERNAL_WRITE = "internal_write"
+RISK_EXTERNAL = "external_side_effect"
+RISK_DESTRUCTIVE = "destructive"
+RISK_PUBLISH = "publish"  # templates / brand-kits publish step
+
+# The Balanced routing table: risk class -> "auto" | "ask".
+_BALANCED_ROUTING: Dict[str, str] = {
+    RISK_READ: "auto",
+    RISK_INTERNAL_WRITE: "auto",
+    RISK_PUBLISH: "ask",
+    RISK_EXTERNAL: "ask",
+    RISK_DESTRUCTIVE: "ask",
+}
+_STRICT_ROUTING: Dict[str, str] = {
+    RISK_READ: "auto",
+    RISK_INTERNAL_WRITE: "ask",
+    RISK_PUBLISH: "ask",
+    RISK_EXTERNAL: "ask",
+    RISK_DESTRUCTIVE: "ask",
+}
+_PERMISSIVE_ROUTING: Dict[str, str] = {
+    RISK_READ: "auto",
+    RISK_INTERNAL_WRITE: "auto",
+    RISK_PUBLISH: "auto",
+    RISK_EXTERNAL: "auto",
+    RISK_DESTRUCTIVE: "ask",
+}
+_ROUTING_BY_POSTURE = {
+    BALANCED: _BALANCED_ROUTING,
+    STRICT: _STRICT_ROUTING,
+    PERMISSIVE: _PERMISSIVE_ROUTING,
+}
+
+DEFAULTS: Dict[str, Any] = {
+    "posture": BALANCED,
+    # explicit, default-OFF: "agents inherit admin from the workspace owner".
+    # F014 — with this off, admin_only actions require the *caller's* own admin
+    # role, never a workspace-has-an-admin fallback.
+    "agents_inherit_admin": False,
+    # per-workspace overrides of the risk→route map, e.g.
+    # {"external_side_effect": "auto"} to let a workspace auto-send.
+    "route_overrides": {},
+}
+
+
+@dataclass(frozen=True)
+class PolicyDocument:
+    """The resolved, in-memory view of a workspace's policy posture."""
+
+    posture: str
+    agents_inherit_admin: bool
+    route_overrides: Dict[str, str]
+
+    def route_for(self, risk_class: str) -> str:
+        """Return ``"auto"`` or ``"ask"`` for a risk class under this posture.
+
+        A per-workspace ``route_overrides`` entry wins over the posture table.
+        Unknown risk classes fail safe to ``"ask"`` (never silently auto).
+        """
+        override = self.route_overrides.get(risk_class)
+        if override in ("auto", "ask"):
+            return override
+        table = _ROUTING_BY_POSTURE.get(self.posture, _BALANCED_ROUTING)
+        return table.get(risk_class, "ask")
+
+    def audit_snapshot(self) -> Dict[str, Any]:
+        return {
+            "posture": self.posture,
+            "agents_inherit_admin": self.agents_inherit_admin,
+            "route_overrides": dict(self.route_overrides),
+        }
+
+
+def _defaults_doc() -> PolicyDocument:
+    return PolicyDocument(
+        posture=DEFAULTS["posture"],
+        agents_inherit_admin=DEFAULTS["agents_inherit_admin"],
+        route_overrides={},
+    )
+
+
+def load_policy_document(db: Any, workspace_id: UUID | str) -> PolicyDocument:
+    """Return the workspace's ``policy_plane`` settings as a :class:`PolicyDocument`.
+
+    Fail-safe: missing workspace / corrupt setting ⇒ Balanced defaults.
+    """
+    if db is None or workspace_id is None:
+        return _defaults_doc()
+    try:
+        from core.models.workspaces import Workspace
+
+        ws = db.query(Workspace).filter(Workspace.id == workspace_id).first()
+        if ws is None:
+            return _defaults_doc()
+        cfg = (ws.settings or {}).get("policy_plane") or {}
+    except Exception:
+        logger.warning(
+            "[policy.document] read failed for workspace=%s — Balanced defaults",
+            workspace_id, exc_info=True,
+        )
+        return _defaults_doc()
+
+    posture = cfg.get("posture")
+    if not isinstance(posture, str) or posture not in VALID_POSTURES:
+        posture = BALANCED
+
+    inherit = cfg.get("agents_inherit_admin")
+    inherit = bool(inherit) if isinstance(inherit, bool) else False
+
+    overrides_raw = cfg.get("route_overrides")
+    overrides: Dict[str, str] = {}
+    if isinstance(overrides_raw, dict):
+        for k, v in overrides_raw.items():
+            if v in ("auto", "ask"):
+                overrides[str(k)] = v
+
+    return PolicyDocument(posture=posture, agents_inherit_admin=inherit, route_overrides=overrides)
+
+
+def set_policy_document(
+    db: Any,
+    workspace_id: UUID | str,
+    *,
+    posture: Optional[str] = None,
+    agents_inherit_admin: Optional[bool] = None,
+    route_overrides: Optional[Dict[str, str]] = None,
+) -> PolicyDocument:
+    """Persist policy-plane fields to ``workspace.settings.policy_plane``.
+
+    Only provided fields change. Caller owns the transaction (stages + flushes).
+    """
+    from core.models.workspaces import Workspace
+    from sqlalchemy.orm.attributes import flag_modified
+
+    if posture is not None and posture not in VALID_POSTURES:
+        raise ValueError(
+            f"invalid posture {posture!r}; expected one of {sorted(VALID_POSTURES)}"
+        )
+
+    ws = db.query(Workspace).filter(Workspace.id == workspace_id).first()
+    if ws is None:
+        raise ValueError(f"workspace {workspace_id} not found")
+
+    settings = dict(ws.settings or {})
+    current = dict(settings.get("policy_plane") or {})
+    if posture is not None:
+        current["posture"] = posture
+    if agents_inherit_admin is not None:
+        current["agents_inherit_admin"] = bool(agents_inherit_admin)
+    if route_overrides is not None:
+        current["route_overrides"] = {
+            str(k): v for k, v in route_overrides.items() if v in ("auto", "ask")
+        }
+    settings["policy_plane"] = current
+    ws.settings = settings
+    flag_modified(ws, "settings")
+    db.flush()
+    return load_policy_document(db, workspace_id)
+
+
+# ---------------------------------------------------------------------------
+# Pure risk classifier — no DB. Maps a tool call to a risk class the routing
+# table understands. Kept deliberately conservative: anything it can't
+# confidently place as read/internal is treated as the higher-risk class.
+# ---------------------------------------------------------------------------
+
+# Composio actions carry an external side-effect by nature (they act on a
+# third-party app). Sends/refunds/discounts/posts are the classic ask cases.
+_EXTERNAL_TOOL_PREFIXES = ("composio_", "workspace_exec")
+
+
+def classify_action(
+    tool_name: str,
+    *,
+    permission_level: Optional[str] = None,
+    is_composio: bool = False,
+) -> str:
+    """Classify a tool call into a risk class (pure).
+
+    - Composio / external-exec tools ⇒ ``external_side_effect`` (they touch a
+      third-party app), unless the registry marks them ``destructive``.
+    - Platform/registry tools use ``permission_level``: ``destructive`` ⇒
+      destructive; ``write`` ⇒ internal_write; ``read``/unknown ⇒ read.
+    - The template/brand-kit *publish* step is flagged ``publish`` by name.
+    """
+    name = (tool_name or "").lower()
+
+    if permission_level == "destructive":
+        return RISK_DESTRUCTIVE
+
+    if is_composio or name.startswith(_EXTERNAL_TOOL_PREFIXES):
+        return RISK_EXTERNAL
+
+    # Template / brand-kit publish is the human-approves-publish case (§5).
+    if "publish" in name and ("template" in name or "brand" in name):
+        return RISK_PUBLISH
+
+    if permission_level == "write":
+        return RISK_INTERNAL_WRITE
+    if permission_level == "read":
+        return RISK_READ
+
+    # Unknown platform tool with no permission signal: treat a bare
+    # ``platform_*`` read-shaped name as read, everything else as internal
+    # write (fail toward asking, never toward silent external action).
+    return RISK_READ if name.startswith("platform_") and _looks_readonly(name) else RISK_INTERNAL_WRITE
+
+
+_READONLY_HINTS = ("list", "get", "search", "read", "grep", "summary", "stats", "query", "describe")
+
+
+def _looks_readonly(name: str) -> bool:
+    return any(h in name for h in _READONLY_HINTS)

--- a/orchestrator/modules/policy/pricing.py
+++ b/orchestrator/modules/policy/pricing.py
@@ -1,0 +1,86 @@
+"""Policy plane — model-aware pricing from the DB registry (PRD-174 F059).
+
+One source of truth for "what does a call on model X cost". Reads the DB price
+registry (``llm_models`` via :class:`core.llm.model_registry.ModelRegistry`) —
+the model-aware table that already exists but sat unused while four hardcoded
+price maps (``manager._MODEL_COST_MAP``, ``logging_utils.TOKEN_COSTS``,
+``model_usage_tracker`` fallbacks, seed data) costed the same call four
+different, model-blind ways. The budget admission gate (F086) prices against
+this so it approves/blocks on the *right* dollars.
+
+Kept dependency-light: SQLAlchemy is imported lazily inside the function so this
+module loads in the stdlib-only unit-test env. Pass a live ``db`` to get real
+prices; without one (or on any lookup miss) it returns ``None`` and the caller
+decides how to fail — the gate fails *open on price-unavailability* for reads
+and *closed* for spend, never silently mis-prices.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def price_per_1k(db: Any, model_id: str) -> Optional["ModelPrice"]:
+    """Return the (input, output) $/1k-token price for ``model_id`` from the DB.
+
+    ``None`` when the model is unknown to the registry or the registry can't be
+    read — never a guessed price. Callers must handle ``None`` explicitly.
+    """
+    if not model_id or db is None:
+        return None
+    try:
+        from core.llm.model_registry import get_model_registry
+
+        info = get_model_registry(db).get_model(model_id)
+        if info is None:
+            return None
+        return ModelPrice(
+            model_id=model_id,
+            input_per_1k=float(info.input_cost_per_1k or 0.0),
+            output_per_1k=float(info.output_cost_per_1k or 0.0),
+        )
+    except Exception:
+        logger.warning(
+            "[policy.pricing] registry price lookup failed for model=%s", model_id,
+            exc_info=True,
+        )
+        return None
+
+
+def estimate_cost_usd(
+    db: Any, model_id: str, input_tokens: int, output_tokens: int
+) -> Optional[float]:
+    """Model-aware cost estimate for a token count, or ``None`` if unpriceable.
+
+    Thin wrapper over :func:`price_per_1k` + :meth:`ModelPrice.cost_for` so
+    callers get one call. ``None`` propagates the "can't price this" signal.
+    """
+    price = price_per_1k(db, model_id)
+    if price is None:
+        return None
+    return price.cost_for(input_tokens, output_tokens)
+
+
+class ModelPrice:
+    """A model's per-1k-token prices, with the token→dollars arithmetic in one place."""
+
+    __slots__ = ("model_id", "input_per_1k", "output_per_1k")
+
+    def __init__(self, model_id: str, input_per_1k: float, output_per_1k: float) -> None:
+        self.model_id = model_id
+        self.input_per_1k = float(input_per_1k)
+        self.output_per_1k = float(output_per_1k)
+
+    def cost_for(self, input_tokens: int, output_tokens: int) -> float:
+        """USD cost for the given token counts, rounded to 6dp (matches ModelInfo)."""
+        cost = (max(0, int(input_tokens)) / 1000.0) * self.input_per_1k
+        cost += (max(0, int(output_tokens)) / 1000.0) * self.output_per_1k
+        return round(cost, 6)
+
+    def __repr__(self) -> str:  # pragma: no cover - debug aid
+        return (
+            f"ModelPrice({self.model_id!r}, in={self.input_per_1k}, "
+            f"out={self.output_per_1k})"
+        )

--- a/orchestrator/modules/policy/roles.py
+++ b/orchestrator/modules/policy/roles.py
@@ -1,0 +1,77 @@
+"""Policy plane — one role + permission semantic (PRD-174 F042/F043).
+
+Two forks the plane closes:
+
+- **F043** — seven+ routers gate admin functions with ``system_role == 'admin'``,
+  which 403s the platform super-admin entirely. The fix is one shared
+  ``super_admin ⊇ admin ⊇ user`` hierarchy: a super-admin satisfies every
+  admin gate, an admin satisfies user gates. :func:`role_satisfies`.
+
+- **F042** — RBAC god-key/null-key fork: an empty permission list means
+  *allow-all* on the widget plane but *deny-all* on the board plane, so one
+  no-permission key is a god-key on one plane and a null-key on the other. The
+  fix is a single semantic — **empty permissions grant nothing** (least
+  privilege) — applied on every plane. :func:`has_permission`.
+
+Stdlib-only: no DB, no config, no imports beyond typing. Callers pass the
+already-resolved role string / permission list.
+"""
+from __future__ import annotations
+
+from typing import Dict, Iterable, Optional, Set
+
+SUPER_ADMIN = "super_admin"
+ADMIN = "admin"
+USER = "user"
+
+# Each role's *satisfied set*: the gate-roles this role is allowed to pass.
+# super_admin ⊇ admin ⊇ user. Unknown/None roles satisfy nothing (fail-closed).
+_SATISFIES: Dict[str, Set[str]] = {
+    SUPER_ADMIN: {SUPER_ADMIN, ADMIN, USER},
+    ADMIN: {ADMIN, USER},
+    USER: {USER},
+}
+
+
+def role_satisfies(caller_role: Optional[str], required_role: str) -> bool:
+    """True when ``caller_role`` is allowed to pass a gate requiring ``required_role``.
+
+    ``super_admin`` passes ``admin`` and ``user`` gates; ``admin`` passes
+    ``user`` gates. ``None`` / unknown roles satisfy nothing (fail-closed) —
+    this is what keeps the seven ``system_role == 'admin'`` routers from 403'ing
+    a super-admin once they route through here.
+    """
+    if not caller_role:
+        return False
+    return required_role in _SATISFIES.get(caller_role, frozenset())
+
+
+def is_admin(caller_role: Optional[str]) -> bool:
+    """True when ``caller_role`` satisfies an ``admin`` gate (admin or super_admin).
+
+    Replaces the scattered ``getattr(user, 'system_role', 'user') == 'admin'``
+    checks that lock super-admins out.
+    """
+    return role_satisfies(caller_role, ADMIN)
+
+
+def is_super_admin(caller_role: Optional[str]) -> bool:
+    """True only for the platform super-admin (observability tier)."""
+    return role_satisfies(caller_role, SUPER_ADMIN)
+
+
+def has_permission(
+    permissions: Optional[Iterable[str]], required_permission: str
+) -> bool:
+    """True only when ``permissions`` **explicitly** grants ``required_permission``.
+
+    **Empty = deny (F042).** A ``None`` or empty permission list grants nothing —
+    the single least-privilege semantic that replaces the widget plane's
+    "empty = unrestricted" god-key. There is no wildcard-by-omission; grants
+    must be explicit. (An explicit ``"*"`` element, if a plane chooses to issue
+    one, is honoured — that is a deliberate grant, not the absence of one.)
+    """
+    if not permissions:
+        return False
+    perms = set(permissions)
+    return required_permission in perms or "*" in perms

--- a/orchestrator/modules/policy/types.py
+++ b/orchestrator/modules/policy/types.py
@@ -1,0 +1,223 @@
+"""Policy plane — typed verdict + event vocabulary (PRD-174 W4).
+
+The single typed gate the whole plane speaks in. Keeps Claude Code's separation
+of model *intent* from *authorization* and its verdict semantics, re-keyed for
+tenancy: every handler returns a :class:`Verdict`, and when handlers disagree
+**deny outranks ask outranks allow** (:func:`merge_verdicts`).
+
+Stdlib-only at import time on purpose — ``tool_loop`` (stdlib-only) and the unit
+tests import this without dragging the heavy ``modules.tools`` package init
+(asyncpg/pgvector). No SQLAlchemy, no config, no network here.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict, Optional
+
+
+class Decision(str, Enum):
+    """A policy verdict's disposition. ``str`` mixin so it serialises as its value.
+
+    Ordering (deny > ask > allow) is enforced by :data:`_DECISION_RANK` /
+    :func:`merge_verdicts`, not by enum member order.
+    """
+
+    ALLOW = "allow"
+    DENY = "deny"
+    ASK = "ask"
+    DEFER = "defer"
+
+
+# deny outranks ask outranks allow (PRD §4.2). ``defer`` sits between allow and
+# ask: it means "no opinion / let a later stage decide", so it must never
+# override an explicit allow but must yield to ask/deny.
+_DECISION_RANK: Dict[Decision, int] = {
+    Decision.ALLOW: 0,
+    Decision.DEFER: 1,
+    Decision.ASK: 2,
+    Decision.DENY: 3,
+}
+
+
+class Event(str, Enum):
+    """The event taxonomy (PRD §4.2) — Claude Code's hook points, tenant-scoped.
+
+    The plane fires these in-process (NOT as shell hooks): handlers are typed
+    Python callables with tenant scope only.
+    """
+
+    RUN_START = "RunStart"
+    PRE_TOOL_USE = "PreToolUse"
+    POST_TOOL_USE = "PostToolUse"
+    POST_TOOL_BATCH = "PostToolBatch"
+    ROUND_END = "RoundEnd"
+    RUN_END = "RunEnd"
+    PRE_COMPACT = "PreCompact"
+
+
+@dataclass(frozen=True)
+class PolicyError:
+    """Errors-as-data (PRD §4.2). A denial the *model* can read and adapt to,
+    not an opaque failure.
+
+    - ``code``: machine-stable reason slug (e.g. ``"permission_denied"``,
+      ``"budget_exceeded"``, ``"rate_limited"``).
+    - ``message_for_model``: one line the LLM sees as tool content so it can
+      relay/adjust instead of erroring.
+    - ``remediation``: what would make the call succeed (escalate, approve,
+      wait, drop a field). May be ``None`` when nothing helps.
+    - ``retryable``: whether an identical retry could ever succeed (rate limits:
+      yes; a hard permission deny: no).
+    """
+
+    code: str
+    message_for_model: str
+    remediation: Optional[str] = None
+    retryable: bool = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "code": self.code,
+            "message_for_model": self.message_for_model,
+            "remediation": self.remediation,
+            "retryable": self.retryable,
+        }
+
+
+@dataclass(frozen=True)
+class Verdict:
+    """The typed result of evaluating one tool call against the plane.
+
+    Mirrors Claude Code's hook verdict, re-keyed for tenancy:
+
+    - ``decision``: allow | deny | ask | defer.
+    - ``updated_input``: a replacement tool-input dict the plane wants used
+      instead of the model's (e.g. an injected ``_agent_id``/``field_id``).
+      ``None`` = use the original input unchanged.
+    - ``injected_context``: extra context string the plane wants folded into
+      the model's view (prerequisite hints, policy notes). ``None`` = nothing.
+    - ``reason``: human/audit-facing one-liner for why this disposition.
+    - ``error``: on a deny/ask, the structured errors-as-data payload the model
+      reads. Always present when ``decision`` is deny; present for ask when the
+      ask carries a message; ``None`` for allow/defer.
+    """
+
+    decision: Decision
+    reason: str = ""
+    updated_input: Optional[Dict[str, Any]] = None
+    injected_context: Optional[str] = None
+    error: Optional[PolicyError] = None
+
+    # -- constructors (readability at call sites) --------------------------
+
+    @classmethod
+    def allow(
+        cls,
+        reason: str = "",
+        *,
+        updated_input: Optional[Dict[str, Any]] = None,
+        injected_context: Optional[str] = None,
+    ) -> "Verdict":
+        return cls(
+            Decision.ALLOW,
+            reason=reason,
+            updated_input=updated_input,
+            injected_context=injected_context,
+        )
+
+    @classmethod
+    def defer(cls, reason: str = "") -> "Verdict":
+        """No opinion — let a later stage decide. Never overrides an allow."""
+        return cls(Decision.DEFER, reason=reason)
+
+    @classmethod
+    def deny(cls, error: PolicyError, *, reason: Optional[str] = None) -> "Verdict":
+        return cls(
+            Decision.DENY,
+            reason=reason if reason is not None else error.message_for_model,
+            error=error,
+        )
+
+    @classmethod
+    def ask(
+        cls,
+        error: PolicyError,
+        *,
+        reason: Optional[str] = None,
+        injected_context: Optional[str] = None,
+    ) -> "Verdict":
+        return cls(
+            Decision.ASK,
+            reason=reason if reason is not None else error.message_for_model,
+            error=error,
+            injected_context=injected_context,
+        )
+
+    # -- helpers -----------------------------------------------------------
+
+    @property
+    def blocks_execution(self) -> bool:
+        """True when this verdict must stop the tool from executing.
+
+        deny and ask both block: deny is final, ask suspends pending approval.
+        allow and defer let the call proceed.
+        """
+        return self.decision in (Decision.DENY, Decision.ASK)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "decision": self.decision.value,
+            "reason": self.reason,
+            "updated_input": self.updated_input,
+            "injected_context": self.injected_context,
+            "error": self.error.to_dict() if self.error is not None else None,
+        }
+
+
+def merge_verdicts(*verdicts: Optional[Verdict]) -> Verdict:
+    """Combine handler verdicts under **deny > ask > allow** (PRD §4.2).
+
+    The highest-ranked disposition wins the ``decision`` and its ``error``.
+    ``updated_input`` and ``injected_context`` from *allowing* handlers are still
+    threaded through (an allow can rewrite input / inject context), but a
+    blocking verdict (deny/ask) is authoritative for the decision. ``None`` and
+    ``defer`` verdicts are treated as "no opinion".
+
+    With no verdicts (or all ``None``/``defer``) the result is a plain allow —
+    the plane never invents a block out of silence.
+    """
+    present = [v for v in verdicts if v is not None]
+    if not present:
+        return Verdict.allow("no policy opinion")
+
+    winner = max(present, key=lambda v: _DECISION_RANK[v.decision])
+
+    # Thread input-rewrites / injected-context from every non-blocking verdict
+    # so an allowing handler's rewrite is not lost when another allows too.
+    # A blocking winner owns the decision but we still surface its own rewrites.
+    updated_input = winner.updated_input
+    injected_parts = []
+    for v in present:
+        if v.injected_context:
+            injected_parts.append(v.injected_context)
+        if updated_input is None and v.updated_input is not None and not v.blocks_execution:
+            updated_input = v.updated_input
+
+    injected = "\n".join(injected_parts) if injected_parts else None
+
+    if winner.decision in (Decision.ALLOW, Decision.DEFER):
+        # Normalise a bare defer up to allow at the boundary so callers only
+        # ever branch on allow/deny/ask.
+        return Verdict.allow(
+            winner.reason or "allowed",
+            updated_input=updated_input,
+            injected_context=injected,
+        )
+    return Verdict(
+        decision=winner.decision,
+        reason=winner.reason,
+        updated_input=updated_input,
+        injected_context=injected,
+        error=winner.error,
+    )

--- a/orchestrator/modules/tools/discovery/platform_executor.py
+++ b/orchestrator/modules/tools/discovery/platform_executor.py
@@ -546,6 +546,38 @@ class PlatformActionExecutor:
             )
             return False
 
+    def _agent_inherits_admin(self) -> bool:
+        """Whether an agent (no caller identity) may act as admin here.
+
+        PRD-174 F014: closes the ``admin_only`` no-op. Historically a missing
+        caller_context fell back to "does the workspace have *an* admin member"
+        (true for every workspace) — so ``admin_only`` never actually gated an
+        agent. Under the policy plane this fallback is opt-in: it applies only
+        when the workspace's explicit, default-OFF ``agents_inherit_admin``
+        policy is set (and there really is an admin/owner to inherit from).
+
+        Plane OFF ⇒ historical behaviour (always fall back to the owner check)
+        so the rollout is byte-for-byte reversible.
+        """
+        try:
+            from modules.policy import policy_plane_enabled
+
+            if policy_plane_enabled():
+                from modules.policy.policy_document import load_policy_document
+
+                doc = load_policy_document(self.db, self.workspace_id)
+                if not doc.agents_inherit_admin:
+                    return False  # explicit default-off policy → agent is NOT admin
+                return self._workspace_has_admin_owner()
+        except Exception:
+            logger.warning(
+                "[PlatformExecutor] agents_inherit_admin policy read failed for %s "
+                "— falling back to legacy owner check", self.workspace_id,
+                exc_info=True,
+            )
+        # Plane OFF (or read failure): historical always-fallback behaviour.
+        return self._workspace_has_admin_owner()
+
     def _full_autonomy(self) -> bool:
         """True when this workspace is dialled to full autonomy.
 
@@ -639,10 +671,13 @@ class PlatformActionExecutor:
                         or caller_context.get("system_role") == "admin"
                     )
                 else:
-                    # No caller_context (heartbeat, agent factory, etc.) —
-                    # resolve from workspace owner's role.  Agents inherit
-                    # admin privileges from their workspace owner.
-                    is_admin = self._workspace_has_admin_owner()
+                    # No caller_context (heartbeat, agent factory, etc.).
+                    # PRD-174 F014: the "agents inherit admin from the workspace
+                    # owner" fallback is no longer implicit — under the policy
+                    # plane it applies ONLY when the explicit, default-OFF
+                    # ``agents_inherit_admin`` workspace policy is set. Plane OFF
+                    # keeps the historical always-fallback behaviour.
+                    is_admin = self._agent_inherits_admin()
                 if not is_admin:
                     logger.warning(
                         "[PlatformExecutor] Admin-only action '%s' denied — "

--- a/orchestrator/modules/tools/execution/tool_loop.py
+++ b/orchestrator/modules/tools/execution/tool_loop.py
@@ -102,6 +102,32 @@ class ToolPostResult:
 
 
 @dataclass
+class PreToolResult:
+    """Return type of the PRD-174 ``on_pre_tool`` seam (fires beside dedup).
+
+    - ``block``: when True the tool is NOT executed; ``block_content`` is
+      surfaced to the LLM as the tool result (errors-as-data — a policy deny/ask
+      the model can read and adapt to). Mirrors the plane's deny/ask verdict at
+      the loop level.
+    - ``updated_input``: an optional replacement args dict the plane wants used
+      instead of the model's (e.g. an injected id). ``None`` = unchanged.
+
+    The default (returning ``None`` from the hook, or leaving ``on_pre_tool``
+    unset) is "no opinion" — the loop behaves byte-for-byte as before.
+    """
+
+    block: bool = False
+    block_content: Optional[str] = None
+    updated_input: Optional[Dict[str, Any]] = None
+
+
+# on_pre_tool hook: (name, args, workspace_id) -> Optional[PreToolResult]
+PreToolHook = Callable[
+    [str, Dict[str, Any], Optional[Any]], Awaitable[Optional[PreToolResult]]
+]
+
+
+@dataclass
 class ToolLoopResult:
     """The return value of :meth:`ToolLoopExecutor.run`.
 
@@ -192,6 +218,7 @@ class ToolLoopExecutor:
         on_round_end: Optional[
             Callable[[RoundState], Awaitable[Optional[ToolPostResult]]]
         ] = None,
+        on_pre_tool: Optional[PreToolHook] = None,
     ) -> ToolLoopResult:
         """Run the tool loop. Returns the final LLM response + iteration count.
 
@@ -250,6 +277,7 @@ class ToolLoopExecutor:
                 iteration=iteration,
                 on_event=on_event,
                 on_tool_result=on_tool_result,
+                on_pre_tool=on_pre_tool,
             )
             if forced is not None:
                 # Caller asked us to short-circuit — return the synthesized response.
@@ -324,6 +352,7 @@ class ToolLoopExecutor:
         on_tool_result: Optional[
             Callable[[str, Dict[str, Any], Any], Awaitable[Optional[ToolPostResult]]]
         ],
+        on_pre_tool: Optional[PreToolHook] = None,
     ) -> Tuple[List[Message], Optional[LLMResponse], RoundState]:
         """Execute a single round of tool calls.
 
@@ -363,6 +392,31 @@ class ToolLoopExecutor:
                     "reason": reason,
                 })
                 continue
+
+            # PRD-174 W4 — on_pre_tool policy seam (beside dedup). The natural
+            # attach point for blueprint / approval / budget policy: a deny/ask
+            # verdict blocks the call and surfaces its reason to the LLM as the
+            # tool result (errors-as-data); an updated_input rewrites the args.
+            # Unset hook (or a None return) is no-op — byte-for-byte the old loop.
+            if on_pre_tool is not None:
+                pre = await on_pre_tool(name, args, workspace_id)
+                if pre is not None:
+                    if pre.block:
+                        block_msg = pre.block_content or f"Blocked by policy: {name}"
+                        logger.info("[tool-loop] pre-tool block %s: %s", name, block_msg)
+                        tool_results.append(_tool_msg(call_id, name, block_msg))
+                        state.had_skips = True
+                        await _emit(on_event, {
+                            "type": "tool-end",
+                            "tool_call_id": call_id,
+                            "tool_name": name,
+                            "success": False,
+                            "blocked": True,
+                            "reason": block_msg,
+                        })
+                        continue
+                    if pre.updated_input is not None:
+                        args = pre.updated_input
 
             self.tracker.record_execution(name, args)
             attempts[name] = attempts.get(name, 0) + 1

--- a/orchestrator/modules/tools/execution/unified_executor.py
+++ b/orchestrator/modules/tools/execution/unified_executor.py
@@ -198,6 +198,74 @@ class UnifiedToolExecutor:
         return self._tool_registry
 
     # ------------------------------------------------------------------
+    # Policy plane chokepoint (PRD-174 W4)
+    # ------------------------------------------------------------------
+
+    def _policy_gate_check(
+        self,
+        tool_name: str,
+        parameters: Dict[str, Any],
+        *,
+        agent_id: int,
+        workspace_id: Optional[UUID],
+        caller_context: Optional[Dict[str, Any]],
+        trace: str,
+    ) -> Optional[Dict[str, Any]]:
+        """Evaluate one tool call through the unified PolicyGate.
+
+        Returns ``None`` when execution may proceed (plane OFF, or an ``allow``
+        verdict). Returns an errors-as-data result dict when the plane BLOCKS the
+        call (deny/ask) — the caller returns it directly, so the tool never runs.
+
+        Never raises: a fault in the plane must not wedge tool execution, so any
+        error here is logged and treated as "proceed" (the downstream per-tool
+        gates in ``platform_executor`` remain in force for platform actions).
+        """
+        try:
+            from modules.policy import policy_plane_enabled
+
+            if not policy_plane_enabled():
+                return None  # flag OFF — byte-for-byte the legacy per-router gates
+
+            from modules.policy import PolicyGate, ToolCall, Decision
+            from modules.policy.errors import verdict_to_result
+
+            # Resolve the effective action for the meta-dispatcher: platform_execute
+            # nests the real action under "action" (params may be flat or wrapped).
+            effective_name = tool_name
+            effective_params = parameters if isinstance(parameters, dict) else {}
+            if tool_name == "platform_execute" and isinstance(parameters, dict):
+                action_name = (parameters.get("action") or "").strip()
+                if action_name:
+                    effective_name = action_name
+                    effective_params = parameters.get("params") or {
+                        k: v for k, v in parameters.items() if k not in ("action", "params")
+                    }
+
+            verdict = PolicyGate(self.db).check(
+                ToolCall(
+                    tool_name=effective_name,
+                    parameters=effective_params,
+                    workspace_id=workspace_id,
+                    agent_id=agent_id,
+                    caller_context=caller_context,
+                )
+            )
+            if verdict.decision is Decision.ALLOW:
+                return None
+            logger.info(
+                "[tool-trace %s] policy plane %s '%s': %s",
+                trace, verdict.decision.value, effective_name, verdict.reason,
+            )
+            return verdict_to_result(verdict, tool_name)
+        except Exception:
+            logger.warning(
+                "[tool-trace %s] policy gate errored for '%s' — proceeding "
+                "(downstream gates still apply)", trace, tool_name, exc_info=True,
+            )
+            return None
+
+    # ------------------------------------------------------------------
     # Main dispatch
     # ------------------------------------------------------------------
 
@@ -238,6 +306,20 @@ class UnifiedToolExecutor:
                 f"workspace={workspace_id}"
             )
             logger.info(f"[tool-trace {trace}] Parameters keys={list(parameters.keys()) if isinstance(parameters, dict) else type(parameters).__name__}")
+
+            # PRD-174 W4 — the single policy chokepoint. When the plane is ON,
+            # EVERY tool call (platform, workspace, Composio, registry) is
+            # evaluated by one typed gate HERE, so Composio/workspace/registry
+            # stop routing around the platform gate stack (F085/F060). A deny/ask
+            # returns errors-as-data the model can read and never executes.
+            # Flag OFF ⇒ this block is a no-op and behaviour is byte-for-byte the
+            # per-router gates below.
+            _policy_block = self._policy_gate_check(
+                tool_name, parameters, agent_id=agent_id,
+                workspace_id=workspace_id, caller_context=caller_context, trace=trace,
+            )
+            if _policy_block is not None:
+                return _policy_block
 
             # PRD-64: Single dispatcher for platform actions
             if tool_name == "platform_execute":

--- a/orchestrator/modules/tools/tool_router.py
+++ b/orchestrator/modules/tools/tool_router.py
@@ -726,7 +726,7 @@ class ToolRouter:
                 else error
             )
             logger.warning(f"[tool-trace {trace_id}] {tool_name} failed: {error}")
-            return {
+            envelope = {
                 "success": False,
                 "frontend_data": {},
                 "llm_context": f"Tool {tool_name} failed: {llm_error}",
@@ -734,6 +734,12 @@ class ToolRouter:
                 "fatal_error": fatal_error,
                 "error_type": error_type,
             }
+            # PRD-174 §4.2 — errors-as-data: give the model a stable
+            # {code, message_for_model, remediation, retryable} block so it can
+            # adapt (escalate / approve / drop a field) instead of seeing an
+            # opaque failure. A policy deny already carries policy_error; this
+            # backfills everything else. Additive + flag-gated (OFF = unchanged).
+            return self._maybe_add_error_envelope(envelope, result)
 
         except Exception as e:
             error_msg = str(e)
@@ -746,7 +752,7 @@ class ToolRouter:
             logger.error(f"[tool-trace {trace_id}] {tool_name} exception: {error_msg}")
             # PRD-141 US-019: a thrown tool is a failure outcome too.
             self._record_tool_signal(tool_name, False, agent_id, workspace_id, caller_context)
-            return {
+            envelope = {
                 "success": False,
                 "frontend_data": {},
                 "llm_context": f"Tool {tool_name} error: {llm_error}",
@@ -754,6 +760,36 @@ class ToolRouter:
                 "fatal_error": fatal_error,
                 "error_type": "dependency_missing" if fatal_error else None,
             }
+            # PRD-174 §4.2 — errors-as-data (see above); backfill on the thrown path too.
+            return self._maybe_add_error_envelope(envelope, {"success": False, "error": error_msg})
+
+    @staticmethod
+    def _maybe_add_error_envelope(
+        envelope: Dict[str, Any], raw_result: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Backfill the errors-as-data ``policy_error`` block when the plane is on.
+
+        Additive: the returned dict keeps every existing key; it only adds
+        ``policy_error`` (a ``{code, message_for_model, remediation, retryable}``
+        payload derived from the failing result). Flag OFF ⇒ returned unchanged,
+        so today's callers see byte-for-byte the same shape. Never raises.
+        """
+        try:
+            from modules.policy import policy_plane_enabled
+
+            if not policy_plane_enabled():
+                return envelope
+            from modules.policy.errors import ensure_error_envelope
+
+            # Preserve a policy_error the raw result already carries (a gate deny).
+            source = dict(raw_result) if isinstance(raw_result, dict) else {}
+            source.setdefault("success", False)
+            enriched = ensure_error_envelope(source)
+            if "policy_error" in enriched:
+                envelope["policy_error"] = enriched["policy_error"]
+        except Exception:
+            logger.debug("[tool_router] error-envelope backfill skipped", exc_info=True)
+        return envelope
 
     @staticmethod
     def _record_tool_signal(

--- a/orchestrator/tests/test_prd174_executor_chokepoint.py
+++ b/orchestrator/tests/test_prd174_executor_chokepoint.py
@@ -1,0 +1,116 @@
+"""PRD-174 W4 — executor chokepoint characterization (§6.1/§6.2, safety rule #1/#2).
+
+The headline, at the real integration point (``UnifiedToolExecutor.execute_tool``):
+
+- **Flag OFF ⇒ byte-for-byte** — ``_policy_gate_check`` returns ``None`` (a no-op),
+  so dispatch proceeds exactly as it did before PRD-174. Composio/workspace/
+  registry routing is unchanged.
+- **Flag ON + deny ⇒ the tool NEVER dispatches** and the caller gets an
+  errors-as-data result (``policy_error`` block the model can read).
+
+``UnifiedToolExecutor`` imports the DB stack, so this suite is **CI-gated**: it
+is skipped when the DB isn't configured (the local ``py_compile`` + pure-unit
+tests cover the logic; CI runs this against a real DB). We monkeypatch the gate
+verdict + the downstream dispatch so no tool actually executes and no network is
+touched — we assert on *whether dispatch was reached*.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_ORCH = Path(__file__).resolve().parents[1]
+if str(_ORCH) not in sys.path:
+    sys.path.insert(0, str(_ORCH))
+
+# CI gate: import the executor or skip the whole module. The executor pulls the
+# DB stack, which raises ValueError (not ImportError) when creds are absent, so
+# importorskip alone won't catch it — guard on any exception.
+try:
+    import modules.tools.execution.unified_executor as unified_executor  # noqa: E402
+except Exception as _exc:  # pragma: no cover - environment-dependent skip
+    pytest.skip(
+        f"UnifiedToolExecutor unavailable (CI-gated): {type(_exc).__name__}",
+        allow_module_level=True,
+    )
+
+from modules.policy.types import PolicyError, Verdict  # noqa: E402
+
+
+class _FakeSession:
+    """No-op DB session — the gate is monkeypatched so it's never really used."""
+
+    def query(self, *a, **k):
+        raise AssertionError("gate was monkeypatched; DB should not be queried")
+
+
+def _make_executor():
+    return unified_executor.UnifiedToolExecutor(db_session=_FakeSession())
+
+
+@pytest.mark.asyncio
+async def test_flag_off_gate_is_noop(monkeypatch):
+    """Flag OFF ⇒ _policy_gate_check returns None (byte-for-byte, no gate)."""
+    monkeypatch.setattr("modules.policy.policy_plane_enabled", lambda: False, raising=False)
+    ex = _make_executor()
+    blocked = ex._policy_gate_check(
+        "platform_delete_agent", {"id": 1}, agent_id=1,
+        workspace_id="ws", caller_context=None, trace="t",
+    )
+    assert blocked is None  # no policy result → dispatch proceeds as before
+
+
+@pytest.mark.asyncio
+async def test_flag_on_deny_blocks_before_dispatch(monkeypatch):
+    """Flag ON + deny ⇒ execute_tool returns the errors-as-data block and the
+    tool is NEVER dispatched."""
+    monkeypatch.setattr("modules.policy.policy_plane_enabled", lambda: True, raising=False)
+
+    # Force the gate to deny, regardless of DB/registry.
+    deny = Verdict.deny(PolicyError(
+        code="approval_required",
+        message_for_model="Blocked: needs approval; NOT executed.",
+        remediation="approve in the queue", retryable=True,
+    ))
+    monkeypatch.setattr(
+        "modules.policy.PolicyGate.check", lambda self, call: deny, raising=False
+    )
+
+    ex = _make_executor()
+
+    # Trip-wire: if dispatch is reached, fail loudly. It must not be.
+    async def _tripwire(*a, **k):
+        raise AssertionError("denied call reached dispatch — it must not execute")
+
+    monkeypatch.setattr(ex, "_execute_platform_action", _tripwire)
+
+    result = await ex.execute_tool(
+        "platform_delete_agent", {"id": 1}, agent_id=1, workspace_id="ws",
+    )
+    assert result["success"] is False
+    assert result.get("policy_error", {}).get("code") == "approval_required"
+    assert "NOT executed" in result["llm_context"]
+
+
+@pytest.mark.asyncio
+async def test_flag_on_allow_reaches_dispatch(monkeypatch):
+    """Flag ON + allow ⇒ the gate is a pass-through; dispatch is reached."""
+    monkeypatch.setattr("modules.policy.policy_plane_enabled", lambda: True, raising=False)
+    monkeypatch.setattr(
+        "modules.policy.PolicyGate.check",
+        lambda self, call: Verdict.allow("fine"), raising=False,
+    )
+    ex = _make_executor()
+
+    reached = {"dispatched": False}
+
+    async def _dispatch(*a, **k):
+        reached["dispatched"] = True
+        return {"success": True, "tool": "platform_list_agents"}
+
+    monkeypatch.setattr(ex, "_execute_platform_action", _dispatch)
+
+    await ex.execute_tool("platform_list_agents", {}, agent_id=1, workspace_id="ws")
+    assert reached["dispatched"] is True

--- a/orchestrator/tests/test_prd174_flag_gating.py
+++ b/orchestrator/tests/test_prd174_flag_gating.py
@@ -1,0 +1,122 @@
+"""PRD-174 W4 — flag gating & byte-for-byte OFF (§6.4/§6.6, safety rule #1).
+
+Proves the flag actually flips behaviour and that OFF is today's behaviour:
+
+- ``core/auth/roles.caller_is_admin`` — OFF ⇒ exactly ``system_role == 'admin'``
+  (super-admin still excluded, byte-for-byte); ON ⇒ super_admin ⊇ admin (the
+  seven-router F043 fix).
+- ``modules.policy.roles.has_permission`` — the empty=deny semantic both planes
+  converge on under the flag (F042).
+- ``modules.policy.flag.policy_plane_enabled`` reads the config flag and fails
+  safe (OFF) if config can't be read.
+- F040 — the SlowAPIMiddleware registration in ``main.py`` is guarded by the
+  flag (grep-level assertion; importing main pulls the whole app).
+
+The flag is toggled by monkeypatching ``config.config.POLICY_PLANE_ENABLED`` —
+the single source of truth (no ``os.getenv`` outside config).
+"""
+from __future__ import annotations
+
+import sys
+import types as _types
+from pathlib import Path
+
+import pytest
+
+_ORCH = Path(__file__).resolve().parents[1]
+if str(_ORCH) not in sys.path:
+    sys.path.insert(0, str(_ORCH))
+
+_LEAKED_PARENT_STUBS = {}
+for _pkg in ("modules", "modules.tools", "modules.tools.execution"):
+    if _pkg not in sys.modules:
+        _stub = _types.ModuleType(_pkg)
+        _stub.__path__ = [str(_ORCH / _pkg.replace(".", "/"))]
+        sys.modules[_pkg] = _stub
+        _LEAKED_PARENT_STUBS[_pkg] = _stub
+
+
+def teardown_module(module):
+    for _name, _stub in _LEAKED_PARENT_STUBS.items():
+        if sys.modules.get(_name) is _stub:
+            del sys.modules[_name]
+
+
+import config as _config_mod  # noqa: E402
+from core.auth.roles import caller_is_admin  # noqa: E402
+
+
+class _User:
+    def __init__(self, role):
+        self.system_role = role
+
+
+@pytest.fixture
+def flag(monkeypatch):
+    """Toggle the policy-plane flag at its single source of truth."""
+    def set_flag(value: bool):
+        monkeypatch.setattr(_config_mod.config, "POLICY_PLANE_ENABLED", value)
+    return set_flag
+
+
+# ---------------------------------------------------------------------------
+# F043 — caller_is_admin: OFF byte-for-byte, ON widens to super_admin
+# ---------------------------------------------------------------------------
+
+def test_caller_is_admin_flag_off_is_legacy_exact_check(flag):
+    flag(False)
+    assert caller_is_admin(_User("admin")) is True
+    assert caller_is_admin(_User("super_admin")) is False   # legacy: excluded (byte-for-byte)
+    assert caller_is_admin(_User("user")) is False
+    assert caller_is_admin(None) is False
+
+
+def test_caller_is_admin_flag_on_super_admin_passes(flag):
+    flag(True)
+    assert caller_is_admin(_User("admin")) is True
+    assert caller_is_admin(_User("super_admin")) is True    # F043 fix: no longer 403'd
+    assert caller_is_admin(_User("user")) is False
+
+
+# ---------------------------------------------------------------------------
+# F042 — empty permission = deny (the semantic both planes take under the flag)
+# ---------------------------------------------------------------------------
+
+def test_has_permission_empty_is_deny():
+    from modules.policy.roles import has_permission
+    # This is what the widget plane switches to under the flag, matching the
+    # board plane's _sdk_key_has_scope (empty grants nothing).
+    assert has_permission([], "widget:chat") is False
+    assert has_permission(None, "widget:chat") is False
+    assert has_permission(["widget:chat"], "widget:chat") is True
+
+
+# ---------------------------------------------------------------------------
+# flag reader fails safe
+# ---------------------------------------------------------------------------
+
+def test_policy_plane_enabled_reads_config(flag):
+    from modules.policy.flag import policy_plane_enabled
+    flag(True)
+    assert policy_plane_enabled() is True
+    flag(False)
+    assert policy_plane_enabled() is False
+
+
+# ---------------------------------------------------------------------------
+# F040 — SlowAPIMiddleware registration is flag-guarded in main.py
+# ---------------------------------------------------------------------------
+
+def test_f040_middleware_registration_is_flag_guarded():
+    main_src = (_ORCH / "main.py").read_text()
+    # The middleware is registered, and only under the flag guard.
+    assert "SlowAPIMiddleware" in main_src
+    assert "if _policy_plane_on:" in main_src
+    # Fail-closed swallow_errors follows the flag (closed when the plane is on).
+    assert "swallow_errors=not _policy_plane_on" in main_src
+
+
+def test_config_flag_defaults_off():
+    """The master flag must default OFF (safety rule #1)."""
+    src = (_ORCH / "config.py").read_text()
+    assert 'os.getenv("AUTOMATOS_POLICY_PLANE", "false")' in src

--- a/orchestrator/tests/test_prd174_policy_chokepoint.py
+++ b/orchestrator/tests/test_prd174_policy_chokepoint.py
@@ -1,0 +1,245 @@
+"""PRD-174 W4 — the headline characterization (§6.1) at the seams.
+
+Two load-bearing guarantees, both stdlib-only:
+
+1. **A denied tool call NEVER executes** and the model gets a **structured denial
+   it can read** — proven at the ``on_pre_tool`` seam in the converged tool loop:
+   a blocking verdict means the tool callback is never invoked, and the reason
+   reaches the LLM as the tool result.
+
+2. **Flag OFF is byte-for-byte today's behaviour** — proven at the tool loop
+   (no ``on_pre_tool`` hook ⇒ every call executes exactly as before) and at the
+   ``PolicyGate`` chokepoint helper (plane OFF ⇒ the gate is a no-op).
+
+The full ``UnifiedToolExecutor`` pulls asyncpg/pgvector, so the executor-level
+flag-OFF/ON path is exercised through its extracted ``_policy_gate_check`` logic
+re-expressed here against the same ``PolicyGate`` + ``verdict_to_result`` the
+executor calls — no DB, no heavy import.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+import types as _types
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+_ORCH = Path(__file__).resolve().parents[1]
+if str(_ORCH) not in sys.path:
+    sys.path.insert(0, str(_ORCH))
+
+_LEAKED_PARENT_STUBS = {}
+for _pkg in ("modules", "modules.tools", "modules.tools.execution"):
+    if _pkg not in sys.modules:
+        _stub = _types.ModuleType(_pkg)
+        _stub.__path__ = [str(_ORCH / _pkg.replace(".", "/"))]
+        sys.modules[_pkg] = _stub
+        _LEAKED_PARENT_STUBS[_pkg] = _stub
+
+
+def teardown_module(module):
+    for _name, _stub in _LEAKED_PARENT_STUBS.items():
+        if sys.modules.get(_name) is _stub:
+            del sys.modules[_name]
+
+
+from modules.tools.execution.tool_loop import (  # noqa: E402
+    ToolLoopExecutor,
+    PreToolResult,
+)
+from modules.policy.types import Decision, PolicyError, Verdict  # noqa: E402
+from modules.policy.errors import verdict_to_result  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Doubles (mirror test_tool_loop_characterization's shapes).
+# ---------------------------------------------------------------------------
+
+def _resp(content=None, tool_calls=None, finish_reason=None):
+    return SimpleNamespace(
+        content=content, tool_calls=tool_calls, finish_reason=finish_reason,
+        usage={}, model="test", provider="test",
+    )
+
+
+def _tc(name: str, args: Dict[str, Any], call_id: str = "call_1") -> Dict[str, Any]:
+    return {"id": call_id, "type": "function",
+            "function": {"name": name, "arguments": json.dumps(args)}}
+
+
+class _ScriptedLLM:
+    def __init__(self, *responses):
+        self._responses = list(responses)
+        self.call_count = 0
+
+    async def __call__(self, messages, tools=None):
+        self.call_count += 1
+        if not self._responses:
+            return _resp(content="done")
+        return self._responses.pop(0)
+
+
+class _RecordingTool:
+    def __init__(self):
+        self.calls: List[str] = []
+
+    async def __call__(self, name, args, call_id, workspace_id):
+        self.calls.append(name)
+        return {"success": True, "llm_context": "ok", "raw_result": {}}
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ---------------------------------------------------------------------------
+# §6.1 — a denied tool call NEVER executes (loop seam)
+# ---------------------------------------------------------------------------
+
+def test_denied_pre_tool_call_never_executes_and_model_reads_reason():
+    tool = _RecordingTool()
+    # LLM asks to delete, then (after the block) writes a final answer.
+    llm = _ScriptedLLM(
+        _resp(tool_calls=[_tc("platform_delete_agent", {"id": 7})]),
+        _resp(content="ok, I won't delete"),
+    )
+    executor = ToolLoopExecutor(llm_callback=llm, tool_callback=tool, max_iterations=3)
+
+    # errors-as-data the model can read — exactly what verdict_to_result produces.
+    verdict = Verdict.deny(PolicyError(
+        code="approval_required",
+        message_for_model="Deleting an agent needs human approval; it was NOT executed.",
+        remediation="Ask a human to approve in the queue.",
+        retryable=True,
+    ))
+    block_content = verdict.error.message_for_model
+
+    async def on_pre_tool(name, args, ws):
+        if name == "platform_delete_agent":
+            return PreToolResult(block=True, block_content=block_content)
+        return None
+
+    result = _run(executor.run(
+        initial_response=_resp(tool_calls=[_tc("platform_delete_agent", {"id": 7})]),
+        messages=[{"role": "user", "content": "delete agent 7"}],
+        on_pre_tool=on_pre_tool,
+    ))
+
+    # 1) the tool NEVER ran
+    assert tool.calls == [], "denied tool must not execute"
+    # 2) the structured reason reached the LLM as the tool result content
+    #    (the loop appends a tool message carrying block_content before re-invoking)
+    assert result.iterations >= 1
+
+
+def test_denied_call_surfaces_structured_reason_as_tool_message():
+    """The block content the model sees is the errors-as-data message, verbatim."""
+    tool = _RecordingTool()
+    llm = _ScriptedLLM(_resp(content="acknowledged"))
+    executor = ToolLoopExecutor(llm_callback=llm, tool_callback=tool, max_iterations=2)
+
+    captured_messages: List[Dict[str, Any]] = []
+
+    async def spy_llm(messages, tools=None):
+        captured_messages.extend([dict(m) for m in messages])
+        return _resp(content="acknowledged")
+
+    executor2 = ToolLoopExecutor(llm_callback=spy_llm, tool_callback=tool, max_iterations=2)
+
+    msg = "Refund needs approval; NOT executed."
+
+    async def on_pre_tool(name, args, ws):
+        return PreToolResult(block=True, block_content=msg)
+
+    _run(executor2.run(
+        initial_response=_resp(tool_calls=[_tc("composio_refund", {"order": 1})]),
+        messages=[{"role": "user", "content": "refund order 1"}],
+        on_pre_tool=on_pre_tool,
+    ))
+
+    assert tool.calls == []
+    # the tool-result message fed back to the LLM contains the exact reason
+    tool_msgs = [m for m in captured_messages if m.get("role") == "tool"]
+    assert any(msg in (m.get("content") or "") for m in tool_msgs), \
+        "model must see the structured denial reason as tool content"
+
+
+def test_updated_input_rewrite_is_applied_to_the_call():
+    """An allow-with-rewrite verdict changes the args the tool actually receives."""
+    seen_args: Dict[str, Any] = {}
+
+    async def capturing_tool(name, args, call_id, workspace_id):
+        seen_args.update(args)
+        return {"success": True, "llm_context": "ok"}
+
+    llm = _ScriptedLLM(_resp(content="done"))
+    executor = ToolLoopExecutor(llm_callback=llm, tool_callback=capturing_tool, max_iterations=2)
+
+    async def on_pre_tool(name, args, ws):
+        return PreToolResult(updated_input={**args, "_agent_id": 42})
+
+    _run(executor.run(
+        initial_response=_resp(tool_calls=[_tc("platform_read_document", {"doc": "x"})]),
+        messages=[{"role": "user", "content": "read doc x"}],
+        on_pre_tool=on_pre_tool,
+    ))
+    assert seen_args.get("_agent_id") == 42
+    assert seen_args.get("doc") == "x"
+
+
+# ---------------------------------------------------------------------------
+# Flag OFF byte-for-byte — no on_pre_tool hook ⇒ every call executes as before
+# ---------------------------------------------------------------------------
+
+def test_no_pre_tool_hook_executes_normally():
+    tool = _RecordingTool()
+    llm = _ScriptedLLM(_resp(content="done"))
+    executor = ToolLoopExecutor(llm_callback=llm, tool_callback=tool, max_iterations=2)
+    _run(executor.run(
+        initial_response=_resp(tool_calls=[_tc("platform_delete_agent", {"id": 7})]),
+        messages=[{"role": "user", "content": "delete"}],
+        # NO on_pre_tool → the loop must behave exactly as it did before PRD-174
+    ))
+    assert tool.calls == ["platform_delete_agent"], "without the seam the call runs as before"
+
+
+def test_pre_tool_returning_none_executes_normally():
+    tool = _RecordingTool()
+    llm = _ScriptedLLM(_resp(content="done"))
+    executor = ToolLoopExecutor(llm_callback=llm, tool_callback=tool, max_iterations=2)
+
+    async def noop(name, args, ws):
+        return None  # "no opinion" — must not change behaviour
+
+    _run(executor.run(
+        initial_response=_resp(tool_calls=[_tc("platform_list_agents", {})]),
+        messages=[{"role": "user", "content": "list"}],
+        on_pre_tool=noop,
+    ))
+    assert tool.calls == ["platform_list_agents"]
+
+
+# ---------------------------------------------------------------------------
+# Chokepoint helper semantics — the exact composition execute_tool uses.
+# verdict_to_result(deny) is a non-success result the executor returns instead
+# of dispatching, so the tool never runs.
+# ---------------------------------------------------------------------------
+
+def test_chokepoint_deny_result_is_non_success_and_blocks():
+    v = Verdict.deny(PolicyError("permission_denied", "no", remediation="escalate"))
+    r = verdict_to_result(v, "platform_delete_agent")
+    # the executor returns this instead of dispatching → the tool never executes
+    assert r["success"] is False
+    assert r["policy_error"]["code"] == "permission_denied"
+    assert r["policy_decision"] == "deny"
+
+
+def test_chokepoint_allow_does_not_block():
+    # An allow verdict is NOT rendered to a result — the executor proceeds.
+    v = Verdict.allow("fine")
+    assert v.decision is Decision.ALLOW
+    assert v.blocks_execution is False

--- a/orchestrator/tests/test_prd174_policy_gate.py
+++ b/orchestrator/tests/test_prd174_policy_gate.py
@@ -1,0 +1,230 @@
+"""PRD-174 W4 — PolicyGate acceptance (§6.2/§6.5/§6.6/§6.7).
+
+Drives ``PolicyGate.check()`` directly with lightweight fakes for the DB /
+registry / autonomy so we exercise the *gate's* decisions with no real DB:
+
+- **F060/F085** — a Composio (and workspace, and registry) tool is evaluated by
+  the gate, not routed around it; a destructive/external one is asked, not run.
+- **F014** — an ``admin_only`` action is denied when the caller isn't admin;
+  the workspace-owner fallback fires only with ``agents_inherit_admin`` on.
+- **F043** — a ``super_admin`` passes the super-admin gate; an admin/user does not.
+- **Balanced (§5)** — read/internal → allow (auto), destructive/external → ask.
+
+The gate's lazy hooks (registry lookup, ``is_full_autonomy``, workspace-admin
+query) are monkeypatched, so this stays DB-free and deterministic.
+"""
+from __future__ import annotations
+
+import sys
+import types as _types
+from pathlib import Path
+
+import pytest
+
+_ORCH = Path(__file__).resolve().parents[1]
+if str(_ORCH) not in sys.path:
+    sys.path.insert(0, str(_ORCH))
+
+_LEAKED_PARENT_STUBS = {}
+for _pkg in ("modules", "modules.tools", "modules.tools.execution"):
+    if _pkg not in sys.modules:
+        _stub = _types.ModuleType(_pkg)
+        _stub.__path__ = [str(_ORCH / _pkg.replace(".", "/"))]
+        sys.modules[_pkg] = _stub
+        _LEAKED_PARENT_STUBS[_pkg] = _stub
+
+
+def teardown_module(module):
+    for _name, _stub in _LEAKED_PARENT_STUBS.items():
+        if sys.modules.get(_name) is _stub:
+            del sys.modules[_name]
+
+
+from modules.policy import gate as gate_mod  # noqa: E402
+from modules.policy.gate import PolicyGate, ToolCall  # noqa: E402
+from modules.policy.types import Decision  # noqa: E402
+from modules.policy import policy_document as pd  # noqa: E402
+
+
+class _ActionDef:
+    """Stand-in for ActionDefinition (only the fields the gate reads)."""
+
+    def __init__(self, permission_level="read", admin_only=False,
+                 super_admin_only=False, requires_confirmation=False):
+        self.permission_level = permission_level
+        self.admin_only = admin_only
+        self.super_admin_only = super_admin_only
+        self.requires_confirmation = requires_confirmation
+
+
+@pytest.fixture
+def patched_gate(monkeypatch):
+    """A PolicyGate whose DB-bound hooks are replaced with in-memory config.
+
+    Returns a helper that builds the gate for a given (action registry map,
+    policy document, full_autonomy, has_admin_owner) so each test sets only what
+    it cares about.
+    """
+    def make(*, actions=None, doc=None, full_autonomy=False, has_admin_owner=True,
+             budget_allows=True):
+        actions = actions or {}
+        doc = doc or pd.PolicyDocument(pd.BALANCED, False, {})
+
+        g = PolicyGate(db="fake-db")
+        monkeypatch.setattr(g, "_lookup_action", lambda name: actions.get(name))
+        monkeypatch.setattr(g, "_full_autonomy", lambda ws: full_autonomy)
+        monkeypatch.setattr(g, "_workspace_has_admin_owner", lambda ws: has_admin_owner)
+        # policy document + budget are module functions the gate calls.
+        monkeypatch.setattr(gate_mod._policy_doc, "load_policy_document",
+                            lambda db, ws: doc)
+        from modules.policy.budget import BudgetDecision
+        monkeypatch.setattr(
+            gate_mod._budget, "check_budget",
+            lambda db, ws, **kw: BudgetDecision(budget_allows, "test budget"),
+        )
+        return g
+
+    return make
+
+
+def _call(name, *, caller=None, ws="ws-1"):
+    return ToolCall(tool_name=name, parameters={}, workspace_id=ws, caller_context=caller)
+
+
+# ---------------------------------------------------------------------------
+# F060/F085 — Composio / workspace / registry tools are evaluated (not bypassed)
+# ---------------------------------------------------------------------------
+
+def test_composio_send_routes_to_ask_not_bypassed(patched_gate):
+    g = patched_gate()  # no action_def (Composio isn't in the platform registry)
+    v = g.check(_call("COMPOSIO_GMAIL_SEND_EMAIL"))
+    # classified external → Balanced routes to ASK; crucially it was EVALUATED.
+    assert v.decision is Decision.ASK
+    assert v.error is not None and v.error.code == "approval_required"
+
+
+def test_workspace_exec_routes_to_ask(patched_gate):
+    g = patched_gate()
+    v = g.check(_call("workspace_exec_shell"))
+    assert v.decision is Decision.ASK  # external-exec → ask under Balanced
+
+
+def test_registry_read_tool_allowed(patched_gate):
+    actions = {"platform_list_agents": _ActionDef(permission_level="read")}
+    g = patched_gate(actions=actions)
+    v = g.check(_call("platform_list_agents"))
+    assert v.decision is Decision.ALLOW  # read → auto
+
+
+def test_internal_write_allowed_under_balanced(patched_gate):
+    actions = {"platform_update_task": _ActionDef(permission_level="write")}
+    g = patched_gate(actions=actions)
+    v = g.check(_call("platform_update_task"))
+    assert v.decision is Decision.ALLOW  # low-risk internal write → auto
+
+
+def test_destructive_routes_to_ask(patched_gate):
+    actions = {"platform_delete_agent": _ActionDef(permission_level="destructive")}
+    g = patched_gate(actions=actions)
+    v = g.check(_call("platform_delete_agent"))
+    assert v.decision is Decision.ASK
+
+
+# ---------------------------------------------------------------------------
+# F043 — super-admin gate
+# ---------------------------------------------------------------------------
+
+def test_super_admin_only_denies_non_super_admin(patched_gate):
+    actions = {"platform_obs_dump": _ActionDef(super_admin_only=True)}
+    g = patched_gate(actions=actions)
+    assert g.check(_call("platform_obs_dump", caller={"system_role": "admin"})).decision is Decision.DENY
+    assert g.check(_call("platform_obs_dump", caller=None)).decision is Decision.DENY
+
+
+def test_super_admin_only_allows_super_admin(patched_gate):
+    actions = {"platform_obs_dump": _ActionDef(super_admin_only=True, permission_level="read")}
+    g = patched_gate(actions=actions)
+    v = g.check(_call("platform_obs_dump", caller={"system_role": "super_admin"}))
+    assert v.decision is Decision.ALLOW  # passes super-admin gate, read → auto
+
+
+# ---------------------------------------------------------------------------
+# F014 — admin_only requires the caller's own role; owner-fallback is opt-in
+# ---------------------------------------------------------------------------
+
+def test_admin_only_denied_for_non_admin_caller(patched_gate):
+    actions = {"platform_admin_thing": _ActionDef(admin_only=True)}
+    g = patched_gate(actions=actions)
+    v = g.check(_call("platform_admin_thing", caller={"system_role": "user"}))
+    assert v.decision is Decision.DENY
+    assert v.error.code == "admin_required"
+
+
+def test_admin_only_allowed_for_admin_caller(patched_gate):
+    actions = {"platform_admin_thing": _ActionDef(admin_only=True, permission_level="read")}
+    g = patched_gate(actions=actions)
+    v = g.check(_call("platform_admin_thing", caller={"system_role": "admin"}))
+    assert v.decision is Decision.ALLOW
+
+
+def test_admin_only_super_admin_caller_also_allowed(patched_gate):
+    actions = {"platform_admin_thing": _ActionDef(admin_only=True, permission_level="read")}
+    g = patched_gate(actions=actions)
+    v = g.check(_call("platform_admin_thing", caller={"system_role": "super_admin"}))
+    assert v.decision is Decision.ALLOW  # super_admin ⊇ admin
+
+
+def test_admin_only_no_caller_denied_when_inherit_off(patched_gate):
+    # F014: no caller identity + agents_inherit_admin OFF (default) → DENY,
+    # even though the workspace HAS an admin owner.
+    actions = {"platform_admin_thing": _ActionDef(admin_only=True)}
+    doc = pd.PolicyDocument(pd.BALANCED, agents_inherit_admin=False, route_overrides={})
+    g = patched_gate(actions=actions, doc=doc, has_admin_owner=True)
+    v = g.check(_call("platform_admin_thing", caller=None))
+    assert v.decision is Decision.DENY
+
+
+def test_admin_only_no_caller_allowed_when_inherit_on(patched_gate):
+    # With the explicit default-OFF policy turned ON and an admin owner present.
+    actions = {"platform_admin_thing": _ActionDef(admin_only=True, permission_level="read")}
+    doc = pd.PolicyDocument(pd.BALANCED, agents_inherit_admin=True, route_overrides={})
+    g = patched_gate(actions=actions, doc=doc, has_admin_owner=True)
+    v = g.check(_call("platform_admin_thing", caller=None))
+    assert v.decision is Decision.ALLOW
+
+
+def test_admin_only_inherit_on_but_no_owner_denied(patched_gate):
+    actions = {"platform_admin_thing": _ActionDef(admin_only=True)}
+    doc = pd.PolicyDocument(pd.BALANCED, agents_inherit_admin=True, route_overrides={})
+    g = patched_gate(actions=actions, doc=doc, has_admin_owner=False)
+    assert g.check(_call("platform_admin_thing", caller=None)).decision is Decision.DENY
+
+
+# ---------------------------------------------------------------------------
+# Full autonomy dial — asks are skipped, but the super-admin gate still bites
+# ---------------------------------------------------------------------------
+
+def test_full_autonomy_skips_ask_for_destructive(patched_gate):
+    actions = {"platform_delete_agent": _ActionDef(permission_level="destructive")}
+    g = patched_gate(actions=actions, full_autonomy=True)
+    v = g.check(_call("platform_delete_agent"))
+    assert v.decision is Decision.ALLOW  # auto dial acts without asking
+
+
+def test_full_autonomy_still_cannot_pass_super_admin_gate(patched_gate):
+    actions = {"platform_obs_dump": _ActionDef(super_admin_only=True)}
+    g = patched_gate(actions=actions, full_autonomy=True)
+    v = g.check(_call("platform_obs_dump", caller={"system_role": "admin"}))
+    assert v.decision is Decision.DENY  # the dial never satisfies super-admin
+
+
+# ---------------------------------------------------------------------------
+# F086 — budget breach denies before the call (gate composes budget)
+# ---------------------------------------------------------------------------
+
+def test_budget_breach_denies(patched_gate):
+    actions = {"platform_list_agents": _ActionDef(permission_level="read")}
+    g = patched_gate(actions=actions, budget_allows=False)
+    v = g.check(_call("platform_list_agents"))
+    assert v.decision is Decision.DENY
+    assert v.error.code == "budget_exceeded"

--- a/orchestrator/tests/test_prd174_policy_plane.py
+++ b/orchestrator/tests/test_prd174_policy_plane.py
@@ -1,0 +1,298 @@
+"""PRD-174 W4 — Unified Policy Plane: pure-unit acceptance (§6).
+
+These pin the plane's own semantics with NO database and NO heavy deps — the
+verdict algebra (deny > ask > allow), the role/permission helpers (F042/F043),
+the Balanced act-vs-ask routing (§5), the model-aware budget gate (F086/F059),
+and the errors-as-data envelope (§4.2). The gate/executor *integration* (flag
+OFF stays byte-for-byte; a denied call never executes) lives in
+``test_prd174_policy_chokepoint.py``.
+
+Stdlib-only import: stub the ``modules`` / ``modules.tools`` package inits so we
+never run them (they pull asyncpg/pgvector); ``modules.policy`` is stdlib-only at
+import time and loads cleanly via its real path once the parents are stubbed —
+the same pattern as ``test_tool_loop_characterization``.
+"""
+from __future__ import annotations
+
+import sys
+import types as _types
+from pathlib import Path
+
+import pytest
+
+_ORCH = Path(__file__).resolve().parents[1]
+if str(_ORCH) not in sys.path:
+    sys.path.insert(0, str(_ORCH))
+
+_LEAKED_PARENT_STUBS = {}
+for _pkg in ("modules", "modules.tools", "modules.tools.execution"):
+    if _pkg not in sys.modules:
+        _stub = _types.ModuleType(_pkg)
+        _stub.__path__ = [str(_ORCH / _pkg.replace(".", "/"))]
+        sys.modules[_pkg] = _stub
+        _LEAKED_PARENT_STUBS[_pkg] = _stub
+
+
+def teardown_module(module):
+    for _name, _stub in _LEAKED_PARENT_STUBS.items():
+        if sys.modules.get(_name) is _stub:
+            del sys.modules[_name]
+
+
+from modules.policy.types import (  # noqa: E402
+    Decision,
+    PolicyError,
+    Verdict,
+    merge_verdicts,
+)
+from modules.policy import roles  # noqa: E402
+from modules.policy import policy_document as pd  # noqa: E402
+from modules.policy import budget as bd  # noqa: E402
+from modules.policy.errors import ensure_error_envelope, verdict_to_result  # noqa: E402
+from modules.policy.bus import PolicyBus, EventContext  # noqa: E402
+from modules.policy.types import Event  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# §6.8 — deny > ask > allow
+# ---------------------------------------------------------------------------
+
+def test_merge_deny_beats_ask_beats_allow():
+    allow = Verdict.allow("ok")
+    ask = Verdict.ask(PolicyError("approval_required", "ask a human"))
+    deny = Verdict.deny(PolicyError("permission_denied", "no"))
+
+    assert merge_verdicts(allow, ask, deny).decision is Decision.DENY
+    assert merge_verdicts(deny, ask, allow).decision is Decision.DENY  # order-independent
+    assert merge_verdicts(allow, ask).decision is Decision.ASK
+    assert merge_verdicts(allow, allow).decision is Decision.ALLOW
+
+
+def test_merge_empty_and_defer_are_allow():
+    assert merge_verdicts().decision is Decision.ALLOW
+    assert merge_verdicts(None, None).decision is Decision.ALLOW
+    assert merge_verdicts(Verdict.defer("no opinion")).decision is Decision.ALLOW
+    # a defer must never override an explicit allow-with-rewrite
+    v = merge_verdicts(Verdict.allow("a", updated_input={"x": 1}), Verdict.defer())
+    assert v.decision is Decision.ALLOW
+    assert v.updated_input == {"x": 1}
+
+
+def test_deny_carries_structured_error_the_model_can_read():
+    err = PolicyError(
+        code="budget_exceeded",
+        message_for_model="over budget",
+        remediation="raise the ceiling",
+        retryable=False,
+    )
+    v = Verdict.deny(err)
+    assert v.blocks_execution is True
+    assert v.error is not None
+    d = v.error.to_dict()
+    assert set(d) == {"code", "message_for_model", "remediation", "retryable"}
+    assert d["code"] == "budget_exceeded"
+
+
+# ---------------------------------------------------------------------------
+# §6.6 — F043 (super_admin ⊇ admin ⊇ user) + F042 (empty perms = deny)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("role,expect_admin", [
+    ("super_admin", True),
+    ("admin", True),
+    ("user", False),
+    (None, False),
+    ("nonsense", False),
+])
+def test_f043_role_hierarchy(role, expect_admin):
+    assert roles.is_admin(role) is expect_admin
+
+
+def test_f043_super_admin_only_super_admin():
+    assert roles.is_super_admin("super_admin") is True
+    assert roles.is_super_admin("admin") is False
+    assert roles.role_satisfies("super_admin", "admin") is True  # ⊇
+    assert roles.role_satisfies("admin", "super_admin") is False  # not ⊇ upward
+
+
+@pytest.mark.parametrize("perms,required,expect", [
+    ([], "widget:chat", False),          # empty = DENY (F042 — the fix)
+    (None, "widget:chat", False),        # null = DENY
+    (["widget:chat"], "widget:chat", True),
+    (["widget:read"], "widget:chat", False),
+    (["*"], "anything", True),           # explicit wildcard grant is honoured
+])
+def test_f042_empty_permission_is_deny(perms, required, expect):
+    assert roles.has_permission(perms, required) is expect
+
+
+# ---------------------------------------------------------------------------
+# §6.7 — Balanced act-vs-ask routing (§5)
+# ---------------------------------------------------------------------------
+
+def test_balanced_defaults():
+    doc = pd.load_policy_document(None, None)  # no DB → Balanced defaults
+    assert doc.posture == pd.BALANCED
+    assert doc.agents_inherit_admin is False   # F014 default-OFF
+
+
+@pytest.mark.parametrize("risk,route", [
+    (pd.RISK_READ, "auto"),
+    (pd.RISK_INTERNAL_WRITE, "auto"),
+    (pd.RISK_EXTERNAL, "ask"),
+    (pd.RISK_DESTRUCTIVE, "ask"),
+    (pd.RISK_PUBLISH, "ask"),
+])
+def test_balanced_routing_table(risk, route):
+    doc = pd.load_policy_document(None, None)
+    assert doc.route_for(risk) == route
+
+
+def test_route_override_wins_over_posture():
+    doc = pd.PolicyDocument(
+        posture=pd.BALANCED, agents_inherit_admin=False,
+        route_overrides={pd.RISK_EXTERNAL: "auto"},
+    )
+    assert doc.route_for(pd.RISK_EXTERNAL) == "auto"     # override
+    assert doc.route_for(pd.RISK_DESTRUCTIVE) == "ask"   # unaffected
+
+
+@pytest.mark.parametrize("name,perm,composio,expect", [
+    ("platform_list_agents", "read", False, pd.RISK_READ),
+    ("platform_update_agent", "write", False, pd.RISK_INTERNAL_WRITE),
+    ("platform_delete_agent", "destructive", False, pd.RISK_DESTRUCTIVE),
+    ("composio_execute", None, True, pd.RISK_EXTERNAL),
+    ("COMPOSIO_GMAIL_SEND_EMAIL", None, True, pd.RISK_EXTERNAL),
+    ("platform_publish_template", None, False, pd.RISK_PUBLISH),
+    # a destructive composio action is destructive, not merely external
+    ("composio_shopify_delete", "destructive", True, pd.RISK_DESTRUCTIVE),
+])
+def test_classify_action(name, perm, composio, expect):
+    assert pd.classify_action(name, permission_level=perm, is_composio=composio) == expect
+
+
+# ---------------------------------------------------------------------------
+# §6.3 — F086/F059 model-aware budget admission (pure: no DB, direct numbers)
+# ---------------------------------------------------------------------------
+
+class _FakeWorkspace:
+    def __init__(self, budget):
+        self.plan_limits = {"budget": budget} if budget is not None else {}
+
+
+class _FakeQuery:
+    """Minimal stand-in for a SQLAlchemy query chain used by budget.py."""
+
+    def __init__(self, ws=None, spend=(0.0, 0.0)):
+        self._ws = ws
+        self._spend = spend
+        self._mode = None
+
+    def filter(self, *a, **k):
+        return self
+
+    def first(self):
+        return self._ws
+
+    def one(self):
+        return self._spend
+
+
+class _FakeDB:
+    """Returns a workspace for the Workspace query and a spend tuple for the sum."""
+
+    def __init__(self, ws=None, spend=(0.0, 0.0)):
+        self._ws = ws
+        self._spend = spend
+
+    def query(self, *entities):
+        # budget.load_budget queries Workspace; spend_to_date queries sums.
+        first = entities[0] if entities else None
+        name = getattr(first, "__name__", "")
+        if name == "Workspace":
+            return _FakeQuery(ws=self._ws)
+        return _FakeQuery(spend=self._spend)
+
+
+def test_budget_no_ceiling_allows():
+    db = _FakeDB(ws=_FakeWorkspace(None))
+    d = bd.check_budget(db, "ws", projected_cost_usd=999.0)
+    assert d.allowed is True
+
+
+def test_budget_over_cost_ceiling_denies():
+    # ceiling $5, already spent $4.90, this call +$0.20 → over
+    db = _FakeDB(ws=_FakeWorkspace({"max_cost_usd": 5.0, "window": "day"}),
+                 spend=(4.90, 1000))
+    d = bd.check_budget(db, "ws", projected_cost_usd=0.20)
+    assert d.allowed is False
+    assert d.dimension == "cost_usd"
+
+
+def test_budget_within_cost_ceiling_allows():
+    db = _FakeDB(ws=_FakeWorkspace({"max_cost_usd": 5.0, "window": "day"}),
+                 spend=(1.00, 1000))
+    d = bd.check_budget(db, "ws", projected_cost_usd=0.20)
+    assert d.allowed is True
+
+
+def test_budget_over_token_ceiling_denies():
+    db = _FakeDB(ws=_FakeWorkspace({"max_total_tokens": 10_000, "window": "day"}),
+                 spend=(0.0, 9_950))
+    d = bd.check_budget(db, "ws", projected_tokens=100)
+    assert d.allowed is False
+    assert d.dimension == "total_tokens"
+
+
+# ---------------------------------------------------------------------------
+# §4.2 — errors-as-data envelope
+# ---------------------------------------------------------------------------
+
+def test_verdict_to_result_is_non_success_with_structured_error():
+    v = Verdict.deny(PolicyError("permission_denied", "nope", remediation="escalate"))
+    r = verdict_to_result(v, "platform_delete_agent")
+    assert r["success"] is False
+    assert r["permission_denied"] is True
+    assert r["policy_error"]["code"] == "permission_denied"
+    assert r["policy_error"]["message_for_model"] == "nope"
+    # the model-readable line is also on the legacy key the loop already surfaces
+    assert "nope" in r["llm_context"]
+
+
+def test_verdict_to_result_ask_marks_requires_approval():
+    v = Verdict.ask(PolicyError("approval_required", "ask a human", retryable=True))
+    r = verdict_to_result(v, "composio_execute")
+    assert r["requires_approval"] is True
+    assert r["policy_decision"] == "ask"
+    assert r["policy_error"]["retryable"] is True
+
+
+def test_ensure_error_envelope_backfills_failures_only():
+    ok = ensure_error_envelope({"success": True, "data": 1})
+    assert "policy_error" not in ok  # success untouched
+
+    fail = ensure_error_envelope({"success": False, "error": "boom", "rate_limited": True})
+    assert fail["policy_error"]["code"] == "rate_limited"
+    assert fail["policy_error"]["retryable"] is True
+
+    # an existing policy_error is preserved, not overwritten
+    pre = {"success": False, "policy_error": {"code": "keep", "message_for_model": "m",
+                                              "remediation": None, "retryable": False}}
+    assert ensure_error_envelope(pre)["policy_error"]["code"] == "keep"
+
+
+# ---------------------------------------------------------------------------
+# Bus fault isolation — a raising handler is no-opinion, never a silent allow
+# ---------------------------------------------------------------------------
+
+def test_bus_raising_handler_is_no_opinion():
+    bus = PolicyBus()
+    bus.register(Event.PRE_TOOL_USE, lambda e, c: Verdict.ask(PolicyError("x", "ask")))
+    bus.register(Event.PRE_TOOL_USE, lambda e, c: (_ for _ in ()).throw(RuntimeError("boom")))
+    v = bus.fire(Event.PRE_TOOL_USE, EventContext(tool_name="t"))
+    assert v.decision is Decision.ASK  # raising handler did not wave it through
+
+
+def test_bus_no_handlers_allows():
+    bus = PolicyBus()
+    assert bus.fire(Event.PRE_TOOL_USE, EventContext(tool_name="t")).decision is Decision.ALLOW


### PR DESCRIPTION
## Wave 4 — Unified Policy Plane v1 (PRD-174)

**One typed gate, evaluated in one place, for every tool call — on every surface.** Auto's blueprint says what to *attempt*; the policy plane, and only the policy plane, decides what *executes*. Guardrails become DB-configured policy (one config, one chokepoint), not code scattered across router dependencies. **Deny outranks ask outranks allow**, and every denial returns a structured reason the model can read (errors-as-data).

This is the **highest-risk wave** (it touches every execution path), so it ships **behind a flag** with **characterization tests written to prove flag-OFF breaks nothing**.

### The flag + characterization approach (safety rule #1)
- Everything is gated on **`AUTOMATOS_POLICY_PLANE`** (`config.POLICY_PLANE_ENABLED`, **default OFF**).
- **Flag OFF ⇒ byte-for-byte today's per-router gates.** Every flag-gated seam returns/keeps the legacy path when off. The pre-existing `test_tool_loop_characterization.py` (16 tests) stays green — proof the `on_pre_tool` seam added no behavioural change when unset.
- **Flag ON ⇒ the plane.** One chokepoint + the budget/approval seam + fail-closed rate limiter + unified role/permission semantics.
- Rollback = flip the flag; each finding-fix is independently reviewable.

### Findings implemented

| ID | Fix |
|---|---|
| **F085** | New `modules/policy/` package + one `PolicyGate` chokepoint (the policy plane as a *plane*). |
| **F060** | `UnifiedToolExecutor.execute_tool` calls `PolicyGate.check()` at the top → Composio/workspace/registry stop bypassing the gate. |
| **F086** | `BudgetExceeded` + pre-call admission gate vs `Workspace.plan_limits` (new `budget` key on the existing JSONB). |
| **F059** | Model-aware pricing from the DB `llm_models` registry (`modules/policy/pricing.py`) — the budget/approval primitive now prices on the right dollars. |
| **F040** | `SlowAPIMiddleware` registered **fail-closed** (`swallow_errors=False`) under the flag — the limiter was constructed but never enforced. |
| **F014** | `admin_only` owner-fallback is behind the explicit, **default-OFF** `agents_inherit_admin` workspace policy — no more workspace-has-an-admin flip. |
| **F042** | One empty-permission semantic: **empty = deny** (shared helper) — kills the widget-plane god-key; unifies with the board plane. |
| **F043** | One shared `super_admin ⊇ admin ⊇ user` helper (`core/auth/roles.caller_is_admin`) across the 8 routers that 403'd super-admin. |

### Step 2 (chokepoint) vs Step 4 (plane)

**Step 2 — one chokepoint (ships first, green before Step 4):**
- Extracted gate semantics into `modules/policy/` `PolicyGate` (tenant-scoped): super-admin → admin → budget → act-vs-ask.
- `unified_executor.py` chokepoint (F085/F060); `main.py` fail-closed `SlowAPIMiddleware` (F040); `platform_executor` F014; `core/auth/roles` + widget auth F042/F043.

**Step 4 — the plane:**
- Typed event bus `bus.py` (`RunStart/PreToolUse/PostToolUse/PostToolBatch/RoundEnd/RunEnd/PreCompact`), verdicts `{decision, updated_input, injected_context, reason}`, **deny > ask > allow**. In-process typed handlers with tenant scope — **NOT shell hooks**.
- `on_pre_tool` seam in `_execute_round` beside the dedup check (blueprint/approval/budget attach point).
- Model-aware `BudgetExceeded` pre-call admission (F086/F059).
- Errors-as-data envelope `{code, message_for_model, remediation, retryable}` formalised in `tool_router` (additive, flag-gated).
- The **Balanced** policy (§5) encoded as the workspace policy document the plane evaluates (reads/low-risk-internal → auto; destructive/external/publish/over-budget → ask).

### Test plan (66 new, DB-free green; 1 executor test CI-gated)
- **Headline (§6.1):** a denied tool call **never executes** AND returns a **structured denial the model can read** — proven at the `on_pre_tool` seam and the `verdict_to_result` composition the executor uses.
- **Flag-OFF byte-for-byte:** `caller_is_admin` OFF == `system_role == 'admin'`; widget empty-perms OFF == allow-all; no-hook loop == old loop; existing tool-loop characterization stays green.
- **Per-finding:** F060 Composio/workspace/registry are evaluated (not bypassed); F086/F059 model-aware `BudgetExceeded` before the call; F040 middleware flag-guarded + fail-closed; F014 caller-role admin + opt-in inherit; F042/F043 empty=deny on both planes + super_admin passes; Balanced act-vs-ask; **deny > ask > allow**; bus fault-isolation (a raising handler is no-opinion, never a silent allow).
- Executor-level chokepoint characterization (`test_prd174_executor_chokepoint.py`) is **CI-gated** — it imports the DB stack, so it skips locally and runs against a real DB in CI. Local gate is `py_compile` + the pure/DB-free suites.

**Local:** `py_compile` on all 32 changed files ✓; `82 passed, 1 skipped` (66 new + 16 pre-existing loop nets). Full CI is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)