### PR TITLE
feat(prd-190): Wave-1 Deliverables — durable links, template_id on autonomy lane, unresolved gate, clean-render metric

### DIFF
--- a/orchestrator/api/document_generation.py
+++ b/orchestrator/api/document_generation.py
@@ -20,6 +20,7 @@ from core.auth.hybrid import get_request_context_hybrid
 from core.auth.dependencies import RequestContext
 from core.database.database import get_db
 from config import config
+from modules.documents.models import UnresolvedDeliverableError
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/documents", tags=["document-generation"])
@@ -276,6 +277,19 @@ async def preview_template(
             template_id=template.id,
             user_id=ctx.user.id if ctx.user else None,
         )
+    except UnresolvedDeliverableError as e:
+        # P2-09 S3: the finalisation gate — tell the caller WHICH variables
+        # blocked the file so they can fill the data / brand kit / template.
+        # (The Studio live preview, /templates/preview-blocks, stays the
+        # visible-marker surface and is not gated.)
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "message": "Document blocked: template variables did not resolve",
+                "unresolved": e.unresolved,
+                "unknown": e.unknown,
+            },
+        )
     except Exception as e:
         logger.error(f"Document preview failed: {e}", exc_info=True)
         raise HTTPException(status_code=400, detail="Document preview failed")
@@ -367,6 +381,18 @@ async def generate_document(
             template_name=body.template_name,
             template_id=UUID(body.template_id) if body.template_id else None,
             user_id=ctx.user.id if ctx.user else None,
+        )
+    except UnresolvedDeliverableError as e:
+        # P2-09 S3: a Deliverable with [[unresolved]]/unknown variables is
+        # blocked at finalisation — surface the offending paths, loudly.
+        logger.warning(f"Document generation blocked by unresolved variables: {e}")
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "message": "Document blocked: template variables did not resolve",
+                "unresolved": e.unresolved,
+                "unknown": e.unknown,
+            },
         )
     except (ValueError, FileNotFoundError) as e:
         logger.warning(f"Document generation validation error: {e}")

--- a/orchestrator/modules/documents/generation_service.py
+++ b/orchestrator/modules/documents/generation_service.py
@@ -633,15 +633,21 @@ class DocumentGenerationService:
     def _build_result(
         self, path: str, fmt: str, title: str, workspace_id: UUID = None
     ) -> GeneratedDocument:
-        """Build a GeneratedDocument from a file on disk, uploading to S3 for persistence."""
+        """Build a GeneratedDocument from a file on disk, uploading to S3 for persistence.
+
+        The persisted ``download_url`` is the STABLE app path
+        (``/api/documents/generated/{filename}``), never the raw presigned S3 URL —
+        a presign expires after an hour, which rotted every persisted Deliverable
+        link (P2-09 S1 / F030). ``serve_generated_file`` re-mints a fresh presign
+        on each request, so the app path stays live for the Deliverable's lifetime.
+        """
         filename = os.path.basename(path)
         size = os.path.getsize(path)
 
-        # Upload to S3 for persistent storage (containers are ephemeral)
+        # Upload a persistence copy to S3 (containers are ephemeral); the link we
+        # persist stays the app path — the re-mint endpoint owns presigning.
         download_url = f"/api/documents/generated/{filename}"
