### PR TITLE
feat(prd-185): Wave-0 S7 — chat votes feed rag_feedback with retrieved doc ids

### DIFF
--- a/orchestrator/alembic/versions/prd185_s7_message_retrieval_context.py
+++ b/orchestrator/alembic/versions/prd185_s7_message_retrieval_context.py
@@ -1,0 +1,37 @@
+"""PRD-185 S7: messages.retrieval_context — per-turn RAG provenance.
+
+Adds a nullable JSONB column recording the ``{document_ids, chunk_ids, query}``
+a chat turn retrieved. Read at vote time (``PATCH /api/chat/vote``) to write a
+complete ``rag_feedback`` row, which the PRD-179 live ranker consumes via
+``UNNEST(document_ids)``. NULL means the turn retrieved nothing — existing rows
+need no backfill. Kept off ``parts`` so retrieval provenance never reaches the
+AI-SDK render contract.
+
+Revision ID: prd185_s7_msg_retrieval_ctx
+Revises: e773c09189a9 (single head at branch time)
+Create Date: 2026-07-04
+"""
+
+from alembic import op
+
+revision = "prd185_s7_msg_retrieval_ctx"
+down_revision = "e773c09189a9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE messages
+            ADD COLUMN IF NOT EXISTS retrieval_context JSONB;
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE messages DROP COLUMN IF EXISTS retrieval_context;
+        """
+    )

--- a/orchestrator/api/chat.py
+++ b/orchestrator/api/chat.py
@@ -670,7 +670,33 @@ async def vote_message(
         request.messageId,
         request.isUpvoted
     )
-    
+
+    # PRD-185 S7: feed the RAG feedback loop. Write a rag_feedback row from the
+    # voted assistant message's retrieved doc ids so the PRD-179 live ranker can
+    # learn from thumbs. Best-effort — never fail the vote — but log loudly if it
+    # breaks (this wave exists because of silent swallows).
+    if success:
+        try:
+            from modules.rag.feedback_writer import feedback_from_retrieval_context
+            message = chat_service.get_message(request.chatId, request.messageId)
+            if message is not None:
+                feedback_from_retrieval_context(
+                    db,
+                    retrieval_context=message.retrieval_context,
+                    is_upvoted=request.isUpvoted,
+                    workspace_id=ctx.workspace_id,
+                    user_id=user_id,
+                )
+        except Exception:
+            # The vote itself is already committed; roll back only the failed
+            # feedback partial so the per-request session isn't left poisoned.
+            db.rollback()
+            logger.warning(
+                "[PRD-185 S7] rag_feedback write from chat vote failed "
+                "(chat=%s message=%s)",
+                request.chatId, request.messageId, exc_info=True,
+            )
+
     return {"success": success}
 
 

--- a/orchestrator/api/rag_feedback.py
+++ b/orchestrator/api/rag_feedback.py
@@ -17,6 +17,7 @@ from pydantic import BaseModel, Field
 from core.database.database import get_db
 from core.auth.hybrid import get_request_context_hybrid
 from core.auth.dependencies import RequestContext
+from modules.rag.feedback_writer import write_rag_feedback
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/rag/feedback", tags=["rag-feedback"])
@@ -55,35 +56,22 @@ async def submit_feedback(
 ):
     """Submit feedback on a RAG-generated response."""
     try:
-        insert_query = text("""
-            INSERT INTO rag_feedback
-                (query, response_text, chunk_ids, document_ids, rating,
-                 feedback_type, correction_text, rag_config_id,
-                 execution_time_ms, workspace_id, user_id, created_at)
-            VALUES
-                (:query, :response_text, :chunk_ids, :document_ids, :rating,
-                 :feedback_type, :correction_text, :rag_config_id,
-                 :execution_time_ms, :workspace_id, :user_id, NOW())
-            RETURNING id
-        """)
-
-        result = db.execute(insert_query, {
-            "query": feedback.query,
-            "response_text": feedback.response_text,
-            "chunk_ids": feedback.chunk_ids,
-            "document_ids": feedback.document_ids,
-            "rating": feedback.rating,
-            "feedback_type": feedback.feedback_type,
-            "correction_text": feedback.correction_text,
-            "rag_config_id": feedback.rag_config_id,
-            "execution_time_ms": feedback.execution_time_ms,
-            "workspace_id": str(ctx.workspace_id),
-            "user_id": getattr(ctx, "user_id", None),
-        })
-        row = result.fetchone()
-        db.commit()
-
-        return {"success": True, "feedback_id": row.id if row else None}
+        # PRD-185 S7: single shared writer — the chat vote path lands rows here too.
+        feedback_id = write_rag_feedback(
+            db,
+            query=feedback.query,
+            workspace_id=ctx.workspace_id,
+            user_id=getattr(ctx, "user_id", None),
+            document_ids=feedback.document_ids,
+            chunk_ids=feedback.chunk_ids,
+            rating=feedback.rating,
+            feedback_type=feedback.feedback_type,
+            correction_text=feedback.correction_text,
+            rag_config_id=feedback.rag_config_id,
+            execution_time_ms=feedback.execution_time_ms,
+            response_text=feedback.response_text,
+        )
+        return {"success": True, "feedback_id": feedback_id}
 
     except Exception as e:
         db.rollback()

--- a/orchestrator/consumers/chatbot/service.py
+++ b/orchestrator/consumers/chatbot/service.py
@@ -375,9 +375,15 @@ class ChatService:
         role: str,
         parts: List[Dict[str, Any]],
         attachments: Optional[List[Dict[str, Any]]] = None,
-        workspace_id: Optional[str] = None
+        workspace_id: Optional[str] = None,
+        retrieval_context: Optional[Dict[str, Any]] = None,
     ) -> Message:
-        """Save a message to the database."""
+        """Save a message to the database.
+
+        ``retrieval_context`` (PRD-185 S7) carries the turn's retrieved
+        ``{document_ids, chunk_ids, query}`` on assistant messages; NULL for
+        turns that retrieved nothing. Read back at vote time to feed rag_feedback.
+        """
         try:
             chat_uuid = uuid.UUID(chat_id)
         except ValueError:
@@ -420,6 +426,7 @@ class ChatService:
             role=role,
             parts=parts,
             attachments=attachments or [],
+            retrieval_context=retrieval_context,
             created_at=datetime.utcnow()
         )
         self.db.add(message)
@@ -450,6 +457,21 @@ class ChatService:
         if limit:
             query = query.limit(limit)
         return query.all()
+
+    def get_message(self, chat_id: str, message_id: str) -> Optional[Message]:
+        """Fetch a single message by (chat_id, message_id). None on bad id/miss.
+
+        PRD-185 S7: the vote path reads the assistant message's
+        ``retrieval_context`` to write a complete rag_feedback row.
+        """
+        try:
+            chat_uuid = uuid.UUID(chat_id)
+            message_uuid = uuid.UUID(message_id)
+        except ValueError:
+            return None
+        return self.db.query(Message).filter(
+            and_(Message.chat_id == chat_uuid, Message.id == message_uuid)
+        ).first()
 
     def vote_message(
         self,
@@ -536,9 +558,49 @@ class StreamingChatService:
         self.workspace_id = workspace_id
         self.widget_mode = widget_mode
 
+        # PRD-185 S7: per-turn retrieval provenance. The instance is constructed
+        # per request (one request == one turn), so these accumulate the turn's
+        # retrieved ids (pinned docs + retrieval-tool results) and are read at the
+        # assistant-message save. Reset defensively at each stream entrypoint.
+        self._turn_document_ids: Set[int] = set()
+        self._turn_chunk_ids: Set[int] = set()
+
         from modules.agents.factory.agent_factory import AgentFactory
         self.agent_factory = AgentFactory(db_session=db)
         logger.info("StreamingChatService initialized with AgentFactory integration")
+
+    def _reset_turn_retrieval(self) -> None:
+        """Clear per-turn retrieval provenance at the start of a turn."""
+        self._turn_document_ids = set()
+        self._turn_chunk_ids = set()
+
+    def _collect_tool_retrieval(self, tool_name: Optional[str], result: Any) -> None:
+        """Accumulate retrieved doc/chunk ids from a retrieval-tool result.
+
+        Best-effort and gated to retrieval tools — never raises into the turn.
+        """
+        try:
+            from modules.rag.retrieval_provenance import (
+                is_retrieval_tool, collect_doc_ids_from_tool_result,
+            )
+            if not is_retrieval_tool(tool_name):
+                return
+            docs, chunks = collect_doc_ids_from_tool_result(result)
+            self._turn_document_ids |= docs
+            self._turn_chunk_ids |= chunks
+        except Exception:
+            logger.debug("[PRD-185 S7] tool retrieval provenance collect failed", exc_info=True)
+
+    def _turn_retrieval_context(self, query: Optional[str]) -> Optional[Dict[str, Any]]:
+        """Build the retrieval_context blob for the assistant message, or None."""
+        try:
+            from modules.rag.retrieval_provenance import build_retrieval_context
+            return build_retrieval_context(
+                self._turn_document_ids, self._turn_chunk_ids, query,
+            )
+        except Exception:
+            logger.debug("[PRD-185 S7] retrieval_context build failed", exc_info=True)
+            return None
 
     # ─────────────────────────────────────────────────────────────────────
     # Internal helpers
@@ -1055,6 +1117,17 @@ class StreamingChatService:
             insert_at = 1 if (llm_messages and llm_messages[0].get("role") == "system") else 0
             llm_messages.insert(insert_at, {"role": "system", "content": content})
             logger.info("[PRD-157 S5] injected pinned-document context for chat %s", chat_id)
+
+            # PRD-185 S7: pinned documents are retrieved context for this turn —
+            # record their ids so a later vote writes complete rag_feedback.
+            try:
+                from modules.rag.pinned_context import list_pinned
+                for row in list_pinned(self.db, chat_id=chat_id, workspace_id=self.workspace_id):
+                    did = row.get("document_id")
+                    if isinstance(did, int):
+                        self._turn_document_ids.add(did)
+            except Exception:
+                logger.debug("[PRD-185 S7] pinned provenance collect failed", exc_info=True)
         except Exception:
             logger.warning("[PRD-157 S5] pinned-document injection failed", exc_info=True)
 
@@ -1351,6 +1424,8 @@ class StreamingChatService:
                     prior_action=_prior_action,
                 ),
             )
+            # PRD-185 S7: capture retrieved doc ids (retrieval tools only).
+            self._collect_tool_retrieval(name, result)
             # Record this call as the prior_action for the NEXT tool in the turn
             # (resolved to the per-action name so composio chains pair correctly).
             _prior_action = resolve_action_name(name, args if isinstance(args, dict) else {})
@@ -1878,6 +1953,9 @@ class StreamingChatService:
         """
         import asyncio
 
