### PR TITLE
feat(prd-185): Wave-0 S9 — vendor-neutral tracing seam at the two chokepoints

### DIFF
--- a/orchestrator/config.py
+++ b/orchestrator/config.py
@@ -795,6 +795,22 @@ class Config:
     TOOL_SELECTION_STASH_MAXSIZE: int = int(os.getenv("TOOL_SELECTION_STASH_MAXSIZE", "512"))
 
     # =============================================================================
+    # OBSERVABILITY / TRACING (PRD-185 S9) — vendor-neutral trace seam
+    # =============================================================================
+    # Default OFF: zero overhead + zero data egress until explicitly enabled.
+    # When ON, live traces/scores land at the tool-dispatch and retrieval
+    # chokepoints via a vendor-neutral seam (core/observability/tracer.py) —
+    # "was the tool call good / was retrieval grounded" as a queryable number.
+    # Backend today = Langfuse Cloud; swappable behind the seam (data residency
+    # is the axis that flips to self-host). `langfuse` is an OPTIONAL import: the
+    # OFF path never imports it, and enabled-but-missing degrades to no-op.
+    TRACING_ENABLED: bool = os.getenv("TRACING_ENABLED", "false").lower() in ("true", "1", "yes")
+    TRACING_BACKEND: str = os.getenv("TRACING_BACKEND", "langfuse")
+    LANGFUSE_PUBLIC_KEY: str = os.getenv("LANGFUSE_PUBLIC_KEY")
+    LANGFUSE_SECRET_KEY: str = os.getenv("LANGFUSE_SECRET_KEY")
+    LANGFUSE_HOST: str = os.getenv("LANGFUSE_HOST", "https://cloud.langfuse.com")
+
+    # =============================================================================
     # AWS S3 VECTORS (PRD-42: Cloud Document Sync)
     # =============================================================================
     AWS_REGION: str = os.getenv("AWS_REGION", "us-east-1")

--- a/orchestrator/core/observability/__init__.py
+++ b/orchestrator/core/observability/__init__.py
@@ -1,0 +1,33 @@
+"""Observability — vendor-neutral tracing seam (PRD-185 S9).
+
+External distributed tracing lives here (kept distinct from ``core/monitoring``,
+which holds internal metrics/logging/alerts). The seam is config-gated and
+default-OFF; see ``tracer.py``.
+"""
+from core.observability.tracer import (
+    Tracer,
+    NoOpTracer,
+    LangfuseTracer,
+    get_tracer,
+    reset_tracer,
+    should_trace,
+    fire_tool_trace,
+    fire_retrieval_score,
+    STATUS_HIT,
+    STATUS_EMPTY,
+    STATUS_ERROR,
+)
+
+__all__ = [
+    "Tracer",
+    "NoOpTracer",
+    "LangfuseTracer",
+    "get_tracer",
+    "reset_tracer",
+    "should_trace",
+    "fire_tool_trace",
+    "fire_retrieval_score",
+    "STATUS_HIT",
+    "STATUS_EMPTY",
+    "STATUS_ERROR",
+]