-        s3_url = self._upload_to_s3(path, filename, workspace_id)
-        if s3_url:
-            download_url = s3_url
+        self._upload_to_s3(path, filename, workspace_id)
 
         return GeneratedDocument(
             path=path,
@@ -654,18 +660,21 @@ class DocumentGenerationService:
 
     def _upload_to_s3(
         self, local_path: str, filename: str, workspace_id: UUID = None
-    ) -> Optional[str]:
-        """Upload generated document to S3 and return a presigned download URL.
+    ) -> bool:
+        """Upload a generated document to S3 for persistence across ephemeral containers.
 
-        Returns None if S3 is not configured (falls back to local serving).
+        Returns True when the upload happened, False when S3 is not configured or
+        the upload failed (local serving still works for the container's lifetime).
+        No download link is minted here — ``serve_generated_file`` presigns on
+        demand, so persisted URLs never expire (P2-09 S1).
         """
         if not boto3:
             logger.debug("[DocGen] boto3 not available, skipping S3 upload")
-            return None
+            return False
 
         if not config.AWS_ACCESS_KEY_ID or not config.AWS_SECRET_ACCESS_KEY:
             logger.debug("[DocGen] AWS credentials not configured, skipping S3 upload")
-            return None
+            return False
 
         ws_id = workspace_id or self.workspace_id
         bucket = config.S3_DOCUMENTS_BUCKET or "automatos-ai"
@@ -693,23 +702,12 @@ class DocumentGenerationService:
                     ContentType=content_type,
                 )
 
-            # Generate presigned URL (1 hour expiry)
-            presigned_url = client.generate_presigned_url(
-                "get_object",
-                Params={
-                    "Bucket": bucket,
-                    "Key": s3_key,
-                    "ResponseContentDisposition": f'attachment; filename="{filename}"',
-                },
-                ExpiresIn=3600,
-            )
-
             logger.info(
                 "[DocGen] Uploaded to S3: s3://%s/%s (%d bytes)",
                 bucket, s3_key, os.path.getsize(local_path),
             )
-            return presigned_url
+            return True
 
         except Exception:
             logger.exception("[DocGen] S3 upload failed, falling back to local serving")
-            return None
+            return False

--- a/orchestrator/modules/documents/generation_service.py
+++ b/orchestrator/modules/documents/generation_service.py
@@ -215,6 +215,12 @@ class DocumentGenerationService:
         Source attribution travels in ``extra`` (template_id) + ``source_type``. Called
         only for real generations — previews never register. Best-effort: a registration
         failure never fails the generation itself.
+
+        P2-09 S4: per-generation render quality rides the same ``extra`` JSONB —
+        ``render.unresolved_count`` / ``render.unknown_count`` / ``render.template_lane``
+        — no new table, no new column. ``DeliverableService.get_stats`` aggregates it
+        into the clean-render rate; post-S3 the counts double as a durable audit that
+        the finalisation gate held (block-lane documents register only when clean).
         """
         ws = self.workspace_id
         if not ws:
@@ -222,7 +228,15 @@ class DocumentGenerationService:
         try:
             from services.deliverable_service import DeliverableService
 
-            extra = {"template_id": str(template_id)} if template_id else None
+            extra = {
+                "render": {
+                    "unresolved_count": len(result.unresolved),
+                    "unknown_count": len(result.unknown),
+                    "template_lane": result.template_lane,
+                }
+            }
+            if template_id:
+                extra["template_id"] = str(template_id)
             return DeliverableService(self.db, ws).register(
                 file_path=f"generated/{result.filename}",
                 title=title or result.filename,
@@ -273,6 +287,9 @@ class DocumentGenerationService:
         block_payload = getattr(template, "blocks", None) if template else None
         unresolved: list = []
         unknown: list = []
+        # P2-09 S4: which lane rendered the file — "block" (canonical) vs
+        # "legacy" (Jinja HTML). Tracks the PRD-167 migration off Jinja.
+        template_lane = "block"
 
         if block_payload:
             # Path 1: canonical block template.
@@ -287,6 +304,7 @@ class DocumentGenerationService:
                 self._validate_and_backfill(data, template.data_schema)
             # PRD-167 S4: expose the brand kit to legacy templates as {{ brand.* }} so
             # they pick up workspace palette instead of hardcoded Automatos colours.
+            template_lane = "legacy"
             render_ctx = {**data, "brand": self._brand_kit_for(workspace_id)}
             try:
                 jinja_template = self._jinja_env.from_string(template.template_content)
@@ -311,7 +329,7 @@ class DocumentGenerationService:
 
         return self._build_result(
             output_path, "pdf", title, workspace_id,
-            unresolved=unresolved, unknown=unknown,
+            unresolved=unresolved, unknown=unknown, template_lane=template_lane,
         )
 
     # ------------------------------------------------------------------
@@ -351,7 +369,7 @@ class DocumentGenerationService:
             rendered.document.save(output_path)
             return self._build_result(
                 output_path, "docx", title, workspace_id,
-                unresolved=unresolved, unknown=unknown,
+                unresolved=unresolved, unknown=unknown, template_lane="block",
             )
 
         # Path 2: legacy uploaded .docx template via docxtpl.
@@ -388,7 +406,9 @@ class DocumentGenerationService:
         doc.render(data)
         doc.save(output_path)
 
-        return self._build_result(output_path, "docx", title, workspace_id)
+        return self._build_result(
+            output_path, "docx", title, workspace_id, template_lane="legacy"
+        )
 
     # ------------------------------------------------------------------
     # XLSX Generation (XlsxWriter)
@@ -669,6 +689,7 @@ class DocumentGenerationService:
         *,
         unresolved: Optional[list] = None,
         unknown: Optional[list] = None,
+        template_lane: Optional[str] = None,
     ) -> GeneratedDocument:
         """Build a GeneratedDocument from a file on disk, uploading to S3 for persistence.
 
@@ -680,7 +701,8 @@ class DocumentGenerationService:
 
         ``unresolved``/``unknown`` are the render-honesty lists captured off the
         block render (P2-09 S3); non-empty lists make :meth:`generate` block
-        finalisation.
+        finalisation. ``template_lane`` records which renderer produced the file
+        ("block"/"legacy", P2-09 S4) for the clean-render/lane-coverage metric.
         """
         filename = os.path.basename(path)
         size = os.path.getsize(path)
@@ -699,6 +721,7 @@ class DocumentGenerationService:
             preview_url=download_url if fmt == "pdf" else None,
             unresolved=list(unresolved or []),
             unknown=list(unknown or []),
+            template_lane=template_lane,
         )
 
     def _upload_to_s3(

--- a/orchestrator/modules/documents/generation_service.py
+++ b/orchestrator/modules/documents/generation_service.py
@@ -65,7 +65,7 @@ except ImportError:
 from config import config
 from core.models.core import DocumentTemplate
 from core.models.workspaces import Workspace
-from modules.documents.models import GeneratedDocument
+from modules.documents.models import GeneratedDocument, UnresolvedDeliverableError
 from modules.documents.template_service import DocumentTemplateService
 from modules.documents.brand_kit import get_brand_kit
 from modules.documents.blocks import (
@@ -154,6 +154,21 @@ class DocumentGenerationService:
         else:
             raise ValueError(f"Unsupported format: {format}. Use pdf, docx, or xlsx.")
 
+        # P2-09 S3 — the finalisation gate. The render-honesty primitives
+        # (RenderedHtml/RenderedDocx.unresolved, ResolvedVariables.unknown) used
+        # to be logged and discarded, so a client could still receive a document
+        # with visible [[variable]] markers. A Deliverable that did not resolve
+        # clean is BLOCKED, loudly — never delivered. (The Studio live preview
+        # renders outside generate() and keeps its visible red markers.)
+        if result.unresolved or result.unknown:
+            logger.warning(
+                "[DocGen] BLOCKED finalisation of '%s' (%s): %d unresolved / %d unknown variable(s)",
+                title, format, len(result.unresolved), len(result.unknown),
+            )
+            raise UnresolvedDeliverableError(
+                unresolved=result.unresolved, unknown=result.unknown
+            )
+
         # Attach markdown content for live widget display
         result.content = self._data_to_markdown(data, title)
         return result
@@ -167,18 +182,22 @@ class DocumentGenerationService:
         return get_brand_kit(getattr(ws, "settings", None))
 
     def _render_block_html(self, block_doc, data, workspace_id, user_id, title):
-        """Resolve a block document's variables and render it to a full HTML page."""
+        """Resolve a block document's variables and render it to a full HTML page.
+
+        Returns ``(html, unresolved, unknown)`` — the render-honesty lists are
+        captured for the finalisation gate in :meth:`generate` (P2-09 S3), not
+        discarded behind a log line. The renderer marks BOTH empty-known and
+        unknown paths as visible ``[[markers]]``; the authoring errors (unknown)
+        are split out so each list stays honest.
+        """
         paths = collect_variable_paths(block_doc)
         resolver = VariableResolver(self.db)
         resolved = resolver.resolve(workspace_id, user_id, paths, extra_data=data)
         brand_kit = self._brand_kit_for(workspace_id)
         rendered = render_document_html(block_doc, resolved.values, brand_kit, title=title)
-        if rendered.unresolved:
-            logger.warning(
-                "[DocGen] %d unresolved variable(s) in block render: %s",
-                len(rendered.unresolved), ", ".join(rendered.unresolved),
-            )
-        return rendered.html
+        unknown = list(resolved.unknown)
+        unresolved = [p for p in rendered.unresolved if p not in set(unknown)]
+        return rendered.html, unresolved, unknown
 
     def register_as_deliverable(
         self,
@@ -252,11 +271,15 @@ class DocumentGenerationService:
             )
 
         block_payload = getattr(template, "blocks", None) if template else None
+        unresolved: list = []
+        unknown: list = []
 
         if block_payload:
             # Path 1: canonical block template.
             block_doc = validate_blocks(block_payload)
-            rendered_html = self._render_block_html(block_doc, data, workspace_id, user_id, title)
+            rendered_html, unresolved, unknown = self._render_block_html(
+                block_doc, data, workspace_id, user_id, title
+            )
         elif template and template.template_content:
             # Path 2: legacy user-authored Jinja HTML (kept until per-workspace
             # templates are migrated to blocks — see PRD-167 sunset note).
@@ -275,7 +298,9 @@ class DocumentGenerationService:
             # Path 3: no template — brand-aware block render of the legacy data shape.
             logger.info("No template found — rendering data via brand-aware block fallback")
             block_doc = blocks_from_legacy(data)
-            rendered_html = self._render_block_html(block_doc, data, workspace_id, user_id, title)
+            rendered_html, unresolved, unknown = self._render_block_html(
+                block_doc, data, workspace_id, user_id, title
+            )
 
         # Generate PDF
         output_path = self._output_path(workspace_id, title, "pdf")
@@ -284,7 +309,10 @@ class DocumentGenerationService:
         except Exception as e:
             raise RuntimeError(f"PDF generation failed: {e}")
 
-        return self._build_result(output_path, "pdf", title, workspace_id)
+        return self._build_result(
+            output_path, "pdf", title, workspace_id,
+            unresolved=unresolved, unknown=unknown,
+        )
 
     # ------------------------------------------------------------------
     # DOCX Generation (python-docx-template)
@@ -316,13 +344,15 @@ class DocumentGenerationService:
             )
             brand_kit = self._brand_kit_for(workspace_id)
             rendered = render_document_docx(block_doc, resolved.values, brand_kit)
-            if rendered.unresolved:
-                logger.warning(
-                    "[DocGen] %d unresolved variable(s) in DOCX render: %s",
-                    len(rendered.unresolved), ", ".join(rendered.unresolved),
-                )
+            # P2-09 S3: capture the render-honesty lists for the finalisation
+            # gate in generate() — same unknown/unresolved split as the HTML path.
+            unknown = list(resolved.unknown)
+            unresolved = [p for p in rendered.unresolved if p not in set(unknown)]
             rendered.document.save(output_path)
-            return self._build_result(output_path, "docx", title, workspace_id)
+            return self._build_result(
+                output_path, "docx", title, workspace_id,
+                unresolved=unresolved, unknown=unknown,
+            )
 
         # Path 2: legacy uploaded .docx template via docxtpl.
         try:
@@ -631,7 +661,14 @@ class DocumentGenerationService:
         return os.path.join(directory, f"{timestamp}_{safe_title}.{ext}")
 
     def _build_result(
-        self, path: str, fmt: str, title: str, workspace_id: UUID = None
+        self,
+        path: str,
+        fmt: str,
+        title: str,
+        workspace_id: UUID = None,
+        *,
+        unresolved: Optional[list] = None,
+        unknown: Optional[list] = None,
     ) -> GeneratedDocument:
         """Build a GeneratedDocument from a file on disk, uploading to S3 for persistence.
 
@@ -640,6 +677,10 @@ class DocumentGenerationService:
         a presign expires after an hour, which rotted every persisted Deliverable
         link (P2-09 S1 / F030). ``serve_generated_file`` re-mints a fresh presign
         on each request, so the app path stays live for the Deliverable's lifetime.
+
+        ``unresolved``/``unknown`` are the render-honesty lists captured off the
+        block render (P2-09 S3); non-empty lists make :meth:`generate` block
+        finalisation.
         """
         filename = os.path.basename(path)
         size = os.path.getsize(path)
@@ -656,6 +697,8 @@ class DocumentGenerationService:
             size=size,
             download_url=download_url,
             preview_url=download_url if fmt == "pdf" else None,
+            unresolved=list(unresolved or []),
+            unknown=list(unknown or []),
         )
 
     def _upload_to_s3(

--- a/orchestrator/modules/documents/models.py
+++ b/orchestrator/modules/documents/models.py
@@ -3,7 +3,33 @@ Data models for the Document Generation module (PRD-63).
 """
 
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import List, Optional
+
+
+class UnresolvedDeliverableError(Exception):
+    """A generated document still contains unresolved/unknown template variables.
+
+    Raised by ``DocumentGenerationService.generate`` at finalisation (P2-09 S3):
+    a client-facing Deliverable with visible ``[[variable]]`` markers must be
+    BLOCKED, never delivered. ``unresolved`` are known catalog paths that
+    resolved empty (e.g. no ``company.address`` on file); ``unknown`` are
+    authoring errors — paths that are not in the variable catalog at all.
+    """
+
+    def __init__(self, unresolved: Optional[List[str]] = None, unknown: Optional[List[str]] = None):
+        self.unresolved = list(unresolved or [])
+        self.unknown = list(unknown or [])
+        parts = []
+        if self.unresolved:
+            parts.append(f"unresolved (no value on file): {', '.join(self.unresolved)}")
+        if self.unknown:
+            parts.append(f"unknown (not in the variable catalog): {', '.join(self.unknown)}")
+        super().__init__(
+            "Document blocked at finalisation — template variables did not resolve: "
+            + "; ".join(parts)
+            + ". Supply the missing values (brand kit / business profile / data.*) "
+            "or fix the template's variable paths, then regenerate."
+        )
 
 
 @dataclass
@@ -16,3 +42,8 @@ class GeneratedDocument:
     download_url: Optional[str] = None
     preview_url: Optional[str] = None
     content: Optional[str] = None  # Markdown content for live widget display
+    # P2-09 S3: render honesty, captured off the block render instead of being
+    # discarded behind a log line. Non-empty lists block finalisation in
+    # ``DocumentGenerationService.generate`` (UnresolvedDeliverableError).
+    unresolved: List[str] = field(default_factory=list)  # known paths, empty value
+    unknown: List[str] = field(default_factory=list)     # paths not in the catalog

--- a/orchestrator/modules/documents/models.py
+++ b/orchestrator/modules/documents/models.py
@@ -47,3 +47,8 @@ class GeneratedDocument:
     # ``DocumentGenerationService.generate`` (UnresolvedDeliverableError).
     unresolved: List[str] = field(default_factory=list)  # known paths, empty value
     unknown: List[str] = field(default_factory=list)     # paths not in the catalog
+    # P2-09 S4: which render lane produced the file — "block" (canonical block
+    # renderer, incl. the no-template brand-aware fallback) or "legacy" (Jinja
+    # HTML / uploaded-docx). None when no template render applies (xlsx).
+    # Persisted on the Deliverable ``extra`` so lane coverage is a tracked number.
+    template_lane: Optional[str] = None

--- a/orchestrator/modules/tools/registry/tool_registry.py
+++ b/orchestrator/modules/tools/registry/tool_registry.py
@@ -1215,6 +1215,19 @@ class ToolRegistry:
                     description="Template to use (e.g., 'Basic Report', 'Invoice'). Omit for auto-selection.",
                     required=False
                 ),
+                # P2-09 S2 (F031/J2): the handler already parses/validates template_id,
+                # but only the chatbot's inline schema declared it — so id-driven
+                # template generation worked in chat and nowhere else. Declaring it
+                # here gives the non-chat autonomy lane (missions/board/scheduled)
+                # parity, and makes platform_get_template_schema's "use before
+                # generate_document" discovery flow followable. Wording mirrors the
+                # inline chat schema (agent_platform_tools.get_available_tools).
+                ToolParameter(
+                    name="template_id",
+                    type="string",
+                    description="UUID of a specific template to fill (from platform_list_templates). Takes precedence over template_name.",
+                    required=False
+                ),
             ],
             returns="JSON with filename, format, download_url, and size_kb",
             security_level=SecurityLevel.CAUTIOUS,

--- a/orchestrator/services/deliverable_service.py
+++ b/orchestrator/services/deliverable_service.py
@@ -508,7 +508,15 @@ class DeliverableService:
     # ------------------------------------------------------------------
 
     def get_stats(self) -> Dict[str, Any]:
-        """Aggregate counts for the workspace: total, by_type, by_agent."""
+        """Aggregate counts for the workspace: total, by_type, by_agent — plus the
+        clean-render rate over rendered documents (P2-09 S4).
+
+        ``extra.render`` is written at registration by the document generation
+        service (``unresolved_count`` / ``unknown_count`` / ``template_lane``);
+        rows without it (blog posts, reports, pre-P2-09 documents) are excluded
+        from the render aggregate. Honest empty: no rendered documents →
+        ``clean_render_rate`` is ``None``, never a fabricated 100%.
+        """
         try:
             total = self.db.execute(
                 text("""
@@ -548,6 +556,36 @@ class DeliverableService:
                 {"workspace_id": str(self.workspace_id)},
             ).fetchall()
 
+            # P2-09 S4 — clean-render rate + template-lane coverage over the
+            # rendered Deliverables (rows carrying `extra.render`).
+            render_row = self.db.execute(
+                text("""
+                    SELECT
+                        COUNT(*) AS rendered_total,
+                        COUNT(*) FILTER (
+                            WHERE COALESCE((extra->'render'->>'unresolved_count')::int, 0) = 0
+                              AND COALESCE((extra->'render'->>'unknown_count')::int, 0) = 0
+                        ) AS rendered_clean,
+                        COUNT(*) FILTER (
+                            WHERE extra->'render'->>'template_lane' = 'block'
+                        ) AS lane_block,
+                        COUNT(*) FILTER (
+                            WHERE extra->'render'->>'template_lane' = 'legacy'
+                        ) AS lane_legacy
+                    FROM v_workspace_outputs
+                    WHERE workspace_id = :workspace_id
+                      AND deleted_at IS NULL
+                      AND (extra -> 'render') IS NOT NULL
+                """),
+                {"workspace_id": str(self.workspace_id)},
+            ).fetchone()
+
+            rendered_total = int(render_row.rendered_total or 0) if render_row else 0
+            rendered_clean = int(render_row.rendered_clean or 0) if render_row else 0
+            clean_render_rate = (
+                rendered_clean / rendered_total if rendered_total else None
+            )
+
             return {
                 "success": True,
                 "total": total,
@@ -560,6 +598,15 @@ class DeliverableService:
                     }
                     for r in by_agent_rows
                 ],