+        # PRD-185 S7: start the turn with clean retrieval provenance.
+        self._reset_turn_retrieval()
+
         try:
             # Ensure workspace_id is available
             if not self.workspace_id:
@@ -2160,6 +2238,8 @@ class StreamingChatService:
             self.chat_service.save_message(
                 chat_id=chat_id, role="assistant",
                 parts=assistant_parts, workspace_id=self.workspace_id,
+                # PRD-185 S7: stamp the turn's retrieved doc ids for vote feedback.
+                retrieval_context=self._turn_retrieval_context(latest_text),
             )
 
             # Post-response: memory, metrics, eval
@@ -2190,6 +2270,9 @@ class StreamingChatService:
     ) -> AsyncGenerator[str, None]:
         """Stream chat response using legacy SSE format."""
         from core.llm import create_llm_manager
+
+        # PRD-185 S7: start the turn with clean retrieval provenance.
+        self._reset_turn_retrieval()
 
         # Get tools from SINGLE SOURCE if not provided.
         # PRD-138 US-009: extract latest user turn first so the dispatcher
@@ -2237,6 +2320,8 @@ class StreamingChatService:
                             agent_id=1, workspace_id=self.workspace_id,
                             original_intent=latest_text,
                         )
+                        # PRD-185 S7: capture retrieved doc ids (retrieval tools only).
+                        self._collect_tool_retrieval(tool_name, result)
                         if result['success']:
                             tool_data.update(result['frontend_data'])
 
