### PR TITLE
feat(prd-185): Wave-0 S2 telemetry canary + S11 stop memory injecting noise

### DIFF
--- a/orchestrator/config.py
+++ b/orchestrator/config.py
@@ -644,6 +644,21 @@ class Config:
     # today's per-router gates (nothing new enters the path). Flag ON ⇒ the plane.
     POLICY_PLANE_ENABLED: bool = os.getenv("AUTOMATOS_POLICY_PLANE", "false").lower() in ("true", "1", "yes")
 
+    # PRD-185 S2 — per-lane telemetry canary. The type-poison outage S1 repaired
+    # went unseen for ~2 months because nothing alarmed on "organic tool-execution
+    # rows/day = 0". This canary counts production (telemetry_source='production')
+    # ToolExecutionLog rows per lane (app_name) over a window and logs LOUD when a
+    # lane — or the platform — has gone silent. Default ON (it only reads + logs).
+    TELEMETRY_CANARY_ENABLED: bool = os.getenv("TELEMETRY_CANARY_ENABLED", "true").lower() == "true"
+    # How often the scheduled check runs (default hourly). Its first run fires at
+    # boot as the boot-probe.
+    TELEMETRY_CANARY_INTERVAL_SECONDS: int = int(os.getenv("TELEMETRY_CANARY_INTERVAL_SECONDS", "3600"))
+    # Look-back window for "have any organic rows landed?" (default 24h).
+    TELEMETRY_CANARY_WINDOW_SECONDS: int = int(os.getenv("TELEMETRY_CANARY_WINDOW_SECONDS", "86400"))
+    # Platform-wide organic-row count at/under which the canary alarms (default 0
+    # → alarm only on a totally silent platform; raise to catch partial silence).
+    TELEMETRY_CANARY_MIN_ROWS: int = int(os.getenv("TELEMETRY_CANARY_MIN_ROWS", "0"))
+
     # =============================================================================
     # PRD-181 W11 — Governance & Compliance staging
     # =============================================================================

--- a/orchestrator/consumers/chatbot/smart_memory.py
+++ b/orchestrator/consumers/chatbot/smart_memory.py
@@ -213,6 +213,26 @@ class SmartMemoryManager:
 
                 memories = global_memories + agent_memories
 
+                # PRD-185 S11: assembly-side guard — never inject sub-floor or
+                # noise-typed (heartbeat/playbook-summary) memories into the prompt.
+                # The relevance floor is also applied at the L3 search boundary
+                # (mem0_client.filter_by_relevance_floor, PRD-159 S3); re-asserting
+                # it over the MERGED set closes the content-type gap the search
+                # layer lacks, at the one chokepoint that feeds the LLM formatter.
+                from modules.memory.injection_filter import filter_injectable_memories
+                try:
+                    from config import config as _cfg
+                    _floor = float(getattr(_cfg, "MEMORY_RELEVANCE_FLOOR", 0.3))
+                except Exception:
+                    _floor = 0.3
+                _before = len(memories)
+                memories = filter_injectable_memories(memories, floor=_floor)
+                if len(memories) != _before:
+                    logger.info(
+                        "[SmartMemory] Injection guard dropped %d/%d memories (floor+type)",
+                        _before - len(memories), _before,
+                    )
+
                 if memories:
                     for i, mem in enumerate(memories[:3]):
                         tier = mem.get("_tier", "global")