+                "clean_render_rate": clean_render_rate,
+                "render": {
+                    "total": rendered_total,
+                    "clean": rendered_clean,
+                    "by_lane": {
+                        "block": int(render_row.lane_block or 0) if render_row else 0,
+                        "legacy": int(render_row.lane_legacy or 0) if render_row else 0,
+                    },
+                },
             }
         except Exception as exc:
             logger.error(
@@ -572,6 +619,8 @@ class DeliverableService:
                 "total": 0,
                 "by_type": {},
                 "by_agent": [],
+                "clean_render_rate": None,
+                "render": {"total": 0, "clean": 0, "by_lane": {"block": 0, "legacy": 0}},
             }
 
     # ------------------------------------------------------------------

--- a/orchestrator/tests/services/test_deliverable_service.py
+++ b/orchestrator/tests/services/test_deliverable_service.py
@@ -403,7 +403,14 @@ class TestGetStats:
         ag = MagicMock(agent_id=42, cnt=5)
         ag.agent_name = "Scout"
         by_agent_result.fetchall.return_value = [ag]
-        db.execute.side_effect = [total_result, by_type_result, by_agent_result]
+        # P2-09 S4: get_stats also aggregates the clean-render rate.
+        render_result = MagicMock()
+        render_result.fetchone.return_value = MagicMock(
+            rendered_total=2, rendered_clean=1, lane_block=1, lane_legacy=1
+        )
+        db.execute.side_effect = [
+            total_result, by_type_result, by_agent_result, render_result,
+        ]
 
         svc = DeliverableService(db, WORKSPACE_ID)
         out = svc.get_stats()
