### PR TITLE
perf(rag): parallelize multi-query retrieval variations — cut the ~80-113s prep

### DIFF
--- a/orchestrator/modules/rag/service.py
+++ b/orchestrator/modules/rag/service.py
@@ -651,23 +651,36 @@ class RAGService:
         # Collect results from each query variation
         all_results = defaultdict(lambda: {"ranks": [], "doc": None})
         
-        for query in queries[:5]:  # Max 5 query variations
+        # Run the query variations CONCURRENTLY. Each variation is an
+        # independent embed + vector search, so the old serial await-loop made
+        # retrieval latency the SUM of all variations — the dominant cost in the
+        # ~80-113s context-prep times. asyncio.gather bounds it to the slowest
+        # single variation. RRF is order-independent (a sum of 1/(k+rank) per
+        # doc) and results are consumed in query order, so the fused output is
+        # byte-identical to the serial version.
+        import asyncio
+
+        async def _candidates_for(q: str) -> List[Dict]:
             try:
-                results = await self._get_candidates(
-                    query,
+                return await self._get_candidates(
+                    q,
                     limit=limit_per_query,
                     min_similarity=min_similarity,
-                    workspace_id=workspace_id
+                    workspace_id=workspace_id,
                 )
-                
-                for rank, doc in enumerate(results):
-                    doc_id = doc.get("id", doc.get("content", "")[:100])
-                    all_results[doc_id]["ranks"].append(rank)
-                    all_results[doc_id]["doc"] = doc
-                    
             except Exception as e:
                 logger.debug(f"Query variation failed: {e}")
-                continue
+                return []
+
+        per_query_results = await asyncio.gather(
+            *[_candidates_for(q) for q in queries[:5]]
+        )
+
+        for results in per_query_results:
+            for rank, doc in enumerate(results):
+                doc_id = doc.get("id", doc.get("content", "")[:100])
+                all_results[doc_id]["ranks"].append(rank)
+                all_results[doc_id]["doc"] = doc
         
         # Calculate RRF scores
         k = self.config.rrf_k  # Standard RRF constant (usually 60)

--- a/orchestrator/tests/test_rag_parallel_retrieval.py
+++ b/orchestrator/tests/test_rag_parallel_retrieval.py
@@ -1,0 +1,64 @@
+"""Multi-query RAG retrieval runs its query variations CONCURRENTLY
+(``asyncio.gather``) instead of a serial ``await`` loop.
+
+The serial loop made retrieval latency the SUM of all variations — the dominant
+cost in the ~80-113s context-prep times observed in prod (2026-07-09). RRF
+fusion must stay byte-identical: a sum of ``1/(k+rank)`` per doc, order-
+independent, results consumed in query order.
+
+Pure unit test — ``_get_candidates`` is mocked; no DB / network / embeddings.
+"""
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+
+def _svc():
+    try:
+        from modules.rag.service import RAGService
+    except Exception as e:  # env without the heavy service deps
+        pytest.skip(f"rag.service not importable in this env: {e}")
+    svc = RAGService.__new__(RAGService)  # bypass heavy __init__
+    svc.config = SimpleNamespace(rrf_k=60)
+    return svc
+
+
+def test_all_variations_queried_and_fused():
+    svc = _svc()
+    seen = []
+
+    async def fake_candidates(q, **kw):
+        seen.append(q)
+        # one doc unique to this query + one shared across all queries
+        return [{"id": f"only-{q}", "content": q}, {"id": "shared", "content": "s"}]
+
+    svc._get_candidates = fake_candidates
+
+    queries = ["q1", "q2", "q3"]
+    out = asyncio.run(svc._multi_query_retrieval_with_rrf(queries, workspace_id="ws"))
+
+    # every variation was queried (not just the first)
+    assert set(seen) == set(queries)
+    assert {d["id"] for d in out} == {"only-q1", "only-q2", "only-q3", "shared"}
+    # the doc present in all 3 variations fuses to the top with query_count=3
+    shared = next(d for d in out if d["id"] == "shared")
+    assert shared["query_count"] == 3
+    assert out[0]["id"] == "shared"
+
+
+def test_one_failing_variation_does_not_sink_the_rest():
+    svc = _svc()
+
+    async def fake_candidates(q, **kw):
+        if q == "boom":
+            raise RuntimeError("provider down")
+        return [{"id": f"doc-{q}", "content": q}]
+
+    svc._get_candidates = fake_candidates
+
+    out = asyncio.run(
+        svc._multi_query_retrieval_with_rrf(["good1", "boom", "good2"], workspace_id="ws")
+    )
+    # the two healthy variations still fuse; the failing one is skipped, not fatal
+    assert {d["id"] for d in out} == {"doc-good1", "doc-good2"}


### PR DESCRIPTION
## Summary
Runs RAG's (up to 5) query variations **concurrently** via `asyncio.gather` instead of a serial `await` loop in `_multi_query_retrieval_with_rrf`.

## Why
Each variation is an independent embed + vector round-trip. The serial loop made retrieval latency the **SUM** of all variations — the dominant cost in the ~80–113s `prep_time` seen in prod (2026-07-09). Concurrency bounds it to the **slowest single variation**.

## Safety
RRF fusion is **unchanged / byte-identical**: it sums `1/(k+rank)` per doc (order-independent), and `per_query_results` is consumed in query order. Per-variation failures still degrade to `[]` and are skipped, not fatal.

## Test plan
- [x] `test_rag_parallel_retrieval.py` — all variations queried + RRF fusion correct (shared doc tops, `query_count=3`); one failing variation doesn't sink the rest.
- [ ] CI green.
- [ ] Post-merge: prod trace to confirm `prep_time` drops. Remaining levers if needed: embedding-provider retries, cache the per-query S3 index check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multi-query retrieval now runs query variations in parallel for faster candidate gathering.
  * Retrieval is more resilient: if one query variation fails, the others can still return results.
* **Bug Fixes**
  * Improved result fusion so shared documents are consistently ranked appropriately across query variations.
* **Tests**
  * Added coverage for concurrent retrieval behavior, result merging, and partial failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->