### PR TITLE
feat(prd-179): Wave 9 — planning intelligence completion

### DIFF
--- a/docs/PRDS/PRD-179-WAVE-9-PLANNING-COMPLETION.md
+++ b/docs/PRDS/PRD-179-WAVE-9-PLANNING-COMPLETION.md
@@ -1,0 +1,87 @@
+# PRD-179: Wave 9 — Planning Intelligence Completion
+
+**Phase:** C — Moat Compounding (weeks 16–24)
+**Branch:** `feat/w9-planning-completion` · **Worktree:** `automatos-ai-prd179`
+**Dependencies:** Wave 1 (F001 spine fix) + Wave 4 (policy plane, for HARNESS actuation) — **both merged to main (`5768c2d5b`)**
+**Build size:** M · **Risk:** Low–Medium
+**OS Review refs:** §5, §12.6, roadmap Phase C
+
+---
+
+## Overview
+
+PRD-164 (planning-intelligence-seams) is **fully merged** (PR #457, all four stories). This wave is **not** an unbuilt PRD — it lands the verified remainders that never merged and repairs what shipped broken: the heartbeat/planning memory read-half, the starved mission-synthesis flywheel, HARNESS prescriptions that escalate instead of actuate, and `rag_feedback` that writes without reading back. All four are small, named diffs verified absent from the #457 diff.
+
+---
+
+## Ownership boundary (parallel-safe)
+
+Runs concurrently with W7 (PRD-177) and W8 (PRD-178).
+
+- **W9 OWNS:** `modules/context/modes.py` **heartbeat (~76–88) and planning (~141–149)** regions, `modules/context/service.py` (context assembly), `services/coordinator_service.py:~1136-1152`, `services/harness_service.py:~1679`, `api/board_tasks.py` (dispatch of prescriptions), `core/services/approval_policy.py` (read-only reuse), `api/rag_feedback.py`, `modules/rag/service.py`.
+- **W9 MUST NOT TOUCH:** `platform_executor.py` (**W8 owns** — W8's F020 fix removes the F021 shadowing symptom; W9's F021 is only the `modes.py` read-half), `graph_router.py` / `edge_builder.py` / `telemetry.py` (**W7 owns** — for F070 use the **ranking path in `rag/service.py`**, not affinity edges), `modes.py` lines ~40–46 (**W7 owns** the chain-hints gate).
+
+`modes.py` is edited by both W7 (~40–46) and W9 (~76–88, ~141–149) in **different regions** — git auto-merges. Grep to confirm regions before editing.
+
+---
+
+## Findings & Scope
+
+| Finding | Issue (verified) | Fix |
+|---|---|---|
+| **F021** | Heartbeat agents are memory-blind by design (`modes.py:~76-88`); planning mode has no field/memory section (`modes.py:~141-149`). The Q60 memory read-half never merged in #457 | Add a workspace-scoped field/durable-memory digest to the **HEARTBEAT** and **PLANNING** context modes |
+| **F049** | Mission-synthesis flywheel ingests 3 arbitrary `COMPLETED` runs — no `ORDER BY`, no exclusion of already-ingested runs → starves once >3 accumulate (`coordinator_service.py:~1136-1152`) | Add `ORDER BY created_at DESC`, SQL-side already-ingested exclusion (marker), and failure markers |
+| **F048** | Human-approved HARNESS prescriptions escalate admins to a surface that returns HTTP 409 — they never actuate. Flag is off by default (`config.py:~583`) | Route approved prescriptions as **board tasks through the Wave-4 policy plane / ask verdict**; enable behind the flag |
+| **F070** | `rag_feedback` stores signals that feed nothing back into ranking — write-only bucket (`api/rag_feedback.py:~50-70`) | Feed feedback into retrieval ranking so marked-unhelpful docs de-rank |
+
+---
+
+## Stories (test-first)
+
+### S1 · Memory digest in heartbeat + planning modes (F021 read-half) — S/M
+**Files:** `modules/context/modes.py` (HEARTBEAT ~76-88 and PLANNING ~141-149), `modules/context/service.py` (assembly, ~55-120).
+**Test (this is the W8+W9 integration gate):** `test_planning_reads_field` asserts a completed mission's field distillation appears in the **next code-touching mission's planning pack**. `test_heartbeat_memory_read` asserts a heartbeat-mode agent's context includes the workspace-scoped memory digest.
+**Notes:** Add a budgeted, workspace-scoped field/durable-memory digest section alongside documents + knowledge graph. Reuse the existing digest builder used elsewhere — do not invent a second one. Thread `workspace_id` so only scoped entries appear. This reads what W8 promotes to durable; both can build in parallel and meet at merge.
+
+### S2 · Mission-synthesis flywheel ordering + dedup (F049) — S
+**Files:** `services/coordinator_service.py:~1136-1152`.
+**Test:** `test_flywheel_dedup_and_order` creates 10 completed missions, runs the ingest sweep, asserts the correct most-recent set is ingested (`ORDER BY created_at DESC`), and a second run ingests only new missions (SQL-side already-ingested exclusion works).
+**Notes:** Prefer a marker/`last_ingested_at` column check or `NOT IN (SELECT ... FROM <ingested marker>)` on the SQL side — do not pull all rows and filter in Python. Record failure markers so a failed ingest doesn't silently re-loop.
+
+### S3 · HARNESS prescription actuation via the policy plane (F048) — M
+**Files:** `services/harness_service.py:~1679`, `api/board_tasks.py`, `core/services/approval_policy.py` (reuse the Wave-4 plane — do not build a parallel approval path).
+**Test:** `test_harness_prescription_actuates` approves a prescription, asserts it becomes a board task routed through the policy plane's ask verdict, dispatches, executes, and completes (`status=done`, result ≠ null) — no HTTP 409 escalation.
+**Notes:** This is **governed activation**, not an auto-apply. Approved prescription → board task → same ask verdict every other governed action passes through (Wave 4). Enable behind the existing config flag (via `config.py`).
+
+### S4 · rag_feedback as a ranking feature (F070) — M
+**Files:** `api/rag_feedback.py`, `modules/rag/service.py`.
+**Test:** `test_rag_feedback_to_ranking` marks a retrieved doc unhelpful via `POST /rag/feedback`, runs a follow-up retrieval on the same query, asserts the marked doc de-ranks (lower score or absent from top-K).
+**Notes:** Integrate the feedback signal into `RAGService` retrieval ranking on the **live hot path** (not offline eval). **Use the ranking path, not tool-affinity edges** — affinity edges live in `edge_builder.py`, which W7 owns; keep W9 off that file.
+
+---
+
+## Acceptance & Verification
+
+**Acceptance (W9 gate):** `test_planning_reads_field` — a completed mission's field distillation appears in the next code-touching mission's planning pack (spans W8's promotion + W9's digest; W9 owns the assertion).
+
+**Verification (no servers/Docker/browser):** `py_compile` every changed file + **pure pytest** with DB/RAG mocked at the boundary; seed `workspaces` rows in any DB-touching test (known FK trap). CI is the integration gate.
+
+```
+python -m py_compile <changed files>
+python -m pytest orchestrator/services -k "flywheel or harness" -q
+python -m pytest orchestrator/modules/context -k "planning or heartbeat" -q
+python -m pytest orchestrator/... <rag feedback tests> -q
+```
+
+---
+
+## Conventions (see automatos-ai/CLAUDE.md)
+- No `os.getenv()` outside `config.py`; reuse the Wave-4 policy plane and existing digest builder — no parallel implementations.
+- No backward-compat shims; delete what you replace. Immutable patterns; small functions; full error handling. SQLAlchemy 2.0 raw-SQL: use `CAST(:p AS type)` not `:p::type`.
+- Commit to `feat/w9-planning-completion`. **Do not push or open a PR** — stop after local verify and report.
+
+## Success metrics
+- Heartbeat + planning contexts include the workspace-scoped memory digest.
+- Flywheel ingests in order and deduplicates — no starvation past 3 missions.
+- Approved HARNESS prescriptions actuate through the policy plane (no 409).
+- RAG feedback de-ranks unhelpful docs on the live retrieval path.

--- a/orchestrator/api/harness_commands.py
+++ b/orchestrator/api/harness_commands.py
@@ -181,11 +181,12 @@ async def handle_harness_command(
         }
 
     if cmd == "approve":
-        return await _approve(svc, executor, workspace_id, task, rx_id, caller_identity)
+        return await _approve(db, svc, executor, workspace_id, task, rx_id, caller_identity)
     return await _reject(db, workspace_id, task, rx_id, caller_identity)
 
 
 async def _approve(
+    db,
     svc,
     executor: Any,
     workspace_id: UUID,
@@ -193,7 +194,19 @@ async def _approve(
     rx_id: str,
     caller_identity: Optional[Dict[str, Any]],
 ) -> Dict[str, Any]:
-    """Apply an approved prescription now and record it in the US-021 ledger."""
+    """Actuate an approved prescription as a GOVERNED ACTIVATION (PRD-179 S3,
+    F048) and record it in the US-021 ledger.
+
+    The actuation is routed through the Wave-4 policy plane's ask verdict
+    (``core.services.approval_policy.evaluate_approval``) — the same verdict every
+    other governed action passes through — rather than a dark direct apply. The
+    admin's explicit /approve is the per-request override the plane already
+    models, but the plane can still deny (fail-safe). Only when the verdict
+    approves does the prescription actuate; the board task is then marked done
+    with the actuation result written to it (status=done, result != null).
+    """
+    from core.services.approval_policy import evaluate_approval
+
     task_id = str(task.get("id"))
     user_id = _caller_user_id(caller_identity)
 
@@ -217,6 +230,24 @@ async def _approve(
             "message": f"Could not resolve the target for {rx_id}; nothing applied",
         }
 
+    # GOVERNED ACTIVATION: route through the policy plane's ask verdict before
+    # actuating. A self-management change makes no LLM spend, so the estimated
+    # cost is $0; the admin approve is the explicit per-request override. The
+    # plane can still refuse (e.g. a locked-down workspace policy), in which case
+    # the prescription does NOT actuate.
+    decision = evaluate_approval(
+        db, workspace_id, 0.0, override_auto_approve=True
+    )
+    if not decision.auto_approve:
+        logger.info(
+            "[HARNESS] Policy plane declined actuation of rx=%s in workspace=%s: %s",
+            rx_id, workspace_id, decision.reason,
+        )
+        return {
+            "success": False,
+            "message": f"Policy plane declined {rx_id}: {decision.reason}",
+        }
+
     current_before = svc._snapshot_current_value(rx)
     apply_result = await svc._auto_apply_prescription(executor, rx)
     if not apply_result.get("success"):
@@ -225,12 +256,13 @@ async def _approve(
             "message": f"Failed to apply {rx_id}: {apply_result.get('error', 'unknown')}",
         }
 
-    # Apply succeeded — only now mark the board task done (so a failed apply
-    # never leaves a task falsely completed). 'done' is a valid action status,
-    # so this also sets completed_at via the handler.
+    # Apply succeeded — mark the board task done WITH the actuation result, so a
+    # completed governed action never leaves a null result (and a failed apply
+    # above never marks the task done). status='done' also sets completed_at.
     await executor.execute(
         "platform_update_task_status", {"task_id": task.get("id"), "status": "done"}
     )
+    _record_board_task_result(db, workspace_id, task.get("id"), apply_result, decision)
 
     entry = {
         "task_id": task_id,
@@ -243,12 +275,13 @@ async def _approve(
         "applied_at": datetime.now(timezone.utc).isoformat(),
         "approved_via": "command",
         "approved_by": user_id,
+        "policy_verdict": decision.reason,
     }
     applied_ids.add(task_id)
     svc._write_applied_tasks(workspace_id, ledger, applied_ids, [entry])
 
     logger.info(
-        "[HARNESS] APPROVED rx=%s (%s for %s) in workspace=%s by user=%s",
+        "[HARNESS] APPROVED rx=%s (%s for %s) in workspace=%s by user=%s via policy plane",
         rx_id, rx.get("change_type"), rx.get("target_name"), workspace_id, user_id,
     )
     return {
@@ -257,6 +290,49 @@ async def _approve(
         "change_type": rx.get("change_type"),
         "target_name": rx.get("target_name"),
     }
+
+
+def _record_board_task_result(
+    db, workspace_id: UUID, raw_task_id: Any, apply_result: Dict[str, Any], decision
+) -> None:
+    """Write the actuation outcome onto the board task's ``result`` column.
+
+    The status action carries no result field, so — as with ``_reject`` — the
+    ORM row is set directly (this is internal server code, not an LLM tool call).
+    Best-effort: a failure here must not undo an already-applied change, so it is
+    logged and swallowed. Keeps the completed governed task from carrying a null
+    result (the F048 acceptance: status=done, result != null).
+    """
+    import json as _json
+
+    from core.models.core import BoardTask
+
+    try:
+        row = (
+            db.query(BoardTask)
+            .filter(
+                BoardTask.id == int(raw_task_id),
+                BoardTask.workspace_id == workspace_id,
+            )
+            .first()
+        )
+    except (TypeError, ValueError):
+        row = None
+    if not row:
+        return
+    try:
+        row.result = _json.dumps({
+            "actuated": True,
+            "policy_verdict": decision.reason,
+            "apply_result": apply_result.get("data", apply_result),
+        })
+        row.completed_at = datetime.now(timezone.utc)
+        db.commit()
+    except Exception:
+        logger.warning(
+            "[HARNESS] Could not persist board-task result for task %s", raw_task_id,
+            exc_info=True,
+        )
 
 
 async def _reject(

--- a/orchestrator/config.py
+++ b/orchestrator/config.py
@@ -852,6 +852,11 @@ class Config:
     FIELD_PRUNE_THRESHOLD: float = float(os.getenv("FIELD_PRUNE_THRESHOLD", "0.01"))
     FIELD_COMPACTION_MAX_SCAN: int = int(os.getenv("FIELD_COMPACTION_MAX_SCAN", "10000"))
     SHARED_CONTEXT_BACKEND: str = os.getenv("SHARED_CONTEXT_BACKEND", "vector_field")  # "vector_field" or "redis"
+    # PRD-179 S2 (F049): how many completed missions the synthesis-flywheel ingest
+    # sweep processes per coordinator tick. The sweep now orders newest-first and
+    # excludes already-ingested / previously-failed runs SQL-side, so raising this
+    # drains a backlog faster without ever re-touching a done run.
+    FLYWHEEL_INGEST_BATCH: int = int(os.getenv("FLYWHEEL_INGEST_BATCH", "3"))
 
     # =============================================================================
     # EMBEDDINGS

--- a/orchestrator/config.py
+++ b/orchestrator/config.py
@@ -921,7 +921,17 @@ class Config:
             return str(val).lower() == "true" if val else False
         except Exception:
             return os.getenv("RAG_RERANK_ENABLED", "false").lower() == "true"
-    
+
+    # PRD-179 S4 (F070): rag_feedback feeds retrieval ranking. A document that
+    # accrued negative feedback (thumbs_down, or a rating at/below the floor) has
+    # its retrieval score multiplied by this factor on the live hot path — a doc
+    # marked unhelpful de-ranks and can fall out of the top-K. 1.0 disables it.
+    RAG_FEEDBACK_PENALTY_FACTOR: float = float(os.getenv("RAG_FEEDBACK_PENALTY_FACTOR", "0.5"))
+    # A rating at/below this counts as negative (thumbs_down is always negative).
+    RAG_FEEDBACK_NEGATIVE_RATING_MAX: int = int(os.getenv("RAG_FEEDBACK_NEGATIVE_RATING_MAX", "2"))
+    # Only feedback from the last N days shapes ranking (stale opinions decay out).
+    RAG_FEEDBACK_LOOKBACK_DAYS: int = int(os.getenv("RAG_FEEDBACK_LOOKBACK_DAYS", "90"))
+
     # =============================================================================
     # LLM ANALYTICS (PRD-54: Model Tiers & Cost Optimization)
     # =============================================================================

--- a/orchestrator/modules/context/modes.py
+++ b/orchestrator/modules/context/modes.py
@@ -73,14 +73,14 @@ MODE_CONFIGS: dict[ContextMode, ModeConfig] = {
         max_tokens=8000,
     ),
     # personality=False: heartbeat agents execute scheduled tasks autonomously.
-    # NOTE: memory intentionally excluded to keep context lean. No memory
-    # section also means no daily logs. Heartbeat agents are stateless by
-    # design — add "memory" here if agents need cross-run learning.
-    # See PRD-81 Task 3.5 / Task 5.5.
+    # PRD-179 S1 (F021 read-half): the workspace-scoped "field_memory" digest
+    # gives recurring agents the cross-run learning they were previously blind to
+    # (patterns earlier missions accumulated). User-memory / daily logs stay out
+    # to keep the tick lean — this is the durable-field slice, not chat memory.
     ContextMode.HEARTBEAT_AGENT: ModeConfig(
         sections=[
             "identity", "skills", "composio", "plugins",
-            "platform_actions", "task_context", "datetime_context",
+            "platform_actions", "task_context", "field_memory", "datetime_context",
         ],
         tool_loading="full",
         personality=False,
@@ -137,11 +137,14 @@ MODE_CONFIGS: dict[ContextMode, ModeConfig] = {
     # every planner — MissionPlanner, board plan_task, AutoBrain — assembled
     # exclusively by ContextService.build_planning_context (the one assembler).
     # planning_history has priority 2 so recorded failures survive budget
-    # pressure (the learning demo).
+    # pressure (the learning demo). PRD-179 S1 (F021 read-half): "field_memory"
+    # adds the workspace-scoped field digest so a completed mission's promoted
+    # distillation reaches the next mission's plan — the compounding arm PRD-164
+    # left open (documents + KG but never the field).
     ContextMode.PLANNING: ModeConfig(
         sections=[
             "planning_knowledge", "planning_history",
-            "business_graph", "agent_roster",
+            "business_graph", "field_memory", "agent_roster",
         ],
         tool_loading="none",
         personality=False,

--- a/orchestrator/modules/context/sections/__init__.py
+++ b/orchestrator/modules/context/sections/__init__.py
@@ -12,6 +12,7 @@ from modules.context.sections.composio import ComposioSection
 from modules.context.sections.conversation import ConversationSection
 from modules.context.sections.custom import CustomSection
 from modules.context.sections.datetime_context import DatetimeContextSection
+from modules.context.sections.field_memory import FieldMemorySection
 from modules.context.sections.graph_context import GraphSection
 from modules.context.sections.identity import IdentitySection
 from modules.context.sections.memory import MemorySection
@@ -44,6 +45,7 @@ SECTION_REGISTRY: dict[str, type[BaseSection]] = {
     "playbook_context": PlaybookContextSection,
     "datetime_context": DatetimeContextSection,
     "business_graph": GraphSection,
+    "field_memory": FieldMemorySection,
     "conversation": ConversationSection,
     "custom": CustomSection,
 }
@@ -56,6 +58,7 @@ __all__ = [
     "ConversationSection",
     "CustomSection",
     "DatetimeContextSection",
+    "FieldMemorySection",
     "GraphSection",
     "IdentitySection",
     "MemorySection",

--- a/orchestrator/modules/context/sections/field_memory.py
+++ b/orchestrator/modules/context/sections/field_memory.py
@@ -1,0 +1,126 @@
+"""
+FieldMemorySection — workspace-scoped field / durable-memory digest.
+
+The read-half of F021 (PRD-179 S1). Heartbeat agents were memory-blind by
+design and the planning pack consulted documents + the knowledge graph but never
+the field, so patterns a mission accumulates never reached the next mission's
+planning (the compounding claim the OS review §12.6 flags as roadmap).
+
+This section reads the WORKSPACE-persistent field — the collection Wave 8's
+field-to-durable promotion writes into — via
+``VectorFieldSharedContext.query_workspace`` and renders it through the ONE
+existing digest builder (``field_scoring.budget_results`` +
+``field_scoring.format_digest``, the same pipeline ``_attach_field_digest`` uses
+for dispatch). No second builder, no second ranking.
+
+Included in HEARTBEAT_AGENT and PLANNING modes only. Priority 7 (just after the
+user-memory section at 6): dropped before task-critical sections under budget
+pressure, but ahead of the knowledge-graph excerpt.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, List, Optional
+
+from modules.context.factory import get_shared_context
+from modules.context.sections.base import BaseSection, SectionContext
+
+logger = logging.getLogger(__name__)
+
+
+class FieldMemorySection(BaseSection):
+    """Workspace-scoped accumulated-knowledge digest for planning + heartbeat.
+
+    Reads the workspace-persistent field and renders the top patterns as the
+    same ``## Field memory`` block agents already see at dispatch, so planners
+    and recurring agents inherit what earlier missions learned.
+    """
+
+    name: str = "field_memory"
+    priority: int = 7
+    max_tokens: Optional[int] = None
+
+    def __init__(self) -> None:
+        super().__init__()
+        from config import config
+
+        # Reuse the field digest budget — the same cap the dispatch digest uses.
+        self.max_tokens = config.FIELD_QUERY_TOKEN_BUDGET
+
+    async def render(self, ctx: SectionContext) -> str:
+        """Return the workspace field digest, or '' on any failure/emptiness.
+
+        Never raises — a memory read must not crash a prompt build.
+        """
+        try:
+            return await self._build(ctx)
+        except Exception:
+            logger.exception(
+                "FieldMemorySection.render failed — skipping field digest"
+            )
+            return ""
+
+    async def _build(self, ctx: SectionContext) -> str:
+        query = self._extract_query(ctx)
+        if not query:
+            return ""
+
+        rows = await self._query_workspace_field(str(ctx.workspace_id), query)
+        if not rows:
+            return ""
+
+        # Render through the ONE shared digest builder (PRD-166 S2/S3): trim to
+        # the field budget, then format the same block dispatch pins.
+        from modules.context import field_scoring
+        from config import config
+
+        kept, truncated = field_scoring.budget_results(
+            rows, config.FIELD_QUERY_TOKEN_BUDGET
+        )
+        if not kept:
+            return ""
+        return field_scoring.format_digest(kept, truncated=truncated)
+
+    @staticmethod
+    async def _query_workspace_field(
+        workspace_id: str, query: str
+    ) -> List[dict[str, Any]]:
+        """Workspace-scoped field read via the shared-context backend.
+
+        Reaches the ``query_workspace`` method on the inner adapter through the
+        instrumentation wrapper (the ``getattr(field, '_inner', field)`` idiom
+        the coordinator uses). Returns [] when the backend is unavailable so the
+        section degrades to nothing rather than failing the build.
+        """
+        from config import config
+
+        field = get_shared_context()
+        if field is None:
+            return []
+        inner = getattr(field, "_inner", field)
+        query_workspace = getattr(inner, "query_workspace", None)
+        if query_workspace is None:
+            return []
+        results = await query_workspace(
+            workspace_id=workspace_id,
+            query=query,
+            top_k=config.FIELD_QUERY_TOP_K,
+        )
+        return list(results or [])
+
+    @staticmethod
+    def _extract_query(ctx: SectionContext) -> str:
+        """Query the field with the latest user message, else the goal / task.
+
+        In PLANNING mode there are no messages — ``task_description`` carries the
+        goal, which is exactly what a planner should retrieve accumulated
+        knowledge against.
+        """
+        if ctx.messages:
+            for msg in reversed(ctx.messages):
+                if isinstance(msg, dict) and msg.get("role") == "user":
+                    content = msg.get("content", "")
+                    if isinstance(content, str) and content.strip():
+                        return content.strip()
+        return ctx.task_description or ""

--- a/orchestrator/modules/rag/service.py
+++ b/orchestrator/modules/rag/service.py
@@ -328,6 +328,11 @@ class RAGService:
         if self.config.enable_reranking:
             candidates = await self._rerank_candidates(query, candidates)
 
+        # PRD-179 S4 (F070): rag_feedback shapes ranking on the live path — a
+        # document a user marked unhelpful de-ranks (and can fall out of top-K).
+        if workspace_id:
+            candidates = self._apply_feedback_penalty(candidates, workspace_id)
+
         # Parent-child context expansion (PRD-172 F005: scoped to workspace).
         candidates = await self._expand_to_parent_context(
             candidates, self.config.expansion_window, workspace_id=workspace_id
@@ -401,7 +406,109 @@ class RAGService:
                 db.close()
         except Exception as e:
             logger.debug(f"Document access tracking failed: {e}")
-    
+
+    # ------------------------------------------------------------------
+    # PRD-179 S4 (F070): rag_feedback → live retrieval ranking
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _negative_feedback_doc_ids(workspace_id: str) -> set:
+        """Document ids this workspace marked unhelpful (recent, hot-path read).
+
+        Negative = a ``thumbs_down`` or a ``rating`` at/below
+        ``RAG_FEEDBACK_NEGATIVE_RATING_MAX``, within the lookback window. Returns
+        a set of stringified doc ids. Fail-soft: any error yields an empty set so
+        retrieval ranking is never blocked by the feedback read.
+        """
+        from config import config
+        from core.database.database import SessionLocal
+        from sqlalchemy import text
+
+        db = SessionLocal()
+        try:
+            # UNNEST expands the document_ids INT[] so each flagged doc surfaces
+            # once. Bind params go through CAST(:p AS type), the SQLAlchemy-2.0
+            # form (the raw colon-colon cast does not bind under 2.0).
+            rows = db.execute(
+                text(
+                    """
+                    SELECT DISTINCT UNNEST(document_ids) AS doc_id
+                    FROM rag_feedback
+                    WHERE workspace_id = CAST(:ws AS uuid)
+                      AND document_ids IS NOT NULL
+                      AND (
+                            feedback_type = 'thumbs_down'
+                            OR (rating IS NOT NULL AND rating <= CAST(:rating_max AS int))
+                      )
+                      AND created_at >= NOW() - CAST(:days AS int) * INTERVAL '1 day'
+                    """
+                ),
+                {
+                    "ws": str(workspace_id),
+                    "rating_max": config.RAG_FEEDBACK_NEGATIVE_RATING_MAX,
+                    "days": config.RAG_FEEDBACK_LOOKBACK_DAYS,
+                },
+            ).fetchall()
+            return {str(r.doc_id) for r in rows if r.doc_id is not None}
+        except Exception as e:
+            logger.debug(f"rag_feedback ranking read failed: {e}")
+            return set()
+        finally:
+            db.close()
+
+    def _apply_feedback_penalty(
+        self, candidates: List[Dict[str, Any]], workspace_id: str
+    ) -> List[Dict[str, Any]]:
+        """De-rank candidates whose document was marked unhelpful (F070).
+
+        Multiplies the retrieval score of each penalised candidate by
+        ``RAG_FEEDBACK_PENALTY_FACTOR`` and re-sorts descending, so a doc a user
+        thumbed-down drops in rank (and out of a tight top-K) on the next
+        retrieval. Pure re-ranking on the ranking path — no tool-affinity edges.
+        Immutable: returns a new list of shallow-copied candidates. Fail-soft.
+        """
+        from config import config
+
+        if not candidates:
+            return candidates
+        factor = config.RAG_FEEDBACK_PENALTY_FACTOR
+        if factor >= 1.0:  # feature disabled — leave ranking untouched
+            return candidates
+        try:
+            penalised_ids = self._negative_feedback_doc_ids(workspace_id)
+        except Exception as e:
+            logger.debug(f"feedback penalty skipped (read failed): {e}")
+            return candidates
+        if not penalised_ids:
+            return candidates
+
+        adjusted: List[Dict[str, Any]] = []
+        demoted = 0
+        for c in candidates:
+            doc_id = self._candidate_doc_id(c)
+            if doc_id is not None and doc_id in penalised_ids:
+                new_c = dict(c)
+                # Lower every score key the downstream ranker might sort on.
+                for key in ("score", "similarity", "rerank_score", "rrf_score"):
+                    if isinstance(new_c.get(key), (int, float)):
+                        new_c[key] = new_c[key] * factor
+                new_c["feedback_penalised"] = True
+                adjusted.append(new_c)
+                demoted += 1
+            else:
+                adjusted.append(c)
+
+        if demoted:
+            adjusted.sort(
+                key=lambda x: x.get("score", x.get("similarity", 0.0) or 0.0),
+                reverse=True,
+            )
+            logger.info(
+                "[RAG] Feedback penalty de-ranked %d/%d candidates (ws=%s)",
+                demoted, len(candidates), workspace_id,
+            )
+        return adjusted
+
     @staticmethod
     def _candidate_doc_id(c: Dict) -> Optional[str]:
         """Best-effort document id for a candidate chunk (S3 stores it as external_file_id)."""

--- a/orchestrator/services/coordinator_service.py
+++ b/orchestrator/services/coordinator_service.py
@@ -865,6 +865,20 @@ class CoordinatorService:
             return document_id
         except Exception as e:
             logger.warning("[Mission] Failed to save output document for %s: %s", run.id, e, exc_info=True)
+            # PRD-179 S2 (F049): stamp a failure marker so the flywheel sweep's
+            # SQL-side exclusion drops this run next tick instead of re-selecting
+            # it forever. Without it, one poison run silently starves the backlog.
+            try:
+                run.config = {
+                    **(run.config or {}),
+                    "output_ingest_failed": datetime.now(timezone.utc).isoformat(),
+                }
+                db.flush()
+            except Exception:
+                logger.debug(
+                    "[Mission] Could not persist ingest-failure marker for run %s",
+                    run.id, exc_info=True,
+                )
             return None
 
     async def _emit_mission_document(
@@ -1134,21 +1148,35 @@ class CoordinatorService:
             logger.debug("[Coordinator] legacy-collection sweep skipped", exc_info=True)
 
     async def _save_pending_output_documents(self, db: Session) -> None:
-        """Save output documents for completed missions that don't have one yet."""
-        completed_without_output = (
+        """Route completed missions that have not been ingested through the
+        synthesis flywheel (PRD-179 S2, F049).
+
+        The exclusion of already-handled runs is done SQL-side, not by pulling a
+        batch and filtering in Python: a run is a candidate only when it carries
+        NONE of the three terminal markers — ``output_document_id`` (ingested),
+        ``output_ingest`` (opted out / skipped), ``output_ingest_failed``
+        (previous ingest errored). Ordering is ``created_at DESC`` so the newest
+        completed missions ingest first. Together these stop the pre-fix
+        starvation where an unordered ``LIMIT 3`` kept re-selecting the same
+        already-done rows once more than three accumulated.
+        """
+        candidates = (
             db.query(OrchestrationRun)
             .filter(
                 OrchestrationRun.state == RunState.COMPLETED.value,
+                # SQL-side already-ingested / failure exclusion (JSONB ->> IS NULL).
+                OrchestrationRun.config["output_document_id"].astext.is_(None),
+                OrchestrationRun.config["output_ingest"].astext.is_(None),
+                OrchestrationRun.config["output_ingest_failed"].astext.is_(None),
             )
-            .limit(3)
+            .order_by(OrchestrationRun.created_at.desc())
+            .limit(Config.FLYWHEEL_INGEST_BATCH)
             .all()
         )
-        for run in completed_without_output:
-            cfg = run.config or {}
-            # output_document_id == saved; output_ingest marker == workspace
-            # opted out of the flywheel (Q58) — don't retry every tick.
-            if cfg.get("output_document_id") or cfg.get("output_ingest"):
-                continue
+        for run in candidates:
+            # _save_mission_output_as_document owns its own failure handling and
+            # stamps the output_ingest_failed marker on error (so a poison run
+            # drops out of the candidate set). The sweep stays a thin driver.
             await self._save_mission_output_as_document(db, run)
 
     # ------------------------------------------------------------------

--- a/orchestrator/tests/test_context/test_modes.py
+++ b/orchestrator/tests/test_context/test_modes.py
@@ -114,7 +114,7 @@ class TestSectionRegistry:
         "identity", "skills", "composio", "plugins",
         "platform_actions", "memory", "tools",
         "task_context", "playbook_context", "datetime_context",
-        "business_graph", "conversation", "custom",
+        "business_graph", "field_memory", "conversation", "custom",
         "onboarding", "mission_context", "agent_roster",
         "planning_knowledge", "planning_history",
     }

--- a/orchestrator/tests/test_harness_commands.py
+++ b/orchestrator/tests/test_harness_commands.py
@@ -48,6 +48,15 @@ def _install_fake_apscheduler():
 _install_fake_apscheduler()
 
 from config import config
+
+# config caches POSTGRES_* at import; a sibling conftest may have imported it
+# with no env set (local dev), and /approve now routes through the policy plane
+# (core.services), whose package __init__ builds the DB URL at import. Backfill
+# the cached attrs so that import does not refuse on missing creds. No-op on CI.
+for _k in ("POSTGRES_USER", "POSTGRES_PASSWORD", "POSTGRES_HOST", "POSTGRES_PORT", "POSTGRES_DB"):
+    if not getattr(config, _k, None):
+        setattr(config, _k, os.environ[_k])
+
 import api.harness_commands as hc
 
 _WS_ID = "00000000-0000-0000-0000-000000000001"

--- a/orchestrator/tests/test_prd164_planning_pack.py
+++ b/orchestrator/tests/test_prd164_planning_pack.py
@@ -255,10 +255,12 @@ class TestPlanningModeRegistered:
             assert name in SECTION_REGISTRY, f"section '{name}' not registered"
 
     def test_planning_sections_cover_the_four_sources(self):
-        # RAG-on-goal, mission memory, KG subgraph, roster+performance (S1).
+        # RAG-on-goal, mission memory, KG subgraph, roster+performance (PRD-164
+        # S1) + the workspace field digest (PRD-179 S1, F021 read-half — a
+        # completed mission's promoted distillation reaching the next plan).
         assert MODE_CONFIGS[ContextMode.PLANNING].sections == [
             "planning_knowledge", "planning_history",
-            "business_graph", "agent_roster",
+            "business_graph", "field_memory", "agent_roster",
         ]
 
     def test_planning_budget_exists(self):

--- a/orchestrator/tests/test_prd179_field_read.py
+++ b/orchestrator/tests/test_prd179_field_read.py
@@ -1,0 +1,190 @@
+"""PRD-179 S1 (F021 read-half) — field/durable memory digest in the HEARTBEAT
+and PLANNING context modes.
+
+PRD-164 wired planning to documents + the knowledge graph but never the field,
+and heartbeat agents were memory-blind by design (`modes.py:76-88`, F021
+CONFIRMED). This adds a workspace-scoped field digest to both modes by reading
+what Wave 8 promotes into the workspace-persistent field
+(`VectorFieldSharedContext.query_workspace`) and rendering it through the ONE
+existing digest builder (`field_scoring.budget_results` + `format_digest`) — no
+second builder.
+
+`test_planning_reads_field` is the W9 acceptance gate: a completed mission's
+field distillation appears in the next code-touching mission's planning pack. It
+spans Wave 8's promotion (mocked here at the workspace-read boundary) and this
+digest. Pure — the field backend is mocked, no Qdrant / DB.
+"""
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+from typing import Any, Dict, List
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+os.environ.setdefault("POSTGRES_USER", "test")
+os.environ.setdefault("POSTGRES_PASSWORD", "test")
+os.environ.setdefault("POSTGRES_HOST", "127.0.0.1")
+os.environ.setdefault("POSTGRES_PORT", "59432")
+os.environ.setdefault("POSTGRES_DB", "test")
+
+from config import config as _config  # noqa: E402
+
+for _k in ("POSTGRES_USER", "POSTGRES_PASSWORD", "POSTGRES_HOST", "POSTGRES_PORT", "POSTGRES_DB"):
+    if not getattr(_config, _k, None):
+        setattr(_config, _k, os.environ[_k])
+
+from modules.context.modes import MODE_CONFIGS, ContextMode  # noqa: E402
+from modules.context.sections import SECTION_REGISTRY  # noqa: E402
+from modules.context.sections.base import SectionContext  # noqa: E402
+from modules.context.sections.field_memory import FieldMemorySection  # noqa: E402
+
+WS = "11111111-1111-1111-1111-111111111111"
+
+# What Wave 8 promotes into the workspace-persistent field: a completed
+# mission's distilled finding, keyed by the task/mission it came from.
+PROMOTED_FINDING = {
+    "key": "Refactor auth module",
+    "value": "The auth module's token refresh must run BEFORE the request retry; "
+             "reversing them double-charges the rate limiter (learned last mission).",
+    "score": 0.91,
+}
+
+
+def _fake_field(rows: List[Dict[str, Any]]):
+    """A stand-in shared-context backend whose workspace read returns *rows*.
+
+    Mirrors the instrumentation wrapper shape: the real workspace-scoped method
+    lives on the inner adapter, reached via ``getattr(field, '_inner', field)``.
+    """
+    inner = SimpleNamespace(query_workspace=AsyncMock(return_value=rows))
+    return SimpleNamespace(_inner=inner)
+
+
+# ---------------------------------------------------------------------------
+# S1a — the section itself renders the promoted finding through the ONE builder
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_field_section_renders_workspace_digest():
+    section = FieldMemorySection()
+    ctx = SectionContext(
+        agent=None,
+        workspace_id=WS,
+        task_description="Refactor the auth module for the retry path",
+    )
+    with patch(
+        "modules.context.sections.field_memory.get_shared_context",
+        return_value=_fake_field([PROMOTED_FINDING]),
+    ):
+        out = await section.render(ctx)
+
+    assert PROMOTED_FINDING["value"] in out, "promoted finding not surfaced in digest"
+    assert "Field memory" in out, "digest not built by the shared format_digest builder"
+
+
+@pytest.mark.asyncio
+async def test_field_section_empty_when_no_patterns():
+    """No promoted patterns → empty string (never a misleading 'no memory' block)."""
+    section = FieldMemorySection()
+    ctx = SectionContext(agent=None, workspace_id=WS, task_description="anything")
+    with patch(
+        "modules.context.sections.field_memory.get_shared_context",
+        return_value=_fake_field([]),
+    ):
+        out = await section.render(ctx)
+    assert out == ""
+
+
+@pytest.mark.asyncio
+async def test_field_section_workspace_scoped_read():
+    """The section reads the WORKSPACE-scoped field (query_workspace), not a
+    mission-scoped one — so only this workspace's promoted patterns can appear."""
+    section = FieldMemorySection()
+    field = _fake_field([PROMOTED_FINDING])
+    ctx = SectionContext(agent=None, workspace_id=WS, task_description="refactor auth")
+    with patch(
+        "modules.context.sections.field_memory.get_shared_context",
+        return_value=field,
+    ):
+        await section.render(ctx)
+    field._inner.query_workspace.assert_awaited_once()
+    _, kwargs = field._inner.query_workspace.call_args
+    passed_ws = kwargs.get("workspace_id") or field._inner.query_workspace.call_args.args[0]
+    assert str(passed_ws) == WS
+
+
+@pytest.mark.asyncio
+async def test_field_section_never_raises():
+    """A backend explosion degrades to '' — memory read must never crash a prompt."""
+    section = FieldMemorySection()
+    ctx = SectionContext(agent=None, workspace_id=WS, task_description="x")
+    boom = SimpleNamespace(_inner=SimpleNamespace(
+        query_workspace=AsyncMock(side_effect=RuntimeError("qdrant down"))
+    ))
+    with patch(
+        "modules.context.sections.field_memory.get_shared_context",
+        return_value=boom,
+    ):
+        out = await section.render(ctx)
+    assert out == ""
+
+
+# ---------------------------------------------------------------------------
+# S1b — both modes actually include the section (the wiring)
+# ---------------------------------------------------------------------------
+
+def test_field_memory_registered():
+    assert "field_memory" in SECTION_REGISTRY
+    assert SECTION_REGISTRY["field_memory"] is FieldMemorySection
+
+
+def test_heartbeat_mode_includes_field_memory():
+    assert "field_memory" in MODE_CONFIGS[ContextMode.HEARTBEAT_AGENT].sections
+
+
+def test_planning_mode_includes_field_memory():
+    assert "field_memory" in MODE_CONFIGS[ContextMode.PLANNING].sections
+
+
+def test_field_memory_not_added_to_chatbot_region():
+    """W7 owns the CHATBOT / chain-hints region — W9 must not touch it. CHATBOT
+    already carries the 'memory' section; it must NOT gain 'field_memory'."""
+    assert "field_memory" not in MODE_CONFIGS[ContextMode.CHATBOT].sections
+
+
+# ---------------------------------------------------------------------------
+# S1c — W9 GATE: a completed mission's distillation reaches the planning pack
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_planning_reads_field():
+    """W9 ACCEPTANCE GATE. Build the ONE planning pack for a code-touching goal;
+    the workspace field (holding a prior completed mission's promoted finding —
+    what Wave 8 writes) must appear in the assembled pack.
+
+    Wave 8's promotion is mocked at the workspace-read boundary; this proves the
+    W9 half — the pack now consults the field — so the two meet at merge.
+    """
+    from modules.context.service import ContextService
+
+    field = _fake_field([PROMOTED_FINDING])
+    svc = ContextService(db_session=None)
+
+    with patch(
+        "modules.context.sections.field_memory.get_shared_context",
+        return_value=field,
+    ):
+        pack = await svc.build_planning_context(
+            goal="Refactor the auth module retry path",
+            workspace_id=WS,
+            include_roster=False,
+        )
+
+    assert PROMOTED_FINDING["value"] in pack.content, (
+        "completed mission's field distillation absent from the planning pack"
+    )
+    assert "field_memory" in pack.sections_included, (
+        f"planning pack did not include the field section (got {pack.sections_included})"
+    )

--- a/orchestrator/tests/test_prd179_flywheel_order.py
+++ b/orchestrator/tests/test_prd179_flywheel_order.py
@@ -1,0 +1,219 @@
+"""PRD-179 S2 (F049) — mission-synthesis flywheel ordering + dedup.
+
+The flywheel's ingest sweep (`CoordinatorService._save_pending_output_documents`)
+used to `SELECT ... FROM orchestration_runs WHERE state='completed' LIMIT 3`
+with **no ORDER BY** and filtered the already-ingested markers in Python. Once
+more than three ingested runs sat at the front of the unordered scan, every
+tick re-fetched the same already-done rows and ingested nothing — the flywheel
+starved (F049 CONFIRMED, OS review §12.6).
+
+These tests are pure: they drive the sweep against an in-memory fake query
+layer that faithfully models the two things the fix must get right —
+`ORDER BY created_at DESC` and a SQL-side exclusion of already-ingested /
+failed runs — so no Postgres is required. The real SQL is exercised by CI.
+"""
+from __future__ import annotations
+
+import os
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from typing import Any, Dict, List
+from unittest.mock import AsyncMock
+
+import pytest
+
+# Dummy POSTGRES_* satisfies the config chain (blessed pattern) — nothing here
+# touches a DB; the fake query layer stands in for it.
+os.environ.setdefault("POSTGRES_USER", "test")
+os.environ.setdefault("POSTGRES_PASSWORD", "test")
+os.environ.setdefault("POSTGRES_HOST", "127.0.0.1")
+os.environ.setdefault("POSTGRES_PORT", "59432")
+os.environ.setdefault("POSTGRES_DB", "test")
+
+# config caches POSTGRES_* as class attributes at import — and a sibling test's
+# conftest may already have imported config with no env set (local dev). Backfill
+# the cached attrs so the lazy engine builder in the CoordinatorService import
+# chain doesn't refuse on missing creds. No-op on CI where the vars are real.
+from config import config as _config  # noqa: E402
+
+for _k in ("POSTGRES_USER", "POSTGRES_PASSWORD", "POSTGRES_HOST", "POSTGRES_PORT", "POSTGRES_DB"):
+    if not getattr(_config, _k, None):
+        setattr(_config, _k, os.environ[_k])
+
+
+# ---------------------------------------------------------------------------
+# Fake ORM query layer that models ORDER BY / WHERE the way Postgres would.
+# ---------------------------------------------------------------------------
+
+_BASE = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+
+def _make_run(idx: int, *, ingested: bool = False, failed: bool = False) -> SimpleNamespace:
+    """A fake OrchestrationRun row. created_at ascends with idx (idx 9 newest)."""
+    cfg: Dict[str, Any] = {}
+    if ingested:
+        cfg["output_document_id"] = 1000 + idx
+    if failed:
+        cfg["output_ingest_failed"] = "2026-01-01T00:00:00+00:00"
+    return SimpleNamespace(
+        id=idx,
+        workspace_id="ws-1",
+        state="completed",
+        config=cfg,
+        created_at=_BASE + timedelta(hours=idx),
+    )
+
+
+class _FakeQuery:
+    """Chainable query that honours .filter (marker exclusion), .order_by
+    (created_at DESC), and .limit — the three things the fix relies on. Records
+    what it was asked to do so tests can assert the real code built the query
+    with a SQL-side exclusion and a DESC order (not a Python-side filter)."""
+
+    def __init__(self, rows: List[SimpleNamespace], recorder: dict):
+        self._rows = list(rows)
+        self._recorder = recorder
+        self._desc = False
+        self._limit: int | None = None
+
+    def filter(self, *criteria: Any) -> "_FakeQuery":
+        # Record the SQL text of each criterion so a test can assert the marker
+        # columns are excluded server-side. Then model the intended predicate so
+        # the behavioural tests can run without Postgres.
+        self._recorder["filter_sql"] = [str(c) for c in criteria]
+        kept = [
+            r for r in self._rows
+            if not (r.config or {}).get("output_document_id")
+            and not (r.config or {}).get("output_ingest")
+            and not (r.config or {}).get("output_ingest_failed")
+        ]
+        self._rows = kept
+        return self
+
+    def order_by(self, *args: Any) -> "_FakeQuery":
+        self._recorder["order_by_sql"] = [str(a) for a in args]
+        self._desc = True
+        return self
+
+    def limit(self, n: int) -> "_FakeQuery":
+        self._recorder["limit"] = n
+        self._limit = n
+        return self
+
+    def all(self) -> List[SimpleNamespace]:
+        rows = self._rows
+        if self._desc:
+            rows = sorted(rows, key=lambda r: r.created_at, reverse=True)
+        if self._limit is not None:
+            rows = rows[: self._limit]
+        return rows
+
+
+class _FakeSession:
+    def __init__(self, rows: List[SimpleNamespace]):
+        self.rows = rows
+        self.recorder: dict = {}
+
+    def query(self, *_models: Any) -> _FakeQuery:
+        return _FakeQuery(self.rows, self.recorder)
+
+    def flush(self) -> None:  # pragma: no cover - trivial
+        pass
+
+
+@pytest.fixture
+def coordinator():
+    """A CoordinatorService with the actual sweep, but the per-run ingest call
+    stubbed so we assert *which* runs the sweep selected, not the ingest guts."""
+    from services.coordinator_service import CoordinatorService
+
+    svc = CoordinatorService()
+    svc._save_mission_output_as_document = AsyncMock(return_value=1)
+    return svc
+
+
+@pytest.mark.asyncio
+async def test_flywheel_dedup_and_order(coordinator):
+    """10 completed missions, none ingested. The sweep must pick the MOST
+    RECENT batch (ORDER BY created_at DESC), and a second sweep — after the
+    first batch is marked ingested — must pick only *new* (older) runs, never
+    re-processing the already-ingested ones (SQL-side exclusion)."""
+    runs = [_make_run(i) for i in range(10)]  # idx 9 == newest
+    db = _FakeSession(runs)
+
+    # --- First sweep: newest batch by created_at DESC ---
+    await coordinator._save_pending_output_documents(db)
+    first_batch = [c.args[1].id for c in coordinator._save_mission_output_as_document.call_args_list]
+
+    assert first_batch, "sweep ingested nothing on a fresh backlog (starvation)"
+    # Must be the most-recent ids (descending), never an arbitrary/oldest slice.
+    assert first_batch == sorted(first_batch, reverse=True), (
+        f"batch not ordered newest-first: {first_batch}"
+    )
+    assert max(first_batch) == 9, f"newest run (id=9) not in first batch: {first_batch}"
+    batch_size = len(first_batch)
+
+    # Mark the first batch as ingested (what a successful ingest does).
+    for rid in first_batch:
+        runs[rid].config = {**(runs[rid].config or {}), "output_document_id": 5000 + rid}
+
+    # --- Second sweep: only NEW runs, none of the already-ingested set ---
+    coordinator._save_mission_output_as_document.reset_mock()
+    await coordinator._save_pending_output_documents(db)
+    second_batch = [c.args[1].id for c in coordinator._save_mission_output_as_document.call_args_list]
+
+    assert not (set(second_batch) & set(first_batch)), (
+        f"second sweep re-ingested already-done runs: "
+        f"{set(second_batch) & set(first_batch)}"
+    )
+    # The next newest un-ingested runs surface next (proves progress past 3).
+    remaining = sorted((set(range(10)) - set(first_batch)), reverse=True)
+    assert second_batch == remaining[:batch_size], (
+        f"second batch {second_batch} != expected next-newest {remaining[:batch_size]}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_flywheel_query_is_sql_side_ordered_and_excluded(coordinator):
+    """The fix must push ordering and exclusion into the query, not do them in
+    Python. Assert the real code emitted a DESC order on created_at and a filter
+    referencing all three terminal markers — so a regression to an unordered
+    ``LIMIT`` with Python-side filtering is caught even without Postgres."""
+    db = _FakeSession([_make_run(i) for i in range(4)])
+    await coordinator._save_pending_output_documents(db)
+
+    order_sql = " ".join(db.recorder.get("order_by_sql", [])).lower()
+    assert "created_at" in order_sql and "desc" in order_sql, (
+        f"sweep did not ORDER BY created_at DESC (got {db.recorder.get('order_by_sql')})"
+    )
+
+    # The marker keys are bound parameters (SQLAlchemy parameterises ->> keys),
+    # so assert the *shape*: three JSONB ->> IS NULL exclusions on config, which
+    # is exactly one guard per terminal marker (ingested / opted-out / failed).
+    filter_sql = " ".join(db.recorder.get("filter_sql", [])).lower()
+    assert filter_sql.count("config ->>") >= 3, (
+        f"sweep filter lacks the three JSONB marker exclusions (got {filter_sql})"
+    )
+    assert filter_sql.count("is null") >= 3, (
+        f"sweep filter does not exclude already-handled runs server-side (got {filter_sql})"
+    )
+    assert db.recorder.get("limit") == 3, "batch size no longer bounded by config"
+
+
+@pytest.mark.asyncio
+async def test_flywheel_excludes_failed_marker(coordinator):
+    """A run that previously failed to ingest carries a failure marker and must
+    be excluded from the sweep — so a persistently-failing run can never wedge
+    the batch and silently starve the newer ones behind it."""
+    runs = [
+        _make_run(0, failed=True),   # poisoned — must be skipped
+        _make_run(1),
+        _make_run(2),
+    ]
+    db = _FakeSession(runs)
+
+    await coordinator._save_pending_output_documents(db)
+    picked = [c.args[1].id for c in coordinator._save_mission_output_as_document.call_args_list]
+
+    assert 0 not in picked, "sweep re-processed a run already marked ingest-failed"
+    assert set(picked) == {1, 2}, f"expected the two healthy runs, got {picked}"

--- a/orchestrator/tests/test_prd179_flywheel_order.py
+++ b/orchestrator/tests/test_prd179_flywheel_order.py
@@ -121,10 +121,31 @@ class _FakeSession:
         pass
 
 
+def _purge_stub_modules() -> None:
+    """Drop origin-less stub modules a sibling test left in sys.modules, so the
+    CoordinatorService import resolves against real packages. Runs at FIXTURE
+    time (not just collection) because sibling tests pollute sys.modules after
+    this module is collected — notably the harness suite installs a bare
+    ``apscheduler`` fake (no ``.triggers`` submodule) that the coordinator import
+    chain (heartbeat_service) needs the REAL package for."""
+    import sys
+
+    def _is_stub(name: str, mod: object) -> bool:
+        prefixed = (
+            name in ("modules", "consumers", "apscheduler")
+            or name.startswith(("modules.", "consumers.", "apscheduler."))
+        )
+        return prefixed and getattr(mod, "__spec__", None) is None
+
+    for name in [n for n, m in list(sys.modules.items()) if _is_stub(n, m)]:
+        sys.modules.pop(name, None)
+
+
 @pytest.fixture
 def coordinator():
     """A CoordinatorService with the actual sweep, but the per-run ingest call
     stubbed so we assert *which* runs the sweep selected, not the ingest guts."""
+    _purge_stub_modules()
     from services.coordinator_service import CoordinatorService
 
     svc = CoordinatorService()

--- a/orchestrator/tests/test_prd179_harness_actuation.py
+++ b/orchestrator/tests/test_prd179_harness_actuation.py
@@ -1,0 +1,264 @@
+"""PRD-179 S3 (F048) — HARNESS prescription actuation through the policy plane.
+
+Today a human-approved prescription either dead-ends (the flag is off by default,
+so the approve endpoint returns HTTP 409) or, with the flag on, actuates via a
+DARK direct call to ``_auto_apply_prescription`` that bypasses the Wave-4 policy
+plane entirely. F048 (adjusted): make approval a GOVERNED ACTIVATION — the
+prescription's actuation is routed through the same ``evaluate_approval`` ask
+verdict every other governed action passes through (Wave 4), the board task is
+marked done WITH a result, and there is no 409.
+
+Reuses ``core.services.approval_policy.evaluate_approval`` — no parallel approval
+path. The admin's explicit approve is the per-request override the plane already
+models. Enabled behind the existing ``HARNESS_SELF_MANAGEMENT_ENABLED`` flag.
+
+Unit-level: the DB is faked to the handler's two queries and the executor is the
+in-memory fake from the US-021 suite; the policy plane is real (pure function).
+"""
+import asyncio
+import json
+import os
+import sys
+import types
+
+os.environ.pop("HARNESS_SELF_MANAGEMENT_ENABLED", None)
+os.environ.setdefault("POSTGRES_USER", "test")
+os.environ.setdefault("POSTGRES_PASSWORD", "test")
+os.environ.setdefault("POSTGRES_HOST", "localhost")
+os.environ.setdefault("POSTGRES_PORT", "5432")
+os.environ.setdefault("POSTGRES_DB", "test")
+
+
+def _install_fake_apscheduler():
+    if "apscheduler" in sys.modules:
+        return
+    aps = types.ModuleType("apscheduler")
+    schedulers = types.ModuleType("apscheduler.schedulers")
+    asyncio_mod = types.ModuleType("apscheduler.schedulers.asyncio")
+    asyncio_mod.AsyncIOScheduler = type("AsyncIOScheduler", (), {})
+    jobstores = types.ModuleType("apscheduler.jobstores")
+    memory_mod = types.ModuleType("apscheduler.jobstores.memory")
+    memory_mod.MemoryJobStore = type("MemoryJobStore", (), {})
+    aps.schedulers = schedulers
+    aps.jobstores = jobstores
+    schedulers.asyncio = asyncio_mod
+    jobstores.memory = memory_mod
+    sys.modules.update({
+        "apscheduler": aps,
+        "apscheduler.schedulers": schedulers,
+        "apscheduler.schedulers.asyncio": asyncio_mod,
+        "apscheduler.jobstores": jobstores,
+        "apscheduler.jobstores.memory": memory_mod,
+    })
+
+
+_install_fake_apscheduler()
+
+from config import config  # noqa: E402
+
+# config caches POSTGRES_* at import; a sibling conftest may have imported it
+# with no env set (local dev). Backfill so the lazy engine builder in the
+# harness import chain does not refuse on missing creds. No-op on CI.
+for _k in ("POSTGRES_USER", "POSTGRES_PASSWORD", "POSTGRES_HOST", "POSTGRES_PORT", "POSTGRES_DB"):
+    if not getattr(config, _k, None):
+        setattr(config, _k, os.environ[_k])
+
+import api.harness_commands as hc  # noqa: E402
+
+_WS_ID = "00000000-0000-0000-0000-000000000001"
+_RX_ID = "rx-actuate-1"
+
+
+def _ledger_path(volume, workspace_id=_WS_ID):
+    return os.path.join(str(volume), str(workspace_id), "harness", "applied_tasks.json")
+
+
+def _harness_task(task_id=7, rx_id=_RX_ID, risk=2):
+    return {
+        "id": task_id,
+        "title": f"[HARNESS] heartbeat_tune for ScribeAgent",
+        "description": (
+            f"**Risk Score:** {risk}/5\n\n"
+            f"**Change Type:** heartbeat_tune\n\n"
+            f"**Current:** {json.dumps({'interval_minutes': 30})}\n\n"
+            f"**Proposed:** {json.dumps({'interval_minutes': 90})}\n\n"
+            f"**Rationale:** because reasons\n\n"
+            f"**Expected Improvement:** save tokens"
+        ),
+        "tags": ["harness", "org-review", f"risk-{risk}", f"rx:{rx_id}"],
+    }
+
+
+class _FakeExecutor:
+    """Records execute() calls. The prescription actuation and the board-task
+    status update BOTH return a non-null result payload, so the test can assert
+    the task completes with a result (status=done, result != null)."""
+
+    def __init__(self, tasks, agents):
+        self._tasks = tasks
+        self._agents = agents
+        self.calls = []
+        self.task_status = {}
+        self.task_result = {}
+
+    async def execute(self, action, params):
+        self.calls.append((action, params))
+        if action == "platform_list_tasks":
+            return {"data": self._tasks}
+        if action == "platform_list_agents":
+            return {"data": self._agents}
+        if action == "platform_update_task_status":
+            self.task_status[params.get("task_id")] = params.get("status")
+            if params.get("result") is not None:
+                self.task_result[params.get("task_id")] = params.get("result")
+            return {"success": True, "data": {"status": params.get("status")}}
+        if action == "platform_configure_agent_heartbeat":
+            # The actuation returns a concrete, non-null result.
+            return {"success": True, "data": {"agent_id": params.get("agent_id"),
+                                              "interval_minutes": params.get("interval_minutes")}}
+        return {"success": True}
+
+    def actions(self):
+        return [action for action, _ in self.calls]
+
+
+class _FakeBoardTask:
+    """Stands in for the BoardTask ORM row the actuation writes its result onto."""
+
+    def __init__(self, task_id):
+        self.id = task_id
+        self.workspace_id = _WS_ID
+        self.status = "review"
+        self.result = None
+        self.completed_at = None
+
+
+class _FakeQuery:
+    def __init__(self, result):
+        self._result = result
+
+    def filter(self, *args, **kwargs):
+        return self
+
+    def first(self):
+        return self._result
+
+
+class _FakeDB:
+    def __init__(self, member=None, board_task=None):
+        self._member = member
+        self._board_task = board_task
+        self.committed = False
+
+    def query(self, model):
+        name = getattr(model, "__name__", "")
+        if name == "WorkspaceMember":
+            return _FakeQuery(self._member)
+        if name == "BoardTask":
+            return _FakeQuery(self._board_task)
+        return _FakeQuery(None)
+
+    def commit(self):
+        self.committed = True
+
+
+_ADMIN_MEMBER = object()
+_ADMIN = {"user_id": 5}
+
+
+def _patch_executor(monkeypatch, ex):
+    monkeypatch.setattr(hc, "_make_executor", lambda db, workspace_id: ex)
+
+
+def test_harness_prescription_actuates(monkeypatch, tmp_path):
+    """Approve → routed through the policy-plane ask verdict → actuates → board
+    task done with a non-null result. No 409, no dark direct-apply."""
+    monkeypatch.setattr(config, "HARNESS_SELF_MANAGEMENT_ENABLED", True)
+    monkeypatch.setattr(config, "WORKSPACE_VOLUME_PATH", str(tmp_path))
+
+    # Spy on the policy plane so we prove the actuation is GOVERNED — the same
+    # evaluate_approval verdict every other governed action passes through.
+    import core.services.approval_policy as ap
+    verdicts = []
+    real_eval = ap.evaluate_approval
+
+    def _spy(db, workspace_id, cost, **kw):
+        d = ap.ApprovalDecision(
+            auto_approve=True, reason="harness admin approve (per-request override)",
+            policy="override", ceiling=None, estimated_cost=cost, countdown_seconds=None,
+        )
+        verdicts.append((workspace_id, kw))
+        return d
+
+    monkeypatch.setattr(hc, "evaluate_approval", _spy, raising=False)
+    # Also patch at the source in case the handler imports it lazily by module.
+    monkeypatch.setattr(ap, "evaluate_approval", _spy)
+
+    task = _harness_task(task_id=7)
+    ex = _FakeExecutor(tasks=[task], agents=[{"id": 42, "name": "ScribeAgent"}])
+    _patch_executor(monkeypatch, ex)
+    board_row = _FakeBoardTask(7)
+    db = _FakeDB(member=_ADMIN_MEMBER, board_task=board_row)
+
+    result = asyncio.run(hc.handle_harness_command(db, _WS_ID, "/approve", _RX_ID, _ADMIN))
+
+    # 1. It succeeded (no 409 dead-end).
+    assert result["success"] is True, result
+
+    # 2. It went through the policy plane's ask verdict (governed activation).
+    assert verdicts, "actuation did not route through evaluate_approval (policy plane)"
+
+    # 3. The actuation actually ran against the resolved agent.
+    assert (
+        "platform_configure_agent_heartbeat",
+        {"agent_id": 42, "interval_minutes": 90},
+    ) in ex.calls
+
+    # 4. The board task completed with status=done AND a non-null result.
+    assert ex.task_status.get(7) == "done", ex.task_status
+    assert board_row.result is not None, "board task completed with a null result"
+    assert board_row.completed_at is not None
+
+
+def test_actuation_blocked_when_policy_denies(monkeypatch, tmp_path):
+    """If the policy plane denies the verdict, the prescription does NOT actuate —
+    governed activation means the plane can still say no."""
+    monkeypatch.setattr(config, "HARNESS_SELF_MANAGEMENT_ENABLED", True)
+    monkeypatch.setattr(config, "WORKSPACE_VOLUME_PATH", str(tmp_path))
+
+    import core.services.approval_policy as ap
+
+    def _deny(db, workspace_id, cost, **kw):
+        return ap.ApprovalDecision(
+            auto_approve=False, reason="denied by policy", policy="always_ask",
+            ceiling=None, estimated_cost=cost, countdown_seconds=None,
+        )
+
+    monkeypatch.setattr(hc, "evaluate_approval", _deny, raising=False)
+    monkeypatch.setattr(ap, "evaluate_approval", _deny)
+
+    task = _harness_task(task_id=7)
+    ex = _FakeExecutor(tasks=[task], agents=[{"id": 42, "name": "ScribeAgent"}])
+    _patch_executor(monkeypatch, ex)
+    db = _FakeDB(member=_ADMIN_MEMBER)
+
+    result = asyncio.run(hc.handle_harness_command(db, _WS_ID, "/approve", _RX_ID, _ADMIN))
+
+    assert result["success"] is False, "a denied verdict must not actuate"
+    assert "platform_configure_agent_heartbeat" not in ex.actions()
+    assert ex.task_status.get(7) != "done"
+    assert not os.path.exists(_ledger_path(tmp_path))
+
+
+def test_disabled_flag_still_dark(monkeypatch):
+    """Flag off → the whole path stays inert (feature dark by default)."""
+    monkeypatch.setattr(config, "HARNESS_SELF_MANAGEMENT_ENABLED", False)
+    ex = _FakeExecutor(tasks=[_harness_task()], agents=[])
+    _patch_executor(monkeypatch, ex)
+    db = _FakeDB(member=_ADMIN_MEMBER)
+
+    result = asyncio.run(hc.handle_harness_command(db, _WS_ID, "/approve", _RX_ID, _ADMIN))
+
+    assert result["success"] is False
+    assert "disabled" in result["message"].lower()
+    assert ex.calls == []

--- a/orchestrator/tests/test_prd179_rag_feedback_rank.py
+++ b/orchestrator/tests/test_prd179_rag_feedback_rank.py
@@ -1,0 +1,159 @@
+"""PRD-179 S4 (F070) — rag_feedback as a live ranking feature.
+
+`rag_feedback` used to be a write-only bucket: the endpoint INSERTed thumbs /
+ratings that fed nothing back into retrieval (F070 CONFIRMED,
+`api/rag_feedback.py:50-70`). This wires the negative signal into
+`RAGService.retrieve()` ranking on the live hot path so a document marked
+unhelpful de-ranks (lower score, and drops out of the top-K when the field is
+tight) on the next retrieval of the same query.
+
+Uses the RANKING path in `modules/rag/service.py` — NOT tool-affinity edges
+(`edge_builder.py` is Wave 7's). Pure: the feedback DB read is mocked at the
+boundary, so no Postgres.
+"""
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List
+from unittest.mock import patch
+
+import pytest
+
+os.environ.setdefault("POSTGRES_USER", "test")
+os.environ.setdefault("POSTGRES_PASSWORD", "test")
+os.environ.setdefault("POSTGRES_HOST", "127.0.0.1")
+os.environ.setdefault("POSTGRES_PORT", "59432")
+os.environ.setdefault("POSTGRES_DB", "test")
+
+from config import config as _config  # noqa: E402
+
+for _k in ("POSTGRES_USER", "POSTGRES_PASSWORD", "POSTGRES_HOST", "POSTGRES_PORT", "POSTGRES_DB"):
+    if not getattr(_config, _k, None):
+        setattr(_config, _k, os.environ[_k])
+
+from modules.rag.service import RAGService  # noqa: E402
+
+WS = "22222222-2222-2222-2222-222222222222"
+
+
+def _candidate(doc_id: int, score: float, text: str = "chunk") -> Dict[str, Any]:
+    return {
+        "document_id": doc_id,
+        "content": f"{text}-{doc_id}",
+        "score": score,
+        "similarity": score,
+        "metadata": {"document_id": doc_id},
+    }
+
+
+@pytest.fixture
+def svc() -> RAGService:
+    # __new__ avoids the heavy __init__ (embedders / optimizers); we only test
+    # the pure ranking method, which needs no initialised collaborators.
+    return RAGService.__new__(RAGService)
+
+
+def test_marked_unhelpful_doc_is_deranked(svc):
+    """Doc 7 is top by similarity but was marked unhelpful → after the feedback
+    penalty it must rank BELOW the un-penalised doc 3."""
+    candidates = [_candidate(7, 0.90), _candidate(3, 0.70), _candidate(5, 0.65)]
+
+    with patch.object(
+        RAGService, "_negative_feedback_doc_ids", return_value={"7"}
+    ):
+        ranked = svc._apply_feedback_penalty(candidates, workspace_id=WS)
+
+    order = [c["document_id"] for c in ranked]
+    assert order.index(3) < order.index(7), (
+        f"unhelpful doc 7 was not de-ranked below doc 3 (order={order})"
+    )
+    # The penalty lowers the score, it doesn't just reorder ties.
+    penalised = next(c for c in ranked if c["document_id"] == 7)
+    assert penalised["score"] < 0.90
+
+
+def test_no_feedback_leaves_order_untouched(svc):
+    """No negative feedback → identical ranking (feature is inert until used)."""
+    candidates = [_candidate(7, 0.90), _candidate(3, 0.70)]
+    with patch.object(RAGService, "_negative_feedback_doc_ids", return_value=set()):
+        ranked = svc._apply_feedback_penalty(candidates, workspace_id=WS)
+    assert [c["document_id"] for c in ranked] == [7, 3]
+    assert ranked[0]["score"] == 0.90
+
+
+def test_penalty_can_drop_doc_from_top_k(svc):
+    """With a strong penalty an unhelpful doc that was #1 falls out of top-1 —
+    the 'absent from top-K' half of the acceptance criterion."""
+    candidates = [_candidate(7, 0.88), _candidate(3, 0.80)]
+    with patch.object(RAGService, "_negative_feedback_doc_ids", return_value={"7"}):
+        ranked = svc._apply_feedback_penalty(candidates, workspace_id=WS)
+    top_1 = [c["document_id"] for c in ranked][:1]
+    assert 7 not in top_1, f"unhelpful doc still occupies top-1 (top={top_1})"
+
+
+def test_feedback_penalty_never_raises(svc):
+    """A feedback-read explosion must not break retrieval — degrade to the
+    original candidate order."""
+    candidates = [_candidate(7, 0.90), _candidate(3, 0.70)]
+    with patch.object(
+        RAGService, "_negative_feedback_doc_ids", side_effect=RuntimeError("db down")
+    ):
+        ranked = svc._apply_feedback_penalty(candidates, workspace_id=WS)
+    assert [c["document_id"] for c in ranked] == [7, 3]
+
+
+def test_retrieve_calls_feedback_penalty_on_hot_path():
+    """The live retrieve() path must invoke the feedback penalty — proves the
+    signal feeds ranking, not just that a helper exists."""
+    import inspect
+
+    src = inspect.getsource(RAGService.retrieve)
+    assert "_apply_feedback_penalty" in src, (
+        "retrieve() does not apply rag_feedback to ranking on the live path"
+    )
+
+
+def test_negative_feedback_query_is_workspace_scoped(svc):
+    """The feedback read must be workspace-scoped and use CAST(:p AS type) (the
+    SQLAlchemy-2.0 bind idiom), never :p::type."""
+    import inspect
+
+    src = inspect.getsource(RAGService._negative_feedback_doc_ids)
+    assert "workspace_id" in src, "feedback read is not workspace-scoped"
+    assert "rag_feedback" in src, "feedback read does not query rag_feedback"
+    assert "::" not in src, "raw ::cast used — must be CAST(:p AS type) under SQLAlchemy 2.0"
+
+
+def test_rag_feedback_to_ranking(svc):
+    """W9 acceptance (F070): the signal the POST /rag/feedback endpoint WRITES is
+    exactly the signal the ranking READS, and a doc so-marked de-ranks on the
+    follow-up retrieval.
+
+    The write side (endpoint INSERT) and the read side (ranking query) must
+    agree on the contract: a ``thumbs_down`` carrying ``document_ids``. This
+    asserts that contract from both ends, then drives a follow-up retrieval whose
+    negative-feedback read returns the marked doc and confirms it de-ranks —
+    closing the write-only-bucket gap end to end (DB mocked at the boundary).
+    """
+    import inspect
+
+    # Write side: the endpoint persists feedback_type + document_ids to rag_feedback.
+    from api import rag_feedback as rag_feedback_api
+
+    write_src = inspect.getsource(rag_feedback_api.submit_feedback)
+    assert "INSERT INTO rag_feedback" in write_src
+    assert "document_ids" in write_src and "feedback_type" in write_src
+
+    # Read side consumes those same columns (thumbs_down / document_ids).
+    read_src = inspect.getsource(RAGService._negative_feedback_doc_ids)
+    assert "thumbs_down" in read_src and "document_ids" in read_src
+
+    # End-to-end behaviour: doc 9 was thumbed-down last turn; on the follow-up
+    # retrieval it de-ranks below the un-flagged doc 4 (was ranked above it).
+    candidates = [_candidate(9, 0.92), _candidate(4, 0.71)]
+    with patch.object(RAGService, "_negative_feedback_doc_ids", return_value={"9"}):
+        ranked = svc._apply_feedback_penalty(candidates, workspace_id=WS)
+    order = [c["document_id"] for c in ranked]
+    assert order.index(4) < order.index(9), (
+        f"doc marked unhelpful via POST /rag/feedback did not de-rank (order={order})"
+    )


### PR DESCRIPTION
## Wave 9 — Planning Intelligence Completion (Phase C)

Completes the verified remainders PRD-164 (merged, PR #457) left behind — **repair, not a new PRD.** Part of the OS Review 2026-07-01 hardening program (Phase C). Depends only on merged Phase A/B.

### Findings addressed
- **F021** (memory read-half, absent from #457) — Heartbeat agents were memory-blind and planning mode had no field section. New `FieldMemorySection` reads the workspace-persistent field via `VectorFieldSharedContext.query_workspace` (what W8's promotion writes into) and renders it through the **existing** digest builder (`field_scoring.budget_results` + `format_digest`) — no second builder. Registered in `SECTION_REGISTRY`, added to the **HEARTBEAT and PLANNING modes only** (chatbot/chain-hints region untouched).
- **F049** — The mission-synthesis flywheel ingested 3 arbitrary COMPLETED runs (no `ORDER BY`, no already-ingested exclusion), starving once >3 accumulate. Now `ORDER BY created_at DESC` + SQL-side exclusion of the three terminal markers (batch via `FLYWHEEL_INGEST_BATCH`), and a poison run is stamped `output_ingest_failed` so it drops out of the backlog instead of starving it.
- **F048** — Human-approved HARNESS prescriptions escalated to a surface that returns HTTP 409, never actuating. `_approve` now routes actuation through `approval_policy.evaluate_approval` — **the same ask verdict every governed action uses, no parallel path** (a policy decline still blocks; governed activation, not auto-apply). On success the board task is marked `done` with its result written. Still gated behind `HARNESS_SELF_MANAGEMENT_ENABLED`.
- **F070** — `rag_feedback` was write-only. `RAGService` now reads workspace-scoped negative feedback (`CAST(:p AS type)`, fail-soft) and applies a score penalty + re-sort on the live retrieve path (**ranking path only, not affinity edges**). The write side (`api/rag_feedback.py`) was already correct — the fix is the read side consuming those same writes, asserted as a write→read contract test.

### Acceptance gate
`test_planning_reads_field` — a completed mission's field distillation appears in the next code-touching mission's planning pack (spans W8's promotion + this wave's digest; W9 owns the assertion). **Passes.**

### Test plan
- [ ] CI green
- Four stories, test-first: `test_prd179_{field_read,flywheel_order,harness_actuation,rag_feedback_rank}` — 50 W9-only + 144 across the context suite pass, across collection orders. Fixed a sibling-suite `sys.modules` isolation trap for the flywheel test.

Verified: `py_compile` on all 14 changed files; no `os.getenv` outside `config.py`; 7 `CAST(...)` uses (no `:p::type`); ownership boundary held (zero W7/W8-owned files touched); clean 3-way merge with W7 + W8.

**Note:** a few pre-existing integration tests (`test_harness_api.py`, `test_prd164_flywheel.py`) fail to collect locally on the DB-URL/config-cache issue — confirmed identical on the base commit, not a regression; CI runs them with a real database.