@@ -412,6 +419,10 @@ class TestGetStats:
         assert out["total"] == 7
         assert out["by_type"] == {"report": 4, "image": 3}
         assert out["by_agent"] == [{"agent_id": 42, "agent_name": "Scout", "count": 5}]
+        assert out["clean_render_rate"] == 0.5
+        assert out["render"] == {
+            "total": 2, "clean": 1, "by_lane": {"block": 1, "legacy": 1},
+        }
 
     def test_get_stats_handles_exception(self):
         db = MagicMock()
@@ -421,6 +432,7 @@ class TestGetStats:
         assert out["success"] is False
         assert out["total"] == 0
         assert out["by_type"] == {}
+        assert out["clean_render_rate"] is None
 
 
 # ---------------------------------------------------------------------------

--- a/orchestrator/tests/test_prd190_deliverables.py
+++ b/orchestrator/tests/test_prd190_deliverables.py
@@ -200,3 +200,95 @@ def test_toolspec_matches_inline_chat_schema_for_template_id():
     exported = spec.to_openai_format()["parameters"]
     assert exported["properties"]["template_id"]["type"] == "string"
     assert "template_id" not in exported["required"]
+
+
+# --------------------------------------------------------------------------- #
+# S3 — enforce the unresolved gate (J5) — the load-bearing assertions
+# --------------------------------------------------------------------------- #
+# generate() is driven end-to-end on the DOCX block path (python-docx is pure
+# Python — no WeasyPrint / native libs needed), with S3 mocked off and the
+# storage dir pointed at tmp_path. The default brand kit has no company.address,
+# so a {{company.address}} chip resolves empty → unresolved.
+
+
+def _gated_service(tmp_path, monkeypatch, template):
+    import modules.documents.generation_service as gs
+
+    monkeypatch.setattr(gs, "GENERATED_DIR", str(tmp_path))
+    monkeypatch.setattr(gs, "boto3", None)  # boundary: no S3 in tests
+    return _service(template=template)
+
+
+@pytest.mark.asyncio
+async def test_unresolved_variable_blocks_finalisation(tmp_path, monkeypatch):
+    """A known-but-empty variable ({{company.address}} with nothing on file)
+    BLOCKS finalisation — raises with the offending path, never returns a
+    document with visible [[markers]]."""
+    from modules.documents.models import UnresolvedDeliverableError
+
+    svc = _gated_service(tmp_path, monkeypatch, _block_template("company.address"))
+
+    with pytest.raises(UnresolvedDeliverableError) as exc:
+        await svc.generate(
+            title="Client Letter", format="docx", data={}, template_name="Branded Letter"
+        )
+
+    assert "company.address" in exc.value.unresolved
+    assert exc.value.unknown == []
+    assert "company.address" in str(exc.value)  # loud AND actionable
+
+
+@pytest.mark.asyncio
+async def test_unknown_variable_blocks_finalisation(tmp_path, monkeypatch):
+    """An authoring error ({{not_a_real.path}}, not in the catalog) is likewise
+    blocked."""
+    from modules.documents.models import UnresolvedDeliverableError
+
+    svc = _gated_service(tmp_path, monkeypatch, _block_template("not_a_real.path"))
+
+    with pytest.raises(UnresolvedDeliverableError) as exc:
+        await svc.generate(
+            title="Client Letter", format="docx", data={}, template_name="Branded Letter"
+        )
+
+    assert "not_a_real.path" in exc.value.unknown
+    assert exc.value.unresolved == []
+
+
+@pytest.mark.asyncio
+async def test_clean_render_passes(tmp_path, monkeypatch):
+    """A fully-resolved template finalises normally — no false positives."""
+    svc = _gated_service(tmp_path, monkeypatch, _block_template("data.client_name"))
+
+    result = await svc.generate(
+        title="Client Letter",
+        format="docx",
+        data={"client_name": "Acme Corp"},
+        template_name="Branded Letter",
+    )
+
+    assert result.unresolved == []
+    assert result.unknown == []
+    assert result.format == "docx"
+    assert result.download_url == f"/api/documents/generated/{result.filename}"
+
+
+def test_pdf_block_render_captures_unresolved():
+    """The shared PDF-path helper captures the honesty lists (and still emits
+    the visible [[marker]] for preview-style consumers) instead of discarding
+    them behind a log line. Pure — no WeasyPrint, no file I/O."""
+    from modules.documents.blocks import validate_blocks
+
+    svc = _service()
+    block_doc = validate_blocks(
+        {"blocks": [
+            {"type": "text", "id": "t0", "content": [{"type": "variable", "path": "company.address"}]},
+            {"type": "text", "id": "t1", "content": [{"type": "variable", "path": "bogus.path"}]},
+        ]}
+    )
+
+    html, unresolved, unknown = svc._render_block_html(block_doc, {}, WS, None, "T")
+
+    assert unresolved == ["company.address"]
+    assert unknown == ["bogus.path"]
+    assert "[[company.address]]" in html

