### PR TITLE
fix(chat): neutral inline-code pill — tone down the orange glow

### DIFF
--- a/frontend/components/chatbot/markdown-components.tsx
+++ b/frontend/components/chatbot/markdown-components.tsx
@@ -61,9 +61,11 @@ export const chatMarkdownComponents = {
     <li className="text-foreground dark:text-gray-100 pl-1">{children}</li>
   ),
   // Inline code ONLY — block code never reaches this because `pre` below
-  // renders fenced blocks itself via CodeBlock.
+  // renders fenced blocks itself via CodeBlock. Neutral tones on purpose:
+  // audit-style replies carry dozens of inline spans per message, and a
+  // brand-orange pill at that density floods the whole transcript.
   code: ({ children }: any) => (
-    <code className="rounded bg-primary/10 px-1.5 py-0.5 text-[13px] font-mono text-primary border border-primary/10">
+    <code className="rounded bg-secondary/60 px-1.5 py-0.5 text-[13px] font-mono text-foreground/90 border border-border/50 dark:bg-white/[0.06] dark:text-gray-200 dark:border-white/10">
       {children}
     </code>
   ),


### PR DESCRIPTION
Follow-up to #520. The resurrected inline-code pill styled spans as `text-primary` on `bg-primary/10` — correct structure, but at audit density (dozens of inline spans per reply, every table cell) the transcript floods brand-orange (see Gerard's screenshots).

Swaps the pill to neutral theme tokens: `bg-secondary/60 text-foreground/90 border-border/50` with explicit dark-mode variants, matching the muted chrome the tables already use. Fenced `CodeBlock` rendering untouched. Structural tests from #520 assert behavior, not classes — unchanged and still green.

Verify: re-open the audit reply — cells should read as quiet monospace pills, orange reserved for actual accents.