### PR TITLE
fix(webhooks): fail closed on signature mismatch or absence (PRD-194 S1 pull-forward)

### DIFF
--- a/orchestrator/api/composio.py
+++ b/orchestrator/api/composio.py
@@ -612,7 +612,9 @@ async def handle_webhook(
     body = await request.body()
 
     # Verify signature — supports both legacy (x-composio-signature)
-    # and V3 (webhook-signature with "v1,<base64>" format)
+    # and V3 (webhook-signature with "v1,<base64>" format).
+    # When a secret is configured, a valid signature is mandatory:
+    # mismatch, verification error, or missing header ⇒ 401 (P2-13).
     webhook_secret = config.COMPOSIO_WEBHOOK_SECRET
     v3_signature = request.headers.get("webhook-signature")
     if webhook_secret and v3_signature:
@@ -626,10 +628,13 @@ async def handle_webhook(
                 hmac.new(base64.b64decode(webhook_secret), signed_content, hashlib.sha256).digest()
             ).decode()
             sig_value = v3_signature.split(",", 1)[-1] if "," in v3_signature else v3_signature
-            if not hmac.compare_digest(sig_value, expected_sig):
-                logger.warning("V3 webhook signature mismatch — allowing through for debugging")
+            signature_ok = hmac.compare_digest(sig_value, expected_sig)
         except Exception:
-            logger.warning("V3 signature verification error — allowing through for debugging", exc_info=True)
+            logger.warning("V3 signature verification error — rejecting", exc_info=True)
+            raise HTTPException(status_code=401, detail="Invalid webhook signature")
+        if not signature_ok:
+            logger.warning("V3 webhook signature mismatch — rejecting")
+            raise HTTPException(status_code=401, detail="Invalid webhook signature")
     elif webhook_secret and x_composio_signature:
         # Legacy format: plain HMAC hex digest
         expected_sig = hmac.new(
@@ -639,6 +644,9 @@ async def handle_webhook(
         ).hexdigest()
         if not hmac.compare_digest(x_composio_signature, expected_sig):
             raise HTTPException(status_code=401, detail="Invalid webhook signature")
+    elif webhook_secret:
+        logger.warning("Webhook rejected: COMPOSIO_WEBHOOK_SECRET is set but no signature header present")
+        raise HTTPException(status_code=401, detail="Missing webhook signature")
 
     # Parse payload
     try:

--- a/orchestrator/api/webhooks.py
+++ b/orchestrator/api/webhooks.py
@@ -5,7 +5,9 @@ General Webhook Endpoints
 Two webhook paths:
 1. POST /api/webhooks/ws/{workspace_key}  — General workspace webhook
    Routes incoming requests through UniversalRouter to the right agent.
-   No auth required — the workspace_key in the URL is the credential.
+   The workspace_key in the URL is the credential floor; when a webhook
+   secret (or Slack signing secret) is configured, a valid signature is
+   additionally mandatory.
 
 2. POST /api/webhooks/recipe/{webhook_id} — Recipe-specific webhook
    (Defined in workflow_recipes.py, registered separately.)
@@ -15,6 +17,7 @@ import asyncio
 import hashlib
 import hmac
 import logging
+import time
 from typing import Any, Dict, Optional, Set
 from uuid import UUID, uuid4
 
@@ -51,8 +54,9 @@ async def _verify_webhook_signature(
     Checks headers: X-Hub-Signature-256 (GitHub), X-Composio-Signature,
     X-Webhook-Signature.
 
-    If a secret is configured and a signature header is present, the signature
-    must match. If no secret is configured, verification is skipped (URL-as-secret
+    When a secret is configured, a valid signature is mandatory: a missing
+    header, a mismatch, or a verification error all reject with 401 (P2-13).
+    If no secret is configured, verification is skipped (URL-as-secret
     pattern still applies).
     """
     if not secret:
@@ -65,8 +69,8 @@ async def _verify_webhook_signature(
         or request.headers.get("x-webhook-signature")
     )
     if not sig_header:
-        # No signature header present — skip if not required
-        return
+        logger.warning("[webhook] Rejected: secret configured but no signature header present")
+        raise HTTPException(status_code=401, detail="Missing webhook signature")
 
     raw_body = await request.body()
 
@@ -81,6 +85,67 @@ async def _verify_webhook_signature(
 
     if not hmac.compare_digest(computed, expected_sig):
         logger.warning("[webhook] HMAC signature mismatch")
+        raise HTTPException(status_code=401, detail="Invalid webhook signature")
+
+
+# Slack's documented v0 replay window: reject requests whose signing
+# timestamp is further than 5 minutes from now.
+_SLACK_TS_SKEW_SECONDS = 60 * 5
+
+
+def _resolve_slack_signing_secret(db: Session, workspace: Workspace) -> Optional[str]:
+    """The signing secret collected for this workspace's Slack channel, if any.
+
+    Prefers an active ``channel_connections`` row; falls back to any Slack row
+    that carries a secret. Returns ``None`` when Slack was never configured
+    with a signing secret (verification is then skipped — URL-as-secret floor).
+    """
+    from core.models.channels import ChannelConnection
+
+    rows = (
+        db.query(ChannelConnection)
+        .filter(
+            ChannelConnection.workspace_id == workspace.id,
+            ChannelConnection.platform == "slack",
+        )
+        .all()
+    )
+    fallback: Optional[str] = None
+    for row in rows:
+        secret = (row.config or {}).get("signing_secret")
+        if not secret:
+            continue
+        if row.status == "active":
+            return str(secret)
+        fallback = fallback or str(secret)
+    return fallback
+
+
+async def _verify_slack_signature(request: Request, signing_secret: str) -> None:
+    """Verify Slack's v0 signing scheme.
+
+    Slack signs ``v0:{timestamp}:{raw_body}`` with the app's signing secret and
+    sends ``X-Slack-Signature: v0=<hex>`` + ``X-Slack-Request-Timestamp``.
+    Mandatory once a signing secret is collected: bad timestamp, stale
+    timestamp, or mismatch ⇒ 401 (P2-13).
+    """
+    sig_header = request.headers.get("x-slack-signature", "")
+    ts = request.headers.get("x-slack-request-timestamp", "")
+    raw_body = await request.body()
+
+    try:
+        ts_int = int(ts)
+    except (TypeError, ValueError):
+        logger.warning("[webhook] Slack signature rejected: bad timestamp header")
+        raise HTTPException(status_code=401, detail="Invalid webhook signature")
+    if abs(time.time() - ts_int) > _SLACK_TS_SKEW_SECONDS:
+        logger.warning("[webhook] Slack signature rejected: stale timestamp")
+        raise HTTPException(status_code=401, detail="Invalid webhook signature")
+
+    base = f"v0:{ts}:".encode("utf-8") + raw_body
+    computed = "v0=" + hmac.new(signing_secret.encode("utf-8"), base, hashlib.sha256).hexdigest()
+    if not hmac.compare_digest(computed, sig_header):
+        logger.warning("[webhook] Slack signature mismatch")
         raise HTTPException(status_code=401, detail="Invalid webhook signature")
 
 
@@ -314,8 +379,9 @@ async def general_workspace_webhook(
     """
     General workspace webhook — routes incoming requests to the right agent.
 
-    The workspace_key in the URL is the credential (URL-as-secret pattern).
-    No authentication required.
+    The workspace_key in the URL is the credential floor (URL-as-secret
+    pattern). When a webhook secret is configured — or a Slack signing
+    secret has been collected — a valid signature is mandatory on top.
 
     Body (JSON):
     - message / text / content: The message to route
@@ -361,9 +427,17 @@ async def general_workspace_webhook(
     if not workspace:
         raise HTTPException(status_code=404, detail="Unknown webhook")
 
-    # 1b. Verify HMAC signature if a webhook secret is configured
-    webhook_secret = (workspace.settings or {}).get("webhook_secret") or config.WEBHOOK_SECRET
-    await _verify_webhook_signature(request, webhook_secret)
+    # 1b. Verify inbound authenticity. Slack signs with its own v0 scheme
+    # (X-Slack-Signature), so Slack-signed requests verify against the
+    # collected signing secret; everything else uses the generic HMAC,
+    # which is mandatory once a webhook secret is configured.
+    if request.headers.get("x-slack-signature"):
+        slack_secret = _resolve_slack_signing_secret(db, workspace)
+        if slack_secret:
+            await _verify_slack_signature(request, slack_secret)
+    else:
+        webhook_secret = (workspace.settings or {}).get("webhook_secret") or config.WEBHOOK_SECRET
+        await _verify_webhook_signature(request, webhook_secret)
 
     # 2. Detect platform and extract reply context
     platform = _detect_platform(body) if isinstance(body, dict) else None

--- a/orchestrator/api/workflow_recipes.py
+++ b/orchestrator/api/workflow_recipes.py
@@ -1759,8 +1759,8 @@ async def recipe_webhook(
     Trigger a recipe execution via webhook.
 
     The webhook_id is a persistent secret stored in the recipe's
-    schedule_config.webhook_id. No authentication required — the
-    URL itself is the credential.
+    schedule_config.webhook_id — the URL is the credential floor. When a
+    webhook secret is configured, a valid HMAC signature is also mandatory.
 
     Body (optional):
     - Any JSON payload — passed as input_data to the recipe executor.
@@ -1797,7 +1797,8 @@ async def recipe_webhook(
     if not recipe:
         raise HTTPException(status_code=404, detail="Unknown webhook")
 
-    # Verify HMAC signature if a webhook secret is configured
+    # Verify HMAC signature — mandatory when a webhook secret is configured:
+    # missing header or mismatch ⇒ 401 (P2-13).
     webhook_secret = (recipe.schedule_config or {}).get("webhook_secret") or config.WEBHOOK_SECRET
     if webhook_secret:
         sig_header = (
@@ -1805,17 +1806,19 @@ async def recipe_webhook(
             or request.headers.get("x-composio-signature")
             or request.headers.get("x-webhook-signature")
         )
-        if sig_header:
-            raw_body = await request.body()
-            expected_sig = sig_header.removeprefix("sha256=")
-            computed = hmac.new(
-                webhook_secret.encode("utf-8"),
-                raw_body,
-                hashlib.sha256,
-            ).hexdigest()
-            if not hmac.compare_digest(computed, expected_sig):
-                logger.warning("[webhook] HMAC signature mismatch for recipe webhook %s", webhook_id)
-                raise HTTPException(status_code=401, detail="Invalid webhook signature")
+        if not sig_header:
+            logger.warning("[webhook] Rejected recipe webhook %s: secret configured but no signature header", webhook_id)
+            raise HTTPException(status_code=401, detail="Missing webhook signature")
+        raw_body = await request.body()
+        expected_sig = sig_header.removeprefix("sha256=")
+        computed = hmac.new(
+            webhook_secret.encode("utf-8"),
+            raw_body,
+            hashlib.sha256,
+        ).hexdigest()
+        if not hmac.compare_digest(computed, expected_sig):
+            logger.warning("[webhook] HMAC signature mismatch for recipe webhook %s", webhook_id)
+            raise HTTPException(status_code=401, detail="Invalid webhook signature")
 
     if not recipe.steps:
         raise HTTPException(status_code=400, detail="Recipe has no steps")

--- a/orchestrator/tests/test_p2w2_webhook_signature_reject.py
+++ b/orchestrator/tests/test_p2w2_webhook_signature_reject.py
@@ -1,0 +1,310 @@
+"""PRD-194 S1 (P2-13, security §1.1 CRITICAL) — webhook reject-on-signature-mismatch.
+
+Until this change, the external webhook lanes failed OPEN on signature
+problems: the Composio V3 block logged "allowing through for debugging" on a
+mismatch or a verification error, and both the workspace and the playbook
+(recipe) lanes silently skipped verification when the signature header was
+absent — so a configured secret bought nothing against an attacker who simply
+omitted the header. Slack inbound was never verifiable at all: no X-Slack-
+Signature scheme existed.
+
+These tests pin the fail-closed contract (the GitHub lane's semantics,
+`github_webhooks.py` — the in-tree template): **when a secret is configured,
+a valid signature is mandatory — mismatch, verification error, or missing
+header ⇒ 401 and nothing dispatches.** No secret configured keeps the
+URL-as-secret floor (unchanged posture).
+
+Pure: requests are hand-built Starlette Requests, the DB is a stub (poisoned
+where the handler must reject before ever touching it); no network, no real
+Composio, no live Slack.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("POSTGRES_USER", "test")
+os.environ.setdefault("POSTGRES_PASSWORD", "test")
+os.environ.setdefault("POSTGRES_HOST", "127.0.0.1")
+os.environ.setdefault("POSTGRES_PORT", "59432")
+os.environ.setdefault("POSTGRES_DB", "test")
+
+import asyncio  # noqa: E402
+import base64  # noqa: E402
+import hashlib  # noqa: E402
+import hmac  # noqa: E402
+import time  # noqa: E402
+from types import SimpleNamespace  # noqa: E402
+from uuid import uuid4  # noqa: E402
+
+import pytest  # noqa: E402
+from fastapi import HTTPException  # noqa: E402
+from starlette.requests import Request  # noqa: E402
+
+import tests.conftest as _conftest  # noqa: E402
+
+_conftest._restore_real_app_modules()
+
+from api import composio as composio_api  # noqa: E402
+from api import webhooks as webhooks_api  # noqa: E402
+from api import workflow_recipes as recipes_api  # noqa: E402
+
+
+# ---------------------------------------------------------------- helpers
+
+def _make_request(headers: dict, body: bytes = b"{}") -> Request:
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/api/webhooks/test",
+        "headers": [(k.lower().encode(), str(v).encode()) for k, v in headers.items()],
+        "query_string": b"",
+    }
+
+    async def receive():
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    return Request(scope, receive)
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+class _PoisonedDb:
+    """A DB the handler must never reach — rejection happens first."""
+
+    def query(self, *args, **kwargs):
+        raise AssertionError("db must not be touched when the signature is rejected")
+
+
+class _StubQuery:
+    def __init__(self, single=None, many=None):
+        self._single = single
+        self._many = many or []
+
+    def filter(self, *args, **kwargs):
+        return self
+
+    def first(self):
+        return self._single
+
+    def all(self):
+        return self._many
+
+
+class _RoutingDb:
+    """query(Model) routed by model name — workspace lookup + channel rows."""
+
+    def __init__(self, workspace=None, channel_rows=None):
+        self._workspace = workspace
+        self._channel_rows = channel_rows or []
+
+    def query(self, model, *args, **kwargs):
+        if model.__name__ == "ChannelConnection":
+            return _StubQuery(many=self._channel_rows)
+        return _StubQuery(single=self._workspace)
+
+
+def _fake_workspace(settings=None):
+    return SimpleNamespace(id=uuid4(), is_active=True, settings=settings or {})
+
+
+# ---------------------------------------------------------------- Composio V3
+
+_COMPOSIO_SECRET_B64 = base64.b64encode(b"composio-test-secret").decode()
+
+
+def _v3_signature(body: bytes, webhook_id: str, webhook_ts: str, secret_b64: str) -> str:
+    signed_content = f"{webhook_id}.{webhook_ts}.".encode() + body
+    digest = hmac.new(base64.b64decode(secret_b64), signed_content, hashlib.sha256).digest()
+    return "v1," + base64.b64encode(digest).decode()
+
+
+def test_composio_webhook_mismatch_rejected(monkeypatch):
+    """A V3 signature mismatch is a 401 and dispatches nothing (was: 200 + dispatch)."""
+    monkeypatch.setattr(composio_api.config, "COMPOSIO_WEBHOOK_SECRET", _COMPOSIO_SECRET_B64)
+    req = _make_request(
+        {
+            "webhook-signature": "v1,definitely-not-the-signature",
+            "webhook-id": "wh_1",
+            "webhook-timestamp": "1700000000",
+        },
+        body=b'{"type": "composio.trigger.message", "data": {}}',
+    )
+    with pytest.raises(HTTPException) as ei:
+        _run(composio_api.handle_webhook(request=req, x_composio_signature=None, db=_PoisonedDb()))
+    assert ei.value.status_code == 401
+
+
+def test_composio_webhook_verification_error_rejected(monkeypatch):
+    """A verification *error* (garbage headers) rejects too — no fail-open on exception."""
+    monkeypatch.setattr(composio_api.config, "COMPOSIO_WEBHOOK_SECRET", "%%% not base64 %%%")
+    req = _make_request(
+        {"webhook-signature": "v1,whatever", "webhook-id": "wh_1", "webhook-timestamp": "1"},
+    )
+    with pytest.raises(HTTPException) as ei:
+        _run(composio_api.handle_webhook(request=req, x_composio_signature=None, db=_PoisonedDb()))
+    assert ei.value.status_code == 401
+
+
+def test_composio_webhook_missing_signature_rejected_when_secret_set(monkeypatch):
+    """Secret configured + no signature header at all ⇒ 401 (was: no verification ran)."""
+    monkeypatch.setattr(composio_api.config, "COMPOSIO_WEBHOOK_SECRET", _COMPOSIO_SECRET_B64)
+    req = _make_request({}, body=b"{}")
+    with pytest.raises(HTTPException) as ei:
+        _run(composio_api.handle_webhook(request=req, x_composio_signature=None, db=_PoisonedDb()))
+    assert ei.value.status_code == 401
+
+
+def test_composio_webhook_valid_v3_signature_accepted(monkeypatch):
+    """A correctly signed request passes verification (fails later on 400, not 401)."""
+    monkeypatch.setattr(composio_api.config, "COMPOSIO_WEBHOOK_SECRET", _COMPOSIO_SECRET_B64)
+    body = b"{}"  # no trigger_name → the handler 400s AFTER the signature gate
+    sig = _v3_signature(body, "wh_1", "1700000000", _COMPOSIO_SECRET_B64)
+    req = _make_request(
+        {"webhook-signature": sig, "webhook-id": "wh_1", "webhook-timestamp": "1700000000"},
+        body=body,
+    )
+    with pytest.raises(HTTPException) as ei:
+        _run(composio_api.handle_webhook(request=req, x_composio_signature=None, db=_PoisonedDb()))
+    assert ei.value.status_code == 400  # missing trigger_name — proof the 401 gate passed
+
+
+# ---------------------------------------------------------------- workspace lane
+
+def test_workspace_webhook_hmac_mandatory_when_secret():
+    """Secret-configured workspace lane 401s when the signature header is absent."""
+    ws = _fake_workspace(settings={"webhook_secret": "topsecret"})
+    req = _make_request({"content-type": "application/json"}, body=b'{"message": "hi"}')
+    with pytest.raises(HTTPException) as ei:
+        _run(webhooks_api.general_workspace_webhook(workspace_key="k", request=req, db=_RoutingDb(ws)))
+    assert ei.value.status_code == 401
+
+
+def test_verify_webhook_signature_paths():
+    """Pure contract of the shared verifier: mandatory-when-secret, floor otherwise."""
+    secret = "topsecret"
+    body = b'{"x": 1}'
+    good = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+    # correct signature (with and without the GitHub sha256= prefix) passes
+    _run(webhooks_api._verify_webhook_signature(
+        _make_request({"x-webhook-signature": good}, body), secret))
+    _run(webhooks_api._verify_webhook_signature(
+        _make_request({"x-hub-signature-256": f"sha256={good}"}, body), secret))
+
+    # mismatch ⇒ 401
+    with pytest.raises(HTTPException):
+        _run(webhooks_api._verify_webhook_signature(
+            _make_request({"x-webhook-signature": "0" * 64}, body), secret))
+
+    # secret set + missing header ⇒ 401 (the deleted silent skip)
+    with pytest.raises(HTTPException):
+        _run(webhooks_api._verify_webhook_signature(_make_request({}, body), secret))
+
+    # no secret ⇒ no-op (URL-as-secret floor unchanged)
+    _run(webhooks_api._verify_webhook_signature(_make_request({}, body), None))
+
+
+# ---------------------------------------------------------------- Slack v0
+
+def _slack_headers(secret: str, body: bytes, ts: int) -> dict:
+    base = f"v0:{ts}:".encode() + body
+    sig = "v0=" + hmac.new(secret.encode(), base, hashlib.sha256).hexdigest()
+    return {"x-slack-signature": sig, "x-slack-request-timestamp": str(ts)}
+
+
+def test_slack_signature_verified():
+    """A valid X-Slack-Signature passes; an invalid one 401s."""
+    secret, body = "slack-signing-secret", b'{"type": "event_callback"}'
+    now = int(time.time())
+
+    _run(webhooks_api._verify_slack_signature(
+        _make_request(_slack_headers(secret, body, now), body), secret))
+
+    with pytest.raises(HTTPException) as ei:
+        _run(webhooks_api._verify_slack_signature(
+            _make_request(_slack_headers("wrong-secret", body, now), body), secret))
+    assert ei.value.status_code == 401
+
+
+def test_slack_signature_stale_or_garbage_timestamp_rejected():
+    secret, body = "slack-signing-secret", b"{}"
+    stale = int(time.time()) - 4000
+    with pytest.raises(HTTPException):
+        _run(webhooks_api._verify_slack_signature(
+            _make_request(_slack_headers(secret, body, stale), body), secret))
+
+    headers = _slack_headers(secret, body, int(time.time()))
+    headers["x-slack-request-timestamp"] = "not-a-number"
+    with pytest.raises(HTTPException):
+        _run(webhooks_api._verify_slack_signature(_make_request(headers, body), secret))
+
+
+def test_slack_lane_enforces_collected_signing_secret():
+    """A Slack-signed request to the workspace lane verifies against the
+    channel's collected signing secret — a mismatch 401s instead of skipping."""
+    ws = _fake_workspace()
+    row = SimpleNamespace(config={"signing_secret": "the-real-secret"}, status="active")
+    headers = _slack_headers("attacker-secret", b'{"message": "hi"}', int(time.time()))
+    headers["content-type"] = "application/json"
+    req = _make_request(headers, body=b'{"message": "hi"}')
+    with pytest.raises(HTTPException) as ei:
+        _run(webhooks_api.general_workspace_webhook(
+            workspace_key="k", request=req, db=_RoutingDb(ws, channel_rows=[row])))
+    assert ei.value.status_code == 401
+
+
+def test_resolve_slack_signing_secret_prefers_active_row():
+    ws = _fake_workspace()
+    inactive = SimpleNamespace(config={"signing_secret": "old"}, status="inactive")
+    active = SimpleNamespace(config={"signing_secret": "new"}, status="active")
+    db = _RoutingDb(ws, channel_rows=[inactive, active])
+    assert webhooks_api._resolve_slack_signing_secret(db, ws) == "new"
+    assert webhooks_api._resolve_slack_signing_secret(_RoutingDb(ws), ws) is None
+
+
+# ---------------------------------------------------------------- recipe lane
+
+def _fake_recipe(secret: str | None):
+    cfg = {"webhook_id": "wh1"}
+    if secret:
+        cfg["webhook_secret"] = secret
+    return SimpleNamespace(schedule_config=cfg, steps=[], name="r", workspace_id=uuid4())
+
+
+class _RecipeDb:
+    def __init__(self, recipe):
+        self._recipe = recipe
+
+    def query(self, *args, **kwargs):
+        return _StubQuery(single=self._recipe)
+
+
+def test_recipe_webhook_hmac_mandatory_when_secret():
+    """Secret-configured playbook lane 401s on a missing or invalid signature."""
+    recipe = _fake_recipe("recipe-secret")
+
+    req = _make_request({"content-type": "application/json"}, body=b"{}")
+    with pytest.raises(HTTPException) as ei:
+        _run(recipes_api.recipe_webhook(webhook_id="wh1", request=req, db=_RecipeDb(recipe)))
+    assert ei.value.status_code == 401
+
+    req = _make_request(
+        {"content-type": "application/json", "x-webhook-signature": "0" * 64}, body=b"{}")
+    with pytest.raises(HTTPException) as ei:
+        _run(recipes_api.recipe_webhook(webhook_id="wh1", request=req, db=_RecipeDb(recipe)))
+    assert ei.value.status_code == 401
+
+
+def test_recipe_webhook_valid_signature_accepted():
+    """A correctly signed request passes the gate (fails later on 400 no-steps, not 401)."""
+    recipe = _fake_recipe("recipe-secret")
+    body = b"{}"
+    good = hmac.new(b"recipe-secret", body, hashlib.sha256).hexdigest()
+    req = _make_request(
+        {"content-type": "application/json", "x-webhook-signature": good}, body=body)
+    with pytest.raises(HTTPException) as ei:
+        _run(recipes_api.recipe_webhook(webhook_id="wh1", request=req, db=_RecipeDb(recipe)))
+    assert ei.value.status_code == 400  # "Recipe has no steps" — past the signature gate


### PR DESCRIPTION
## Summary

Pull-forward of **PRD-194 S1** (P2-13, security appendix §1.1 CRITICAL), approved by Gerard ahead of the Wave-2 build: the external webhook lanes **fail closed** on signature problems instead of allowing through.

Before this PR:
- `api/composio.py` V3 block **logged and allowed through** on signature mismatch *and* on verification error ("allowing through for debugging" ×2).
- Workspace lane (`/api/webhooks/ws/{key}`) and playbook lane (`/recipe/{id}`) **silently skipped verification when the signature header was absent** — omitting the header defeated a configured secret.
- Slack inbound was **never verifiable**: no X-Slack-Signature scheme existed.

Now (GitHub lane semantics — the in-tree template): **when a secret is configured, a valid signature is mandatory — mismatch, verification error, or missing header ⇒ 401 and nothing dispatches.**

## Changes
- **composio V3**: mismatch/error ⇒ 401; secret set + no signature header ⇒ 401 (legacy header path already rejected — unchanged).
- **workspace lane**: missing-header silent skip deleted ⇒ 401; **Slack v0 scheme implemented** (`v0:{ts}:{body}`, 5-min replay window) against the channel's collected `signing_secret` — Slack-signed requests verify, others use the generic HMAC.
- **playbook lane**: HMAC mandatory-when-secret (same change).
- URL-as-secret floor **unchanged** when no secret is configured; fall-throughs **deleted**, no debug-bypass env (CLAUDE.md §5).

## Tests
`orchestrator/tests/test_p2w2_webhook_signature_reject.py` — pure (hand-built Starlette Requests, poisoned/stub DB, no network, no live Slack/Composio):
- [x] mismatch / verification-error / missing-header ⇒ 401 + dispatches nothing (all three lanes)
- [x] correctly signed requests still pass the gate (fail later on 400, proving the 401 gate passed)
- [x] Slack v0 verify: valid passes, invalid 401, stale/garbage timestamp 401, active-row secret resolution
- [ ] CI green (orchestrator-tests) — the merge gate

## Rollout note
Enforcement only binds where a secret **is configured** (`COMPOSIO_WEBHOOK_SECRET`, workspace `webhook_secret`, recipe `webhook_secret`, or a collected Slack `signing_secret`). Unconfigured lanes keep today's URL-as-secret posture — no integration breaks by default; a sender that was relying on a *wrong* signature being tolerated is exactly what this PR is meant to stop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Strengthened webhook authentication by requiring signatures whenever a webhook secret is configured.
  - Invalid, missing, malformed, or mismatched signatures are now rejected with HTTP 401.
  - Added Slack signature verification, including timestamp freshness checks and signing-secret selection.

- **Bug Fixes**
  - Prevented unsigned webhook requests from bypassing authentication.
  - Ensured rejected requests do not trigger downstream processing.

- **Tests**
  - Added coverage for valid, invalid, missing, stale, and malformed webhook signatures across supported webhook types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->