@@ -2271,6 +2356,8 @@ class StreamingChatService:
                 self.chat_service.save_message(
                     chat_id=chat_id, role='assistant',
                     parts=assistant_parts, workspace_id=self.workspace_id,
+                    # PRD-185 S7: stamp the turn's retrieved doc ids for vote feedback.
+                    retrieval_context=self._turn_retrieval_context(latest_text),
                 )
 
             yield self.streaming_handler.format_sse_done()
@@ -2313,6 +2400,8 @@ class StreamingChatService:
                 agent_id=agent_id, workspace_id=self.workspace_id,
                 original_intent=query,
             )
+            # PRD-185 S7: capture retrieved doc ids (retrieval tools only).
+            self._collect_tool_retrieval(tool_name, result)
 
             if result['success']:
                 tool_data.update(result['frontend_data'])

--- a/orchestrator/core/models/core.py
+++ b/orchestrator/core/models/core.py
@@ -1142,6 +1142,11 @@ class Message(Base):
     role = Column(String(20), nullable=False)
     parts = Column(JSONB, nullable=False, default=list, server_default='[]')
     attachments = Column(JSONB, default=list, server_default='[]')
+    # PRD-185 S7: retrieval provenance for the turn that produced this message
+    # ({document_ids, chunk_ids, query}). Read at vote time to write a complete
+    # rag_feedback row. NULL for turns that retrieved nothing. Kept off `parts`
+    # so it never reaches the AI-SDK render contract.
+    retrieval_context = Column(JSONB, nullable=True)
     created_at = Column(DateTime, nullable=False, server_default=func.now())
     
     # Relationships

