### PR TITLE
fix(chat): inline code renders inline — stop every backtick becoming a CodeBlock card

### DIFF
--- a/frontend/components/__tests__/chat-markdown-inline-code.test.tsx
+++ b/frontend/components/__tests__/chat-markdown-inline-code.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * Chat markdown rendering — inline code must stay inline.
+ *
+ * react-markdown v9 removed the `inline` prop from the `code` renderer; the
+ * old chat components destructured it (always undefined), so EVERY backtick
+ * span — including single values inside table cells — rendered as the full
+ * CodeBlock card with a header and Copy button, shredding tables and prose.
+ *
+ * The fix routes fenced blocks through the `pre` renderer (which owns
+ * CodeBlock) and makes the `code` renderer inline-only. These tests pin that
+ * split: inline spans never grow a Copy button; fenced blocks (with or
+ * without a language tag) always do.
+ */
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+
+import { chatMarkdownComponents } from '@/components/chatbot/markdown-components'
+
+function renderMarkdown(md: string) {
+  return render(
+    <ReactMarkdown remarkPlugins={[remarkGfm]} components={chatMarkdownComponents}>
+      {md}
+    </ReactMarkdown>
+  )
+}
+
+describe('chat markdown inline vs block code', () => {
+  it('renders inline code as a plain styled span — no CodeBlock chrome', () => {
+    const { container } = renderMarkdown('Missing required param `run_id` on the call.')
+
+    const code = container.querySelector('code')
+    expect(code).not.toBeNull()
+    expect(code!.textContent).toBe('run_id')
+    // No CodeBlock card: no copy button, no pre wrapper
+    expect(screen.queryByTitle('Copy code')).toBeNull()
+    expect(container.querySelector('pre')).toBeNull()
+    // Inline code sits inside the paragraph, not adjacent to it
+    expect(code!.closest('p')).not.toBeNull()
+  })
+
+  it('renders a language-tagged fenced block via CodeBlock (header + copy)', () => {
+    renderMarkdown('```python\nprint("hello")\n```')
+
+    expect(screen.getByTitle('Copy code')).toBeInTheDocument()
+    expect(screen.getByText('Python')).toBeInTheDocument()
+  })
+
+  it('renders an untagged fenced block via CodeBlock too', () => {
+    renderMarkdown('```\nplain block\n```')
+
+    expect(screen.getByTitle('Copy code')).toBeInTheDocument()
+    expect(screen.getByText('plain block')).toBeInTheDocument()
+  })
+
+  it('keeps inline code inside table cells — tables do not explode into cards', () => {
+    const { container } = renderMarkdown(
+      '| Field | Value |\n|---|---|\n| Agent | `337` |\n| Cost | `4.205629` |'
+    )
+
+    const table = container.querySelector('table')
+    expect(table).not.toBeNull()
+    const cellCodes = table!.querySelectorAll('td code')
+    expect(cellCodes.length).toBe(2)
+    expect(cellCodes[0].textContent).toBe('337')
+    // No CodeBlock chrome anywhere in the table
+    expect(screen.queryByTitle('Copy code')).toBeNull()
+    expect(table!.querySelector('pre')).toBeNull()
+  })
+
+  it('renders inline and fenced code together with the right treatment each', () => {
+    const { container } = renderMarkdown(
+      'Check `status` first:\n\n```bash\necho ok\n```'
+    )
+
+    expect(screen.getByTitle('Copy code')).toBeInTheDocument()
+    expect(screen.getByText('Bash')).toBeInTheDocument()
+    const inline = container.querySelector('p code')
+    expect(inline).not.toBeNull()
+    expect(inline!.textContent).toBe('status')
+  })
+})

