### PR TITLE
perf(auto): decouple the classifier from the planner pack — the real hot-path fix

### DIFF
--- a/orchestrator/consumers/chatbot/auto.py
+++ b/orchestrator/consumers/chatbot/auto.py
@@ -34,9 +34,10 @@ from sqlalchemy.orm import Session
 
 logger = logging.getLogger(__name__)
 
-# PRD-164 S1 (Q61): Tier-3 classification consumes the one planning context
-# pack under a tight budget — the chat hot path can't afford the full 12k.
-_PLANNING_PACK_TOKENS = 2000
+# Tier-3 classification uses a cheap active-agent roster (not the planners'
+# full ContextService pack) — the chat hot path can't afford ~80-113s of
+# doc-RAG + graph BFS just to classify. Cap the roster so the prompt stays lean.
+_ROSTER_LIMIT = 40
 
 
 # ---------------------------------------------------------------------------
@@ -715,32 +716,47 @@ class AutoBrain:
     # ------------------------------------------------------------------
 
     async def _planning_context_block(self, message: str) -> str:
-        """The ONE platform planning pack (PRD-164 S1, Q61) for Tier 3.
+        """Cheap routing hint for Tier-3 classification: the active-agent roster.
 
-        Same assembler as MissionPlanner and board plan_task —
-        ``ContextService.build_planning_context`` — under a tight budget so
-        the hot chat path stays lean. Empty string on any failure: the
-        classifier must never break because context assembly did.
+        The classifier only needs to know which specialisations exist to
+        delegate to. It must NOT share the planners' full
+        ``ContextService.build_planning_context`` pack (doc-RAG + graph BFS +
+        agent-performance history): on the hot path (every non-heuristic
+        message) that ran ~80-113s to inform a decision the message intent
+        already drives. The real planners (MissionPlanner, board plan_task)
+        keep the rich pack; the hot-path classifier does not. Empty string on
+        any failure — the classifier must never break because of this.
         """
         try:
-            from modules.context.service import ContextService
+            from core.models.core import Agent
 
-            pack = await ContextService(self._db).build_planning_context(
-                goal=message,
-                workspace_id=self._workspace_id,
-                max_tokens=_PLANNING_PACK_TOKENS,
+            agents = (
+                self._db.query(Agent)
+                .filter(
+                    Agent.workspace_id == self._workspace_id,
+                    Agent.status == "active",
+                )
+                .limit(_ROSTER_LIMIT)
+                .all()
             )
-            if pack.is_empty:
+            if not agents:
                 return ""
+            lines = []
+            for a in agents:
+                name = getattr(a, "name", None) or getattr(a, "slug", None) or "agent"
+                role = getattr(a, "role", None)
+                desc = (getattr(a, "description", None) or "").strip()
+                label = f"{name} ({role})" if role else str(name)
+                summary = f": {desc[:80]}" if desc else ""
+                lines.append(f"- {label}{summary}")
             return (
-                f"\n## Platform context (for routing)\n{pack.content}\n\n"
-                "Factor this in: prior mission failures suggest which requests "
-                "need careful multi-step handling, and the roster shows which "
-                "specializations actually exist to delegate to.\n"
+                "\n## Available agents (for routing)\n"
+                + "\n".join(lines)
+                + "\n\nThe roster shows which specialisations exist to delegate to.\n"
             )
         except Exception:
             logger.debug(
-                "[AutoBrain] planning context pack unavailable — classifying without it",
+                "[AutoBrain] roster unavailable — classifying without it",
                 exc_info=True,
             )
             return ""

--- a/orchestrator/modules/context/modes.py
+++ b/orchestrator/modules/context/modes.py
@@ -143,14 +143,15 @@ MODE_CONFIGS: dict[ContextMode, ModeConfig] = {
     # left open (documents + KG but never the field).
     ContextMode.PLANNING: ModeConfig(
         sections=[
-            # PERF (2026-07-09): the document-RAG section "planning_knowledge"
-            # was removed here. Running a multi-query document retrieval
-            # (~80-113s, ~3k tokens) on EVERY non-heuristic message just to
-            # classify its complexity was the dominant chat latency/cost drain.
-            # PRD-164 Q61 built one pack to inform routing; the doc-RAG leg was
-            # not worth its cost. Auto retrieves documents on demand via its
-            # search_knowledge / semantic_search tools in the response path.
-            "planning_history", "business_graph", "field_memory", "agent_roster",
+            # The full planner pack. Consumed ONLY by the real planners now —
+            # MissionPlanner + board plan_task (they build execution plans and
+            # want doc grounding). The hot-path AutoBrain classifier no longer
+            # uses this pack (it takes a cheap roster instead), so its ~80-113s
+            # cost is off the per-message path. (Restored planning_knowledge that
+            # PR #517 had stripped from the shared pack, which had also removed
+            # the planners' doc grounding as an unintended side effect.)
+            "planning_knowledge", "planning_history",
+            "business_graph", "field_memory", "agent_roster",
         ],
         tool_loading="none",
         personality=False,

--- a/orchestrator/tests/test_prd164_planning_pack.py
+++ b/orchestrator/tests/test_prd164_planning_pack.py
@@ -1,17 +1,20 @@
-"""PRD-164 S1 — Planning Context Pack consumed by all three planners (Q61).
+"""PRD-164 S1 — Planning Context Pack consumed by the real planners (Q61).
 
 Proves the four S1 acceptance criteria with DB-free tests:
 
 1. GOLDEN (learning demo): a seeded prior-mission failure recalled on the
    PRD-159 path flows through the ONE pack into MissionPlanner's prompt and
    visibly changes the resulting plan (the failed approach is avoided).
-2. GREP GATE: all three planners — MissionPlanner, board ``plan_task``,
-   AutoBrain — call ``ContextService.build_planning_context``; exactly one
+2. GREP GATE: the real planners — MissionPlanner and board ``plan_task`` —
+   call ``ContextService.build_planning_context`` (the hot-path AutoBrain
+   classifier is decoupled: it takes a cheap active-agent roster); exactly one
    assembler definition exists; no planner assembles RAG/memory/KG context
    itself; the pack's RAG section retrieves through the PRD-157 choke point.
 3. BUDGET: the pack stays within its token budget on oversized fixtures
    (both the PRD-157-budgeter cap helper and the full assembler).
-4. Wiring smoke for the AutoBrain and board consumers.
+4. Wiring smoke: the board consumer threads the pack into its prompt; the
+   hot-path AutoBrain classifier threads a cheap active-agent roster instead
+   (it does not build the pack).
 """
 from __future__ import annotations
 