--- a/orchestrator/core/observability/tracer.py
+++ b/orchestrator/core/observability/tracer.py
@@ -1,0 +1,286 @@
+"""PRD-185 S9 — vendor-neutral tracing seam.
+
+Give the platform's two chokepoints a *mouth* so "was the tool call good / was
+retrieval grounded" becomes a **live, queryable number over real traffic**
+instead of a synthetic one (the live complement to S10's offline recall@5/MRR).
+
+Why a seam and not a Langfuse import at the call site:
+- **The hooks are backend-agnostic.** Choosing a backend (Langfuse Cloud today)
+  is a config swap, not a rewrite — the day data-residency demands self-host,
+  only this file changes. That is the whole point of S9 (see the decision brief
+  ``reports/PRD-185-S9-LANGFUSE-DECISION-BRIEF.md``).
+- **Default OFF** (``config.TRACING_ENABLED=false``): ``get_tracer()`` returns
+  :class:`NoOpTracer`, ``langfuse`` is never imported, zero overhead, zero data
+  egress. You flip it on when you want to watch.
+- **Never fails the caller.** Every emit is guarded; a tracing fault is logged
+  and the tool call / retrieval returns normally. Mirrors the fire-and-forget
+  telemetry posture in ``modules/tools/execution/telemetry.py``.
+- **``langfuse`` is an OPTIONAL dependency**, imported lazily only when enabled.
+  Enabled but not installed → we log once and degrade to no-op.
+
+The two emit points map 1:1 to the two chokepoints:
+- :func:`fire_tool_trace`   → tool dispatch (``unified_executor`` finally, beside telemetry)
+- :func:`fire_retrieval_score` → RAG retrieval funnel (``RAGService.retrieve``)
+"""
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+# Retrieval status vocabulary — the "empty-vs-error" signal the brief calls out.
+STATUS_HIT = "hit"      # docs returned
+STATUS_EMPTY = "empty"  # ran clean, returned nothing (not grounded)
+STATUS_ERROR = "error"  # retrieval raised
+
+_SUPPORTED_BACKENDS = ("langfuse",)
+
+
+# ── the seam ──────────────────────────────────────────────────────────────────
+
+
+class Tracer:
+    """Vendor-neutral trace/score surface. Two methods = the two chokepoints.
+
+    Implementations must never raise to the caller; the :func:`fire_*` helpers
+    guard anyway, but a well-behaved tracer swallows its own backend faults.
+    """
+
+    def trace_tool_call(
+        self,
+        *,
+        tool_name: str,
+        success: bool,
+        duration_ms: int,
+        workspace_id: Any = None,
+        agent_id: Any = None,
+        error: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        raise NotImplementedError
+
+    def score_retrieval(
+        self,
+        *,
+        query: str,
+        num_docs: int,
+        top_score: float,
+        status: str,
+        workspace_id: Any = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        raise NotImplementedError
+
+
+class NoOpTracer(Tracer):
+    """The default. Every method returns immediately — zero overhead, zero egress."""
+
+    def trace_tool_call(self, **_: Any) -> None:
+        return None
+
+    def score_retrieval(self, **_: Any) -> None:
+        return None
+
+
+class LangfuseTracer(Tracer):
+    """Langfuse-Cloud implementation of the seam.
+
+    Targets the Langfuse Python SDK **v3** surface (context-manager spans +
+    scores). Every backend call is best-effort and guarded: a wrong SDK method
+    name or a network blip degrades to a logged no-op, never a crash. Because
+    the OFF path never reaches here and CI keeps tracing disabled, the live
+    emission path is exercised only when you enable it — **smoke-test on first
+    enablement** (flip ``TRACING_ENABLED=true`` with keys set, run one tool call
+    + one retrieval, confirm the trace lands in Langfuse).
+    """
+
+    def __init__(self, client: Any):
+        self._client = client
+
+    def trace_tool_call(
+        self,
+        *,
+        tool_name: str,
+        success: bool,
+        duration_ms: int,
+        workspace_id: Any = None,
+        agent_id: Any = None,
+        error: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        md: Dict[str, Any] = {
+            "workspace_id": str(workspace_id) if workspace_id else None,
+            "agent_id": agent_id,
+            "duration_ms": duration_ms,
+        }
+        if error:
+            md["error"] = error[:500]
+        if metadata:
+            md.update(metadata)
+        # One span per tool call, scored 1.0 success / 0.0 failure — never carry
+        # secret param *values*, only names/outcome (keys-only privacy posture).
+        with self._client.start_as_current_span(name=f"tool:{tool_name}") as span:
+            span.update(metadata=md, level="ERROR" if not success else "DEFAULT")
+            self._score(span, "tool_success", 1.0 if success else 0.0)
+
+    def score_retrieval(
+        self,
+        *,
+        query: str,
+        num_docs: int,
+        top_score: float,
+        status: str,
+        workspace_id: Any = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        md: Dict[str, Any] = {
+            "num_docs": num_docs,
+            "status": status,
+            "workspace_id": str(workspace_id) if workspace_id else None,
+        }
+        if metadata:
+            md.update(metadata)
+        with self._client.start_as_current_span(name="rag:retrieve") as span:
+            span.update(input=(query or "")[:500], metadata=md)
+            # Two scores: the raw top similarity, and a binary "was it grounded".
+            self._score(span, "retrieval_top_score", float(top_score))
+            self._score(span, "retrieval_grounded", 1.0 if status == STATUS_HIT else 0.0)
+
+    @staticmethod
+    def _score(span: Any, name: str, value: float) -> None:
+        """Best-effort score attach across Langfuse SDK method-name variants."""
+        for attr in ("score_trace", "score"):
+            fn = getattr(span, attr, None)
+            if callable(fn):
+                fn(name=name, value=value)
+                return
+        logger.debug("[tracing] no score method on span for %s", name)
+
+
+# ── construction (config-gated, memoized) ─────────────────────────────────────
+
+_TRACER: Optional[Tracer] = None
+_LOCK = threading.Lock()
+_WARNED_MISSING_SDK = False
+
+
+def should_trace(cfg: Any) -> bool:
+    """Pure decision: is a real (non-noop) tracer warranted?
+
+    True iff tracing is enabled, the backend is known, and credentials exist.
+    Kept pure (no imports, no side effects) so it is trivially unit-testable
+    without the ``langfuse`` package installed.
+    """
+    if not getattr(cfg, "TRACING_ENABLED", False):
+        return False
+    backend = (getattr(cfg, "TRACING_BACKEND", "") or "").lower()
+    if backend not in _SUPPORTED_BACKENDS:
+        return False
+    return bool(getattr(cfg, "LANGFUSE_PUBLIC_KEY", None)) and bool(
+        getattr(cfg, "LANGFUSE_SECRET_KEY", None)
+    )
+
+
+def _build_tracer() -> Tracer:
+    """Construct the tracer from config. Any failure → NoOpTracer (fail-open)."""
+    global _WARNED_MISSING_SDK
+    try:
+        from config import config as cfg  # canonical singleton (config.py:1177)
+    except Exception:  # pragma: no cover — config is always importable in-app
+        return NoOpTracer()
+
+    if not should_trace(cfg):
+        return NoOpTracer()
+
+    try:
+        from langfuse import Langfuse  # optional dep, imported only when enabled
+    except Exception:
+        if not _WARNED_MISSING_SDK:
+            logger.warning(
+                "[tracing] TRACING_ENABLED but 'langfuse' is not installed — "
+                "tracing disabled (pip install langfuse). Degrading to no-op."
+            )
+            _WARNED_MISSING_SDK = True
+        return NoOpTracer()
+
+    try:
+        client = Langfuse(
+            public_key=cfg.LANGFUSE_PUBLIC_KEY,
+            secret_key=cfg.LANGFUSE_SECRET_KEY,
+            host=getattr(cfg, "LANGFUSE_HOST", None) or "https://cloud.langfuse.com",
+        )
+        logger.info("[tracing] Langfuse tracer active (host=%s)", cfg.LANGFUSE_HOST)
+        return LangfuseTracer(client)
+    except Exception:
+        logger.warning("[tracing] Langfuse client init failed; degrading to no-op", exc_info=True)
+        return NoOpTracer()
+
+
+def get_tracer() -> Tracer:
+    """Return the process-wide tracer (memoized). NoOpTracer when disabled."""
+    global _TRACER
+    if _TRACER is not None:
+        return _TRACER
+    with _LOCK:
+        if _TRACER is None:
+            _TRACER = _build_tracer()
+    return _TRACER
+
+
+def reset_tracer() -> None:
+    """Drop the memoized tracer (config changed at runtime / test isolation)."""
+    global _TRACER
+    _TRACER = None
+
+
+# ── fire-and-forget emit helpers (what the chokepoints call) ──────────────────
+
+
+def fire_tool_trace(
+    *,
+    tool_name: str,
+    success: bool,
+    duration_ms: int,
+    workspace_id: Any = None,
+    agent_id: Any = None,
+    error: Optional[str] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> None:
+    """Emit a tool-dispatch trace. Guarded — a tracing fault never fails the call."""
+    try:
+        get_tracer().trace_tool_call(
+            tool_name=tool_name,
+            success=success,
+            duration_ms=duration_ms,
+            workspace_id=workspace_id,
+            agent_id=agent_id,
+            error=error,
+            metadata=metadata,
+        )
+    except Exception:
+        logger.debug("[tracing] tool trace failed", exc_info=True)
+
+
+def fire_retrieval_score(
+    *,
+    query: str,
+    num_docs: int,
+    top_score: float,
+    status: str,
+    workspace_id: Any = None,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> None:
+    """Emit a retrieval grounding score. Guarded — never fails retrieval."""
+    try:
+        get_tracer().score_retrieval(
+            query=query,
+            num_docs=num_docs,
+            top_score=top_score,
+            status=status,
+            workspace_id=workspace_id,
+            metadata=metadata,
+        )
+    except Exception:
+        logger.debug("[tracing] retrieval score failed", exc_info=True)

--- a/orchestrator/modules/rag/service.py
+++ b/orchestrator/modules/rag/service.py
@@ -31,6 +31,15 @@ def _count_tokens(text: str) -> int:
 
 logger = logging.getLogger(__name__)
 
+# PRD-185 S9: vendor-neutral tracing seam. Import is cheap (no backend loaded at
+# module import — langfuse is lazy, config-gated, default-OFF).
+from core.observability.tracer import (
+    fire_retrieval_score,
+    STATUS_HIT,
+    STATUS_EMPTY,
+    STATUS_ERROR,
+)
+
 
 @dataclass
 class RAGResult:
@@ -221,6 +230,49 @@ class RAGService:
         self._initialized = True
         
     async def retrieve(
+        self,
+        query: str,
+        max_chunks: int = 8,
+        max_tokens: int = None,
+        diversity: float = None,
+        context_type: str = "chatbot",
+        workspace_id: str = None,
+        team: str = None,
+    ) -> RAGResult:
+        """Public retrieval funnel — the single place a turn's docs + scores are
+        known. Wraps the implementation to emit a live grounding score at the
+        retrieval chokepoint (PRD-185 S9): num_docs, top similarity, and a
+        hit/empty/error status (the "was retrieval grounded" number over real
+        traffic). Fire-and-forget + fully guarded — a tracing fault, or the
+        seam being OFF, never changes what retrieval returns.
+        """
+        result: Optional[RAGResult] = None
+        status = STATUS_ERROR
+        try:
+            result = await self._retrieve_impl(
+                query,
+                max_chunks=max_chunks,
+                max_tokens=max_tokens,
+                diversity=diversity,
+                context_type=context_type,
+                workspace_id=workspace_id,
+                team=team,
+            )
+            status = STATUS_HIT if result.chunks else STATUS_EMPTY
+            return result
+        finally:
+            fire_retrieval_score(
+                query=query,
+                num_docs=len(result.chunks) if result else 0,
+                top_score=(
+                    max((c.get("similarity", 0.0) or 0.0 for c in result.chunks), default=0.0)
+                    if result else 0.0
+                ),
+                status=status,
+                workspace_id=workspace_id,
+            )
+
+    async def _retrieve_impl(
         self,
         query: str,
         max_chunks: int = 8,

--- a/orchestrator/modules/tools/execution/unified_executor.py
+++ b/orchestrator/modules/tools/execution/unified_executor.py
@@ -36,6 +36,7 @@ from modules.tools.execution import exec_workspace
 from modules.tools.execution import exec_planning
 from modules.tools.execution.telemetry import fire_telemetry
 from modules.memory.tool_outcome_capture import capture_tool_outcome
+from core.observability.tracer import fire_tool_trace
 
 # PRD-36: Composio Integration (lazy import to avoid startup overhead)
 _composio_executor = None
@@ -612,6 +613,19 @@ class UnifiedToolExecutor:
                 result=result,
                 workspace_id=workspace_id,
                 agent_id=agent_id,
+            )
+            # PRD-185 S9: emit a vendor-neutral trace/score at the tool-dispatch
+            # chokepoint (beside telemetry) — "was the tool call good" as a live
+            # number over real traffic. Config-gated default-OFF (NoOp) + fully
+            # guarded, so it never fails the tool call.
+            _ok = bool(result.get("success", result.get("successful"))) if isinstance(result, dict) else False
+            fire_tool_trace(
+                tool_name=tool_name,
+                success=_ok,
+                duration_ms=_exec_ms,
+                workspace_id=workspace_id,
+                agent_id=agent_id,
+                error=(result.get("error") if isinstance(result, dict) and not _ok else None),
             )
 
     # ------------------------------------------------------------------

--- a/orchestrator/requirements.txt
+++ b/orchestrator/requirements.txt
@@ -127,3 +127,12 @@ prometheus-client>=0.20.0
 
 # PRD-126: Business Knowledge Graph (Graphify Integration)
 graphifyy[leiden]>=0.3.28
+
+# PRD-185 S9: Observability / tracing seam (vendor-neutral, default-OFF).
+# `langfuse` is an OPTIONAL backend — the OFF path never imports it and the seam
+# (core/observability/tracer.py) degrades to a logged no-op if it is absent.
+# Kept OUT of the default install so the default (disabled) posture adds zero
+# weight and zero resolver risk to the pinned dep graph. To activate: uncomment,
+# reinstall, set TRACING_ENABLED=true + LANGFUSE_PUBLIC_KEY/SECRET_KEY
+# (+ optional LANGFUSE_HOST, defaults to Langfuse Cloud).
+# langfuse>=3.0.0,<4.0.0

--- a/orchestrator/tests/test_prd179_rag_feedback_rank.py
+++ b/orchestrator/tests/test_prd179_rag_feedback_rank.py
@@ -104,10 +104,14 @@ def test_feedback_penalty_never_raises(svc):
 
 def test_retrieve_calls_feedback_penalty_on_hot_path():
     """The live retrieve() path must invoke the feedback penalty — proves the
-    signal feeds ranking, not just that a helper exists."""
+    signal feeds ranking, not just that a helper exists.
+
+    PRD-185 S9 wrapped retrieve() in a thin tracing shim that delegates to
+    _retrieve_impl(), so the penalty now lives in the impl. Introspect both so
+    the guard proves the penalty is on the live path regardless of the split."""
     import inspect
 
-    src = inspect.getsource(RAGService.retrieve)
+    src = inspect.getsource(RAGService.retrieve) + inspect.getsource(RAGService._retrieve_impl)
     assert "_apply_feedback_penalty" in src, (
         "retrieve() does not apply rag_feedback to ranking on the live path"
     )

--- a/orchestrator/tests/test_prd185_s9_tracing_seam.py
+++ b/orchestrator/tests/test_prd185_s9_tracing_seam.py
@@ -1,0 +1,269 @@
+"""PRD-185 S9 — vendor-neutral tracing seam.
+
+The two platform chokepoints (tool dispatch + RAG retrieval) must emit a live
+trace/score so "was the tool call good / was retrieval grounded" becomes a
+queryable number over real traffic. The seam is config-gated, default-OFF, and
+never fails the caller.
+
+Pure tests — no DB, network, ``langfuse``, or app import chain (per
+``feedback-no-local-servers``). ``core/observability/tracer.py`` imports nothing
+heavy at module load (langfuse + config are lazy), and the Langfuse client is
+mocked at the boundary.
+"""
+import pathlib
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from core.observability.tracer import (
+    Tracer,
+    NoOpTracer,
+    LangfuseTracer,
+    get_tracer,
+    reset_tracer,
+    should_trace,
+    fire_tool_trace,
+    fire_retrieval_score,
+    STATUS_HIT,
+    STATUS_EMPTY,
+    STATUS_ERROR,
+)
+
+ORCH = pathlib.Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture(autouse=True)
+def _reset_tracer():
+    """Isolate the memoized process-wide tracer between tests."""
+    reset_tracer()
+    yield
+    reset_tracer()
+
+
+# ── should_trace: the pure enable decision ────────────────────────────────────
+
+
+def _cfg(**kw):
+    base = dict(
+        TRACING_ENABLED=True,
+        TRACING_BACKEND="langfuse",
+        LANGFUSE_PUBLIC_KEY="pk-1",
+        LANGFUSE_SECRET_KEY="sk-1",
+        LANGFUSE_HOST="https://cloud.langfuse.com",
+    )
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+def test_should_trace_true_when_enabled_with_backend_and_keys():
+    assert should_trace(_cfg()) is True
+
+
+def test_should_trace_false_when_disabled():
+    # Default posture — the whole point of the flag. Off = no real tracer.
+    assert should_trace(_cfg(TRACING_ENABLED=False)) is False
+
+
+def test_should_trace_false_when_keys_missing():
+    assert should_trace(_cfg(LANGFUSE_SECRET_KEY=None)) is False
+    assert should_trace(_cfg(LANGFUSE_PUBLIC_KEY="")) is False
+
+
+def test_should_trace_false_for_unknown_backend():
+    assert should_trace(_cfg(TRACING_BACKEND="datadog")) is False
+    assert should_trace(_cfg(TRACING_BACKEND=None)) is False
+
+
+# ── get_tracer: default OFF is a memoized no-op ───────────────────────────────
+
+
+def test_get_tracer_default_off_is_noop():
+    # Real path, no patching: CI config has TRACING_ENABLED=false, so the real
+    # _build_tracer returns NoOpTracer WITHOUT importing langfuse. This is the
+    # default posture — zero overhead, zero data egress.
+    reset_tracer()
+    assert isinstance(get_tracer(), NoOpTracer)
+
+
+def test_get_tracer_is_memoized_and_resettable():
+    sentinel = NoOpTracer()
+    with patch("core.observability.tracer._build_tracer", return_value=sentinel) as build:
+        first = get_tracer()
+        second = get_tracer()
+    assert first is second is sentinel
+    assert build.call_count == 1  # built once, then memoized
+
+    reset_tracer()
+    with patch("core.observability.tracer._build_tracer", return_value=NoOpTracer()) as build2:
+        get_tracer()
+    assert build2.call_count == 1  # reset forces a rebuild
+
+
+def test_build_tracer_degrades_to_noop_when_langfuse_missing():
+    # Enabled (should_trace True), but the optional SDK is not installed → no-op,
+    # never a crash. sys.modules[langfuse]=None makes `import langfuse` raise.
+    from core.observability import tracer as tmod
+
+    with patch("core.observability.tracer.should_trace", return_value=True):
+        with patch.dict("sys.modules", {"langfuse": None}):
+            built = tmod._build_tracer()
+    assert isinstance(built, NoOpTracer)
+
+
+def test_noop_tracer_swallows_everything():
+    t = NoOpTracer()
+    assert t.trace_tool_call(tool_name="x", success=True, duration_ms=5) is None
+    assert (
+        t.score_retrieval(query="q", num_docs=0, top_score=0.0, status=STATUS_EMPTY) is None
+    )
+
+
+# ── fire_* helpers: delegate + guard ──────────────────────────────────────────
+
+
+class _SpyTracer(Tracer):
+    def __init__(self):
+        self.tool_calls = []
+        self.scores = []
+
+    def trace_tool_call(self, **kw):
+        self.tool_calls.append(kw)
+
+    def score_retrieval(self, **kw):
+        self.scores.append(kw)
+
+
+def test_fire_tool_trace_delegates_with_args():
+    spy = _SpyTracer()
+    with patch("core.observability.tracer.get_tracer", return_value=spy):
+        fire_tool_trace(
+            tool_name="search_documents",
+            success=True,
+            duration_ms=42,
+            workspace_id="ws-1",
+            agent_id=7,
+            error=None,
+        )
+    assert len(spy.tool_calls) == 1
+    call = spy.tool_calls[0]
+    assert call["tool_name"] == "search_documents"
+    assert call["success"] is True
+    assert call["duration_ms"] == 42
+    assert call["workspace_id"] == "ws-1"
+    assert call["agent_id"] == 7
+
+
+def test_fire_retrieval_score_delegates_with_args():
+    spy = _SpyTracer()
+    with patch("core.observability.tracer.get_tracer", return_value=spy):
+        fire_retrieval_score(
+            query="how do agents work",
+            num_docs=3,
+            top_score=0.87,
+            status=STATUS_HIT,
+            workspace_id="ws-9",
+        )
+    assert len(spy.scores) == 1
+    s = spy.scores[0]
+    assert s["num_docs"] == 3
+    assert s["top_score"] == 0.87
+    assert s["status"] == STATUS_HIT
+    assert s["workspace_id"] == "ws-9"
+
+
+def test_fire_tool_trace_never_raises_on_tracer_fault():
+    boom = MagicMock()
+    boom.trace_tool_call.side_effect = RuntimeError("langfuse down")
+    with patch("core.observability.tracer.get_tracer", return_value=boom):
+        # Must not propagate — a tracing fault cannot break the tool call.
+        fire_tool_trace(tool_name="x", success=False, duration_ms=1)
+
+
+def test_fire_retrieval_score_never_raises_on_tracer_fault():
+    boom = MagicMock()
+    boom.score_retrieval.side_effect = RuntimeError("langfuse down")
+    with patch("core.observability.tracer.get_tracer", return_value=boom):
+        fire_retrieval_score(query="q", num_docs=0, top_score=0.0, status=STATUS_ERROR)
+
+
+# ── LangfuseTracer: maps the seam onto the SDK (client mocked at the boundary) ─
+
+
+def _mock_client_and_span():
+    client = MagicMock()
+    span = client.start_as_current_span.return_value.__enter__.return_value
+    return client, span
+
+
+def test_langfuse_tracer_traces_tool_success():
+    client, span = _mock_client_and_span()
+    LangfuseTracer(client).trace_tool_call(
+        tool_name="search_knowledge", success=True, duration_ms=12, workspace_id="ws-1"
+    )
+    client.start_as_current_span.assert_called_once_with(name="tool:search_knowledge")
+    span.update.assert_called_once()
+    assert span.update.call_args.kwargs["level"] == "DEFAULT"
+    span.score_trace.assert_any_call(name="tool_success", value=1.0)
+
+
+def test_langfuse_tracer_traces_tool_failure_with_error_level():
+    client, span = _mock_client_and_span()
+    LangfuseTracer(client).trace_tool_call(
+        tool_name="query_database", success=False, duration_ms=3, error="boom"
+    )
+    assert span.update.call_args.kwargs["level"] == "ERROR"
+    span.score_trace.assert_any_call(name="tool_success", value=0.0)
+
+
+def test_langfuse_tracer_scores_retrieval_hit():
+    client, span = _mock_client_and_span()
+    LangfuseTracer(client).score_retrieval(
+        query="q", num_docs=4, top_score=0.9, status=STATUS_HIT
+    )
+    client.start_as_current_span.assert_called_once_with(name="rag:retrieve")
+    span.score_trace.assert_any_call(name="retrieval_top_score", value=0.9)
+    span.score_trace.assert_any_call(name="retrieval_grounded", value=1.0)
+
+
+def test_langfuse_tracer_scores_retrieval_empty_as_ungrounded():
+    client, span = _mock_client_and_span()
+    LangfuseTracer(client).score_retrieval(
+        query="q", num_docs=0, top_score=0.0, status=STATUS_EMPTY
+    )
+    span.score_trace.assert_any_call(name="retrieval_grounded", value=0.0)
+
+
+def test_langfuse_score_falls_back_to_score_method():
+    # SDK variant exposing `.score` but not `.score_trace` must still work.
+    client = MagicMock()
+    span = client.start_as_current_span.return_value.__enter__.return_value
+    del span.score_trace  # force the fallback branch
+    LangfuseTracer(client).score_retrieval(
+        query="q", num_docs=1, top_score=0.5, status=STATUS_HIT
+    )
+    span.score.assert_any_call(name="retrieval_top_score", value=0.5)
+
+
+# ── wiring guards: the emits are actually placed at the two chokepoints ────────
+# Pure text guards (no heavy import), the same posture as the PRD-179 F070 /
+# F056 source guards — they prove placement without pulling the app chain.
+
+
+def _src(rel):
+    return (ORCH / rel).read_text(encoding="utf-8")
+
+
+def test_tool_dispatch_chokepoint_is_wired():
+    src = _src("modules/tools/execution/unified_executor.py")
+    assert "from core.observability.tracer import fire_tool_trace" in src
+    assert "fire_tool_trace(" in src
+
+
+def test_retrieval_chokepoint_is_wired():
+    src = _src("modules/rag/service.py")
+    assert "fire_retrieval_score(" in src
+    # retrieve() must delegate to the wrapped impl so every path (incl. the
+    # empty early-returns) is scored — not just the happy path.
+    assert "_retrieve_impl(" in src
+    assert "from core.observability.tracer import" in src


### PR DESCRIPTION
## PRD-185 Wave-0 · S9 — Eval substrate (tracing seam)

The last Wave-0 story with a code path. Gives the two platform chokepoints a
**live number**: "was the tool call good / was retrieval grounded" over real
traffic — the live complement to S10's offline recall@5/MRR. Adopt-don't-build:
two hooks on the *existing* chokepoints, no parallel telemetry stack, no eval
platform.

**Decision baked in (yours, this session):** *Cloud behind the seam.* The hooks
are backend-agnostic; the backend is a config swap. Langfuse Cloud today; the day
a client's documents flow through it, self-host is an env change, not a rewrite.
Full rationale: `reports/PRD-185-S9-LANGFUSE-DECISION-BRIEF.md`.

### What's in it
| Piece | File |
|---|---|
| Vendor-neutral seam (`Tracer` / `NoOpTracer` / `LangfuseTracer` / `get_tracer` / `fire_*`) | `core/observability/tracer.py` (new) |
| Config gate — `TRACING_ENABLED` (default **OFF**) + `TRACING_BACKEND` + `LANGFUSE_*` | `config.py` |
| Tool-dispatch hook (beside `fire_telemetry`) | `modules/tools/execution/unified_executor.py` |
| Retrieval hook (wrap `retrieve()` → `_retrieve_impl`) | `modules/rag/service.py` |
| Optional, commented dep | `requirements.txt` |
| Pure mocked tests | `tests/test_prd185_s9_tracing_seam.py` (new) |

### Design guarantees
- **Default OFF = truly inert.** `get_tracer()` returns `NoOpTracer`; `langfuse`
  is never imported; zero overhead, zero data egress. Flip `TRACING_ENABLED=true`
  + set keys when you want to watch.
- **Never fails the caller.** Every emit is guarded (try/except → debug log),
  mirroring the fire-and-forget telemetry posture.
- **All retrieval paths scored, not just the happy one.** The `retrieve()`
  wrapper captures the empty early-returns (unscoped/no-candidates/team-empty)
  and exceptions too → `status ∈ {hit, empty, error}` + `num_docs` + top score.
- **Backend-swap is a config change.** `TRACING_BACKEND` selects the impl behind
  the seam; self-host Langfuse v3 later touches only `tracer.py`.

### CI / tests
Pure tests (no DB/network/`langfuse`/app-import chain): the enable-decision, the
real **OFF→NoOp** path, guarded emits, the Langfuse mapping mocked at the client
boundary, and source-grep **wiring guards** proving the emits sit at both
chokepoints. Also repoints the PRD-179 F070 feedback-penalty guard to
`_retrieve_impl` (the penalty moved with the body behind the tracing wrapper).

### Two choices I made — flag if you'd rather go the other way
1. **`langfuse` left as a commented/optional dep** (not pinned into the install).
   Keeps the pinned dep graph untouched → zero CI resolver risk; the seam
   degrades to a logged no-op if it's absent. To activate: uncomment
   `langfuse>=3.0.0,<4.0.0`, reinstall, set the flag + keys. Say the word and I
   pin it into `requirements.txt` instead.
2. **The live Langfuse emission path is exercised only when enabled** (never in
   CI, since default-OFF + no keys). It targets the Langfuse **v3** SDK and is
   fully guarded, but **should be smoke-tested on first enablement** (one tool
   call + one retrieval → confirm the trace lands).

### Not in this PR (the rest of Wave-0's non-code work)
S8 (AWS prod doc-vector probe) and the S4 circuit-breaker (your scheduler-scope
call) remain — neither is a code path S9 blocks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional tracing support for tool calls and retrieval activity.
  * Introduced new configuration options to enable tracing and connect to a tracing backend.

* **Bug Fixes**
  * Tracing is now fail-safe: if tracing is disabled or unavailable, normal app behavior continues unchanged.
  * Retrieval and tool execution now emit observability signals without affecting results or performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->