### PR TITLE
fix(evals): pass live document ids through the chunk→doc collapse

### DIFF
--- a/orchestrator/evals/retrieval_recall.py
+++ b/orchestrator/evals/retrieval_recall.py
@@ -334,12 +334,17 @@ OFFLINE_VARIANTS: Dict[str, RetrieverFactory] = {
 def documents_from_chunk_ranking(ranked_chunk_ids: List[str], chunk_to_doc: Dict[str, str]) -> List[str]:
     """Collapse a ranked chunk list to a ranked document list — first
     appearance of each document wins (the "did we land on the right doc" view
-    the gold-set labels)."""
+    the gold-set labels).
+
+    Ids absent from the map pass through unchanged: live mode ranks real
+    document ids the fixture chunk→doc map has never seen (the live
+    retrievers already return document ids). Empty ids are dropped.
+    """
     seen = set()
     docs: List[str] = []
     for cid in ranked_chunk_ids:
-        doc = chunk_to_doc.get(cid)
-        if doc is None or doc in seen:
+        doc = chunk_to_doc.get(cid, cid)
+        if not doc or doc in seen:
             continue
         seen.add(doc)
         docs.append(doc)
@@ -454,8 +459,9 @@ def build_live_variants(workspace_id: str) -> Dict[str, RetrieverFactory]:
                 result = asyncio.run(
                     service.retrieve(query, max_chunks=TOP_K * 4, workspace_id=workspace_id)
                 )
-                # Chunk ids double as ranking ids; map to documents downstream
-                # via the live gold corpus (document_id carried on the chunk).
+                # Document ids ARE the ranking ids here — the driver's
+                # chunk→doc collapse passes ids it can't map straight through
+                # (live ids never appear in the fixture map) and drops empties.
                 return [str(c.get("document_id", "")) for c in result.chunks]
 
             return retrieve

--- a/orchestrator/tests/test_p2w1_retrieval_recall.py
+++ b/orchestrator/tests/test_p2w1_retrieval_recall.py
@@ -88,8 +88,17 @@ def test_documents_from_chunk_ranking_first_appearance_wins():
         "docB",
         "docC",
     ]
-    # Unknown chunk ids are skipped, never crash.
-    assert documents_from_chunk_ranking(["nope", "c2"], chunk_to_doc) == ["docB"]
+    # Ids absent from the map pass through as document ids — live mode ranks
+    # real document ids the fixture map has never seen.
+    assert documents_from_chunk_ranking(["nope", "c2"], chunk_to_doc) == ["nope", "docB"]
+
+
+def test_documents_from_chunk_ranking_live_document_id_passthrough():
+    # Live retrievers return document ids directly (build_live_variants); with
+    # a fixture-only map every non-empty id must survive, deduped, in order —
+    # before the passthrough, live runs collapsed to zero recall.
+    live_ranked = ["doc-live-1", "", "doc-live-1", "doc-live-2"]
+    assert documents_from_chunk_ranking(live_ranked, {}) == ["doc-live-1", "doc-live-2"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

One-line contract fix in `evals/retrieval_recall.py`: `documents_from_chunk_ranking` now passes ids it cannot map straight through (`chunk_to_doc.get(cid, cid)`) and drops empties.

## Why

The `--live` lever grid (`build_live_variants`) returns **real document ids** from `RAGService.retrieve`, but the eval driver collapsed every ranking through the **fixture** chunk→doc map — live ids never appear there, so every one was silently dropped and a `--live` run would have scored **0 recall on all variants** before measuring anything. This was the known follow-up flagged when #522 shipped.

Offline behavior is unchanged for every id the map does know (fixture retrievers only rank corpus chunk ids).

## Changes

- `orchestrator/evals/retrieval_recall.py` — passthrough + empty-drop in `documents_from_chunk_ranking`; stale comment in the live retriever corrected.
- `orchestrator/tests/test_p2w1_retrieval_recall.py` — unknown-id assertion updated to the new contract + a live-shaped passthrough case.

## Test plan

- [x] Unit: `test_documents_from_chunk_ranking_first_appearance_wins` (updated) + `test_documents_from_chunk_ranking_live_document_id_passthrough` (new) — CI `orchestrator-tests` + `retrieval-recall-eval` lane are the gate
- [ ] First real `--live --workspace <id>` grid run against the chosen workspace (needs the live gold set — next step in the ladder)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retrieval result handling so unmapped document identifiers are preserved while empty identifiers are excluded.
  * Maintained deduplication and ranking order for repeated results.

* **Tests**
  * Added coverage for live retrieval scenarios, including repeated identifiers, unmapped identifiers, and empty results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->