@@ -81,11 +84,12 @@ from modules.context.service import ContextService  # noqa: E402
 
 ORCH_ROOT = Path(__file__).resolve().parent.parent
 
-# The three planners Q61 converges (binding story list, PRD-164 S1).
+# The real planners Q61 converges (binding story list, PRD-164 S1). AutoBrain
+# was removed here: the hot-path classifier no longer shares this pack — it takes
+# a cheap active-agent roster (its ~80-113s/message cost is off the hot path).
 PLANNER_SOURCES: Dict[str, Path] = {
     "mission_planner": ORCH_ROOT / "modules" / "coordination" / "planner.py",
     "board_plan_task": ORCH_ROOT / "api" / "board_tasks.py",
-    "auto_brain": ORCH_ROOT / "consumers" / "chatbot" / "auto.py",
 }
 
 FAILURE_MARKER = "LinkedIn blocks automated scraping"
@@ -254,16 +258,15 @@ class TestPlanningModeRegistered:
         for name in MODE_CONFIGS[ContextMode.PLANNING].sections:
             assert name in SECTION_REGISTRY, f"section '{name}' not registered"
 
-    def test_planning_sections_cover_the_cheap_routing_signals(self):
-        # PERF (2026-07-09): the document-RAG leg ("planning_knowledge",
-        # RAG-on-goal) was removed from the classifier's pack — a ~80-113s /
-        # ~3k-token document retrieval on every non-heuristic message just to
-        # classify was the dominant chat latency/cost drain. The pack now
-        # carries only cheap routing signals: mission memory, KG subgraph, the
-        # workspace field digest (PRD-179 S1), and roster+performance. Documents
-        # are retrieved on demand in the response path via Auto's tools.
+    def test_planning_sections_cover_the_four_sources(self):
+        # RAG-on-goal, mission memory, KG subgraph, roster+performance (PRD-164
+        # S1) + the workspace field digest (PRD-179 S1). This is the full planner
+        # pack, now consumed only by the REAL planners (MissionPlanner + board
+        # plan_task); the hot-path AutoBrain classifier takes a cheap active-agent
+        # roster instead of building this pack (perf/classifier-cheap-roster).
         assert MODE_CONFIGS[ContextMode.PLANNING].sections == [
-            "planning_history", "business_graph", "field_memory", "agent_roster",
+            "planning_knowledge", "planning_history",
+            "business_graph", "field_memory", "agent_roster",
         ]
 
     def test_planning_budget_exists(self):
@@ -423,7 +426,7 @@ class TestGoldenLearningDemo:
 
 
 class TestOneAssemblerGrepGate:
-    def test_all_three_planners_call_the_one_assembler(self):
+    def test_the_real_planners_call_the_one_assembler(self):
         for name, path in PLANNER_SOURCES.items():
             src = path.read_text()
             assert "build_planning_context(" in src, (
@@ -501,12 +504,24 @@ def _marker_pack() -> PlanningContextPack:
     )
 
 