--- a/orchestrator/modules/memory/injection_filter.py
+++ b/orchestrator/modules/memory/injection_filter.py
@@ -1,0 +1,71 @@
+"""PRD-185 S11 — assembly-side memory-injection guard.
+
+Sub-floor and noise-typed memories must never reach the prompt. The relevance
+floor is already applied at the L3 search boundary
+(``mem0_client.filter_by_relevance_floor``, PRD-159 S3); this is the guard over
+the **merged** candidate set at the one chokepoint that feeds
+``_format_memories_for_llm`` — so it re-asserts the floor over every source
+(L3 global + agent tiers, and any future L2) AND adds the content-type exclusion
+the search layer lacks (heartbeat digests, playbook execution summaries).
+
+Pure — no I/O — so it unit-tests with plain dicts.
+"""
+from typing import Any, Dict, Iterable, List, Optional
+
+# ``content_type`` / ``metadata.type`` values that are operational noise, never
+# user context: heartbeat digests and playbook/recipe execution summaries. These
+# are excluded from prompt injection. ``recipe_summary`` is the legacy name for
+# ``playbook_summary`` (pre-March rename) — kept so old rows are filtered too.
+EXCLUDED_INJECTION_CONTENT_TYPES = frozenset({
+    "heartbeat_log",
+    "playbook_summary",
+    "recipe_summary",
+})
+
+
+def _content_type_of(mem: Dict[str, Any]) -> Optional[str]:
+    """Best-effort content-type signal across the shapes a memory row takes.
+
+    Mem0 search rows expose ``{id, memory, score, metadata, created_at}`` — the
+    type, when present, rides in ``metadata`` (``content_type`` or ``type``);
+    L2-shaped rows carry a top-level ``content_type`` (or ``category``). Checking
+    every path means the filter bites wherever the tag lands instead of silently
+    no-op-ing on a shape mismatch — the exact failure class this wave exists for.
+    """
+    if not isinstance(mem, dict):
+        return None
+    meta = mem.get("metadata")
+    meta = meta if isinstance(meta, dict) else {}
+    return (
+        mem.get("content_type")
+        or meta.get("content_type")
+        or meta.get("type")
+        or mem.get("category")
+    )
+
+
+def filter_injectable_memories(
+    memories: Iterable[Dict[str, Any]],
+    *,
+    floor: float,
+    excluded_types: Iterable[str] = EXCLUDED_INJECTION_CONTENT_TYPES,
+) -> List[Dict[str, Any]]:
+    """Drop sub-floor and noise-typed memories before prompt injection.
+
+    - Scored-but-below-``floor`` rows are dropped; unscored rows are kept (cannot
+      judge — same rule as ``filter_by_relevance_floor``). ``floor <= 0`` disables
+      the score check.
+    - Rows whose content-type signal is in ``excluded_types`` are dropped.
+    """
+    excluded = frozenset(excluded_types)
+    out: List[Dict[str, Any]] = []
+    for mem in memories:
+        if not isinstance(mem, dict):
+            continue
+        score = mem.get("score")
+        if floor and floor > 0 and score is not None and (score or 0) < floor:
+            continue
+        if _content_type_of(mem) in excluded:
+            continue
+        out.append(mem)
+    return out

--- a/orchestrator/services/heartbeat_service.py
+++ b/orchestrator/services/heartbeat_service.py
@@ -12,7 +12,7 @@ import json
 import logging
 import asyncio
 from typing import Optional, Dict, Any
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.jobstores.memory import MemoryJobStore
@@ -136,6 +136,9 @@ class HeartbeatService:
         self._scheduler: Optional[AsyncIOScheduler] = None
         self._owns_scheduler: bool = False  # True when we created our own scheduler (tests)
         self._running_ticks: Dict[str, bool] = {}  # track concurrent ticks
+        # PRD-185 S11: last emitted memory-primitive status, so the 30s Mem0 probe
+        # writes a heartbeat_results row only on a state CHANGE (not every tick).
+        self._last_mem0_probe_status: Optional[str] = None
         self._max_concurrent_per_workspace = 5
 
     # ------------------------------------------------------------------
@@ -209,6 +212,34 @@ class HeartbeatService:
         except Exception:
             logger.error("[Heartbeat] Failed to schedule Mem0 health probe", exc_info=True)
 
+        # PRD-185 S2: per-lane telemetry canary. Alarms when organic tool-execution
+        # rows stop landing (the 2-month type-poison outage S1 repaired had no such
+        # signal). Registered here beside the Mem0 probe; the first run fires at boot
+        # as the boot-probe, then every TELEMETRY_CANARY_INTERVAL_SECONDS.
+        try:
+            from config import config as _cfg
+
+            if _cfg.TELEMETRY_CANARY_ENABLED:
+                from apscheduler.triggers.interval import IntervalTrigger
+                from services.telemetry_canary import telemetry_canary_tick
+
+                canary_interval = int(_cfg.TELEMETRY_CANARY_INTERVAL_SECONDS)
+                self._scheduler.add_job(
+                    telemetry_canary_tick,
+                    IntervalTrigger(seconds=canary_interval),
+                    id="telemetry_canary",
+                    replace_existing=True,
+                    max_instances=1,
+                    coalesce=True,
+                    next_run_time=datetime.now(timezone.utc),  # boot-probe: run once now
+                )
+                logger.info(
+                    "[Heartbeat] Telemetry canary scheduled every %ds (boot-probe now)",
+                    canary_interval,
+                )
+        except Exception:
+            logger.error("[Heartbeat] Failed to schedule telemetry canary", exc_info=True)
+
         logger.info("[Heartbeat] Service started (daily summary at 01:00 UTC)")
 
     async def stop(self):
@@ -244,6 +275,14 @@ class HeartbeatService:
         if self._scheduler is None:
             return
         primitive_status = "green" if healthy else "down"
