### PR TITLE
feat(prd-185): Wave-0 tail — S4 playbook circuit-breaker + S8 doc-vector probe

### DIFF
--- a/orchestrator/config.py
+++ b/orchestrator/config.py
@@ -528,6 +528,12 @@ class Config:
     PLAYBOOK_DEFAULT_TOTAL_TIMEOUT_SECONDS: int = int(os.getenv("PLAYBOOK_DEFAULT_TOTAL_TIMEOUT_SECONDS", "1800"))  # 30 min
     PLAYBOOK_MIN_STEP_TIMEOUT_SECONDS: int = int(os.getenv("PLAYBOOK_MIN_STEP_TIMEOUT_SECONDS", "300"))            # 5 min floor
     PLAYBOOK_MIN_TOTAL_TIMEOUT_SECONDS: int = int(os.getenv("PLAYBOOK_MIN_TOTAL_TIMEOUT_SECONDS", "900"))          # 15 min floor
+    # PRD-185 S4: repeated-failure circuit breaker for cron playbooks. Once the
+    # last N *terminal* runs of a playbook are all 'failed', the cron scheduler
+    # stops re-firing it (the 2026-06 daily OpenRouter-402 spam re-fired forever).
+    # A manual run that succeeds breaks the streak and auto-resets the breaker.
+    # Set to 0 to disable the breaker entirely.
+    PLAYBOOK_BREAKER_THRESHOLD: int = int(os.getenv("PLAYBOOK_BREAKER_THRESHOLD", "3"))
 
     # =============================================================================
     # RAILWAY API (Log retrieval for agents)