-class TestAutoBrainConsumesPack:
+class TestAutoBrainRosterHint:
+    """The hot-path classifier does NOT build the planner pack. It threads a
+    cheap active-agent roster into the Tier-3 prompt (its ~80-113s/message pack
+    cost is off the per-message path); pack failure must never break classify."""
+
     @pytest.mark.asyncio
-    async def test_tier3_classify_prompt_contains_pack(self):
+    async def test_tier3_classify_prompt_contains_roster(self):
         from consumers.chatbot.auto import AutoBrain
 
-        brain = AutoBrain(db=MagicMock(), workspace_id="ws-auto")
+        db = MagicMock()
+        fake_agents = [
+            SimpleNamespace(name="Lead Scout", role="researcher", description="finds leads"),
+            SimpleNamespace(name="Writer", role="copywriter", description=""),
+        ]
+        # _planning_context_block: db.query(Agent).filter(...).limit(...).all()
+        db.query.return_value.filter.return_value.limit.return_value.all.return_value = fake_agents
+
+        brain = AutoBrain(db=db, workspace_id="ws-auto")
         brain._redis = None
 
         captured: Dict[str, Any] = {}
@@ -520,22 +535,20 @@ class TestAutoBrainConsumesPack:
                     "needs_multi_agent": False, "reasoning": "test",
                 }))
 
-        with patch.object(
-            ContextService, "build_planning_context",
-            new=AsyncMock(return_value=_marker_pack()),
-        ), patch(
-            "core.llm.create_llm_manager", return_value=_ClassifierLLM()
-        ):
+        with patch("core.llm.create_llm_manager", return_value=_ClassifierLLM()):
             assessment = await brain._llm_classify("build me a lead list", 0)
 
-        assert "PACK_MARKER_CONTENT" in captured["prompt"]
+        assert "Available agents" in captured["prompt"]
+        assert "Lead Scout" in captured["prompt"]
         assert assessment.complexity.value == "molecule"
 
     @pytest.mark.asyncio
-    async def test_pack_failure_never_breaks_classification(self):
+    async def test_roster_failure_never_breaks_classification(self):
         from consumers.chatbot.auto import AutoBrain
 
-        brain = AutoBrain(db=MagicMock(), workspace_id="ws-auto")
+        db = MagicMock()
+        db.query.side_effect = RuntimeError("roster query exploded")
+        brain = AutoBrain(db=db, workspace_id="ws-auto")
         brain._redis = None
 
         class _ClassifierLLM:
@@ -546,12 +559,7 @@ class TestAutoBrainConsumesPack:
                     "needs_multi_agent": False, "reasoning": "test",
                 }))
 
-        with patch.object(
-            ContextService, "build_planning_context",
-            new=AsyncMock(side_effect=RuntimeError("pack exploded")),
-        ), patch(
-            "core.llm.create_llm_manager", return_value=_ClassifierLLM()
-        ):
+        with patch("core.llm.create_llm_manager", return_value=_ClassifierLLM()):
             assessment = await brain._llm_classify("hello there friend", 0)
 
         assert assessment is not None


### PR DESCRIPTION
## The real diagnosis (measured, not guessed)
The hot-path **AutoBrain classifier** shared the *planners'* `ContextService.build_planning_context` pack **just to decide message complexity**. That pack builds doc-RAG (7-query retrieval) **+** a 22k-node graph BFS **+** an agent-performance DB history map — **~80–113s and ~3k tokens on every non-heuristic message.**

**#517 removed only the doc-RAG leg. I measured the result: still .** The pack has *multiple co-dominant* expensive steps in parallel, so removing one never moves the wall-clock. The disease isn't which section is slow — it's that **the classifier builds the planner pack at all.**

## The fix
- **Classifier → cheap active-agent roster** (one bounded `Agent` query). It only needs to know which specialisations exist to delegate to; message intent drives complexity. This takes the whole ~80–113s pack build **off the per-message path**.
- **The real planners keep the rich pack** — `MissionPlanner` + board `plan_task` build execution plans and want doc grounding. `build_planning_context` is untouched for them.
- **Restore `planning_knowledge` to `ContextMode.PLANNING`** — #517 stripped it from the *shared* pack, which also removed the planners' doc grounding (unintended). With the classifier decoupled, that cost is off the hot path; planners (rare) keep grounding (parallelized by #516).

## Tests
- AutoBrain dropped from the Q61 `PLANNER_SOURCES` grep-gate (it's intentionally decoupled now).
- AutoBrain wiring smoke **rewritten**: asserts the **roster** (not the pack) reaches the Tier-3 prompt, and that a roster failure never breaks classification.
- Section-list assertion restored to the full 5-section planner pack.

## Verify after merge
Trace a real message: classification `prep_time` should drop from ~95s to **low single digits**, and Auto still retrieves documents on-demand (response path) + routes/delegates correctly from the roster. This is the one that should finally make Auto feel fast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)