### PR TITLE
feat(prd-191): agents-skills data repair — stop the ~5k-token duplicate-skill tax

### DIFF
--- a/orchestrator/alembic/versions/prd191_agent_skills_unique_and_priority.py
+++ b/orchestrator/alembic/versions/prd191_agent_skills_unique_and_priority.py
@@ -1,0 +1,71 @@
+"""PRD-191 S1+S4 — agent_skills: dedupe links, UNIQUE(agent_id, skill_id), real priority
+
+The junction table has been a bare two-column Table since inception — no PK,
+no unique — and the concurrency-unsafe seeders running on hot request paths
+(hybrid/chat/workspaces, multiple workers) duplicated links freely: prod's
+workspace Auto agent is linked to platform-management 4×, and SkillsSection
+renders every link, so the same ~26.5 KB body taxes every Auto turn twice
+(~5k duplicated tokens). The earlier dedupe migration
+(dedupe_skills_unique_workspace_name.py:52) claims an "implicit unique
+(agent_id, skill_id)" that never existed — its link-dedupe had nothing
+backing it.
+
+Order is load-bearing: dedupe FIRST (the live 4× links would fail the
+constraint), then constrain. The defensive re-dedupe is safe even where the
+earlier best-effort dedupe already ran (Gerard's-call box, option a).
+
+Also adds the per-attachment ``priority`` column (S4, closes F054): the
+uncapped-primary slot becomes a decision — mirroring AgentAssignedPlugin's
+real priority — instead of relationship-load order sorted by a phantom
+attribute.
+
+Revision ID: prd191_agent_skills_unique_and_priority
+Revises: prd187_s5_drop_memory_relics  (stacked — merge PRD-187's #525 first)
+Create Date: 2026-07-10
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "prd191_agent_skills_unique_and_priority"
+down_revision = "prd187_s5_drop_memory_relics"
+branch_labels = None
+depends_on = None
+
+
+def survivors(rows):
+    """PURE dedupe policy: given (row_id, agent_id, skill_id) tuples, return
+    the row_ids to KEEP — exactly one per (agent_id, skill_id) pair, the
+    lowest row_id winning. (The SQL below is this function's ctid mirror.)"""
+    keep = {}
+    for row_id, agent_id, skill_id in sorted(rows):
+        keep.setdefault((agent_id, skill_id), row_id)
+    return sorted(keep.values())
+
+
+def upgrade() -> None:
+    # 1. Collapse duplicate links — lowest physical row survives (same
+    #    conflict-safe shape as dedupe_skills_unique_workspace_name's dedupe).
+    op.execute(
+        """
+        DELETE FROM agent_skills a
+        USING agent_skills b
+        WHERE a.agent_id = b.agent_id
+          AND a.skill_id = b.skill_id
+          AND a.ctid > b.ctid
+        """
+    )
+    # 2. The attachment-level priority (S4) — default 0, NOT NULL.
+    op.add_column(
+        "agent_skills",
+        sa.Column("priority", sa.Integer(), nullable=False, server_default="0"),
+    )
+    # 3. Now the identity guarantee the seeders' ON CONFLICT targets (S1).
+    op.create_unique_constraint(
+        "uq_agent_skills_agent_id_skill_id", "agent_skills", ["agent_id", "skill_id"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("uq_agent_skills_agent_id_skill_id", "agent_skills", type_="unique")
+    op.drop_column("agent_skills", "priority")
+    # The deleted duplicate links are not recreated — they were corruption.

--- a/orchestrator/api/agents.py
+++ b/orchestrator/api/agents.py
@@ -79,6 +79,28 @@ def _stable_tool_id(name: str) -> int:
     return -abs(int(h))
 
 
+def _fetch_attachable_skills(db: Session, skill_ids: List[int], ctx: RequestContext) -> List["Skill"]:
+    """Resolve skill ids to rows the caller may attach (PRD-191 S5, Sec §3.2.a).
+
+    Visibility parity with api/skills.py: global (workspace_id IS NULL) or
+    own-workspace skills only — a foreign workspace's private skill is
+    reported exactly like a nonexistent id, never silently attached (and thus
+    never prompt-injected into the caller's agent).
+    """
+    from api.skills import _skill_visible_to
+
+    rows = db.query(Skill).filter(
+        Skill.id.in_(skill_ids),
+        Skill.is_active == True  # noqa: E712
+    ).all()
+    visible = [sk for sk in rows if _skill_visible_to(sk, ctx)]
+    if len(visible) != len(skill_ids):
+        found_ids = {sk.id for sk in visible}
+        missing_ids = [sid for sid in skill_ids if sid not in found_ids]
+        raise HTTPException(status_code=404, detail=f"Skills not found: {missing_ids}")
+    return visible
+
+
 def _assigned_by_user_id(ctx: RequestContext) -> Optional[int]:
     """
     `agent_app_assignments.assigned_by` is an INTEGER in Postgres.
@@ -362,16 +384,9 @@ async def create_agents_bulk(agents: List[AgentCreate], ctx: RequestContext = De
             db.add(agent)
             db.flush()  # Get the ID
 
-            # Add skills if provided
+            # Add skills if provided (PRD-191 S5: visibility-gated)
             if agent_data.skill_ids:
-                skills = db.query(Skill).filter(
-                    Skill.id.in_(agent_data.skill_ids),
-                    Skill.is_active == True
-                ).all()
-                if len(skills) != len(agent_data.skill_ids):
-                    found_ids = [skill.id for skill in skills]
-                    missing_ids = [sid for sid in agent_data.skill_ids if sid not in found_ids]
-                    raise HTTPException(status_code=404, detail=f"Skills not found: {missing_ids}")
+                skills = _fetch_attachable_skills(db, agent_data.skill_ids, ctx)
                 agent.skills.extend(skills)
             
             # Note: agent.tags is the single source of truth for tags.
@@ -432,16 +447,9 @@ async def create_agent(agent_data: AgentCreate, ctx: RequestContext = Depends(ge
         db.add(agent)
         db.flush()  # Get the ID
         
-        # Add skills if provided
+        # Add skills if provided (PRD-191 S5: visibility-gated)
         if agent_data.skill_ids:
-            skills = db.query(Skill).filter(
-                Skill.id.in_(agent_data.skill_ids),
-                Skill.is_active == True
-            ).all()
-            if len(skills) != len(agent_data.skill_ids):
-                found_ids = [skill.id for skill in skills]
-                missing_ids = [sid for sid in agent_data.skill_ids if sid not in found_ids]
-                raise HTTPException(status_code=404, detail=f"Skills not found: {missing_ids}")
+            skills = _fetch_attachable_skills(db, agent_data.skill_ids, ctx)
             agent.skills.extend(skills)
 
         # Note: agent.tags is the single source of truth for tags.
@@ -782,12 +790,7 @@ async def add_agent_skills(agent_id: int, skill_ids: List[int], ctx: RequestCont
         if not agent:
             raise HTTPException(status_code=404, detail="Agent not found")
         
-        skills = db.query(Skill).filter(Skill.id.in_(skill_ids), Skill.is_active == True).all()
-        if len(skills) != len(skill_ids):
-            found_ids = [skill.id for skill in skills]
-            missing_ids = [sid for sid in skill_ids if sid not in found_ids]
-            raise HTTPException(status_code=404, detail=f"Skills not found: {missing_ids}")
-        
+        skills = _fetch_attachable_skills(db, skill_ids, ctx)  # PRD-191 S5
         agent.skills.extend(skills)
         db.commit()
 

--- a/orchestrator/core/models/core.py
+++ b/orchestrator/core/models/core.py
@@ -26,9 +26,13 @@ class PriorityLevel(str, Enum):
     LOW = "low"
 
 # Association tables for many-to-many relationships
+# PRD-191 S1/S4: one link per (agent, skill) — enforced, not implied — and a
+# real per-attachment priority (the uncapped-primary slot is a decision, F054).
 agent_skills = Table('agent_skills', Base.metadata,
     Column('agent_id', Integer, ForeignKey('agents.id')),
-    Column('skill_id', Integer, ForeignKey('skills.id'))
+    Column('skill_id', Integer, ForeignKey('skills.id')),
+    Column('priority', Integer, nullable=False, server_default='0'),
+    UniqueConstraint('agent_id', 'skill_id', name='uq_agent_skills_agent_id_skill_id'),
 )
 
 workflow_agents = Table('workflow_agents', Base.metadata,
@@ -289,7 +293,12 @@ class Agent(Base):
     })  # Model usage tracking
     
     # Relationships
-    skills = relationship("Skill", secondary=agent_skills, back_populates="agents")
+    # PRD-191 S4: ordered by the attachment-level priority so the first skill
+    # is the real primary (highest priority wins; stable within equal priority).
+    skills = relationship(
+        "Skill", secondary=agent_skills, back_populates="agents",
+        order_by=agent_skills.c.priority.desc(),
+    )
     workflows = relationship("Workflow", secondary=workflow_agents, back_populates="agents")
     executions = relationship("WorkflowExecution", back_populates="agent")
     # Tool/app assignments are managed via `AgentAppAssignment` (Composio cache model).

--- a/orchestrator/core/seeds/seed_auto_agent.py
+++ b/orchestrator/core/seeds/seed_auto_agent.py
@@ -87,64 +87,89 @@ def _upsert_platform_management_skill(db: Session) -> Skill | None:
     """
     import hashlib
 
+    from sqlalchemy import text as _sql_text
+    from sqlalchemy.exc import IntegrityError
+
+    # PRD-191 S3: serialize concurrent seeders (hybrid/chat/workspaces run this
+    # on hot paths across workers). The xact-scoped advisory lock releases with
+    # the surrounding transaction; the IntegrityError fallback covers the race
+    # against the live UNIQUE(name) WHERE workspace_id IS NULL index.
     try:
-        skill = db.query(Skill).filter(
+        db.execute(_sql_text(
+            "SELECT pg_advisory_xact_lock(hashtext('seed:platform-management'))"
+        ))
+    except Exception:
+        logger.warning("Advisory lock unavailable — continuing unserialized", exc_info=True)
+
+    skill = db.query(Skill).filter(
+        Skill.name == "platform-management",
+        Skill.skill_source == "builtin-core",
+    ).first()
+
+    if skill:
+        logger.info("Platform-management skill exists (id=%s), skipping seed", skill.id)
+        return skill
+
+    if not _PLATFORM_SKILL_PATH.exists():
+        logger.warning("Platform-management SKILL.md not found at %s", _PLATFORM_SKILL_PATH)
+        return None
+
+    raw = _PLATFORM_SKILL_PATH.read_text(encoding="utf-8").strip()
+
+    # Split YAML frontmatter from markdown body
+    if raw.startswith("---"):
+        parts = raw.split("---", 2)
+        markdown_body = parts[2].strip() if len(parts) > 2 else raw
+    else:
+        markdown_body = raw
+
+    content_hash = hashlib.sha256(markdown_body.encode("utf-8")).hexdigest()
+
+    skill = Skill(
+        name="platform-management",
+        description="Complete platform operations — marketplace, agents, playbooks, heartbeats, board, governance, LLMs, workspace setup",
+        skill_type="technical",
+        category="agent-role",
+        skill_version="1.0.0",
+        skill_source="builtin-core",
+        prompt_template=markdown_body,
+        content_hash=content_hash,
+        tags=["platform", "admin", "marketplace", "agents", "playbooks", "governance"],
+        is_active=True,
+        workspace_id=None,  # global skill
+    )
+    db.add(skill)
+    try:
+        db.flush()
+    except IntegrityError:
+        # Another worker won the insert race despite the lock (or the lock
+        # was unavailable): the row exists — re-select and return it. Never
+        # swallow this into a silent no-seed (the Wave-0 lesson).
+        db.expunge(skill)
+        existing = db.query(Skill).filter(
             Skill.name == "platform-management",
             Skill.skill_source == "builtin-core",
         ).first()
-
-        if skill:
-            logger.info("Platform-management skill exists (id=%s), skipping seed", skill.id)
-            return skill
-
-        if not _PLATFORM_SKILL_PATH.exists():
-            logger.warning("Platform-management SKILL.md not found at %s", _PLATFORM_SKILL_PATH)
-            return None
-
-        raw = _PLATFORM_SKILL_PATH.read_text(encoding="utf-8").strip()
-
-        # Split YAML frontmatter from markdown body
-        if raw.startswith("---"):
-            parts = raw.split("---", 2)
-            markdown_body = parts[2].strip() if len(parts) > 2 else raw
-        else:
-            markdown_body = raw
-
-        content_hash = hashlib.sha256(markdown_body.encode("utf-8")).hexdigest()
-
-        skill = Skill(
-            name="platform-management",
-            description="Complete platform operations — marketplace, agents, playbooks, heartbeats, board, governance, LLMs, workspace setup",
-            skill_type="technical",
-            category="agent-role",
-            skill_version="1.0.0",
-            skill_source="builtin-core",
-            prompt_template=markdown_body,
-            content_hash=content_hash,
-            tags=["platform", "admin", "marketplace", "agents", "playbooks", "governance"],
-            is_active=True,
-            workspace_id=None,  # global skill
-        )
-        db.add(skill)
-        db.flush()
-        logger.info("Platform-management skill created (id=%s)", skill.id)
-        return skill
-    except Exception:
-        logger.exception("Failed to seed platform-management skill")
-        return None
+        logger.info("Platform-management skill seeded by a concurrent worker (id=%s)",
+                    getattr(existing, "id", None))
+        return existing
+    logger.info("Platform-management skill created (id=%s)", skill.id)
+    return skill
 
 
 def _assign_skill_to_agent(db: Session, agent: Agent, skill: Skill) -> None:
-    """Idempotent: link agent ↔ skill via agent_skills join table."""
-    exists = db.execute(
-        agent_skills.select().where(
-            agent_skills.c.agent_id == agent.id,
-            agent_skills.c.skill_id == skill.id,
-        )
-    ).first()
-    if not exists:
-        db.execute(agent_skills.insert().values(agent_id=agent.id, skill_id=skill.id))
-        logger.info("Assigned skill '%s' to agent '%s'", skill.name, agent.name)
+    """Idempotent under concurrency: ON CONFLICT (agent_id, skill_id) DO
+    NOTHING, backed by PRD-191 S1's unique constraint — the SELECT-then-INSERT
+    race that quadruplicated Auto's platform-management link is closed."""
+    from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+    stmt = (
+        pg_insert(agent_skills)
+        .values(agent_id=agent.id, skill_id=skill.id)
+        .on_conflict_do_nothing(index_elements=["agent_id", "skill_id"])
+    )
+    db.execute(stmt)
+    logger.info("Ensured skill '%s' is assigned to agent '%s'", skill.name, agent.name)
 
 
 def seed_auto_agent(db: Session, workspace_id: UUID) -> Agent:

--- a/orchestrator/modules/context/sections/skills.py
+++ b/orchestrator/modules/context/sections/skills.py
@@ -60,12 +60,27 @@ class SkillsSection(BaseSection):
         if not active_skills:
             return ""
 
-        # Sort by skill priority (highest first); the first becomes the primary.
-        active_skills = sorted(
-            active_skills,
-            key=lambda s: getattr(s, "priority", 0) or 0,
-            reverse=True,
-        )
+        # PRD-191 S4 (closes F054): Agent.skills arrives ordered by the REAL
+        # attachment-level priority (agent_skills.priority DESC — model
+        # order_by). The old sort keyed on a phantom Skill.priority attribute
+        # that no column backed, so the uncapped-primary slot was load order.
+        # PRD-191 S2: never render the same body twice — dedup by id, then by
+        # (name, content_hash), keeping the first (= highest-priority) instance.
+        seen_ids = set()
+        seen_bodies = set()
+        deduped = []
+        for s in active_skills:
+            sid = getattr(s, "id", None)
+            body_key = (getattr(s, "name", None), getattr(s, "content_hash", None))
+            if sid is not None and sid in seen_ids:
+                continue
+            if body_key != (None, None) and body_key in seen_bodies:
+                continue
+            if sid is not None:
+                seen_ids.add(sid)
+            seen_bodies.add(body_key)
+            deduped.append(s)
+        active_skills = deduped
 
         primary_text = self._get_skill_content(active_skills[0], ctx)
         aux_texts = [

--- a/orchestrator/tests/test_p2w1_agent_skills_repair.py
+++ b/orchestrator/tests/test_p2w1_agent_skills_repair.py
@@ -1,0 +1,292 @@
+"""PRD-191 — agents-skills data repair (P2-10): stop paying the duplicate-skill tax.
+
+Prod state this wave repairs: 205 duplicated active skill names, the global
+platform-management skill seeded 5×, the workspace Auto agent linked to it
+4× — and SkillsSection rendering every link, taxing every Auto turn with
+~5k duplicated tokens. Pins:
+
+1. S1 — the migration's dedupe policy keeps exactly one link per
+   (agent_id, skill_id), lowest row wins; the model now CARRIES the unique
+   constraint (schema-shape assert, no DB).
+2. S4 — priority is REAL: a column on the attachment, and Agent.skills is
+   ordered by it at the relationship level (F054 closed with a decision).
+3. S2 — SkillsSection never renders the same body twice: dedup by id and by
+   (name, content_hash), first (= highest-priority) instance wins.
+4. S3 — the seeders are idempotent under concurrency: a lost insert race
+   re-selects and returns the existing row (never a silent no-seed), and the
+   link assign emits ON CONFLICT (agent_id, skill_id) DO NOTHING.
+5. S5 — a foreign workspace's private skill cannot be attached by id on the
+   canonical agents router (visibility parity with api/skills.py).
+
+All pure — mocked sessions / in-memory fixtures; no DB, no network.
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import pathlib
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+for _k, _v in {
+    "POSTGRES_USER": "test", "POSTGRES_PASSWORD": "test",
+    "POSTGRES_HOST": "localhost", "POSTGRES_PORT": "5432", "POSTGRES_DB": "test",
+}.items():
+    os.environ.setdefault(_k, _v)
+
+_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+
+# ---------------------------------------------------------------------------
+# 1. S1 — migration dedupe policy + schema shape
+# ---------------------------------------------------------------------------
+
+def _load_migration():
+    spec = importlib.util.spec_from_file_location(
+        "prd191_migration",
+        _ROOT / "alembic" / "versions" / "prd191_agent_skills_unique_and_priority.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_agent_skills_dedupe_keeps_one_link_per_pair():
+    mig = _load_migration()
+    # Mirrors prod: Auto agent 340 → platform-management (skill 7) linked 4×.
+    rows = [
+        (1, 340, 7), (2, 340, 7), (3, 340, 7), (4, 340, 7),
+        (5, 340, 9),
+        (6, 341, 7),
+    ]
+    assert mig.survivors(rows) == [1, 5, 6]
+
+
+def test_agent_skills_dedupe_chains_off_prd187_head():
+    src = (
+        _ROOT / "alembic" / "versions" / "prd191_agent_skills_unique_and_priority.py"
+    ).read_text()
+    assert 'down_revision = "prd187_s5_drop_memory_relics"' in src, (
+        "must chain onto the mainline head — a floating down_revision=None is "
+        "exactly what left the earlier skills dedupe a loose fixup"
+    )
+    # dedupe THEN constrain — the order is load-bearing on live 4× links
+    assert src.index("DELETE FROM agent_skills") < src.index("create_unique_constraint")
+
+
+def test_agent_skills_model_has_unique_and_priority():
+    from core.models.core import agent_skills
+
+    uniques = [
+        c for c in agent_skills.constraints
+        if type(c).__name__ == "UniqueConstraint"
+    ]
+    assert any(
+        [col.name for col in c.columns] == ["agent_id", "skill_id"] for c in uniques
+    ), "agent_skills must carry UNIQUE(agent_id, skill_id)"
+    assert "priority" in agent_skills.c, "the attachment-level priority column is real now"
+
+
+def test_agent_skills_relationship_ordered_by_priority():
+    from core.models.core import Agent
+
+    order_by = Agent.skills.property.order_by
+    assert order_by, "Agent.skills must be ordered (the primary slot is a decision)"
+    assert "priority" in str(order_by[0]), (
+        "Agent.skills order_by must read agent_skills.priority — not load order"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. S2 + S4 — SkillsSection dedup + real ordering (isolated module load,
+#    same fake-graph technique as tests/test_skills_section.py)
+# ---------------------------------------------------------------------------
+
+_estimator_stub = types.ModuleType("modules.context.estimator")
+_estimator_stub.estimate_tokens = lambda text: max(1, len(text) // 4)
+
+
+def _load_skills_section():
+    keys = (
+        "modules", "modules.context", "modules.context.estimator",
+        "modules.context.sections", "modules.context.sections.base",
+    )
+    saved = {k: sys.modules.get(k) for k in keys}
+    try:
+        for name in ("modules", "modules.context", "modules.context.sections"):
+            pkg = types.ModuleType(name)
+            pkg.__path__ = []
+            sys.modules[name] = pkg
+        sys.modules["modules.context.estimator"] = _estimator_stub
+        base = importlib.util.module_from_spec(importlib.util.spec_from_file_location(
+            "modules.context.sections.base", _ROOT / "modules/context/sections/base.py"))
+        sys.modules["modules.context.sections.base"] = base
+        base.__spec__.loader.exec_module(base)
+        skills = importlib.util.module_from_spec(importlib.util.spec_from_file_location(
+            "skills_section_under_test", _ROOT / "modules/context/sections/skills.py"))
+        skills.__spec__.loader.exec_module(skills)
+        return skills
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                sys.modules.pop(k, None)
+            else:
+                sys.modules[k] = v
+
+
+def _skill(sid, name, content, content_hash=None):
+    s = MagicMock()
+    s.id = sid
+    s.name = name
+    s.prompt_template = content
+    s.is_active = True
+    s.tools_schema = None
+    s.content_hash = content_hash or f"hash-{sid}"
+    return s
+
+
+def _render(skills_list):
+    mod = _load_skills_section()
+    section = mod.SkillsSection()
+    ctx = MagicMock()
+    ctx.agent = MagicMock()
+    ctx.agent.skills = skills_list
+    ctx.kwargs = {}
+    return section._build(ctx)
+
+
+def test_skills_section_dedupes_by_id():
+    same = _skill(7, "platform-management", "PLATFORM BODY " * 50)
+    out = _render([same, same])
+    assert out.count("PLATFORM BODY") == 50, (
+        "the same skill row attached twice must render once"
+    )
+
+
+def test_skills_section_dedupes_identical_bodies():
+    body = "SHARED 26KB BODY " * 30
+    builtin = _skill(7, "platform-management", body, content_hash="same-hash")
+    dupe_row = _skill(99, "platform-management", body, content_hash="same-hash")
+    out = _render([builtin, dupe_row])
+    # one render only — the aux budget is not consumed by the duplicate
+    assert out.count("SHARED 26KB BODY") == 30
+
+
+def test_skills_section_first_skill_is_primary_by_arrival_order():
+    # Agent.skills arrives pre-ordered by attachment priority (model order_by);
+    # the section must respect that order — first in, uncapped primary.
+    hi = _skill(1, "hi-priority", "HI-BODY unique-hi")
+    lo = _skill(2, "lo-priority", "LO-BODY unique-lo")
+    out = _render([hi, lo])
+    assert out.index("HI-BODY") < out.index("LO-BODY")
+    flipped = _render([lo, hi])
+    assert flipped.index("LO-BODY") < flipped.index("HI-BODY")
+
+
+def test_skills_section_phantom_priority_sort_is_gone():
+    src = (_ROOT / "modules/context/sections/skills.py").read_text()
+    assert 'getattr(s, "priority", 0)' not in src, (
+        "the phantom Skill.priority sort must not survive (F054)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. S3 — seeder idempotency under the race
+# ---------------------------------------------------------------------------
+
+def test_platform_skill_upsert_reselects_when_race_lost(monkeypatch):
+    from sqlalchemy.exc import IntegrityError
+
+    import core.seeds.seed_auto_agent as seed_mod
+
+    existing = MagicMock(id=42)
+    db = MagicMock()
+    # first .first() → None (row not there yet); second → the winner's row
+    db.query.return_value.filter.return_value.first.side_effect = [None, existing]
+    db.flush.side_effect = IntegrityError("stmt", {}, Exception("duplicate key"))
+    monkeypatch.setattr(seed_mod, "_PLATFORM_SKILL_PATH", MagicMock(
+        exists=lambda: True,
+        read_text=lambda encoding: "---\nname: platform-management\n---\nBODY",
+    ))
+
+    result = seed_mod._upsert_platform_management_skill(db)
+
+    assert result is existing, (
+        "a lost insert race must re-select and return the existing row — "
+        "never swallow the IntegrityError into a silent no-seed"
+    )
+
+
+def test_assign_skill_uses_on_conflict():
+    from sqlalchemy.dialects import postgresql
+
+    import core.seeds.seed_auto_agent as seed_mod
+
+    db = MagicMock()
+    agent = MagicMock(id=340, name="Auto")
+    skill = MagicMock(id=7, name="platform-management")
+
+    seed_mod._assign_skill_to_agent(db, agent, skill)
+
+    stmt = db.execute.call_args.args[0]
+    sql = str(stmt.compile(dialect=postgresql.dialect()))
+    assert "ON CONFLICT (agent_id, skill_id) DO NOTHING" in sql, (
+        "the link insert must be conflict-safe on S1's unique constraint"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4. S5 — attach-visibility parity on the canonical router
+# ---------------------------------------------------------------------------
+
+def _visibility_fixture(monkeypatch):
+    from fastapi import HTTPException
+
+    import api.agents as agents_mod
+    import api.skills as skills_mod
+
+    monkeypatch.setattr(skills_mod, "_is_super_admin", lambda ctx: False)
+    return agents_mod, HTTPException
+
+
+def _skill_row(sid, workspace_id):
+    row = MagicMock()
+    row.id = sid
+    row.workspace_id = workspace_id
+    return row
+
+
+def test_attach_rejects_foreign_workspace_skill(monkeypatch):
+    agents_mod, HTTPException = _visibility_fixture(monkeypatch)
+
+    ctx = MagicMock()
+    ctx.workspace_id = "ws-A"
+    foreign = _skill_row(5, "ws-B")
+    db = MagicMock()
+    db.query.return_value.filter.return_value.all.return_value = [foreign]
+
+    with pytest.raises(HTTPException) as exc:
+        agents_mod._fetch_attachable_skills(db, [5], ctx)
+    assert exc.value.status_code == 404, (
+        "a foreign workspace's private skill must be indistinguishable from a "
+        "nonexistent id — never silently attached (and prompt-injected)"
+    )
+
+
+def test_attach_allows_global_and_own_workspace_skills(monkeypatch):
+    agents_mod, _ = _visibility_fixture(monkeypatch)
+
+    ctx = MagicMock()
+    ctx.workspace_id = "ws-A"
+    global_skill = _skill_row(1, None)
+    own = _skill_row(2, "ws-A")
+    db = MagicMock()
+    db.query.return_value.filter.return_value.all.return_value = [global_skill, own]
+
+    out = agents_mod._fetch_attachable_skills(db, [1, 2], ctx)
+    assert [s.id for s in out] == [1, 2]

--- a/orchestrator/tests/test_p2w1_agent_skills_repair.py
+++ b/orchestrator/tests/test_p2w1_agent_skills_repair.py
@@ -108,7 +108,14 @@ def test_agent_skills_relationship_ordered_by_priority():
 # ---------------------------------------------------------------------------
 
 _estimator_stub = types.ModuleType("modules.context.estimator")
-_estimator_stub.estimate_tokens = lambda text: max(1, len(text) // 4)
+
+
+class _FakeEstimator:
+    def estimate(self, text):
+        return len(text) // 4
+
+
+_estimator_stub.TokenEstimator = _FakeEstimator
 
 
 def _load_skills_section():


### PR DESCRIPTION
## PRD-191 · P2-10 — all 5 stories (S1+S4 one migration, S2, S3, S5)

Prod pays ~5k duplicated prompt tokens on every Auto turn: the workspace Auto agent is linked to `platform-management` **4×**, the global skill was seeded **5×**, and `SkillsSection` renders every link. This makes the corruption impossible, not just cleaned.

- **S1 — `UNIQUE(agent_id, skill_id)`** on the bare junction table (no PK/unique ever existed; the earlier dedupe migration's *"implicit unique"* comment described a constraint that wasn't there). Defensive link-dedupe FIRST (lowest row survives — order is load-bearing on the live 4× links), then the constraint. Migration `prd191_agent_skills_unique_and_priority`.
- **S4 — priority is real** (closes F054): `agent_skills.priority` column + `Agent.skills` relationship `order_by` — the uncapped-primary slot is a decision, mirroring the `AgentAssignedPlugin` precedent. The phantom `getattr(s, 'priority', 0)` sort is deleted.
- **S2 — `SkillsSection` dedups** by id and by `(name, content_hash)` before the primary/aux split — identical bodies never render twice regardless of DB state.
- **S3 — seeders are concurrency-safe**: `pg_advisory_xact_lock` around the platform-management upsert + IntegrityError→re-select (the blanket `except` that silently ate failed seeds is gone); link assign is `INSERT … ON CONFLICT (agent_id, skill_id) DO NOTHING`. This was the root cause of the duplicates.
- **S5 — attach-visibility parity (Sec §3.2.a)**: the three attach sites on the canonical agents router now reuse `_skill_visible_to` via one shared helper — a foreign workspace's private skill 404s instead of silently attaching (prompt-injection by id closed).

## ⚠️ Sequencing + your calls
1. **MERGE #525 (PRD-187) FIRST** — this migration chains onto `prd187_s5_drop_memory_relics` (single-head discipline).
2. Migration is **yours to apply** against prod after merge (dedupe + constraint + column; downgrade drops both).
3. PRD's Gerard's-call box defaults taken as scoped: shipped `(name)`-only global unique left as-is (flag if you want the `(name, skill_source)` re-key); defensive re-dedupe included.

## Test plan
- [x] Pure tests: migration dedupe policy + chain/order asserts · model schema-shape (unique + priority + relationship order) · section dedup ×2 + order-respect + phantom-sort-gone · seeder race re-select + ON CONFLICT SQL shape · attach visibility (foreign 404 / global+own OK) — CI is the gate
- [ ] Post-merge+migration: `SELECT agent_id, skill_id, count(*) FROM agent_skills GROUP BY 1,2 HAVING count(*)>1` → 0 rows; Auto's prompt renders platform-management once

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added attachment-level skill priorities, with higher-priority skills shown first.
  * Prevented duplicate skills from appearing in agent context.
  * Restricted agent skill attachments to global or accessible workspace skills.

* **Bug Fixes**
  * Removed existing duplicate skill links and prevented future duplicates.
  * Improved reliability when multiple processes create or attach skills simultaneously.
  * Added validation to reject unavailable or inaccessible skill IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->