--- a/orchestrator/scripts/probe_document_vectors.py
+++ b/orchestrator/scripts/probe_document_vectors.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+"""PRD-185 S8: read-only production document-vector probe.
+
+The Phase-2 review (finding P2-03) flagged that the committed prod config may not
+be able to construct the F005-guarded S3 Vectors backend — which would leave the
+document-vector plane *dark since W2*, so every agent answer over workspace
+documents would be ungrounded. This script answers that, **without writing or
+mutating anything**:
+
+  1. Which vector backend does the committed config select?  (``S3_VECTORS_ENABLED``)
+  2. Can that backend be CONSTRUCTED from the committed config?  (surfaces the
+     F005 / missing-``{workspace_id}`` / missing-credentials failures)
+  3. Is the document index POPULATED, and at what DIMENSION?  (read-only
+     ``get_index`` + ``list_vectors``, or a pgvector row count)
+
+It then prints a written finding and a recommendation. It performs NO destructive
+action and NO re-embed — the fix-or-fold decision (relight the plane vs fold into
+the Wave-3 Qdrant consolidation, P2-16) is **Gerard's call** per the PRD-185 §S8
+gate; this probe only produces the evidence for it.
+
+Run against a prod-configured environment (needs the same env + AWS creds the
+API uses; DB reachable for the populated check)::
+
+    python -m scripts.probe_document_vectors                 # workspaces with docs (up to --limit)
+    python -m scripts.probe_document_vectors --workspace <uuid>
+    python -m scripts.probe_document_vectors --all
+    python -m scripts.probe_document_vectors --json          # machine-readable
+
+This file is import-safe (no work at import time) so its pure decision logic —
+``classify_plane`` / ``recommend`` — can be unit-tested with no DB / network.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Any, Dict, List, Optional
+
+
+# ---------------------------------------------------------------------------
+# Pure decision logic (unit-tested, no I/O)
+# ---------------------------------------------------------------------------
+
+VERDICT_LIVE = "live"            # active plane is populated and usable
+VERDICT_DEGRADED = "degraded"    # constructs + has data, but a dimension mismatch
+VERDICT_DARK = "dark"            # active plane cannot be built, or is empty
+VERDICT_UNKNOWN = "unknown"      # probe could not reach the backend to decide
+
+
+def classify_plane(
+    active_backend: str,
+    constructable: bool,
+    configured_dimension: int,
+    probes: List[Dict[str, Any]],
+) -> str:
+    """Classify the document-vector plane from probe results. Pure.
+
+    Args:
+        active_backend: "s3_vectors" or "pgvector" — what the committed config selects.
+        constructable: could the active backend be built from the committed config?
+        configured_dimension: the embedding dimension the config expects.
+        probes: per-workspace results, each a dict with keys:
+            ``index_exists`` (bool), ``populated`` (bool), ``dimension`` (int|None),
+            ``error`` (str|None).
+
+    Returns one of VERDICT_*.
+    """
+    if not constructable:
+        # The config can't even build the backend — the plane is dark by construction.
+        return VERDICT_DARK
+
+    reachable = [p for p in probes if not p.get("error")]
+    if not reachable:
+        return VERDICT_UNKNOWN
+
+    populated = [p for p in reachable if p.get("populated")]
+    if not populated:
+        # Backend builds and indexes are reachable, but nothing is stored → dark.
+        return VERDICT_DARK
+
+    # Populated. Flag a dimension mismatch (embeddings unusable against a
+    # differently-dimensioned index) as degraded, not healthy.
+    for p in populated:
+        dim = p.get("dimension")
+        if dim and configured_dimension and dim != configured_dimension:
+            return VERDICT_DEGRADED
+    return VERDICT_LIVE
+
+
+def recommend(verdict: str, active_backend: str) -> str:
+    """Map a verdict to the PRD-185 §S8 gate recommendation. Pure."""
+    if verdict == VERDICT_LIVE:
+        return ("Plane is LIVE — grounding is real. Unblocks Wave-1 P2-07 (RAG "
+                "quality). No relight needed.")
+    if verdict == VERDICT_DEGRADED:
+        return ("Plane has data but a DIMENSION MISMATCH — stored embeddings do "
+                "not match the configured index dimension, so retrieval is "
+                "silently wrong. Re-embed at the correct dimension before any "
+                "RAG-quality work.")
+    if verdict == VERDICT_DARK:
+        if active_backend == "s3_vectors":
+            return ("Plane is DARK — the S3 Vectors backend cannot be built from "
+                    "the committed config, or its index is empty. Decision (§S8, "
+                    "Gerard's call): fix env (S3_VECTORS_BUCKET must carry the "
+                    "'{workspace_id}' placeholder + valid AWS creds) and re-embed "
+                    "as a fast follow, OR fold into the Wave-3 Qdrant "
+                    "consolidation (P2-16). RAG-quality work (P2-07) is gated on "
+                    "this either way.")
+        return ("Plane is DARK — pgvector holds no embedded documents. Ingestion "
+                "has not populated the vector store; re-embed before relying on "
+                "document grounding.")
+    return ("Plane state UNKNOWN — the probe could not reach the backend. Re-run "
+            "with valid credentials / DB access from a prod-configured shell.")
+
+
+# ---------------------------------------------------------------------------
+# I/O: config snapshot + read-only backend inspection
+# ---------------------------------------------------------------------------
+
+def _config_snapshot() -> Dict[str, Any]:
+    """Read the committed config — secrets reported only as present/absent."""
+    from config import config
+    return {
+        "active_backend": "s3_vectors" if config.S3_VECTORS_ENABLED else "pgvector",
+        "S3_VECTORS_ENABLED": bool(config.S3_VECTORS_ENABLED),
+        "S3_VECTORS_BUCKET": config.S3_VECTORS_BUCKET or "(unset)",
+        "S3_VECTORS_BUCKET_has_placeholder": "{workspace_id}" in (config.S3_VECTORS_BUCKET or ""),
+        "S3_VECTORS_INDEX_NAME": config.S3_VECTORS_INDEX_NAME,
+        "S3_VECTORS_DIMENSION": config.S3_VECTORS_DIMENSION,
+        "S3_VECTORS_METRIC": config.S3_VECTORS_METRIC,
+        "AWS_REGION": config.AWS_REGION,
+        "AWS_ACCESS_KEY_ID_present": bool(config.AWS_ACCESS_KEY_ID),
+        "AWS_SECRET_ACCESS_KEY_present": bool(config.AWS_SECRET_ACCESS_KEY),
+        "pgvector_dimension": config.VECTOR_STORE_DIMENSIONS,
+    }
+
+
+def _workspaces_with_documents(db, limit: Optional[int]) -> List[Dict[str, Any]]:
+    """Read-only: workspaces that have uploaded documents, with chunk totals."""
+    from sqlalchemy import func
+    from core.models.core import Document
+
+    q = (
+        db.query(
+            Document.workspace_id,
+            func.count(Document.id),
+            func.coalesce(func.sum(Document.chunk_count), 0),
+        )
+        .group_by(Document.workspace_id)
+        .order_by(func.count(Document.id).desc())
+    )
+    if limit:
+        q = q.limit(limit)
+    return [
+        {"workspace_id": str(ws), "documents": int(docs), "chunks": int(chunks)}
+        for ws, docs, chunks in q.all()
+    ]
+
+
+def _probe_s3_workspace(workspace_id: str) -> Dict[str, Any]:
+    """Read-only S3 Vectors inspection for one workspace: get_index + list_vectors.
+
+    Never calls initialize()/_ensure_setup() — that would CREATE buckets/indexes.
+    """
+    result: Dict[str, Any] = {
+        "workspace_id": workspace_id,
+        "index_exists": False,
+        "populated": False,
+        "dimension": None,
+        "vector_sample_count": 0,
+        "error": None,
+    }
+    try:
+        from botocore.exceptions import ClientError
+        from modules.search.vector_store.backends.s3_vectors_backend import S3VectorsBackend
+
+        backend = S3VectorsBackend(workspace_id=workspace_id)  # __init__ validates config + F005
+        client = backend.client
+        try:
+            index = client.get_index(
+                vectorBucketName=backend.bucket_name,
+                indexName=backend.index_name,
+            )
+            result["index_exists"] = True
+            result["dimension"] = index.get("dimension") or (index.get("index", {}) or {}).get("dimension")
+        except ClientError as e:
+            result["error"] = f"get_index: {e.response.get('Error', {}).get('Code', str(e))}"
+            return result
+
+        try:
+            listed = client.list_vectors(
+                vectorBucketName=backend.bucket_name,
+                indexName=backend.index_name,
+            )
+            sample = listed.get("vectors", []) or []
+            result["vector_sample_count"] = len(sample)
+            result["populated"] = len(sample) > 0
+        except ClientError as e:
+            result["error"] = f"list_vectors: {e.response.get('Error', {}).get('Code', str(e))}"
+    except Exception as e:  # construction / import / auth failure
+        result["error"] = f"{type(e).__name__}: {e}"
+    return result
+
+
+def _probe_pgvector(db, workspaces: List[Dict[str, Any]], configured_dim: int) -> List[Dict[str, Any]]:
+    """Read-only pgvector inspection: does each workspace have embedded chunks?
+
+    ``documents.chunk_count`` is the ingestion-side truth for "was this embedded".
+    """
+    probes = []
+    for w in workspaces:
+        embedded = w["chunks"]
+        probes.append({
+            "workspace_id": w["workspace_id"],
+            "index_exists": True,          # pgvector table always exists
+            "populated": embedded > 0,
+            "dimension": configured_dim,   # pgvector column dimension == configured
+            "vector_sample_count": embedded,
+            "error": None,
+        })
+    return probes
+
+
+def _construct_check(active_backend: str) -> Dict[str, Any]:
+    """Can the active backend be built from the committed config? Read-only."""
+    if active_backend == "pgvector":
+        return {"constructable": True, "error": None}
+    try:
+        from modules.search.vector_store.backends.s3_vectors_backend import S3VectorsBackend
+        # A throwaway probe workspace: __init__ runs the F005 / placeholder /
+        # credential validation without touching AWS state.
+        S3VectorsBackend(workspace_id="00000000-0000-0000-0000-000000000000")
+        return {"constructable": True, "error": None}
+    except Exception as e:
+        return {"constructable": False, "error": f"{type(e).__name__}: {e}"}
+
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+
+def run_probe(workspace: Optional[str], probe_all: bool, limit: int) -> Dict[str, Any]:
+    """Orchestrate the read-only probe and return a structured finding."""
+    from core.database.database import SessionLocal
+
+    cfg = _config_snapshot()
+    active = cfg["active_backend"]
+    construct = _construct_check(active)
+
+    db = SessionLocal()
+    try:
+        if workspace:
+            workspaces = [{"workspace_id": workspace, "documents": None, "chunks": None}]
+        else:
+            workspaces = _workspaces_with_documents(db, None if probe_all else limit)
+
+        if active == "s3_vectors":
+            probes = [_probe_s3_workspace(w["workspace_id"]) for w in workspaces] if construct["constructable"] else []
+        else:
+            # pgvector needs real doc/chunk counts; refetch if a single ws was named
+            if workspace:
+                workspaces = _workspaces_with_documents(db, None) or workspaces
+                workspaces = [w for w in workspaces if w["workspace_id"] == workspace] or workspaces
+            probes = _probe_pgvector(db, workspaces, cfg["pgvector_dimension"])
+    finally:
+        db.close()
+
+    verdict = classify_plane(
+        active_backend=active,
+        constructable=construct["constructable"],
+        configured_dimension=cfg["S3_VECTORS_DIMENSION"] if active == "s3_vectors" else cfg["pgvector_dimension"],
+        probes=probes,
+    )
+    return {
+        "config": cfg,
+        "construct_check": construct,
+        "workspaces_probed": len(probes),
+        "probes": probes,
+        "verdict": verdict,
+        "recommendation": recommend(verdict, active),
+    }
+
+
+def _print_report(finding: Dict[str, Any]) -> None:
+    cfg = finding["config"]
+    print("=" * 72)
+    print("PRD-185 S8 — Document-Vector Plane Probe (read-only)")
+    print("=" * 72)
+    print(f"\nActive backend (committed config): {cfg['active_backend']}")
+    print("\nConfig snapshot:")
+    for k, v in cfg.items():
+        print(f"  {k:38} = {v}")
+
+    c = finding["construct_check"]
+    print(f"\nCan the committed config construct the backend? {c['constructable']}")
+    if c["error"]:
+        print(f"  construction error: {c['error']}")
+
+    print(f"\nWorkspaces probed: {finding['workspaces_probed']}")
+    for p in finding["probes"]:
+        line = (f"  ws={p['workspace_id']}  index_exists={p['index_exists']}  "
+                f"populated={p['populated']}  dimension={p['dimension']}  "
+                f"sample={p['vector_sample_count']}")
+        if p.get("error"):
+            line += f"  ERROR={p['error']}"
+        print(line)
+
+    print(f"\n{'-' * 72}")
+    print(f"VERDICT: {finding['verdict'].upper()}")
+    print(f"RECOMMENDATION: {finding['recommendation']}")
+    print(f"{'-' * 72}")
+    print("\nThis probe is analysis-only. Relight-vs-fold is Gerard's call (PRD-185 §S8).")
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="PRD-185 S8 read-only document-vector probe")
+    parser.add_argument("--workspace", help="Probe a single workspace UUID")
+    parser.add_argument("--all", action="store_true", help="Probe every workspace with documents")
+    parser.add_argument("--limit", type=int, default=5, help="Max workspaces to probe (default 5)")
+    parser.add_argument("--json", action="store_true", help="Emit the structured finding as JSON")
+    args = parser.parse_args(argv)
+
+    finding = run_probe(workspace=args.workspace, probe_all=args.all, limit=args.limit)
+
+    if args.json:
+        import json
+        print(json.dumps(finding, indent=2, default=str))
+    else:
+        _print_report(finding)
+
+    # Exit non-zero when the plane is not healthy, so a CI/ops caller can gate on it.
+    return 0 if finding["verdict"] == VERDICT_LIVE else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/orchestrator/services/playbook_breaker.py
+++ b/orchestrator/services/playbook_breaker.py
@@ -1,0 +1,101 @@
+"""Playbook repeated-failure circuit breaker (PRD-185 S4).
+
+A cron-scheduled playbook that fails on every run re-fires forever. That is what
+happened in 2026-06: an OpenRouter 402 made one playbook fail on every tick, and
+because nothing stopped it, it re-fired daily and spammed the same failure for
+~17 days. The board even reported green over it (fixed separately in #504).
+
+This breaker closes that loop. It reads the playbook's recent execution history
+(``recipe_executions``) and, once the last N *terminal* runs are all ``failed``,
+reports the breaker OPEN so the cron scheduler skips re-firing until a human
+intervenes. The state is **derived, not stored** — no new column, no migration:
+
+- A manual run (which bypasses the breaker) that *succeeds* writes a ``completed``
+  row, which breaks the all-failed streak, so the breaker auto-closes on the next
+  tick. There is no explicit "reset" to forget to call.
+- While the breaker is open the scheduler creates no new execution rows, so the
+  history stays stable and the breaker stays open — "fails, alerts, stops" — until
+  that manual success (or a config change) clears it.
+
+The decision (:func:`is_breaker_open`) is a pure function over a status list so it
+is trivially unit-testable with no DB; :func:`breaker_is_open` is the thin DB-bound
+wrapper the scheduler calls.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import List, Sequence
+
+from sqlalchemy.orm import Session
+
+from config import config
+
+logger = logging.getLogger(__name__)
+
+# Only terminal executions count toward the streak. A pending/running row is not
+# yet an outcome; a cancelled run was deliberately stopped, so it is neither a
+# success that should reset the breaker nor a failure that should trip it.
+_TERMINAL_STATUSES = ("completed", "failed")
+
+
+def is_breaker_open(recent_statuses: Sequence[str], threshold: int) -> bool:
+    """Pure decision: is the breaker open?
+
+    Args:
+        recent_statuses: The playbook's most recent terminal execution statuses,
+            newest first (only ``completed`` / ``failed`` — see ``_TERMINAL_STATUSES``).
+        threshold: Number of consecutive failures that trips the breaker. ``<= 0``
+            disables it.
+
+    Returns:
+        True when there are at least ``threshold`` terminal runs and the most
+        recent ``threshold`` of them are all ``failed``.
+    """
+    if threshold <= 0:
+        return False
+    if len(recent_statuses) < threshold:
+        return False
+    return all(status == "failed" for status in recent_statuses[:threshold])
+
+
+def _recent_terminal_statuses(db: Session, recipe_id: int, limit: int) -> List[str]:
+    """Fetch the newest ``limit`` terminal execution statuses for a playbook.
+
+    Uses the ``idx_recipe_executions_recipe_status`` index on
+    ``(recipe_id, status)``; ordered by ``started_at`` desc so "newest first".
+    """
+    from core.models.core import RecipeExecution
+
+    rows = (
+        db.query(RecipeExecution.status)
+        .filter(
+            RecipeExecution.recipe_id == recipe_id,
+            RecipeExecution.status.in_(_TERMINAL_STATUSES),
+        )
+        .order_by(RecipeExecution.started_at.desc())
+        .limit(limit)
+        .all()
+    )
+    return [row.status for row in rows]
+
+
+def breaker_is_open(db: Session, recipe_id: int) -> bool:
+    """True if playbook ``recipe_id`` should be paused from cron re-firing.
+
+    Thin DB-bound wrapper over :func:`is_breaker_open`. Never raises — a breaker
+    that cannot read history must not take the scheduler down, so on any error it
+    fails *closed* (returns False = "do not block the run") and logs.
+    """
+    threshold = config.PLAYBOOK_BREAKER_THRESHOLD
+    if threshold <= 0:
+        return False
+    try:
+        statuses = _recent_terminal_statuses(db, recipe_id, threshold)
+    except Exception as exc:  # pragma: no cover - defensive; never block on read error
+        logger.warning(
+            "[PlaybookBreaker] Could not read execution history for playbook %s: %s",
+            recipe_id, exc,
+        )
+        return False
+    return is_breaker_open(statuses, threshold)

--- a/orchestrator/services/playbook_scheduler.py
+++ b/orchestrator/services/playbook_scheduler.py
@@ -171,6 +171,22 @@ class PlaybookSchedulerService:
                 logger.warning("[PlaybookScheduler] Playbook %d has no steps, skipping", playbook_id)
                 return
 
+            # PRD-185 S4: repeated-failure circuit breaker. A cron playbook that
+            # fails on every run re-fires forever (the 2026-06 daily 402 spam).
+            # Once the last N terminal runs are all failures, stop re-firing until
+            # a human intervenes; a manual run that succeeds breaks the streak and
+            # auto-resets. Checked BEFORE creating an execution row so an open
+            # breaker adds no history noise and stays stably open.
+            from services.playbook_breaker import breaker_is_open
+            if breaker_is_open(db, playbook.id):
+                from config import config as _cfg
+                logger.warning(
+                    "[PlaybookScheduler] Circuit breaker OPEN for playbook %d (%s) — "
+                    "last %d runs all failed; skipping cron re-fire until a manual run succeeds",
+                    playbook.id, playbook.name, _cfg.PLAYBOOK_BREAKER_THRESHOLD,
+                )
+                return
+
             execution_id = f"cron-{uuid4().hex[:12]}"
             execution = RecipeExecution(
                 execution_id=execution_id,

--- a/orchestrator/tests/test_p2w0_playbook_failure_visibility.py
+++ b/orchestrator/tests/test_p2w0_playbook_failure_visibility.py
@@ -1,15 +1,18 @@
-"""PRD-185 S4: playbook failures are VISIBLE — a notification event + a board
-status of 'failed', not a silent 'done'.
+"""PRD-185 S4: playbook failures are VISIBLE and a broken playbook STOPS.
 
 A ~17-day OpenRouter 402 outage was invisible because (a) no ``playbook_failed``
 event type existed and (b) ``complete_recipe_board_task`` accepted ``success`` but
-hardcoded ``task.status = 'done'`` regardless. This test pins both: the event type
-is registered, and the board bridge honors the flag.
+hardcoded ``task.status = 'done'`` regardless — and it re-fired daily forever
+because (c) nothing stopped a playbook that failed on every run. This test pins
+all three: the event type is registered, the board bridge honors the flag, and
+the repeated-failure circuit breaker pauses cron re-firing after N failures.
 
-Pure unit test — no DB / network (db + task are mocked).
+Pure unit tests — no DB / network (db, task, and history are mocked at the
+boundary); the one scheduler test drives ``_fire_playbook`` with every external
+seam patched.
 """
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -50,3 +53,73 @@ def test_board_task_marked_done_on_success():
     task = SimpleNamespace(status=None, completed_at=None, result=None, error_message=None)
     complete(_mock_db(task), "exec-2", success=True, result="ok")
     assert task.status == "done"
+
+
+# ---------------------------------------------------------------------------
+# PRD-185 S4 (c): repeated-failure circuit breaker. A cron playbook that fails on
+# every run must stop re-firing after N consecutive failures (the daily 402 spam).
+# ---------------------------------------------------------------------------
+
+def _breaker():
+    try:
+        from services.playbook_breaker import is_breaker_open, breaker_is_open
+    except Exception as e:  # pragma: no cover
+        pytest.skip(f"playbook_breaker not importable in this env: {e}")
+    return is_breaker_open, breaker_is_open
+
+
+def test_breaker_opens_when_last_n_all_failed():
+    is_open, _ = _breaker()
+    assert is_open(["failed", "failed", "failed"], threshold=3) is True
+
+
+def test_breaker_closed_when_a_recent_run_succeeded():
+    is_open, _ = _breaker()
+    # statuses are newest-first: a success anywhere in the window breaks the streak
+    assert is_open(["failed", "completed", "failed"], threshold=3) is False
+    assert is_open(["completed", "failed", "failed"], threshold=3) is False
+
+
+def test_breaker_closed_with_too_few_terminal_runs():
+    is_open, _ = _breaker()
+    assert is_open(["failed", "failed"], threshold=3) is False
+    assert is_open([], threshold=3) is False
+
+
+def test_breaker_disabled_when_threshold_zero():
+    is_open, _ = _breaker()
+    assert is_open(["failed", "failed", "failed"], threshold=0) is False
+
+
+def test_breaker_only_counts_the_newest_threshold():
+    is_open, _ = _breaker()
+    # the 3 newest are all failures → open, even though an older run succeeded
+    assert is_open(["failed", "failed", "failed", "completed"], threshold=3) is True
+
+
+def test_breaker_is_open_applies_configured_threshold():
+    """DB-boundary: breaker_is_open reads recent history via the internal fetch
+    and applies config.PLAYBOOK_BREAKER_THRESHOLD. Fetch is patched — no DB."""
+    _, breaker_is_open = _breaker()
+    from config import config
+    n = config.PLAYBOOK_BREAKER_THRESHOLD
+
+    with patch("services.playbook_breaker._recent_terminal_statuses",
+               return_value=["failed"] * n):
+        assert breaker_is_open(MagicMock(), recipe_id=42) is (n > 0)
+
+    with patch("services.playbook_breaker._recent_terminal_statuses",
+               return_value=(["completed"] + ["failed"] * max(n - 1, 0))):
+        assert breaker_is_open(MagicMock(), recipe_id=42) is False
+
+
+def test_breaker_fails_closed_on_read_error():
+    """A breaker that cannot read history must never block the scheduler."""
+    _, breaker_is_open = _breaker()
+    with patch("services.playbook_breaker._recent_terminal_statuses",
+               side_effect=RuntimeError("db down")):
+        assert breaker_is_open(MagicMock(), recipe_id=1) is False
+
+# The AC (c) end-to-end assertion — that _fire_playbook actually SKIPS the
+# cron re-fire when the breaker is open — lives in test_playbook_scheduler.py
+# (TestFirePlaybook), which owns the proven _fire_playbook mocking harness.

--- a/orchestrator/tests/test_p2w0_s8_vector_probe.py
+++ b/orchestrator/tests/test_p2w0_s8_vector_probe.py
@@ -1,0 +1,82 @@
+"""PRD-185 S8: the document-vector probe's verdict logic.
+
+The probe itself is read-only I/O against prod (AWS + DB), run by hand. Its
+*decision* — is the plane live, dark, or degraded, and what to recommend — is a
+pure function so it is pinned here with no DB / network. This guards the gate
+that Wave-1 P2-07 (RAG quality) depends on.
+"""
+import pytest
+
+
+def _probe():
+    try:
+        from scripts.probe_document_vectors import (
+            classify_plane, recommend,
+            VERDICT_LIVE, VERDICT_DARK, VERDICT_DEGRADED, VERDICT_UNKNOWN,
+        )
+    except Exception as e:  # pragma: no cover
+        pytest.skip(f"probe_document_vectors not importable in this env: {e}")
+    return classify_plane, recommend, VERDICT_LIVE, VERDICT_DARK, VERDICT_DEGRADED, VERDICT_UNKNOWN
+
+
+def _p(**kw):
+    base = {"index_exists": True, "populated": True, "dimension": 2048, "error": None}
+    base.update(kw)
+    return base
+
+
+def test_unconstructable_backend_is_dark():
+    classify, _, _LIVE, DARK, _DEG, _UNK = _probe()
+    # committed config can't even build the backend (the F005 / placeholder case)
+    assert classify("s3_vectors", constructable=False, configured_dimension=2048,
+                    probes=[_p()]) == DARK
+
+
+def test_constructable_but_empty_is_dark():
+    classify, _, _LIVE, DARK, _DEG, _UNK = _probe()
+    assert classify("s3_vectors", constructable=True, configured_dimension=2048,
+                    probes=[_p(populated=False)]) == DARK
+
+
+def test_populated_matching_dimension_is_live():
+    classify, _, LIVE, _DARK, _DEG, _UNK = _probe()
+    assert classify("s3_vectors", constructable=True, configured_dimension=2048,
+                    probes=[_p(dimension=2048, populated=True)]) == LIVE
+
+
+def test_dimension_mismatch_is_degraded():
+    classify, _, _LIVE, _DARK, DEGRADED, _UNK = _probe()
+    # stored at 1536 but config expects 2048 → embeddings unusable → degraded
+    assert classify("s3_vectors", constructable=True, configured_dimension=2048,
+                    probes=[_p(dimension=1536, populated=True)]) == DEGRADED
+
+
+def test_all_probes_errored_is_unknown():
+    classify, _, _LIVE, _DARK, _DEG, UNKNOWN = _probe()
+    assert classify("s3_vectors", constructable=True, configured_dimension=2048,
+                    probes=[_p(error="get_index: AccessDenied")]) == UNKNOWN
+
+
+def test_one_populated_workspace_makes_the_plane_live():
+    classify, _, LIVE, _DARK, _DEG, _UNK = _probe()
+    probes = [_p(populated=False), _p(populated=True), _p(error="boom")]
+    assert classify("s3_vectors", constructable=True, configured_dimension=2048,
+                    probes=probes) == LIVE
+
+
+def test_pgvector_empty_is_dark():
+    classify, _, _LIVE, DARK, _DEG, _UNK = _probe()
+    assert classify("pgvector", constructable=True, configured_dimension=2048,
+                    probes=[_p(populated=False)]) == DARK
+
+
+def test_recommendation_tracks_verdict():
+    classify, recommend, LIVE, DARK, DEGRADED, _UNK = _probe()
+    assert "LIVE" in recommend(LIVE, "s3_vectors")
+    assert "DARK" in recommend(DARK, "s3_vectors")
+    # the s3 dark path names the actual fix + the fold-or-relight decision
+    s3_dark = recommend(DARK, "s3_vectors")
+    assert "workspace_id" in s3_dark and "P2-16" in s3_dark
+    assert "MISMATCH" in recommend(DEGRADED, "s3_vectors")
+    # pgvector dark points at ingestion, not the S3 env
+    assert "pgvector" in recommend(DARK, "pgvector")

--- a/orchestrator/tests/test_playbook_scheduler.py
+++ b/orchestrator/tests/test_playbook_scheduler.py
@@ -407,6 +407,55 @@ class TestFirePlaybook:
         # Should NOT create an execution
         mock_db.add.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_fire_playbook_breaker_open(self, mock_playbook):
+        """PRD-185 S4(c): with the repeated-failure breaker OPEN, a cron tick
+        creates no execution row and launches nothing — the daily-402 re-fire
+        spam stops until a manual run succeeds."""
+        svc = PlaybookSchedulerService()
+        svc._scheduler = MagicMock()
+
+        mock_db, db_module = _make_db_mock(first_result=mock_playbook)
+        mock_launch = MagicMock()
+
+        extra = {
+            "api.recipe_executor": MagicMock(launch_recipe_task=mock_launch),
+            # breaker reports OPEN — the scheduler must short-circuit before any
+            # execution row is created or the launch seam is touched
+            "services.playbook_breaker": MagicMock(
+                breaker_is_open=MagicMock(return_value=True)
+            ),
+        }
+
+        with patch.dict(sys.modules, _lazy_import_patches(db_module, extra)):
+            await svc._fire_playbook(mock_playbook.id, str(mock_playbook.workspace_id))
+
+        mock_db.add.assert_not_called()   # no execution-history noise while open
+        mock_launch.assert_not_called()   # broken playbook did not re-fire
+
+    @pytest.mark.asyncio
+    async def test_fire_playbook_breaker_closed_still_fires(self, mock_playbook):
+        """Breaker CLOSED (healthy playbook) -> cron fires normally. Guards
+        against the breaker gating every run."""
+        svc = PlaybookSchedulerService()
+        svc._scheduler = MagicMock()
+
+        mock_db, db_module = _make_db_mock(first_result=mock_playbook)
+        mock_launch = MagicMock()
+
+        extra = {
+            "api.recipe_executor": MagicMock(launch_recipe_task=mock_launch),
+            "services.playbook_breaker": MagicMock(
+                breaker_is_open=MagicMock(return_value=False)
+            ),
+        }
+
+        with patch.dict(sys.modules, _lazy_import_patches(db_module, extra)):
+            await svc._fire_playbook(mock_playbook.id, str(mock_playbook.workspace_id))
+
+        mock_db.add.assert_called_once()   # execution created
+        mock_launch.assert_called_once()   # and launched
+
 
 # ===========================================================================
 # Status


### PR DESCRIPTION
## What

Closes the **Phase-2 Wave-0 (PRD-185)** tail — the two stories left after #504–#509:

- **S4 · playbook repeated-failure circuit-breaker** (the piece #504 left open — it shipped the `playbook_failed` event, `failed` board status, and dispatch, but not the breaker).
- **S8 · read-only production document-vector probe** (the script deliverable; running it + the fix-or-fold decision are yours, per the PRD §S8 gate).

Wave-0 is **12/12 built** with this.

## S4 — circuit-breaker

A cron playbook that fails on every run re-fired forever (the 2026-06 daily OpenRouter-402 spam). Now, once the last **N** *terminal* runs are all `failed`, the cron scheduler stops re-firing it until a human intervenes.

- `services/playbook_breaker.py` — state is **derived** from `recipe_executions` (uses the existing `idx_recipe_executions_recipe_status` index), **not stored**: no new column, no migration. A manual run (which bypasses the breaker) that **succeeds** writes a `completed` row → breaks the streak → the breaker **auto-closes**. No reset to forget.
  - `is_breaker_open(statuses, threshold)` is a pure decision; `breaker_is_open(db, recipe_id)` is a thin wrapper that **fails closed** — a read error never blocks the scheduler.
- Gate lives in `playbook_scheduler._fire_playbook`, beside the existing concurrency guard and **before** the execution row is created — so an open breaker adds no history noise and stays stably open.
- `config.PLAYBOOK_BREAKER_THRESHOLD` (default **3**; `0` disables).

Manual runs are **not** gated (a human can always test a fix); success auto-resets. Failure alerts still fire on every real failure (#504) — the breaker only stops the endless re-fire. "Fails, alerts, stops."

## S8 — doc-vector probe

`scripts/probe_document_vectors.py` answers, **without mutating anything**:
1. Which backend does the committed config select? (`S3_VECTORS_ENABLED`)
2. Can that config **construct** the backend? (surfaces the F005 / missing-`{workspace_id}` failure that would leave the plane dark since W2)
3. Is the index **populated**, at what **dimension**? (read-only `get_index` / `list_vectors`, or a pgvector chunk count)

Prints a verdict (`live` / `dark` / `degraded` / `unknown`) + a relight-vs-fold recommendation. It **never** calls `initialize()`/`_ensure_setup()` (those create buckets/indexes) and does no re-embed. `classify_plane`/`recommend` are pure.

```
python -m scripts.probe_document_vectors            # workspaces with docs (up to --limit)
python -m scripts.probe_document_vectors --all --json
```

> ⚠️ **Your call (PRD §S8 gate, surfaced not deferred):** running it needs prod AWS + DB access, and the outcome — **relight** (fix env + re-embed) vs **fold into Wave-3 P2-16** (Qdrant consolidation) — is yours. This PR ships the evidence-gathering script only. Wave-1 P2-07 (RAG quality) is gated on that decision either way.

## Test plan (pure, no DB/network — CI is the gate)

- `test_p2w0_playbook_failure_visibility.py` — breaker decision, DB-boundary, fail-closed.
- `test_playbook_scheduler.py` — `_fire_playbook` **skips** when the breaker is open (no execution row, no launch) and **still fires** when closed; reuses the existing scheduler mock harness. Confirmed the pre-existing `_fire_playbook` tests stay green (the real breaker reads empty history → closed).
- `test_p2w0_s8_vector_probe.py` — the probe's live/dark/degraded/unknown verdicts + recommendation text.

## Notes

- No migration. No new routes (route-manifest untouched). No source-grep guard renames.
- Follows the platform conventions: stateless DB-first (à la PRD-162), config via `config.py`, no `os.getenv` outside config.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new safeguard that pauses automatic playbook reruns after repeated failures.
  * Added a diagnostic check for document-vector status that reports whether the system is healthy, degraded, dark, or unknown.

* **Bug Fixes**
  * Automatic playbook execution now stops when the failure threshold is reached, helping prevent repeated error loops.

* **Tests**
  * Added coverage for breaker behavior, scheduler short-circuiting, and document-vector verdict and recommendation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->