--- a/orchestrator/tests/test_prd190_deliverables.py
+++ b/orchestrator/tests/test_prd190_deliverables.py
@@ -145,3 +145,58 @@ def test_download_url_stable_when_s3_unconfigured(tmp_path, monkeypatch):
     result = _service()._build_result(str(doc), "xlsx", "Export", WS)
 
     assert result.download_url == f"/api/documents/generated/{doc.name}"
+
+
+# --------------------------------------------------------------------------- #
+# S2 — template_id on the autonomy lane (F031/J2)
+# --------------------------------------------------------------------------- #
+
+
+def _registry_generate_document_spec():
+    from modules.tools.registry.tool_registry import ToolRegistry
+
+    spec = ToolRegistry().get_tool("generate_document")
+    assert spec is not None, "generate_document ToolSpec missing from the registry"
+    return spec
+
+
+def _inline_chat_generate_document_schema():
+    from modules.agents.services.agent_platform_tools import AgentPlatformTools
+
+    # get_available_tools never touches self — call it unbound so the test stays
+    # pure (no RAGService / CodeGraphService construction).
+    tools = AgentPlatformTools.get_available_tools(object())
+    return next(t for t in tools if t["name"] == "generate_document")
+
+
+def test_generate_document_toolspec_exposes_template_id():
+    """The registry ToolSpec (the non-chat lane: missions/board/scheduled) must
+    declare template_id — the handler already parses, validates and threads it."""
+    spec = _registry_generate_document_spec()
+    param = next((p for p in spec.parameters if p.name == "template_id"), None)
+
+    assert param is not None, (
+        "generate_document ToolSpec must expose template_id (P2-09 S2) — "
+        "without it a non-chat agent cannot pass the id platform_get_template_schema gave it"
+    )
+    assert param.type == "string"
+    assert param.required is False
+
+
+def test_toolspec_matches_inline_chat_schema_for_template_id():
+    """Registry ToolSpec and the chatbot inline schema agree on template_id —
+    the chat-only gap is closed, wording and optionality included."""
+    spec = _registry_generate_document_spec()
+    param = next(p for p in spec.parameters if p.name == "template_id")
+
+    inline = _inline_chat_generate_document_schema()
+    inline_prop = inline["parameters"]["properties"]["template_id"]
+
+    assert param.description == inline_prop["description"]
+    assert "template_id" not in inline["parameters"]["required"]
+    assert param.required is False
+    # And the OpenAI-format export (what the autonomy lane actually hands the
+    # LLM) carries it as an optional string parameter.
+    exported = spec.to_openai_format()["parameters"]
+    assert exported["properties"]["template_id"]["type"] == "string"
+    assert "template_id" not in exported["required"]

