### PR TITLE
perf(auto): stop the classifier running document-RAG — cut chat latency + tokens

### DIFF
--- a/orchestrator/modules/context/modes.py
+++ b/orchestrator/modules/context/modes.py
@@ -143,8 +143,14 @@ MODE_CONFIGS: dict[ContextMode, ModeConfig] = {
     # left open (documents + KG but never the field).
     ContextMode.PLANNING: ModeConfig(
         sections=[
-            "planning_knowledge", "planning_history",
-            "business_graph", "field_memory", "agent_roster",
+            # PERF (2026-07-09): the document-RAG section "planning_knowledge"
+            # was removed here. Running a multi-query document retrieval
+            # (~80-113s, ~3k tokens) on EVERY non-heuristic message just to
+            # classify its complexity was the dominant chat latency/cost drain.
+            # PRD-164 Q61 built one pack to inform routing; the doc-RAG leg was
+            # not worth its cost. Auto retrieves documents on demand via its
+            # search_knowledge / semantic_search tools in the response path.
+            "planning_history", "business_graph", "field_memory", "agent_roster",
         ],
         tool_loading="none",
         personality=False,

--- a/orchestrator/tests/test_prd164_planning_pack.py
+++ b/orchestrator/tests/test_prd164_planning_pack.py
@@ -254,13 +254,16 @@ class TestPlanningModeRegistered:
         for name in MODE_CONFIGS[ContextMode.PLANNING].sections:
             assert name in SECTION_REGISTRY, f"section '{name}' not registered"
 
-    def test_planning_sections_cover_the_four_sources(self):
-        # RAG-on-goal, mission memory, KG subgraph, roster+performance (PRD-164
-        # S1) + the workspace field digest (PRD-179 S1, F021 read-half — a
-        # completed mission's promoted distillation reaching the next plan).
+    def test_planning_sections_cover_the_cheap_routing_signals(self):
+        # PERF (2026-07-09): the document-RAG leg ("planning_knowledge",
+        # RAG-on-goal) was removed from the classifier's pack — a ~80-113s /
+        # ~3k-token document retrieval on every non-heuristic message just to
+        # classify was the dominant chat latency/cost drain. The pack now
+        # carries only cheap routing signals: mission memory, KG subgraph, the
+        # workspace field digest (PRD-179 S1), and roster+performance. Documents
+        # are retrieved on demand in the response path via Auto's tools.
         assert MODE_CONFIGS[ContextMode.PLANNING].sections == [
-            "planning_knowledge", "planning_history",
-            "business_graph", "field_memory", "agent_roster",
+            "planning_history", "business_graph", "field_memory", "agent_roster",
         ]
 
     def test_planning_budget_exists(self):


### PR DESCRIPTION
## The problem
AutoBrain Tier-3 classification (`_llm_classify`) builds the **full document-RAG planning pack** (`build_planning_context` → `planning_knowledge`, a multi-query retrieval over ~19k chunks) on **every non-heuristic message** *just to decide its complexity* — `prep_time=80-113s`, ~2,900 input tokens. The **response** then uses a *separate, fast* context (~1.3s) that doesn't include it, and Auto retrieves documents on demand via its `search_knowledge`/`semantic_search` tools. So the classification-time document research is built and **thrown away** — pure overhead, on every message. This is the dominant chat latency + token drain.

## The fix
Remove the `planning_knowledge` (document-RAG) section from `ContextMode.PLANNING` — the only mode the classifier uses. The pack keeps the cheap routing signals (`planning_history`, `business_graph`, `field_memory`, `agent_roster`); documents are retrieved on demand in the response path.

**Expected:** classification prep ~80-113s → ~1-2s, and ~3k fewer input tokens per non-heuristic message.

## Tradeoff (PRD-164 Q61)
The classifier no longer pre-sees document *content* — it routes from message intent + available capabilities, and Auto's tools do the actual retrieval. If routing on document questions regresses, the lever is a cheap intent signal, **not** restoring the 80s retrieval.

## Cleanup flagged
`PlanningKnowledgeSection` is now caller-less (still registered). Candidate for deletion in a follow-up — your call, not deferring unilaterally.

## Test plan
- [x] Updated the PRD-164 mode-list assertion; the registry test is unaffected (section stays registered).
- [ ] CI green.
- [ ] Post-merge: trace a doc-query — classification `prep_time` should be ~1-2s (was 80-113s); confirm Auto still retrieves docs via tools for real document questions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified the planning context setup by removing an extra knowledge section from the default planning signals.
  * Improved planning performance and reduced cost by relying on a smaller set of routing inputs.
  * Kept planning history first in the list for more consistent prioritization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->