### PR TITLE
fix(ci): green F056 test_extract_docstrings at root cause

### DIFF
--- a/orchestrator/modules/codegraph/parsers/treesitter_parser.py
+++ b/orchestrator/modules/codegraph/parsers/treesitter_parser.py
@@ -380,19 +380,27 @@ class TreeSitterParser:
     def _get_docstring(self, node, content_lines: List[str], lang_name: str) -> Optional[str]:
         """Extract docstring or doc comment for a symbol."""
         if lang_name == 'python':
-            # Python docstrings: first child expression_statement containing a string
+            # Python docstrings: first statement in block containing a string.
+            # Grammars with expression_statement as a hidden supertype put the
+            # string directly under the block; older ones wrap it.
             for child in node.children:
                 if child.type == 'block':
                     for block_child in child.children:
-                        if block_child.type == 'expression_statement':
+                        string_node = None
+                        if block_child.type == 'string':
+                            string_node = block_child
+                        elif block_child.type == 'expression_statement':
                             for expr_child in block_child.children:
                                 if expr_child.type == 'string':
-                                    text = expr_child.text.decode('utf-8')
-                                    # Strip triple quotes
-                                    for q in ('"""', "'''"):
-                                        if text.startswith(q) and text.endswith(q):
-                                            return text[3:-3].strip()
-                                    return text.strip('"\'').strip()
+                                    string_node = expr_child
+                                    break
+                        if string_node is not None:
+                            text = string_node.text.decode('utf-8')
+                            # Strip triple quotes
+                            for q in ('"""', "'''"):
+                                if text.startswith(q) and text.endswith(q):
+                                    return text[3:-3].strip()
+                            return text.strip('"\'').strip()
                         break  # Only check first statement in block
         else:
             # JSDoc / Javadoc: look for comment node immediately before


### PR DESCRIPTION
## Root cause

The non-required **Orchestrator module + integration tests (F056)** job has been red on main since the first push on 2026-07-09 (run 29007859572, 09:20 UTC), failing `modules/codegraph/tests/test_codegraph_service.py::TestSymbolExtraction::test_extract_docstrings` with `assert None is not None` — every parsed Python symbol came back with `docstring=None` while name/signature/snippet extracted fine.

**No repo commit caused it.** The last green main run (2026-07-06, #510 merge `649482aa3`) and the first red one (#513 merge `6d664ea26`) differ only by `api/chat.py` + a chat test. The real delta is CI's fresh `pip install`: **tree-sitter-language-pack 1.12.2 → 1.12.5** (requirements.txt pins `>=0.2.0`), visible in the two jobs' install logs.

Chain of causation:
- Since pack **1.12.3**, `get_parser()` returns a real `tree_sitter.Parser` built from `get_language(name)` instead of the pack's vendored parser class (their release notes).
- The pack pins tree-sitter-python at grammar rev `26855eab` — the commit **`feat!: mark expression_statement as a supertype`**. Supertypes are hidden in concrete trees, so a docstring is now a bare `string` node directly under `block`, with no `expression_statement` wrapper (confirmed via that rev's `node-types.json`: `expression_statement` has `subtypes`, and `block` children no longer list it).
- `TreeSitterParser._get_docstring()` asserted the old shape (`block → expression_statement → string`) and cleanly returned `None` on the new one. 1.12.2's vendored parser still produced the wrapped shape, which is why identical repo code was green on 07-06.

This poisons every PR's non-required lane by inheritance from main (seen on #522 and #523).

## Fix

`_get_docstring()` in `orchestrator/modules/codegraph/parsers/treesitter_parser.py` now accepts the docstring `string` node **both bare and wrapped** in an `expression_statement`, so extraction works on either grammar shape. Only-first-statement semantics and quote stripping are unchanged. This is the only `expression_statement` dependency in the orchestrator, and `test_extract_docstrings` was the job's sole failure (1 failed, 93 passed, 7 skipped) — so this single fix greens the lane.

Note: `tree-sitter-language-pack` remains unpinned (`>=0.2.0`), so CI tracks its latest release; the fix is shape-tolerant rather than version-dependent, but pinning is an available hardening call if wanted.

## Test plan

- The **Orchestrator module + integration tests (F056)** lane on this PR is the verification gate (no local runs).
- Expect `test_extract_docstrings` to pass and the job to go green (94 passed, 7 skipped).