+        # PRD-185 S11: emit the memory primitive finding ONLY on a state change.
+        # This 30s probe previously wrote one heartbeat_results row per workspace
+        # EVERY tick (~2880/ws/day) — pure noise that polluted the table and the
+        # primitive-health read. The tile is latest-wins with no freshness gate
+        # (api/analytics_real.get_primitive_health), so one row per transition
+        # keeps it correct while ending the spam. First tick emits the baseline.
+        if primitive_status == self._last_mem0_probe_status:
+            return
         detail = "mem0 probe ok" if healthy else "mem0 probe failed; breakers tripped"
         try:
             for job in self._scheduler.get_jobs():
@@ -252,6 +291,7 @@ class HeartbeatService:
                     continue
                 ws_id = jid[len("orch_hb_"):]
                 emit_primitive_finding(ws_id, "memory", primitive_status, detail)
+            self._last_mem0_probe_status = primitive_status
         except Exception:
             logger.error(
                 "[Heartbeat] memory primitive emit loop errored", exc_info=True
@@ -1027,66 +1067,17 @@ class HeartbeatService:
                     error_count = sum(1 for r in ws_rows if r.status == "error")
                     total_tokens = sum(r.tokens_used or 0 for r in ws_rows)
 
-                    summary_text = (
-                        f"Heartbeat Daily Summary ({cutoff.strftime('%Y-%m-%d')} to {datetime.utcnow().strftime('%Y-%m-%d')}):\n"
-                        f"- Total ticks: {len(ws_rows)}\n"
-                        f"- Successful: {success_count}\n"
-                        f"- Errors: {error_count}\n"
-                        f"- Tokens used: {total_tokens}\n"
+                    # PRD-185 S11: the daily digest is an OPERATIONAL LOG, not a
+                    # memory. It used to be double-written into the memory plane —
+                    # once as a fabricated user/assistant L3 turn (a fake summary
+                    # "request" + digest reply) that then got injected into real
+                    # client prompts, and once as an L2 heartbeat_log row. Both are
+                    # removed: the raw ticks are the source of truth in
+                    # heartbeat_results; the digest is logged here, never injected.
+                    logger.info(
+                        "[Heartbeat] Daily summary ws=%s: %d ticks, %d ok, %d errors, %d tokens",
+                        ws_id, len(ws_rows), success_count, error_count, total_tokens,
                     )
-
-                    # Add notable findings
-                    notable = []
-                    for r in ws_rows:
-                        findings = r.findings if isinstance(r.findings, list) else json.loads(r.findings or "[]")
-                        for f in findings:
-                            if f.get("check") in ("error", "llm_error"):
-                                notable.append(f"[{r.source_type}/{r.source_id}] {f.get('detail', '')[:120]}")
-                    if notable:
-                        summary_text += "\nNotable issues:\n" + "\n".join(f"- {n}" for n in notable[:10])
-
-                    # Store in SmartMemoryManager as long-term memory
-                    try:
-                        from consumers.chatbot.smart_memory import get_smart_memory_manager
-
-                        mem_mgr = get_smart_memory_manager()
-                        await mem_mgr.store_conversation(
-                            workspace_id=ws_id,
-                            agent_id=None,
-                            user_message="Daily heartbeat summary request",
-                            assistant_response=summary_text,
-                            chat_id=None,
-                        )
-                        logger.info("[Heartbeat] Stored daily summary for ws=%s (%d ticks)", ws_id, len(ws_rows))
-                    except Exception as mem_err:
-                        logger.warning("[Heartbeat] Failed to store summary in memory for ws=%s: %s", ws_id, mem_err)
-
-                    # L2: Store heartbeat summary in short-term memory (fire-and-forget)
-                    try:
-                        from modules.memory.unified_memory_service import get_unified_memory_service
-
-                        unified = get_unified_memory_service()
-                        asyncio.create_task(
-                            unified.store_short_term(
-                                workspace_id=ws_id,
-                                content=summary_text[:1500],
-                                content_type="heartbeat_log",
-                                importance=0.4,
-                                metadata={
-                                    "type": "heartbeat_daily_summary",
-                                    "date": cutoff.strftime("%Y-%m-%d"),
-                                    "tick_count": len(ws_rows),
-                                    "success_count": success_count,
-                                    "error_count": error_count,
-                                },
-                            )
-                        )
-                    except Exception:
-                        logger.debug(
-                            "[Heartbeat] L2 store_short_term failed for ws=%s",
-                            ws_id,
-                            exc_info=True,
-                        )
 
             finally:
                 db.close()

--- a/orchestrator/services/telemetry_canary.py
+++ b/orchestrator/services/telemetry_canary.py
@@ -1,0 +1,138 @@
+"""PRD-185 S2 — per-lane telemetry canary.
+
+S1 repaired a type-poisoned telemetry write that had left ``tool_execution_logs``
+with **zero** organic rows for ~two months. Nothing alarmed, because the platform
+had no signal for "organic rows/day = 0". This module is that guardrail: it counts
+production (``telemetry_source == 'production'``) ``ToolExecutionLog`` rows per lane
+(``app_name``) over a window and reports LOUD when the platform — or a lane — has
+gone silent, so S1 can never silently regress again.
+
+It reuses the W10 telemetry source-of-truth (``ToolExecutionLog`` + the
+``telemetry_source`` discriminator, PRD-180) — it does NOT stand up a parallel
+metrics stack. The decision core (``evaluate_telemetry_canary``) is pure so it
+unit-tests with plain dicts; ``run_telemetry_canary`` is the thin DB + log wrapper
+the scheduled job and the boot-probe both call.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta
+from typing import Any, Dict, Optional
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from config import config
+from core.models.composio_cache import ToolExecutionLog
+
+logger = logging.getLogger(__name__)
+
+# The organic discriminator: only real production traffic counts. Eval/replay
+# rows must never mask a silent production lane. (Mirrors slo_metrics.py.)
+_ORGANIC_SOURCE = "production"
+
+
+def evaluate_telemetry_canary(
+    per_lane_counts: Dict[str, int],
+    *,
+    window_seconds: int,
+    min_rows: int,
+) -> Dict[str, Any]:
+    """Pure decision core: given per-lane organic row counts, decide the alarm.
+
+    ``alert`` is True when the platform total is at or below ``min_rows`` (default
+    0 → alarm only on a totally silent platform; raise it to catch partial
+    silence). Per-lane counts ride along for diagnosis. No I/O — takes counts,
+    returns a verdict dict.
+    """
+    per_lane = {str(k): int(v) for k, v in (per_lane_counts or {}).items()}
+    total = sum(per_lane.values())
+    return {
+        "alert": total <= min_rows,
+        "organic_rows": total,
+        "per_lane": per_lane,
+        "window_seconds": window_seconds,
+        "min_rows": min_rows,
+    }
+
+
+def _count_organic_rows_by_lane(db: Session, *, since: datetime) -> Dict[str, int]:
+    """Count production ``ToolExecutionLog`` rows since ``since``, grouped by lane
+    (``app_name``). Thin DB read — the decision lives in
+    ``evaluate_telemetry_canary``."""
+    rows = (
+        db.query(ToolExecutionLog.app_name, func.count().label("n"))
+        .filter(
+            ToolExecutionLog.executed_at >= since,
+            ToolExecutionLog.telemetry_source == _ORGANIC_SOURCE,
+        )
+        .group_by(ToolExecutionLog.app_name)
+        .all()
+    )
+    return {(app or "unknown"): int(n) for app, n in rows}
+
+
+def run_telemetry_canary(
+    db: Session,
+    *,
+    window_seconds: Optional[int] = None,
+    min_rows: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Query organic rows over the window, evaluate, and log the verdict.
+
+    On alarm logs at WARNING (the loud signal the platform lacked for two
+    months); otherwise a terse INFO. Returns the verdict dict so callers (the
+    boot-probe, the scheduled job, a future health tile) can act on it. NEVER
+    raises — a canary that crashes the scheduler is worse than a silent lane.
+    """
+    win = int(window_seconds if window_seconds is not None else config.TELEMETRY_CANARY_WINDOW_SECONDS)
+    floor_rows = int(min_rows if min_rows is not None else config.TELEMETRY_CANARY_MIN_ROWS)
+    try:
+        since = datetime.utcnow() - timedelta(seconds=win)
+        per_lane = _count_organic_rows_by_lane(db, since=since)
+    except Exception:
+        logger.warning(
+            "[TelemetryCanary] query failed — cannot judge organic-row flow",
+            exc_info=True,
+        )
+        return {
+            "alert": False,
+            "organic_rows": None,
+            "per_lane": {},
+            "window_seconds": win,
+            "min_rows": floor_rows,
+            "error": True,
+        }
+
+    verdict = evaluate_telemetry_canary(per_lane, window_seconds=win, min_rows=floor_rows)
+    hours = round(win / 3600.0, 1)
+    if verdict["alert"]:
+        logger.warning(
+            "[TelemetryCanary] ALARM — %d organic tool-execution rows in the last "
+            "%sh (<= %d). The learning plane may be starving (S1 regression? telemetry "
+            "write broken?). per_lane=%s",
+            verdict["organic_rows"], hours, floor_rows, verdict["per_lane"],
+        )
+    else:
+        logger.info(
+            "[TelemetryCanary] ok — %d organic rows in the last %sh across %d lane(s)",
+            verdict["organic_rows"], hours, len(verdict["per_lane"]),
+        )
+    return verdict
+
+
+async def telemetry_canary_tick() -> Dict[str, Any]:
+    """Scheduled-job + boot-probe entrypoint: open a session, run the canary,
+    close it. Registered on the shared scheduler by ``HeartbeatService.start()``
+    and fired once at boot as the boot-probe. Honours the enable flag so it can
+    be switched off without unscheduling."""
+    if not config.TELEMETRY_CANARY_ENABLED:
+        return {"alert": False, "skipped": True}
+
+    from core.database.database import SessionLocal
+
+    db = SessionLocal()
+    try:
+        return run_telemetry_canary(db)
+    finally:
+        db.close()

--- a/orchestrator/tests/test_p2w0_heartbeat_noise.py
+++ b/orchestrator/tests/test_p2w0_heartbeat_noise.py
@@ -1,0 +1,119 @@
+"""PRD-185 S11: heartbeat write-side noise removal.
+
+Two write-side fixes:
+  1. The 30s Mem0 health probe used to write one ``heartbeat_results`` row per
+     workspace EVERY tick (~2880/ws/day). It must now emit only on a health
+     STATE CHANGE (baseline + transitions), killing the steady-state spam while
+     keeping the memory-primitive tile fed.
+  2. The daily summary used to double-write its digest into memory — once as a
+     fabricated user/assistant L3 conversation that got injected into real
+     prompts, once as an L2 heartbeat_log row. Both are gone.
+
+Pure — the probe is driven with mocked Mem0 + a fake scheduler; the daily-summary
+removal is asserted against the source. No DB / network.
+"""
+import sys
+import types
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_orchestrator_root = str(Path(__file__).resolve().parent.parent)
+if _orchestrator_root not in sys.path:
+    sys.path.insert(0, _orchestrator_root)
+
+from services.heartbeat_service import HeartbeatService
+
+
+def _fake_scheduler_with_ws(ws_id: str):
+    job = MagicMock()
+    job.id = f"orch_hb_{ws_id}"
+    sched = MagicMock()
+    sched.get_jobs.return_value = [job]
+    return sched
+
+
+def _install_mem0(monkeypatch, healthy: bool):
+    """Point the probe at a fake Mem0 client with the given health.
+
+    Stubs ``modules.memory.unified_memory_service`` in ``sys.modules`` BEFORE the
+    tick's local ``from ... import get_unified_memory_service`` runs, so the real
+    (pgvector/asyncpg-heavy) memory chain never loads — the project's standard
+    pattern (see test_heartbeat_primitive_findings.py)."""
+    fake_client = MagicMock()
+    fake_client.api_url = "http://mem0.local"
+    fake_client.run_health_probe = AsyncMock(return_value=healthy)
+    fake_unified = MagicMock()
+    fake_unified._mem0 = fake_client
+    fake_module = types.ModuleType("modules.memory.unified_memory_service")
+    fake_module.get_unified_memory_service = lambda: fake_unified
+    monkeypatch.setitem(
+        sys.modules, "modules.memory.unified_memory_service", fake_module
+    )
+    return fake_client
+
+
+@pytest.mark.asyncio
+async def test_probe_emits_only_on_state_change(monkeypatch):
+    svc = HeartbeatService()
+    svc._scheduler = _fake_scheduler_with_ws("ws-1")
+    fake_client = _install_mem0(monkeypatch, healthy=True)
+
+    emits = []
+    monkeypatch.setattr(
+        "services.heartbeat_service.emit_primitive_finding",
+        lambda ws, prim, status, detail="": emits.append((ws, prim, status)),
+    )
+
+    # Tick 1 — baseline green → one emit.
+    await svc._mem0_health_probe_tick()
+    assert emits == [("ws-1", "memory", "green")]
+
+    # Tick 2 — still green → NO new row (the anti-spam guarantee).
+    await svc._mem0_health_probe_tick()
+    assert len(emits) == 1
+
+    # Tick 3 — Mem0 goes down → transition → one more emit.
+    fake_client.run_health_probe = AsyncMock(return_value=False)
+    await svc._mem0_health_probe_tick()
+    assert emits[-1] == ("ws-1", "memory", "down")
+    assert len(emits) == 2
+
+    # Tick 4 — still down → no new row.
+    await svc._mem0_health_probe_tick()
+    assert len(emits) == 2
+
+
+@pytest.mark.asyncio
+async def test_probe_still_steers_breakers_every_tick(monkeypatch):
+    # The breaker trip/reset is the functional part and must run on EVERY tick,
+    # independent of the (now transition-gated) primitive emit.
+    svc = HeartbeatService()
+    svc._scheduler = _fake_scheduler_with_ws("ws-1")
+    fake_client = _install_mem0(monkeypatch, healthy=True)
+    monkeypatch.setattr(
+        "services.heartbeat_service.emit_primitive_finding",
+        lambda *a, **k: True,
+    )
+
+    await svc._mem0_health_probe_tick()
+    await svc._mem0_health_probe_tick()
+    assert fake_client.run_health_probe.await_count == 2
+
+
+def test_daily_summary_no_fabricated_conversation_or_double_write():
+    src = (
+        Path(_orchestrator_root) / "services" / "heartbeat_service.py"
+    ).read_text()
+    # The fabricated "User: … / Assistant: …" heartbeat turn is gone.
+    assert "Daily heartbeat summary request" not in src, (
+        "the fabricated heartbeat conversation must be removed"
+    )
+    # The daily summary must not write the digest into the memory plane at all.
+    assert "store_conversation(" not in src, (
+        "heartbeat must not write the daily digest to L3 memory"
+    )
+    assert "store_short_term(" not in src, (
+        "heartbeat must not write the daily digest to L2 memory"
+    )

--- a/orchestrator/tests/test_p2w0_memory_injection_floor.py
+++ b/orchestrator/tests/test_p2w0_memory_injection_floor.py
@@ -1,0 +1,79 @@
+"""PRD-185 S11: memory-injection assembly guard.
+
+Sub-floor and noise-typed (heartbeat_log / playbook_summary) memories must never
+reach the prompt. The relevance floor is applied at the L3 search boundary
+(PRD-159 S3); this asserts the assembly-side guard over the merged candidate set,
+which also excludes the noise content-types the search layer does not. Pure —
+plain dicts, no DB / network.
+"""
+import sys
+from pathlib import Path
+
+_orchestrator_root = str(Path(__file__).resolve().parent.parent)
+if _orchestrator_root not in sys.path:
+    sys.path.insert(0, _orchestrator_root)
+
+from modules.memory.injection_filter import (
+    EXCLUDED_INJECTION_CONTENT_TYPES,
+    filter_injectable_memories,
+)
+
+
+def test_sub_floor_memories_dropped():
+    mems = [
+        {"memory": "strong", "score": 0.9},
+        {"memory": "weak", "score": 0.1},
+    ]
+    out = filter_injectable_memories(mems, floor=0.3)
+    assert [m["memory"] for m in out] == ["strong"]
+
+
+def test_unscored_memories_kept():
+    # No score → cannot judge → kept (same rule as filter_by_relevance_floor).
+    out = filter_injectable_memories([{"memory": "fact"}], floor=0.3)
+    assert len(out) == 1
+
+
+def test_noise_types_excluded_across_field_paths():
+    # The tag can ride on any of several shapes; the guard must bite on all of
+    # them, never silently no-op on a shape mismatch.
+    mems = [
+        {"memory": "keep", "score": 0.9, "content_type": "exchange"},
+        {"memory": "hb-top", "score": 0.9, "content_type": "heartbeat_log"},
+        {"memory": "hb-meta", "score": 0.9, "metadata": {"content_type": "heartbeat_log"}},
+        {"memory": "pb-metatype", "score": 0.9, "metadata": {"type": "playbook_summary"}},
+        {"memory": "pb-legacy", "score": 0.9, "category": "recipe_summary"},
+    ]
+    out = filter_injectable_memories(mems, floor=0.3)
+    assert [m["memory"] for m in out] == ["keep"]
+
+
+def test_floor_and_type_combined():
+    mems = [
+        {"memory": "keep", "score": 0.8, "content_type": "exchange"},
+        {"memory": "low", "score": 0.05, "content_type": "exchange"},
+        {"memory": "noise", "score": 0.95, "content_type": "heartbeat_log"},
+    ]
+    out = filter_injectable_memories(mems, floor=0.3)
+    assert [m["memory"] for m in out] == ["keep"]
+
+
+def test_floor_zero_disables_score_filter():
+    mems = [{"memory": "a", "score": 0.01}]
+    assert len(filter_injectable_memories(mems, floor=0.0)) == 1
+
+
+def test_excluded_set_holds_the_noise_types():
+    assert "heartbeat_log" in EXCLUDED_INJECTION_CONTENT_TYPES
+    assert "playbook_summary" in EXCLUDED_INJECTION_CONTENT_TYPES
+
+
+def test_smart_memory_wires_the_guard():
+    # Guard the wiring: retrieve_memories must apply the filter, else the guard
+    # is dead code — the failure class this wave exists to kill.
+    src = (
+        Path(_orchestrator_root) / "consumers" / "chatbot" / "smart_memory.py"
+    ).read_text()
+    assert "filter_injectable_memories(" in src, (
+        "smart_memory.retrieve_memories must call the injection guard"
+    )

--- a/orchestrator/tests/test_p2w0_telemetry_canary.py
+++ b/orchestrator/tests/test_p2w0_telemetry_canary.py
@@ -1,0 +1,92 @@
+"""PRD-185 S2: per-lane telemetry canary.
+
+S1 repaired a type-poisoned telemetry write that had left ``tool_execution_logs``
+with zero organic rows for ~2 months, unseen because nothing alarmed on "organic
+rows/day = 0". This canary is that guardrail. Pure tests — the decision core takes
+plain dicts; ``run_telemetry_canary`` is driven with a MagicMock session. No DB /
+network.
+"""
+import logging
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+_orchestrator_root = str(Path(__file__).resolve().parent.parent)
+if _orchestrator_root not in sys.path:
+    sys.path.insert(0, _orchestrator_root)
+
+from services.telemetry_canary import (
+    evaluate_telemetry_canary,
+    run_telemetry_canary,
+)
+
+
+# ---------------------------------------------------------------------------
+# evaluate_telemetry_canary — the pure decision core
+# ---------------------------------------------------------------------------
+
+def test_zero_rows_alarms():
+    v = evaluate_telemetry_canary({}, window_seconds=86400, min_rows=0)
+    assert v["alert"] is True
+    assert v["organic_rows"] == 0
+
+
+def test_rows_present_clears():
+    v = evaluate_telemetry_canary(
+        {"PLATFORM": 5, "WORKSPACE": 3}, window_seconds=86400, min_rows=0
+    )
+    assert v["alert"] is False
+    assert v["organic_rows"] == 8
+    assert v["per_lane"] == {"PLATFORM": 5, "WORKSPACE": 3}
+
+
+def test_min_rows_threshold_catches_partial_silence():
+    # 2 rows with a floor of 5 → still alarming (a lane went quiet).
+    v = evaluate_telemetry_canary({"PLATFORM": 2}, window_seconds=3600, min_rows=5)
+    assert v["alert"] is True
+
+
+# ---------------------------------------------------------------------------
+# run_telemetry_canary — the DB + log wrapper (session mocked at the boundary)
+# ---------------------------------------------------------------------------
+
+def _mock_db_returning(lane_rows):
+    db = MagicMock()
+    db.query.return_value.filter.return_value.group_by.return_value.all.return_value = lane_rows
+    return db
+
+
+def test_run_canary_alarms_when_empty(caplog):
+    db = _mock_db_returning([])
+    with caplog.at_level(logging.WARNING):
+        v = run_telemetry_canary(db, window_seconds=86400, min_rows=0)
+    assert v["alert"] is True
+    assert any(
+        "ALARM" in r.getMessage()
+        for r in caplog.records
+        if r.levelno == logging.WARNING
+    ), "a silent platform must log a loud WARNING"
+
+
+def test_run_canary_clears_when_rows_flow():
+    db = _mock_db_returning([("PLATFORM", 12), ("WORKSPACE", 4)])
+    v = run_telemetry_canary(db, window_seconds=86400, min_rows=0)
+    assert v["alert"] is False
+    assert v["organic_rows"] == 16
+    assert v["per_lane"] == {"PLATFORM": 12, "WORKSPACE": 4}
+
+
+def test_run_canary_coerces_null_lane_name():
+    # A NULL app_name must not blow up the group-by mapping.
+    db = _mock_db_returning([(None, 3)])
+    v = run_telemetry_canary(db, window_seconds=86400, min_rows=0)
+    assert v["per_lane"] == {"unknown": 3}
+
+
+def test_run_canary_never_raises_on_db_error():
+    db = MagicMock()
+    db.query.side_effect = RuntimeError("db down")
+    v = run_telemetry_canary(db, window_seconds=86400, min_rows=0)
+    # A broken query must neither alarm falsely nor raise into the scheduler.
+    assert v["alert"] is False
+    assert v.get("error") is True


### PR DESCRIPTION
Phase-2 **Wave 0 (PRD-185)** continued — the next two independent stories after #504 landed S1/S3/S4/S5/S6. Both are surgical, reuse-first, and CI-gated (pure tests, no DB/network).

## S2 — Per-lane telemetry canary (guardrail for S1's telemetry repair)
S1 repaired a type-poisoned telemetry write that had left `tool_execution_logs` with **zero organic rows for ~2 months**, unseen because nothing alarmed on "organic rows/day = 0". S2 is that missing alarm.

- **`services/telemetry_canary.py`** — counts production (`telemetry_source='production'`) `ToolExecutionLog` rows per lane (`app_name`) over a window; logs **LOUD (WARNING)** when the platform total is at/under the floor (default 0 → alarm on a totally silent platform). Pure decision core (`evaluate_telemetry_canary`) + a thin DB/log wrapper that never raises into the scheduler.
- **Reuses the W10 source-of-truth** (`ToolExecutionLog` + the `telemetry_source` discriminator, PRD-180) — no parallel metrics stack.
- Registered on the shared scheduler beside the Mem0 health probe in `HeartbeatService.start()`; the **first run fires at boot as the boot-probe**, then every `TELEMETRY_CANARY_INTERVAL_SECONDS` (default hourly).
- Config flags added to `config.py` (no `os.getenv` outside config).

## S11 — Stop memory injecting noise
Two halves — assembly-side guard + heartbeat write-side cleanup.

**Assembly-side (`modules/memory/injection_filter.py`, wired into `SmartMemoryManager.retrieve_memories`):**
- A guard over the **merged** recall set that (a) re-asserts the relevance floor (already applied at the L3 search boundary in `mem0_client.filter_by_relevance_floor`, PRD-159 S3) and (b) adds the **content-type exclusion** the search layer lacks — `heartbeat_log` / `playbook_summary` / legacy `recipe_summary`.
- It checks **every field path** a type tag can ride (`content_type`, `metadata.content_type`, `metadata.type`, `category`) so it bites wherever the tag lands instead of silently no-op-ing — the exact failure class this wave exists to kill.

**Write-side (`services/heartbeat_service.py`):**
- The **30s Mem0 health probe** wrote one `heartbeat_results` row **per workspace every tick** (~2880/ws/day) of pure noise. It now emits its memory-primitive finding **only on a health STATE CHANGE** (baseline + transitions). The primitive-health tile is latest-wins with **no freshness gate** (`api/analytics_real.get_primitive_health`), so one row per transition keeps it correct while ending the spam. The breaker trip/reset still runs every tick (the functional part is untouched).
- The **daily summary** no longer double-writes its digest into memory. It used to write a **fabricated `User:/Assistant:` L3 conversation** (which then got injected into real client prompts) **plus** an L2 `heartbeat_log` row. Both removed — the digest is logged as an operational line; the raw ticks stay the source of truth in `heartbeat_results`.

### Design note (probe write)
The PRD suggested "move the 30s probe writes out of `heartbeat_results`." I implemented **transition-only emit** instead of relocating the write, because the memory-primitive tile *reads* `heartbeat_results` and the sole emitter of the `memory` primitive is this probe — relocating would blank the tile and require rewiring the W3-S2 analytics read contract (bigger blast radius). Transition-only delivers the PRD's stated success metric ("heartbeat probe noise no longer pollutes `heartbeat_results`") while keeping the tile fed. Flag me if you want a full relocation instead.

## Test plan (pure — run in CI, no external services)
- `tests/test_p2w0_telemetry_canary.py` — zero-rows alarms; rows clear it; partial-silence floor; NULL lane coercion; never raises on DB error.
- `tests/test_p2w0_memory_injection_floor.py` — sub-floor dropped; unscored kept; noise types excluded across all field paths; floor+type combined; wiring guard (source-asserts `retrieve_memories` calls the filter).
- `tests/test_p2w0_heartbeat_noise.py` — probe emits only on state change (baseline → steady no-write → transition → steady no-write); breaker still steers every tick; daily-summary fabrication + double-write removed (source-assert).

Verified no existing test breaks: the one probe test runs a single tick (baseline still emits); scheduler tests exercise `UnifiedScheduler`/playbook scheduler, not `HeartbeatService.start()`; memory recall tests use `search_long_term` (untouched) with above-floor scores.

Part of the Phase-2 "good bones, open loops" remediation. Wave 0 = make the loops observable, honest, fed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a per-lane telemetry canary with scheduled checks and clear warning logs when production activity is silent or partially silent.
  * Added stronger memory-injection filtering so only relevant memories are eligible for prompt context.
* **Bug Fixes**
  * Reduced duplicate heartbeat noise by only emitting health-related findings when the status changes.
  * Removed daily summary writes from the heartbeat flow and replaced them with operational logging.
* **Tests**
  * Added coverage for telemetry canary behavior, memory filtering rules, and heartbeat noise reduction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->