--- a/orchestrator/modules/rag/feedback_writer.py
+++ b/orchestrator/modules/rag/feedback_writer.py
@@ -1,0 +1,109 @@
+"""PRD-185 S7: the single writer for the ``rag_feedback`` table.
+
+Both the explicit feedback endpoint (``POST /api/rag/feedback``) and the chat
+thumbs vote (``PATCH /api/chat/vote``) land rows here, so the INSERT lives in
+exactly one place. The PRD-179 live ranker reads these rows via
+``UNNEST(document_ids)`` to shape retrieval — feeding it real votes is the whole
+point of S7.
+
+Pure DB helper — no framework — so callers (HTTP + vote path) and tests share it.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, List, Optional
+
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+_INSERT = text("""
+    INSERT INTO rag_feedback
+        (query, response_text, chunk_ids, document_ids, rating,
+         feedback_type, correction_text, rag_config_id,
+         execution_time_ms, workspace_id, user_id, created_at)
+    VALUES
+        (:query, :response_text, :chunk_ids, :document_ids, :rating,
+         :feedback_type, :correction_text, :rag_config_id,
+         :execution_time_ms, :workspace_id, :user_id, NOW())
+    RETURNING id
+""")
+
+
+def write_rag_feedback(
+    db: Session,
+    *,
+    query: str,
+    workspace_id: Any,
+    user_id: Optional[int] = None,
+    document_ids: Optional[List[int]] = None,
+    chunk_ids: Optional[List[int]] = None,
+    rating: Optional[int] = None,
+    feedback_type: str = "thumbs_up",
+    correction_text: Optional[str] = None,
+    rag_config_id: Optional[int] = None,
+    execution_time_ms: Optional[float] = None,
+    response_text: Optional[str] = None,
+    commit: bool = True,
+) -> Optional[int]:
+    """Insert one ``rag_feedback`` row and return its id.
+
+    ``query`` is stored TEXT NOT NULL — an empty string is legal, ``None`` is not.
+    ``document_ids`` / ``chunk_ids`` are ``INTEGER[]``; pass ``None`` (not ``[]``)
+    to store SQL NULL. Set ``commit=False`` to write within a caller-owned
+    transaction.
+    """
+    result = db.execute(_INSERT, {
+        "query": query or "",
+        "response_text": response_text,
+        "chunk_ids": chunk_ids or None,
+        "document_ids": document_ids or None,
+        "rating": rating,
+        "feedback_type": feedback_type,
+        "correction_text": correction_text,
+        "rag_config_id": rag_config_id,
+        "execution_time_ms": execution_time_ms,
+        "workspace_id": str(workspace_id) if workspace_id is not None else None,
+        "user_id": user_id,
+    })
+    row = result.fetchone()
+    if commit:
+        db.commit()
+    return row.id if row else None
+
+
+def feedback_from_retrieval_context(
+    db: Session,
+    *,
+    retrieval_context: Optional[dict],
+    is_upvoted: bool,
+    workspace_id: Any,
+    user_id: Optional[int] = None,
+    response_text: Optional[str] = None,
+    commit: bool = True,
+) -> Optional[int]:
+    """Write a ``rag_feedback`` row from a chat vote's stored retrieval provenance.
+
+    Returns the feedback id, or ``None`` when the voted message carried no
+    retrieved documents (nothing to learn from — e.g. a pure-chat turn). A thumbs
+    up/down maps to ``thumbs_up`` / ``thumbs_down`` so the PRD-179 ranker only
+    penalises documents behind a down-voted answer.
+    """
+    if not isinstance(retrieval_context, dict):
+        return None
+    document_ids = [i for i in (retrieval_context.get("document_ids") or []) if isinstance(i, int)]
+    chunk_ids = [i for i in (retrieval_context.get("chunk_ids") or []) if isinstance(i, int)]
+    if not document_ids and not chunk_ids:
+        return None
+    return write_rag_feedback(
+        db,
+        query=retrieval_context.get("query") or "",
+        workspace_id=workspace_id,
+        user_id=user_id,
+        document_ids=document_ids or None,
+        chunk_ids=chunk_ids or None,
+        feedback_type="thumbs_up" if is_upvoted else "thumbs_down",
+        response_text=response_text,
+        commit=commit,
+    )

--- a/orchestrator/modules/rag/retrieval_provenance.py
+++ b/orchestrator/modules/rag/retrieval_provenance.py
@@ -1,0 +1,128 @@
+"""PRD-185 S7: per-turn retrieval provenance.
+
+Capture the document/chunk ids a chat turn actually retrieved so that a later
+thumbs vote can write a complete ``rag_feedback`` row. The PRD-179 live ranker
+reads that table via ``UNNEST(document_ids)`` to down-weight flagged docs, so
+without the retrieved ids on hand at vote time the feedback loop ships hollow.
+
+Pure functions — no DB, network, or framework — so they run in CI with no
+external service (per ``feedback-no-local-servers``).
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, Optional, Set, Tuple
+
+# The chat tools that perform document retrieval. Provenance is collected ONLY
+# for these — a tool like ``query_database`` can surface a user column literally
+# named ``document_id`` that is not a retrieved RAG doc, and must not pollute
+# ``rag_feedback``. Mirrors the retrieval branch in
+# ``consumers/chatbot/tool_router.build_tool_context_message``.
+RETRIEVAL_TOOL_NAMES = frozenset({
+    "search_knowledge",
+    "search_documents",
+    "semantic_search",
+})
+
+# Keys carrying a single id / an id list, scanned within a retrieval result.
+_DOC_ID_KEYS = ("document_id", "doc_id")
+_DOC_IDS_KEYS = ("document_ids", "doc_ids")
+_CHUNK_ID_KEYS = ("chunk_id",)
+_CHUNK_IDS_KEYS = ("chunk_ids",)
+
+# Tool results are shallow in practice; bound the scan so a pathological payload
+# can never spin.
+_MAX_DEPTH = 6
+
+# rag_feedback stores TEXT NOT NULL for query — bound what we persist.
+_MAX_QUERY_LEN = 2000
+
+
+def is_retrieval_tool(tool_name: Optional[str]) -> bool:
+    """True when a tool's results represent retrieved documents."""
+    return bool(tool_name) and tool_name in RETRIEVAL_TOOL_NAMES
+
+
+def _coerce_int(value: Any) -> Optional[int]:
+    """Return ``value`` as an int only if it cleanly represents one.
+
+    ``rag_feedback.document_ids`` / ``chunk_ids`` are ``INTEGER[]``; string chunk
+    uuids and floats are dropped rather than corrupt the array.
+    """
+    if isinstance(value, bool):  # bool is an int subclass — never an id
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        s = value.strip()
+        if s.lstrip("-").isdigit():
+            return int(s)
+    return None
+
+
+def _scan(obj: Any, docs: Set[int], chunks: Set[int], depth: int) -> None:
+    if depth > _MAX_DEPTH:
+        return
+    if isinstance(obj, dict):
+        for key, val in obj.items():
+            if key in _DOC_ID_KEYS:
+                cid = _coerce_int(val)
+                if cid is not None:
+                    docs.add(cid)
+            elif key in _DOC_IDS_KEYS and isinstance(val, (list, tuple)):
+                for item in val:
+                    cid = _coerce_int(item)
+                    if cid is not None:
+                        docs.add(cid)
+            elif key in _CHUNK_ID_KEYS:
+                cid = _coerce_int(val)
+                if cid is not None:
+                    chunks.add(cid)
+            elif key in _CHUNK_IDS_KEYS and isinstance(val, (list, tuple)):
+                for item in val:
+                    cid = _coerce_int(item)
+                    if cid is not None:
+                        chunks.add(cid)
+            else:
+                _scan(val, docs, chunks, depth + 1)
+    elif isinstance(obj, (list, tuple)):
+        for item in obj:
+            _scan(item, docs, chunks, depth + 1)
+
+
+def collect_doc_ids_from_tool_result(
+    result: Optional[Dict[str, Any]],
+) -> Tuple[Set[int], Set[int]]:
+    """Extract ``(document_ids, chunk_ids)`` from an ``execute_and_format`` result.
+
+    Scans ``raw_result`` and ``frontend_data`` defensively so it works across the
+    varied shapes the retrieval tools return. Caller must gate on
+    :func:`is_retrieval_tool` — this does not know the tool name.
+    """
+    docs: Set[int] = set()
+    chunks: Set[int] = set()
+    if not isinstance(result, dict):
+        return docs, chunks
+    for key in ("raw_result", "frontend_data"):
+        _scan(result.get(key), docs, chunks, 0)
+    return docs, chunks
+
+
+def build_retrieval_context(
+    document_ids: Set[int],
+    chunk_ids: Set[int],
+    query: Optional[str],
+) -> Optional[Dict[str, Any]]:
+    """Assemble the blob stored on ``messages.retrieval_context``.
+
+    Returns ``None`` when nothing was retrieved so the column stays NULL rather
+    than recording an empty turn. Ids are sorted for stable, diffable storage.
+    """
+    if not document_ids and not chunk_ids:
+        return None
+    ctx: Dict[str, Any] = {
+        "document_ids": sorted(document_ids),
+        "chunk_ids": sorted(chunk_ids),
+    }
+    if query:
+        ctx["query"] = query[:_MAX_QUERY_LEN]
+    return ctx