--- a/frontend/components/chatbot/markdown-components.tsx
+++ b/frontend/components/chatbot/markdown-components.tsx
@@ -1,0 +1,122 @@
+'use client'
+
+import type { ReactNode } from 'react'
+import { isValidElement } from 'react'
+import { CodeBlock } from './code-block'
+
+/**
+ * Shared ReactMarkdown component map for chat surfaces.
+ *
+ * react-markdown v9 removed the `inline` prop from the `code` renderer, so
+ * inline-vs-block must be split structurally instead: fenced blocks always
+ * arrive wrapped in a `pre` element, inline code never does. The `pre`
+ * renderer therefore owns block rendering (it reads the child code element's
+ * language + text and delegates to CodeBlock), and the `code` renderer only
+ * ever styles inline spans. Destructuring `inline` (always undefined in v9)
+ * was sending every single backtick — including table-cell values — through
+ * the full CodeBlock card with header and Copy button.
+ */
+
+interface CodeNodeProps {
+  className?: string
+  children?: ReactNode
+}
+
+/** Pull the code text + language off the `code` element nested in a `pre`. */
+function extractCodeChild(children: ReactNode): { code: string; language: string } | null {
+  const nodes = Array.isArray(children) ? children : [children]
+  const codeEl = nodes.find((c) => isValidElement<CodeNodeProps>(c))
+  if (!codeEl || !isValidElement<CodeNodeProps>(codeEl)) return null
+  const match = /language-(\w+)/.exec(codeEl.props.className || '')
+  const raw = codeEl.props.children
+  const code = String(Array.isArray(raw) ? raw.join('') : raw ?? '').replace(/\n$/, '')
+  return { code, language: match?.[1] || '' }
+}
+
+export const chatMarkdownComponents = {
+  p: ({ children }: any) => (
+    <p className="text-foreground leading-relaxed tracking-[0.01em] dark:text-gray-100">{children}</p>
+  ),
+  strong: ({ children }: any) => (
+    <strong className="text-foreground font-semibold dark:text-gray-100">{children}</strong>
+  ),
+  em: ({ children }: any) => <em className="text-muted-foreground italic dark:text-foreground/90">{children}</em>,
+  a: ({ href, children }: any) => (
+    <a
+      href={href}
+      target="_blank"
+      rel="noreferrer"
+      className="text-primary hover:text-primary/80 underline"
+    >
+      {children}
+    </a>
+  ),
+  ul: ({ children }: any) => (
+    <ul className="list-disc pl-5 space-y-1.5 text-foreground dark:text-gray-100">{children}</ul>
+  ),
+  ol: ({ children }: any) => (
+    <ol className="list-decimal pl-5 space-y-1.5 text-foreground dark:text-gray-100">{children}</ol>
+  ),
+  li: ({ children }: any) => (
+    <li className="text-foreground dark:text-gray-100 pl-1">{children}</li>
+  ),
+  // Inline code ONLY — block code never reaches this because `pre` below
+  // renders fenced blocks itself via CodeBlock.
+  code: ({ children }: any) => (
+    <code className="rounded bg-primary/10 px-1.5 py-0.5 text-[13px] font-mono text-primary border border-primary/10">
+      {children}
+    </code>
+  ),
+  pre: ({ children }: any) => {
+    const extracted = extractCodeChild(children)
+    if (!extracted) {
+      return <pre className="overflow-x-auto text-[13px]">{children}</pre>
+    }
+    return <CodeBlock code={extracted.code} language={extracted.language} />
+  },
+  blockquote: ({ children }: any) => (
+    <blockquote className="border-l-2 border-primary/40 pl-4 py-1 bg-primary/5 rounded-r-lg text-foreground/80 dark:text-foreground/90 italic">
+      {children}
+    </blockquote>
+  ),
+  h1: ({ children }: any) => (
+    <h1 className="text-lg font-semibold text-foreground dark:text-gray-100 pb-1 border-b border-border/30 mb-2">{children}</h1>
+  ),
+  h2: ({ children }: any) => (
+    <h2 className="text-base font-semibold text-foreground dark:text-gray-100 pb-1 border-b border-border/20 mb-2">{children}</h2>
+  ),
+  h3: ({ children }: any) => (
+    <h3 className="text-sm font-semibold text-foreground dark:text-gray-100 mb-1">{children}</h3>
+  ),
+  hr: () => (
+    <hr className="border-0 h-px bg-gradient-to-r from-transparent via-primary/30 to-transparent my-4" />
+  ),
+  table: ({ children }: any) => (
+    <div className="overflow-x-auto rounded-xl border border-border/60 bg-card/50 dark:border-gray-800/60 dark:bg-background/40">
+      <table className="min-w-full divide-y divide-border/60 text-sm text-foreground dark:divide-gray-800/70 dark:text-gray-100">
+        {children}
+      </table>
+    </div>
+  ),
+  thead: ({ children }: any) => (
+    <thead className="bg-secondary/40 text-xs uppercase tracking-wide text-muted-foreground dark:bg-background/60 dark:text-muted-foreground">
+      {children}
+    </thead>
+  ),
+  tbody: ({ children }: any) => (
+    <tbody className="divide-y divide-border/50 dark:divide-gray-800/70">{children}</tbody>
+  ),
+  tr: ({ children }: any) => (
+    <tr className="hover:bg-secondary/40 transition-colors dark:hover:bg-background/60">{children}</tr>
+  ),
+  th: ({ children }: any) => (
+    <th className="px-4 py-3 text-left font-semibold text-foreground/80 dark:text-foreground/90">
+      {children}
+    </th>
+  ),
+  td: ({ children }: any) => (
+    <td className="px-4 py-3 align-top text-foreground dark:text-gray-200">{children}</td>
+  ),
+  // Images handled by ImageGallery — strip from markdown
+  img: () => null,
+}