--- a/orchestrator/tests/test_prd190_deliverables.py
+++ b/orchestrator/tests/test_prd190_deliverables.py
@@ -1,0 +1,147 @@
+"""PRD-190 (P2-09) — Deliverables: stop the client-facing artifact rotting.
+
+Pure tests, mocked at the boundaries (boto3/S3, the DB session, the deliverables
+read-model) — no AWS, no Postgres round-trip, no WeasyPrint.
+
+  S1  the persisted Deliverable ``download_url`` is the stable app path
+      (``/api/documents/generated/{filename}``), never the 1-hour presign (F030/J1).
+  S2  the registry ``generate_document`` ToolSpec exposes ``template_id`` so the
+      non-chat autonomy lane (missions/board/scheduled) matches chat (F031/J2).
+  S3  a Deliverable with ``unresolved``/``unknown`` variables is BLOCKED at
+      finalisation — raises ``UnresolvedDeliverableError``, never delivered (J5).
+  S4  clean-render + template-lane are persisted on the Deliverable ``extra`` and
+      aggregated as ``clean_render_rate`` in ``get_stats`` (J3/J7).
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+WS = uuid4()
+
+
+# --------------------------------------------------------------------------- #
+# Boundary fakes
+# --------------------------------------------------------------------------- #
+
+
+class _FakeQuery:
+    """SQLAlchemy Query stub: every lookup resolves to 'not found'."""
+
+    def filter(self, *args, **kwargs):
+        return self
+
+    def order_by(self, *args, **kwargs):
+        return self
+
+    def first(self):
+        return None
+
+
+class _FakeDb:
+    """Session stub for pure tests — no row ever exists."""
+
+    def query(self, *args, **kwargs):
+        return _FakeQuery()
+
+
+def _block_template(*paths):
+    """A DocumentTemplate-shaped stub whose blocks reference the given variable paths."""
+    blocks = {
+        "blocks": [
+            {"type": "text", "id": f"t{i}", "content": [{"type": "variable", "path": p}]}
+            for i, p in enumerate(paths)
+        ]
+        or [{"type": "text", "id": "t0", "content": [{"type": "text", "text": "Hello"}]}]
+    }
+    return SimpleNamespace(
+        blocks=blocks, template_content=None, template_file_path=None, data_schema=None
+    )
+
+
+def _service(template=None):
+    """DocumentGenerationService on a fake Session; template lookups return `template`."""
+    import modules.documents.generation_service as gs
+
+    svc = gs.DocumentGenerationService(_FakeDb(), WS)
+    if template is not None:
+        svc.template_service = SimpleNamespace(
+            get_template=lambda template_id, ws: template,
+            get_template_by_name=lambda ws, name: template,
+        )
+    return svc
+
+
+def _mock_s3(monkeypatch, gs):
+    """Mock boto3 at the module boundary so the S3 upload SUCCEEDS in-process.
+
+    The presign the client *would* mint is a realistic expiring URL, so a
+    regression back to persisting it fails these tests loudly.
+    """
+    fake_boto = MagicMock()
+    client = fake_boto.client.return_value
+    client.generate_presigned_url.return_value = (
+        "https://test-bucket.s3.amazonaws.com/workspaces/x/generated-documents/f.pdf"
+        "?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Expires=3600&X-Amz-Signature=deadbeef"
+    )
+    monkeypatch.setattr(gs, "boto3", fake_boto)
+    monkeypatch.setattr(gs.config, "AWS_ACCESS_KEY_ID", "test-key")
+    monkeypatch.setattr(gs.config, "AWS_SECRET_ACCESS_KEY", "test-secret")
+    monkeypatch.setattr(gs.config, "S3_DOCUMENTS_BUCKET", "test-bucket")
+    return fake_boto
+
+
+# --------------------------------------------------------------------------- #
+# S1 — kill the link-rot (F030/J1)
+# --------------------------------------------------------------------------- #
+
+
+def test_deliverable_download_url_is_stable_app_path(tmp_path, monkeypatch):
+    """With the S3 upload mocked to succeed, the persisted link is the stable
+    app path — not the raw presign that 404s after an hour."""
+    import modules.documents.generation_service as gs
+
+    fake_boto = _mock_s3(monkeypatch, gs)
+    doc = tmp_path / "20260710_090000_Report.pdf"
+    doc.write_bytes(b"%PDF-1.4 test")
+
+    result = _service()._build_result(str(doc), "pdf", "Report", WS)
+
+    assert result.download_url == f"/api/documents/generated/{doc.name}"
+    assert result.preview_url == result.download_url  # pdf preview rides the same path
+    # The persistence upload is KEPT (containers are ephemeral)...
+    fake_boto.client.return_value.put_object.assert_called_once()
+    # ...but no presign is minted at generation time — serve_generated_file
+    # re-mints on demand, so the persisted link never expires.
+    fake_boto.client.return_value.generate_presigned_url.assert_not_called()
+
+
+def test_download_url_survives_presign_expiry(tmp_path, monkeypatch):
+    """The persisted download_url carries no expiring-signature query params."""
+    import modules.documents.generation_service as gs
+
+    _mock_s3(monkeypatch, gs)
+    doc = tmp_path / "20260710_090000_Invoice.docx"
+    doc.write_bytes(b"PK docx test")
+
+    result = _service()._build_result(str(doc), "docx", "Invoice", WS)
+
+    assert "X-Amz-Expires" not in result.download_url
+    assert "X-Amz-Signature" not in result.download_url
+    assert "?" not in result.download_url
+    assert result.download_url.startswith("/api/documents/generated/")
+
+
+def test_download_url_stable_when_s3_unconfigured(tmp_path, monkeypatch):
+    """No S3 at all (local/OSS edition) → same stable app path, served locally."""
+    import modules.documents.generation_service as gs
+
+    monkeypatch.setattr(gs, "boto3", None)
+    doc = tmp_path / "20260710_090000_Export.xlsx"
+    doc.write_bytes(b"xlsx test")
+
+    result = _service()._build_result(str(doc), "xlsx", "Export", WS)
+
+    assert result.download_url == f"/api/documents/generated/{doc.name}"

--- a/orchestrator/tests/test_prd190_deliverables.py
+++ b/orchestrator/tests/test_prd190_deliverables.py
@@ -292,3 +292,94 @@ def test_pdf_block_render_captures_unresolved():
     assert unresolved == ["company.address"]
     assert unknown == ["bogus.path"]
     assert "[[company.address]]" in html
+
+
+# --------------------------------------------------------------------------- #
+# S4 — clean-render + template-lane become tracked numbers (J3/J7)
+# --------------------------------------------------------------------------- #
+
+
+def test_clean_render_recorded_on_extra(monkeypatch):
+    """Registration persists render quality on the Deliverable `extra` JSONB:
+    unresolved/unknown counts + which template lane produced the file."""
+    import modules.documents.generation_service as gs
+    import services.deliverable_service as ds
+
+    captured = {}
+
+    class _FakeDeliverableService:
+        def __init__(self, db, workspace_id):
+            pass
+
+        def register(self, **kwargs):
+            captured.update(kwargs)
+            return {"success": True, "deliverable_id": "d-1", "created": True}
+
+    monkeypatch.setattr(ds, "DeliverableService", _FakeDeliverableService)
+
+    template_id = uuid4()
+    result = gs.GeneratedDocument(
+        path="/data/x.pdf",
+        format="pdf",
+        filename="x.pdf",
+        size=1024,
+        download_url="/api/documents/generated/x.pdf",
+        unresolved=[],
+        unknown=[],
+        template_lane="block",
+    )
+    registration = gs.DocumentGenerationService(_FakeDb(), WS).register_as_deliverable(
+        result, title="Q3 Report", source_type="agent_output", template_id=template_id
+    )
+
+    assert registration["success"] is True
+    render = captured["extra"]["render"]
+    assert render["unresolved_count"] == 0
+    assert render["unknown_count"] == 0
+    assert render["template_lane"] in {"block", "legacy"}
+    # template_id attribution (PRD-167 S6) still rides the same extra dict.
+    assert captured["extra"]["template_id"] == str(template_id)
+    assert captured["preview_url"] == "/api/documents/generated/x.pdf"
+
+
+def _stats_service(render_row):
+    """DeliverableService over a fake Session keyed on the SQL each query runs."""
+    from services.deliverable_service import DeliverableService
+
+    def execute(query, params=None):
+        sql = str(query)
+        if "render" in sql:
+            return SimpleNamespace(fetchone=lambda: render_row)
+        if "artifact_type" in sql:
+            return SimpleNamespace(fetchall=lambda: [])
+        if "agent_id" in sql:
+            return SimpleNamespace(fetchall=lambda: [])
+        return SimpleNamespace(scalar=lambda: 6)
+
+    return DeliverableService(SimpleNamespace(execute=execute), WS)
+
+
+def test_get_stats_reports_clean_render_rate():
+    """With a mix of clean and (pre-gate / legacy-lane) generations recorded,
+    get_stats() reports clean ÷ total plus lane coverage."""
+    stats = _stats_service(
+        SimpleNamespace(rendered_total=4, rendered_clean=3, lane_block=3, lane_legacy=1)
+    ).get_stats()
+
+    assert stats["success"] is True
+    assert stats["clean_render_rate"] == pytest.approx(0.75)
+    assert stats["render"]["total"] == 4
+    assert stats["render"]["clean"] == 3
+    assert stats["render"]["by_lane"] == {"block": 3, "legacy": 1}
+
+
+def test_get_stats_clean_render_rate_honest_empty():
+    """No rendered documents → clean_render_rate is None (honest empty), never
+    a fabricated 100%."""
+    stats = _stats_service(
+        SimpleNamespace(rendered_total=0, rendered_clean=0, lane_block=0, lane_legacy=0)
+    ).get_stats()
+
+    assert stats["success"] is True
+    assert stats["clean_render_rate"] is None
+    assert stats["render"] == {"total": 0, "clean": 0, "by_lane": {"block": 0, "legacy": 0}}


### PR DESCRIPTION
PRD-190 (P2-09) — the four edge-fixes on the deliverables plane: the client-facing artifact stops rotting, id-driven templates work on the autonomy lane, `[[unresolved]]` documents are blocked at finalise, and clean-render becomes a tracked number. No new tables, no new endpoints, **no migration**.

## Stories

### S1 — Kill the link-rot (F030/J1)
`_build_result` overwrote the stable app path with the raw presigned S3 URL (`ExpiresIn=3600`), so every persisted Deliverable link 404'd after an hour. The overwrite is **deleted**: the persisted `download_url` is now the stable `/api/documents/generated/{filename}` path; the S3 persistence upload stays; the existing `serve_generated_file` endpoint (local-then-S3-redirect) owns presigning on demand. `_upload_to_s3` no longer mints a presign at all — no `_legacy` fallback kept.

### S2 — `template_id` on the autonomy lane (F031/J2)
One `ToolParameter` added to the registry `generate_document` ToolSpec (wording verbatim from the chatbot inline schema). The handler already parsed/validated/threaded `template_id` — missions/board/scheduled agents simply couldn't pass it. No handler change, no second generation path.

### S3 — Enforce the unresolved gate (J5/C-4)
Both render call sites captured-then-discarded the honesty lists behind `logger.warning` and shipped the file anyway. Now: `_render_block_html` and the DOCX block path capture `unresolved` (known path, empty value) and `unknown` (not in the catalog) onto `GeneratedDocument`, and `generate()` — the single finalisation choke — raises a typed **`UnresolvedDeliverableError`** carrying the offending paths. Never swallowed:
- `/api/documents/generate` and `/api/documents/templates/{id}/preview` map it to **422** with `{message, unresolved, unknown}` (explicit catch, not a masked generic 400).
- Agent lane / playbook step / mission coordinator surface it through their existing error handling — the message names the paths, so an agent can fix its `data.*` and retry.
- The Studio live preview (`/templates/preview-blocks`) renders outside `generate()` and keeps its visible red `[[markers]]` — preview unchanged, the gate is on finalise.

### S4 — Clean-render + template-lane metric (J3/J7, dossier G-1)
`register_as_deliverable` persists `render.unresolved_count` / `render.unknown_count` / `render.template_lane` on the Deliverable `extra` JSONB it already builds (no new table/column). `DeliverableService.get_stats` aggregates `clean_render_rate` (clean ÷ rendered; honest `None` when nothing rendered) plus block/legacy lane counts — additive keys on the existing stats surface Wave 0 exposes; no new endpoint, no new tile.

## Drift check (PRD anchors vs worktree @ `d26ce039d`, post-#525)
PRD verified its anchors at `649482aa3`; the tree has since taken the memory-unsplit merge. All anchors re-verified — **no semantic drift**, minor line drift only:
- `generate_document` ToolSpec: PRD `tool_registry.py:1185-1218` → now `1173-1241` (same content, still no `template_id`).
- `serve_generated_file`: PRD `:528-596` → `:528-602` (intact; contract asserted in S1 tests via the persisted path shape).
- `get_stats`: PRD `:510-528` → `:510-575`. Freshness endpoint: PRD `analytics_real.py:530-570` → `:529-573` (untouched, as specified).
- All others (`_build_result` overwrite `:640-644`, presign `:704`, warn-and-proceed `:176-180`/`:319-323`, inline schema `:227-229`, handler `:721-799`, `register` extra `:172/:274`) confirmed exactly.

## Surfaced decisions (§12 — flagged, not silently decided)
1. **S3 gate strictness** — shipped the PRD's proposed default **(a) hard-block always**; no `allow_unresolved` opt-in. If a workspace legitimately wants a known-blank optional field, option (b) is a small follow-up — Gerard's call (PRD Open Question 2).
2. **Template file-preview endpoint now gated** — `/templates/{template_id}/preview` generates a real file through `generate()`, so a template whose sample data leaves variables unresolved now returns 422 with the paths (previously: a file with red markers). The Studio live preview stays marker-visible. This follows the PRD's gate placement (generate() = finalise); flagging the UX change explicitly.
3. **`template_lane` semantics** — `"block"` covers both block templates and the no-template `blocks_from_legacy` fallback (both render through the block renderer); `"legacy"` = Jinja HTML + uploaded-docx (docxtpl); `None` for XLSX (no template render). Per PRD Open Question 3, post-S3 the block lane only registers clean documents, so the live signal is lane coverage + a durable gate audit.
4. **Chat tool results now carry the app-relative URL** (S1) — consistent with every other Deliverable link (`_workspace_file_url`, mission panel, gallery all anchor relative `/api/...` paths).
5. **Existing `get_stats` unit test updated** (`tests/services/test_deliverable_service.py`) for the fourth query + new keys — its 3-item `side_effect` would otherwise StopIteration.
6. **J4 (`repeat`/`each` block) + J6 (Plate editor)** — stated by the PRD itself as not-this-PRD (its Open Question 1); nothing additionally descoped here.

## Migration
**None created** — the PRD specifies no migration (no new tables/columns; S4 rides the existing `extra` JSONB). No `down_revision` chain, no merge-order constraint vs PRD-189/191.

## Routes
No routes added/changed (handler internals + response payload keys only) → `route-manifest.json` untouched.

## Test plan (CI is the gate — no local runs)
12 new pure tests in `orchestrator/tests/test_prd190_deliverables.py` + 2 updated in `tests/services/test_deliverable_service.py`. All mock at boundaries: boto3 module-level (S1), in-process registry + unbound inline schema (S2), fake Session + tmp_path storage + python-docx block render (S3 — no WeasyPrint), SQL-keyed fake Session for the read-model (S4).
- [ ] `orchestrator-tests` (required lane) green — incl. `test_unresolved_variable_blocks_finalisation` (the load-bearing assertion: BLOCKED, raises, not returns), `test_deliverable_download_url_is_stable_app_path`, `test_download_url_survives_presign_expiry`, `test_generate_document_toolspec_exposes_template_id`, `test_toolspec_matches_inline_chat_schema_for_template_id`, `test_clean_render_recorded_on_extra`, `test_get_stats_reports_clean_render_rate`
- [ ] frontend-ci route-contract unchanged (no route delta)
- [ ] Post-merge (live): generate a branded document, confirm the Deliverable link still downloads after >1h; pass a `template_id` from a mission step; confirm `/api/deliverables/stats` reports `clean_render_rate`