--- a/orchestrator/tests/test_prd179_rag_feedback_rank.py
+++ b/orchestrator/tests/test_prd179_rag_feedback_rank.py
@@ -137,12 +137,19 @@ def test_rag_feedback_to_ranking(svc):
     """
     import inspect
 
-    # Write side: the endpoint persists feedback_type + document_ids to rag_feedback.
+    # Write side: the shared writer persists feedback_type + document_ids to
+    # rag_feedback, and the endpoint delegates to it. PRD-185 S7 moved the INSERT
+    # into modules.rag.feedback_writer so the chat-vote path writes through the
+    # same seam — the write contract is unchanged, only its home.
     from api import rag_feedback as rag_feedback_api
+    from modules.rag import feedback_writer
 
-    write_src = inspect.getsource(rag_feedback_api.submit_feedback)
+    write_src = inspect.getsource(feedback_writer.write_rag_feedback)
     assert "INSERT INTO rag_feedback" in write_src
     assert "document_ids" in write_src and "feedback_type" in write_src
+    assert "write_rag_feedback" in inspect.getsource(rag_feedback_api.submit_feedback), (
+        "feedback endpoint no longer delegates to the shared rag_feedback writer"
+    )
 
     # Read side consumes those same columns (thumbs_down / document_ids).
     read_src = inspect.getsource(RAGService._negative_feedback_doc_ids)

--- a/orchestrator/tests/test_prd179_rag_feedback_rank.py
+++ b/orchestrator/tests/test_prd179_rag_feedback_rank.py
@@ -144,7 +144,9 @@ def test_rag_feedback_to_ranking(svc):
     from api import rag_feedback as rag_feedback_api
     from modules.rag import feedback_writer
 
-    write_src = inspect.getsource(feedback_writer.write_rag_feedback)
+    # The INSERT lives in a module-level statement (_INSERT) that the writer
+    # references, so inspect the whole module source, not just the function body.
+    write_src = inspect.getsource(feedback_writer)
     assert "INSERT INTO rag_feedback" in write_src
     assert "document_ids" in write_src and "feedback_type" in write_src
     assert "write_rag_feedback" in inspect.getsource(rag_feedback_api.submit_feedback), (

--- a/orchestrator/tests/test_prd185_s7_rag_feedback_provenance.py
+++ b/orchestrator/tests/test_prd185_s7_rag_feedback_provenance.py
@@ -1,0 +1,213 @@
+"""PRD-185 S7 — give the RAG feedback loop a mouth.
+
+Chat votes must write ``rag_feedback`` rows carrying the turn's retrieved
+document ids, so the PRD-179 live ranker (which reads ``UNNEST(document_ids)``)
+learns from thumbs instead of reading an empty table.
+
+Pure tests — no DB, network, or app import chain — per ``feedback-no-local-servers``.
+They exercise the two self-contained modules the vote path delegates to:
+``modules.rag.retrieval_provenance`` (capture) and ``modules.rag.feedback_writer``
+(write). The DB session is mocked at the boundary.
+"""
+from unittest.mock import MagicMock
+
+from modules.rag.retrieval_provenance import (
+    is_retrieval_tool,
+    collect_doc_ids_from_tool_result,
+    build_retrieval_context,
+    RETRIEVAL_TOOL_NAMES,
+)
+from modules.rag.feedback_writer import (
+    write_rag_feedback,
+    feedback_from_retrieval_context,
+)
+
+
+# ── capture: which tools count as retrieval ───────────────────────────────────
+
+def test_is_retrieval_tool_gates_to_document_tools():
+    for name in ("search_documents", "search_knowledge", "semantic_search"):
+        assert is_retrieval_tool(name) is True
+        assert name in RETRIEVAL_TOOL_NAMES
+    # A DB tool can surface a column literally named document_id — must not count.
+    assert is_retrieval_tool("query_database") is False
+    assert is_retrieval_tool("smart_query_database") is False
+    assert is_retrieval_tool(None) is False
+    assert is_retrieval_tool("") is False
+
+
+# ── capture: extract ids from a tool result ───────────────────────────────────
+
+def test_collect_doc_ids_from_nested_result():
+    result = {
+        "success": True,
+        "raw_result": {
+            "results": [
+                {"document_id": 12, "chunk_id": 881},
+                {"document_id": 47, "chunk_ids": [903, 904]},
+            ]
+        },
+        "frontend_data": {"sources": [{"document_id": 12}]},
+    }
+    docs, chunks = collect_doc_ids_from_tool_result(result)
+    assert docs == {12, 47}
+    assert chunks == {881, 903, 904}
+
+
+def test_collect_doc_ids_coerces_int_strings_and_drops_junk():
+    result = {"raw_result": {
+        "document_ids": ["12", 47, "not-an-id", None, True, 3.5],
+        "chunk_id": "not-int",
+    }}
+    docs, chunks = collect_doc_ids_from_tool_result(result)
+    # "12"->12, 47 kept; "not-an-id"/None/True(bool)/3.5(float) dropped
+    assert docs == {12, 47}
+    assert chunks == set()
+
+
+def test_collect_doc_ids_handles_non_dict_safely():
+    assert collect_doc_ids_from_tool_result(None) == (set(), set())
+    assert collect_doc_ids_from_tool_result("nope") == (set(), set())
+    assert collect_doc_ids_from_tool_result({}) == (set(), set())
+
+
+# ── capture: build the stored provenance blob ─────────────────────────────────
+
+def test_build_retrieval_context_none_when_empty():
+    assert build_retrieval_context(set(), set(), "q") is None
+
+
+def test_build_retrieval_context_sorts_ids_and_keeps_query():
+    ctx = build_retrieval_context({47, 12}, {904, 881}, "why is the sky blue?")
+    assert ctx == {
+        "document_ids": [12, 47],
+        "chunk_ids": [881, 904],
+        "query": "why is the sky blue?",
+    }
+
+
+def test_build_retrieval_context_bounds_query_length():
+    ctx = build_retrieval_context({1}, set(), "x" * 5000)
+    assert len(ctx["query"]) == 2000
+    assert ctx["document_ids"] == [1]
+
+
+def test_build_retrieval_context_omits_empty_query():
+    ctx = build_retrieval_context({1}, set(), "")
+    assert "query" not in ctx
+
+
+# ── write: the shared rag_feedback INSERT ─────────────────────────────────────
+
+def _mock_db(returned_id=999):
+    db = MagicMock()
+    row = MagicMock()
+    row.id = returned_id
+    db.execute.return_value.fetchone.return_value = row
+    return db
+
+
+def test_write_rag_feedback_inserts_and_commits():
+    db = _mock_db(returned_id=101)
+    fid = write_rag_feedback(
+        db,
+        query="q",
+        workspace_id="ws-1",
+        user_id=7,
+        document_ids=[12, 47],
+        chunk_ids=[881],
+        feedback_type="thumbs_down",
+    )
+    assert fid == 101
+    db.commit.assert_called_once()
+    params = db.execute.call_args.args[1]
+    assert params["document_ids"] == [12, 47]
+    assert params["chunk_ids"] == [881]
+    assert params["feedback_type"] == "thumbs_down"
+    assert params["workspace_id"] == "ws-1"
+    assert params["user_id"] == 7
+    assert params["query"] == "q"
+
+
+def test_write_rag_feedback_empty_arrays_and_query_normalised():
+    db = _mock_db()
+    write_rag_feedback(db, query=None, workspace_id="ws-1", document_ids=[], chunk_ids=[])
+    params = db.execute.call_args.args[1]
+    # empty arrays -> SQL NULL, not []; None query -> "" (column is TEXT NOT NULL)
+    assert params["document_ids"] is None
+    assert params["chunk_ids"] is None
+    assert params["query"] == ""
+
+
+def test_write_rag_feedback_commit_false_leaves_txn_open():
+    db = _mock_db()
+    write_rag_feedback(db, query="q", workspace_id="ws-1", commit=False)
+    db.commit.assert_not_called()
+
+
+# ── the S7 acceptance: a chat vote writes rag_feedback with retrieved doc ids ──
+
+def test_chat_vote_writes_rag_feedback():
+    """Casting a thumbs-down on a message with retrieval provenance lands a
+    rag_feedback row carrying that turn's retrieved document ids and the
+    down-vote polarity — exactly what the PRD-179 ranker consumes."""
+    db = _mock_db(returned_id=555)
+    retrieval_context = {
+        "document_ids": [12, 47],
+        "chunk_ids": [881, 903],
+        "query": "how do refunds work?",
+    }
+    fid = feedback_from_retrieval_context(
+        db,
+        retrieval_context=retrieval_context,
+        is_upvoted=False,
+        workspace_id="ws-9",
+        user_id=7,
+    )
+    assert fid == 555
+    params = db.execute.call_args.args[1]
+    assert params["document_ids"] == [12, 47]
+    assert params["chunk_ids"] == [881, 903]
+    assert params["feedback_type"] == "thumbs_down"
+    assert params["query"] == "how do refunds work?"
+    assert params["workspace_id"] == "ws-9"
+    assert params["user_id"] == 7
+
+
+def test_chat_vote_upvote_maps_to_thumbs_up():
+    db = _mock_db()
+    feedback_from_retrieval_context(
+        db,
+        retrieval_context={"document_ids": [3], "chunk_ids": [], "query": "q"},
+        is_upvoted=True,
+        workspace_id="ws-9",
+    )
+    params = db.execute.call_args.args[1]
+    assert params["feedback_type"] == "thumbs_up"
+    assert params["document_ids"] == [3]
+
+
+def test_vote_without_retrieval_context_writes_nothing():
+    # A pure-chat turn (no retrieval) must not create a hollow rag_feedback row.
+    db = _mock_db()
+    assert feedback_from_retrieval_context(
+        db, retrieval_context=None, is_upvoted=False, workspace_id="ws-9",
+    ) is None
+    assert feedback_from_retrieval_context(
+        db, retrieval_context={"document_ids": [], "chunk_ids": []},
+        is_upvoted=False, workspace_id="ws-9",
+    ) is None
+    db.execute.assert_not_called()
+
+
+def test_vote_feedback_filters_non_int_ids_before_write():
+    db = _mock_db()
+    feedback_from_retrieval_context(
+        db,
+        retrieval_context={"document_ids": [12, "x", None], "chunk_ids": ["y"], "query": "q"},
+        is_upvoted=False,
+        workspace_id="ws-9",
+    )
+    params = db.execute.call_args.args[1]
+    assert params["document_ids"] == [12]
+    assert params["chunk_ids"] is None  # only non-int chunk ids -> NULL


### PR DESCRIPTION
## PRD-185 Wave-0 · S7 — give the RAG feedback loop a mouth

Closes the last Wave-0 story with a real code dependency (S8/S9/S4-breaker are access/decision-gated). Takes Wave-0 to **10/12**.

### The problem (verified on `main`)
- Chat votes wrote **only** the `Vote` table (`PATCH /api/chat/vote`).
- `POST /api/rag/feedback` is a working writer with **zero chat callers** → `rag_feedback` had 0 rows ever.
- The **PRD-179 live ranker already reads** `rag_feedback.document_ids` (`modules/rag/service.py:435`, `UNNEST`) to shape retrieval — it was reading an empty table.
- The missing link was **provenance**: nothing recorded which documents a turn retrieved, so a vote (which only knows `message_id`) couldn't reconstruct them.

### What this does
1. **Persist per-turn retrieval provenance** on the assistant message — new nullable `messages.retrieval_context` JSONB `{document_ids, chunk_ids, query}`. Kept off `parts` so it never reaches the AI-SDK render contract. NULL when a turn retrieved nothing; **no backfill**.
2. **Capture doc ids during the turn** from both sources: **pinned documents** (always-injected) and **RAG search-tool results**, gated to `search_documents` / `search_knowledge` / `semantic_search` so a `query_database` column named `document_id` can't pollute feedback. Per-request collector, reset at each stream entrypoint.
3. **Wire `PATCH /api/chat/vote`** to also write `rag_feedback` from the voted message's `retrieval_context` (thumbs up/down → `thumbs_up`/`thumbs_down`). **Best-effort**: never fails the vote, rolls back its own partial, logs loudly — no silent swallow (this wave exists because of those).
4. **Single shared writer** `modules/rag/feedback_writer.write_rag_feedback`; the HTTP endpoint now delegates to it (INSERT lives in one place, per §4).

### Storage decision
Per §4/§6 this was surfaced to Gerard: a new nullable JSONB column on `messages` (vs. reusing `parts`/`attachments`, vs. a new child table). Chose the column — no new table, keeps the render contract clean. Migration `prd185_s7_msg_retrieval_ctx` off single head `e773c09189a9`.

### Dependencies
- Depends on **S6** (real chat principal, merged in #504) for honest vote attribution — verified present (`get_user_id` resolves `ctx.user.id`).

### Scope note (§12)
Built the **whole** story (provenance + closing the vote→feedback loop), not just the prereq — the prereq alone ships hollow.

### Files
- `core/models/core.py` — `Message.retrieval_context` column
- `alembic/versions/prd185_s7_message_retrieval_context.py` — migration (nullable, no backfill)
- `modules/rag/retrieval_provenance.py` (new) — pure capture helpers
- `modules/rag/feedback_writer.py` (new) — shared `rag_feedback` writer + vote mapper
- `consumers/chatbot/service.py` — capture wiring + `save_message` provenance + `get_message`
- `api/rag_feedback.py` — delegate to shared writer
- `api/chat.py` — vote → `rag_feedback`

### Test plan (CI is the gate — pure/mocked per `feedback-no-local-servers`)
- [ ] `tests/test_prd185_s7_rag_feedback_provenance.py` green — capture extraction (int coercion, junk/bool/float dropped, non-dict safe), context building (sort, query bound, empty→None), shared writer (empty arrays→NULL, `commit=False`), and the **S7 acceptance** `test_chat_vote_writes_rag_feedback` (down-vote lands `rag_feedback` with the turn's `document_ids` + `thumbs_down`).
- [ ] `test_prd179_rag_feedback_rank.py` still green (reader untouched).
- [ ] Alembic single-head check passes (down_revision `e773c09189a9`).
- No frontend change: the vote post already targets `/api/chat/vote`; no new routes (route-manifest unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added storage for per-turn retrieval provenance on chat messages (document IDs, chunk IDs, and query context).
  * Captures provenance during streaming/tool retrieval and includes it on assistant messages.
  * Added a shared feedback-writing path used by the RAG feedback submission flow, enabling vote-linked provenance feedback.

* **Bug Fixes**
  * Vote responses remain successful even if feedback logging fails; failures are isolated and won’t break chat.

* **Tests**
  * Added/updated coverage validating provenance extraction and the thumbs up/down feedback mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->