--- a/frontend/components/chatbot/message.tsx
+++ b/frontend/components/chatbot/message.tsx
@@ -7,7 +7,7 @@ import { Badge } from '@/components/ui/badge'
 import type { ChatMessage, Artifact, CodeSnippet, DocumentReference, DatabaseResult, ToolCall, UseChatHelpers } from '@/types'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
-import { CodeBlock } from './code-block'
+import { chatMarkdownComponents } from './markdown-components'
 import { ImageGallery, type ChatImage } from './image-gallery'
 import { MessageActions } from './message-actions'
 import { VoiceMessage } from '@/components/voice/VoiceMessage'
@@ -59,95 +59,6 @@ export function Message({
     return textParts?.join('\n') || message.content || ''
   }, [message.parts, message.content])
 
-  const markdownComponents = useMemo(() => ({
-    p: ({ children }: any) => (
-      <p className="text-foreground leading-relaxed tracking-[0.01em] dark:text-gray-100">{children}</p>
-    ),
-    strong: ({ children }: any) => (
-      <strong className="text-foreground font-semibold dark:text-gray-100">{children}</strong>
-    ),
-    em: ({ children }: any) => <em className="text-muted-foreground italic dark:text-foreground/90">{children}</em>,
-    a: ({ href, children }: any) => (
-      <a
-        href={href}
-        target="_blank"
-        rel="noreferrer"
-        className="text-primary hover:text-primary/80 underline"
-      >
-        {children}
-      </a>
-    ),
-    ul: ({ children }: any) => (
-      <ul className="list-disc pl-5 space-y-1.5 text-foreground dark:text-gray-100">{children}</ul>
-    ),
-    ol: ({ children }: any) => (
-      <ol className="list-decimal pl-5 space-y-1.5 text-foreground dark:text-gray-100">{children}</ol>
-    ),
-    li: ({ children }: any) => (
-      <li className="text-foreground dark:text-gray-100 pl-1">{children}</li>
-    ),
-    code: ({ inline, className, children }: any) => {
-      if (inline) {
-        return (
-          <code className="rounded bg-primary/10 px-1.5 py-0.5 text-[13px] font-mono text-primary border border-primary/10">
-            {children}
-          </code>
-        )
-      }
-      // Block code: extract language and delegate to CodeBlock
-      const match = /language-(\w+)/.exec(className || '')
-      const lang = match ? match[1] : ''
-      const code = String(children).replace(/\n$/, '')
-      return <CodeBlock code={code} language={lang} />
-    },
-    pre: ({ children }: any) => <>{children}</>,
-    blockquote: ({ children }: any) => (
-      <blockquote className="border-l-2 border-primary/40 pl-4 py-1 bg-primary/5 rounded-r-lg text-foreground/80 dark:text-foreground/90 italic">
-        {children}
-      </blockquote>
-    ),
-    h1: ({ children }: any) => (
-      <h1 className="text-lg font-semibold text-foreground dark:text-gray-100 pb-1 border-b border-border/30 mb-2">{children}</h1>
-    ),
-    h2: ({ children }: any) => (
-      <h2 className="text-base font-semibold text-foreground dark:text-gray-100 pb-1 border-b border-border/20 mb-2">{children}</h2>
-    ),
-    h3: ({ children }: any) => (
-      <h3 className="text-sm font-semibold text-foreground dark:text-gray-100 mb-1">{children}</h3>
-    ),
-    hr: () => (
-      <hr className="border-0 h-px bg-gradient-to-r from-transparent via-primary/30 to-transparent my-4" />
-    ),
-    table: ({ children }: any) => (
-      <div className="overflow-x-auto rounded-xl border border-border/60 bg-card/50 dark:border-gray-800/60 dark:bg-background/40">
-        <table className="min-w-full divide-y divide-border/60 text-sm text-foreground dark:divide-gray-800/70 dark:text-gray-100">
-          {children}
-        </table>
-      </div>
-    ),
-    thead: ({ children }: any) => (
-      <thead className="bg-secondary/40 text-xs uppercase tracking-wide text-muted-foreground dark:bg-background/60 dark:text-muted-foreground">
-        {children}
-      </thead>
-    ),
-    tbody: ({ children }: any) => (
-      <tbody className="divide-y divide-border/50 dark:divide-gray-800/70">{children}</tbody>
-    ),
-    tr: ({ children }: any) => (
-      <tr className="hover:bg-secondary/40 transition-colors dark:hover:bg-background/60">{children}</tr>
-    ),
-    th: ({ children }: any) => (
-      <th className="px-4 py-3 text-left font-semibold text-foreground/80 dark:text-foreground/90">
-        {children}
-      </th>
-    ),
-    td: ({ children }: any) => (
-      <td className="px-4 py-3 align-top text-foreground dark:text-gray-200">{children}</td>
-    ),
-    // Images handled by ImageGallery — strip from markdown
-    img: () => null,
-  }), [])
-
   const proseClass = "prose prose-sm md:prose-base max-w-none space-y-3 break-words [overflow-wrap:anywhere] dark:prose-invert prose-headings:text-foreground dark:prose-headings:text-gray-100 prose-p:text-foreground dark:prose-p:text-gray-100 prose-a:text-primary dark:prose-a:text-primary"
 
   const renderMarkdownWithImages = (text: string, keyPrefix = '') => {
@@ -159,7 +70,7 @@ export function Message({
             key={`${keyPrefix}md`}
             remarkPlugins={[remarkGfm]}
             className={proseClass}
-            components={markdownComponents}
+            components={chatMarkdownComponents}
           >
             {cleanText}
           </ReactMarkdown>

--- a/frontend/components/widgets/DocumentWidget/index.tsx
+++ b/frontend/components/widgets/DocumentWidget/index.tsx
@@ -149,27 +149,28 @@ export function DocumentWidget({
         {children}
       </a>
     ),
-    // Inline code
-    code: ({ inline, className, children, ...props }: any) => {
-      if (inline) {
+    // react-markdown v9 has no `inline` prop: inline code is any code node
+    // NOT wrapped in a pre, so the pre wrapper below re-styles its child and
+    // this renderer only ever handles inline spans.
+    code: ({ className, children, ...props }: any) => {
+      if (/language-/.test(className || '')) {
+        // Fenced block child (rendered inside the pre wrapper below)
         return (
-          <code className="rounded-md bg-[#343942] px-1.5 py-0.5 text-[13px] font-mono text-[#e6edf3]" {...props}>
+          <code className={cn("text-[13px] font-mono text-[#e6edf3]", className)} {...props}>
             {children}
           </code>
         )
       }
-      // Code blocks (inside pre)
-      const match = /language-(\w+)/.exec(className || '')
-      const lang = match?.[1] || ''
       return (
-        <code className={cn("text-[13px] font-mono text-[#e6edf3]", className)} {...props}>
+        <code className="rounded-md bg-[#343942] px-1.5 py-0.5 text-[13px] font-mono text-[#e6edf3]" {...props}>
           {children}
         </code>
       )
     },
-    // Code blocks wrapper
+    // Code blocks wrapper — normalizes the child so even untagged fenced
+    // blocks lose the inline pill styling.
     pre: ({ children }: any) => (
-      <pre className="rounded-md bg-[#161b22] border border-[#30363d] p-4 overflow-x-auto my-4">
+      <pre className="rounded-md bg-[#161b22] border border-[#30363d] p-4 overflow-x-auto my-4 [&_code]:rounded-none [&_code]:bg-transparent [&_code]:p-0 [&_code]:border-0">
         {children}
       </pre>
     ),


### PR DESCRIPTION
## What

Auto's chat window rendered **every inline code span** — `run_id`, agent ids, single numbers inside table cells — as the full CodeBlock card (header bar + Copy button). Tables containing backticked values exploded into vertical stacks of giant code tiles; the Internal Audit output was unreadable (see Gerard's screenshots from tonight).

**Root cause:** `react-markdown` v9 removed the `inline` prop that the `code` renderer in `message.tsx` (and `DocumentWidget`) destructured. `inline` was always `undefined`, the inline-pill branch was dead code, and every code node fell through to `<CodeBlock>`.

## Fix

The structural v9 split: fenced blocks always arrive wrapped in `pre`; inline code never does.

- `pre` now owns block rendering — it reads the child code element's language + text and delegates to `CodeBlock`. This also fixes untagged ``` fences, which a `language-*` className check would misclassify.
- `code` only ever styles inline spans (the original pill styling, resurrected).
- Chat's markdown component map is extracted to `markdown-components.tsx` (shared + testable); `message.tsx` consumes it, local copy deleted.
- `DocumentWidget` gets the same dead-prop fix with its own GitHub-style chrome preserved.

## Tests

`chat-markdown-inline-code.test.tsx` (vitest + testing-library) pins the contract:
- inline span → styled `<code>`, **no** Copy button, no `pre`
- tagged fenced block → CodeBlock (header label + Copy)
- **untagged** fenced block → CodeBlock too
- inline code inside GFM table cells stays in the cell — no CodeBlock chrome anywhere in the table
- mixed message renders both treatments correctly

## Verify in app

Ask Auto anything that returns a table with backticked values (e.g. the audit prompt) — cells should show small code pills inside an intact table, and only real fenced blocks should get the CODE/Copy card.