### PR TITLE
fix(governance): ws-admin gate on approval-grant mutations + pending-grant notification (PRD-196 S2 pull-forward)

### DIFF
--- a/orchestrator/api/approval_grants.py
+++ b/orchestrator/api/approval_grants.py
@@ -5,6 +5,11 @@ tasks, playbook runs, and (future) scheduled/webhook agents. A pending grant
 holds its subject blocked; granting it here authorises the subject and re-queues
 a blocked board task; revoking a live grant retracts the authorisation.
 
+PRD-196 S2 (P2-15, governance C.8): the whole surface is workspace-admin gated
+via the canonical ``require_workspace_admin`` dependency (PRD-185 S12) — a
+plain member must not be able to authorise an agent's destructive action, and
+the approvals surface is ws-admin-only by Gerard's posture call (196 Q2).
+
 Every state change is audited (governance action) via the S1 nullable-user audit
 path — the actor here is the human approver.
 """
@@ -16,8 +21,8 @@ from typing import Any, Dict, List, Optional
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
-from core.auth.hybrid import get_request_context_hybrid
 from core.auth.dependencies import RequestContext
+from core.auth.workspace_admin import require_workspace_admin
 from core.database.database import get_db
 from core.models.approval_grants import ApprovalGrant, GrantStatus, SUBJECT_BOARD_TASK
 from core.models.core import BoardTask
@@ -58,7 +63,7 @@ def _audit(db: Session, ctx: RequestContext, action: str, grant: ApprovalGrant) 
 @router.get("")
 async def list_grants(
     status: Optional[str] = None,
-    ctx: RequestContext = Depends(get_request_context_hybrid),
+    ctx: RequestContext = Depends(require_workspace_admin),
     db: Session = Depends(get_db),
 ) -> Dict[str, Any]:
     """List this workspace's approval grants, newest first. Filter by ``status``."""
@@ -83,7 +88,7 @@ def _load_grant(db: Session, ctx: RequestContext, grant_id: int) -> ApprovalGran
 @router.post("/{grant_id}/grant")
 async def grant_approval(
     grant_id: int,
-    ctx: RequestContext = Depends(get_request_context_hybrid),
+    ctx: RequestContext = Depends(require_workspace_admin),
     db: Session = Depends(get_db),
 ) -> Dict[str, Any]:
     """Approve a pending grant (a human says yes) and re-queue any blocked subject."""
@@ -103,7 +108,7 @@ async def grant_approval(
 @router.post("/{grant_id}/deny")
 async def deny_approval(
     grant_id: int,
-    ctx: RequestContext = Depends(get_request_context_hybrid),
+    ctx: RequestContext = Depends(require_workspace_admin),
     db: Session = Depends(get_db),
 ) -> Dict[str, Any]:
     """Refuse a pending grant — the subject fails rather than retrying."""
@@ -123,7 +128,7 @@ async def deny_approval(
 @router.post("/{grant_id}/revoke")
 async def revoke_approval(
     grant_id: int,
-    ctx: RequestContext = Depends(get_request_context_hybrid),
+    ctx: RequestContext = Depends(require_workspace_admin),
     db: Session = Depends(get_db),
 ) -> Dict[str, Any]:
     """Retract a granted authorisation before it expires."""

--- a/orchestrator/core/services/notification_dispatcher.py
+++ b/orchestrator/core/services/notification_dispatcher.py
@@ -48,6 +48,7 @@ VALID_EVENT_TYPES: frozenset[str] = frozenset(
         "task_complete",
         "task_failed",
         "task_sla_breach",
+        "approval_pending",
         "mission_plan_ready",
         "mission_step_complete",
         "mission_complete",

--- a/orchestrator/services/board_approval.py
+++ b/orchestrator/services/board_approval.py
@@ -10,7 +10,9 @@ through the **same** ``evaluate_approval`` primitive missions use (PRD-163):
     **blocked** until a human grants it — not hard-blocked, not auto-allowed.
 
 The grant is the tool-agnostic record the future scheduled/webhook agents share.
-Every grant creation is audited (governance action).
+Every grant creation is audited (governance action), and — PRD-196 S2 (C.8) —
+announced to the workspace's admins via an ``approval_pending`` notification,
+so a blocked task never waits silently.
 
 This module is the decision glue only; the dispatch wiring (moving the board task
 to ``blocked`` and re-queuing it on grant) lives in ``api.board_tasks`` and
@@ -18,12 +20,17 @@ to ``blocked`` and re-queuing it on grant) lives in ``api.board_tasks`` and
 """
 from __future__ import annotations
 
+import asyncio
 import logging
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any, Optional, Set
 from uuid import UUID
 
 logger = logging.getLogger(__name__)
+
+# Strong refs to fire-and-forget notification tasks (the api/webhooks.py
+# background-task idiom) so the loop cannot GC them mid-flight.
+_NOTIFY_TASKS: Set["asyncio.Task"] = set()
 
 
 @dataclass(frozen=True)
@@ -138,6 +145,17 @@ def evaluate_board_task_approval(
         estimated_cost_usd=estimated_cost_usd,
         risk_tier=risk_tier,
     )
+    # PRD-196 S2 (C.8): a pending grant must never wait silently — tell the
+    # workspace's humans. Only on fresh creation (the reuse branch above was
+    # already announced when its grant was created).
+    _notify_approval_pending(
+        workspace_id,
+        grant_id=getattr(grant, "id", None),
+        subject_id=str(task_id),
+        risk_tier=risk_tier,
+        reason=reason,
+        estimated_cost_usd=estimated_cost_usd,
+    )
     return BoardApprovalOutcome(
         requires_approval=True,
         reason=reason,
@@ -145,6 +163,78 @@ def evaluate_board_task_approval(
         policy=policy,
         estimated_cost_usd=estimated_cost_usd,
     )
+
+
+async def _dispatch_approval_pending(
+    workspace_id: str,
+    grant_id: Any,
+    subject_id: str,
+    risk_tier: Optional[str],
+    reason: str,
+    estimated_cost_usd: float,
+) -> None:
+    """Dispatch ``approval_pending`` through the canonical notification seam.
+
+    Owns its session: by the time the loop runs this, the creating caller's
+    transaction is finished (and its session may be closed).
+    """
+    from core.database.database import SessionLocal
+    from core.services.notification_dispatcher import NotificationDispatcher
+
+    db = SessionLocal()
+    try:
+        message = reason
+        if estimated_cost_usd:
+            message = f"{reason} (est. ${estimated_cost_usd:.2f})"
+        if risk_tier:
+            message = f"{message} [risk: {risk_tier}]"
+        await NotificationDispatcher(db, workspace_id).dispatch(
+            event_type="approval_pending",
+            title=f"Approval needed: board task {subject_id}",
+            message=message,
+            link_type="approval_grant",
+            link_id=str(grant_id) if grant_id is not None else None,
+            status="action_required",
+        )
+    except Exception:
+        logger.warning(
+            "[board_approval] approval_pending dispatch failed for grant %s",
+            grant_id, exc_info=True,
+        )
+    finally:
+        db.close()
+
+
+def _notify_approval_pending(
+    workspace_id: UUID | str,
+    *,
+    grant_id: Any,
+    subject_id: str,
+    risk_tier: Optional[str],
+    reason: str,
+    estimated_cost_usd: float,
+) -> None:
+    """Schedule the pending-grant notification without blocking the gate.
+
+    The gate is sync and its live caller runs on the event loop, so the
+    dispatch is scheduled as a tracked task there; with no running loop
+    (scripts, sync tests) it runs inline. Never raises — a notification fault
+    must not wedge board execution (same posture as the gate's caller).
+    """
+    try:
+        coro = _dispatch_approval_pending(
+            str(workspace_id), grant_id, subject_id, risk_tier, reason, estimated_cost_usd,
+        )
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            asyncio.run(coro)
+            return
+        task = loop.create_task(coro)
+        _NOTIFY_TASKS.add(task)
+        task.add_done_callback(_NOTIFY_TASKS.discard)
+    except Exception:
+        logger.warning("[board_approval] approval_pending scheduling failed", exc_info=True)
 
 
 def _decide_from_override(

--- a/orchestrator/tests/test_p2w2_grant_mutation_admin_gate.py
+++ b/orchestrator/tests/test_p2w2_grant_mutation_admin_gate.py
@@ -1,0 +1,216 @@
+"""PRD-196 S2 (P2-15, governance C.8) — arm the door before opening it.
+
+Until this change the grant-mutation endpoints depended only on
+``get_request_context_hybrid``: ANY workspace member could authorise an
+agent's destructive action by POSTing grant/deny/revoke. And nothing told a
+human that a grant was pending — a blocked board task waited silently.
+
+Pinned here:
+- every approval-grant endpoint (list + the three mutations) carries the
+  canonical ``require_workspace_admin`` dependency (PRD-185 S12) — plain
+  members 403, workspace owner/admin and the super-admin pass;
+- creating a fresh pending grant dispatches exactly one ``approval_pending``
+  notification (grant id / subject / risk in the payload), the reuse branch
+  does not re-spam, and denial semantics are untouched;
+- ``approval_pending`` is part of the dispatcher's event vocabulary.
+
+Pure: fake ctx + MagicMock sessions (the PRD-185 S12 test shape); the
+notification dispatch is captured at the module seam — no DB, no network,
+no live dispatcher.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("POSTGRES_USER", "test")
+os.environ.setdefault("POSTGRES_PASSWORD", "test")
+os.environ.setdefault("POSTGRES_HOST", "127.0.0.1")
+os.environ.setdefault("POSTGRES_PORT", "59432")
+os.environ.setdefault("POSTGRES_DB", "test")
+
+import asyncio  # noqa: E402
+import uuid  # noqa: E402
+from types import SimpleNamespace  # noqa: E402
+from unittest.mock import MagicMock  # noqa: E402
+
+import pytest  # noqa: E402
+from fastapi import HTTPException  # noqa: E402
+
+import tests.conftest as _conftest  # noqa: E402
+
+_conftest._restore_real_app_modules()
+
+from api import approval_grants as grants_api  # noqa: E402
+from core.auth.workspace_admin import require_workspace_admin  # noqa: E402
+from services import board_approval  # noqa: E402
+
+
+def _ctx(*, system_role="user", role="user", clerk_user_id=None, workspace_id=None):
+    """A minimal RequestContext-shaped fake (the PRD-185 S12 shape)."""
+    user = SimpleNamespace(
+        id="u", email=None, role=role, system_role=system_role, clerk_user_id=clerk_user_id
+    )
+    return SimpleNamespace(user=user, workspace_id=workspace_id or uuid.uuid4())
+
+
+# ---------------------------------------------------------------------------
+# The gate is wired: every approval-grant route depends on require_workspace_admin
+# ---------------------------------------------------------------------------
+
+def _dependant_calls(dependant) -> set:
+    calls = {getattr(dependant, "call", None)}
+    for sub in getattr(dependant, "dependencies", []) or []:
+        calls |= _dependant_calls(sub)
+    return calls
+
+
+def test_every_grant_route_carries_workspace_admin_gate():
+    expected = {
+        ("/api/v1/approval-grants", "GET"),
+        ("/api/v1/approval-grants/{grant_id}/grant", "POST"),
+        ("/api/v1/approval-grants/{grant_id}/deny", "POST"),
+        ("/api/v1/approval-grants/{grant_id}/revoke", "POST"),
+    }
+    seen = set()
+    for route in grants_api.router.routes:
+        for method in route.methods or ():
+            key = (route.path, method)
+            if key in expected:
+                assert require_workspace_admin in _dependant_calls(route.dependant), (
+                    f"{method} {route.path} is not gated by require_workspace_admin"
+                )
+                seen.add(key)
+    assert seen == expected, f"missing routes: {expected - seen}"
+
+
+def test_plain_member_403s_and_workspace_admin_passes():
+    """Drive the dependency itself: no owner/admin membership row ⇒ 403;
+    super-admin (and any principal may_see_own_workspace_health accepts) ⇒ ctx."""
+    db = MagicMock()
+    db.execute.return_value.fetchone.return_value = None  # plain member — no admin row
+    with pytest.raises(HTTPException) as ei:
+        asyncio.run(require_workspace_admin(ctx=_ctx(clerk_user_id="clerk_1"), db=db))
+    assert ei.value.status_code == 403
+
+    ctx = _ctx(system_role="super_admin")
+    assert asyncio.run(require_workspace_admin(ctx=ctx, db=MagicMock())) is ctx
+
+    db = MagicMock()
+    db.execute.return_value.fetchone.return_value = (1,)  # owner/admin membership row
+    ctx = _ctx(clerk_user_id="clerk_1")
+    assert asyncio.run(require_workspace_admin(ctx=ctx, db=db)) is ctx
+
+
+# ---------------------------------------------------------------------------
+# Pending-grant creation dispatches approval_pending (and only fresh creation)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def capture_dispatch(monkeypatch):
+    calls = []
+
+    async def _fake_dispatch(workspace_id, grant_id, subject_id, risk_tier, reason, estimated_cost_usd):
+        calls.append(
+            {
+                "workspace_id": workspace_id,
+                "grant_id": grant_id,
+                "subject_id": subject_id,
+                "risk_tier": risk_tier,
+                "reason": reason,
+                "estimated_cost_usd": estimated_cost_usd,
+            }
+        )
+
+    monkeypatch.setattr(board_approval, "_dispatch_approval_pending", _fake_dispatch)
+    monkeypatch.setattr(board_approval, "_audit_governance", lambda *a, **k: None)
+    return calls
+
+
+def test_pending_grant_dispatches_notification(monkeypatch, capture_dispatch):
+    ws = uuid.uuid4()
+    fake_grant = SimpleNamespace(id=7, subject_id="42")
+    monkeypatch.setattr("core.services.approval_grants.find_pending_grant", lambda *a, **k: None)
+    monkeypatch.setattr("core.services.approval_grants.create_grant", lambda *a, **k: fake_grant)
+
+    outcome = board_approval.evaluate_board_task_approval(
+        MagicMock(),
+        workspace_id=ws,
+        task_id=42,
+        estimated_cost_usd=1.25,
+        risk_tier="high",
+        _policy_override="always_ask",
+    )
+
+    assert outcome.requires_approval is True
+    assert len(capture_dispatch) == 1, "exactly one approval_pending per fresh grant"
+    call = capture_dispatch[0]
+    assert call["workspace_id"] == str(ws)
+    assert call["grant_id"] == 7
+    assert call["subject_id"] == "42"
+    assert call["risk_tier"] == "high"
+    assert call["estimated_cost_usd"] == 1.25
+
+
+def test_existing_pending_grant_does_not_renotify(monkeypatch, capture_dispatch):
+    existing = SimpleNamespace(id=5, subject_id="42")
+    monkeypatch.setattr("core.services.approval_grants.find_pending_grant", lambda *a, **k: existing)
+    monkeypatch.setattr(
+        "core.services.approval_grants.create_grant",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("must reuse, not create")),
+    )
+
+    outcome = board_approval.evaluate_board_task_approval(
+        MagicMock(), workspace_id=uuid.uuid4(), task_id=42, _policy_override="always_ask",
+    )
+
+    assert outcome.requires_approval is True
+    assert outcome.grant is existing
+    assert capture_dispatch == [], "the reuse branch must not re-spam admins"
+
+
+def test_notification_fault_never_wedges_the_gate(monkeypatch):
+    """A dispatch/scheduling fault is swallowed — approval still asks."""
+    monkeypatch.setattr("core.services.approval_grants.find_pending_grant", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "core.services.approval_grants.create_grant",
+        lambda *a, **k: SimpleNamespace(id=9, subject_id="7"),
+    )
+    monkeypatch.setattr(board_approval, "_audit_governance", lambda *a, **k: None)
+
+    def _boom(*a, **k):
+        raise RuntimeError("dispatcher down")
+
+    monkeypatch.setattr(board_approval, "_dispatch_approval_pending", _boom)
+
+    outcome = board_approval.evaluate_board_task_approval(
+        MagicMock(), workspace_id=uuid.uuid4(), task_id=7, _policy_override="always_ask",
+    )
+    assert outcome.requires_approval is True
+
+
+def test_deny_does_not_requeue():
+    """Guard the existing denial semantics while touching the file: a denied
+    subject fails — it is never returned to the dispatch queue."""
+    task = SimpleNamespace(status="blocked", error_message=None, completed_at=None)
+    db = MagicMock()
+    db.query.return_value.get.return_value = task
+    grant = SimpleNamespace(
+        subject_type="board_task", subject_id="11", workspace_id=uuid.uuid4()
+    )
+
+    grants_api._fail_subject(db, grant)
+
+    assert task.status == "failed"
+    assert task.error_message == "Approval denied by a human reviewer"
+    assert task.completed_at is not None
+
+
+# ---------------------------------------------------------------------------
+# Vocabulary
+# ---------------------------------------------------------------------------
+
+def test_approval_pending_is_a_valid_event_type():
+    from core.services.notification_dispatcher import VALID_EVENT_TYPES
+
+    assert "approval_pending" in VALID_EVENT_TYPES


### PR DESCRIPTION
## Summary

Pull-forward of **PRD-196 S2** (P2-15, governance C.8), approved by Gerard ahead of the Wave-2 build: **arm the approvals door before the Governance tab opens it.**

Before this PR:
- `grant_approval` / `deny_approval` / `revoke_approval` depended only on `get_request_context_hybrid` — **any workspace member could authorise an agent's destructive action**.
- Nothing notified a human that a grant was pending — a blocked board task **waited silently**.

## Changes
- **All four approval-grant endpoints** (list + the three mutations) now carry the canonical `require_workspace_admin` (PRD-185 S12): plain members 403; workspace owner/admin + super-admin pass. The list endpoint is included per Gerard's 196-Q2 posture call (whole approvals surface ws-admin-only). `grep`: zero frontend callers today — nothing user-facing breaks.
- **`approval_pending` notification on fresh grant creation** via the existing `NotificationDispatcher` (grant id, subject, risk tier, est. cost; `action_required`). Reuse-pending branch does **not** re-spam. A dispatch fault never wedges the gate. Fire-and-forget with tracked tasks (the `api/webhooks.py` idiom), self-contained session.
- `approval_pending` added to `VALID_EVENT_TYPES` — the same silence class P2-02 closed for playbooks.

## Tests
`orchestrator/tests/test_p2w2_grant_mutation_admin_gate.py` — pure (PRD-185 S12 test shape; dispatcher captured at the module seam, no DB/network):
- [x] route-wiring sweep: all four endpoints carry `require_workspace_admin`
- [x] plain member ⇒ 403; workspace owner/admin + super-admin ⇒ pass
- [x] exactly one `approval_pending` per fresh grant (id/subject/risk/cost in payload)
- [x] existing-pending reuse ⇒ no re-notify; dispatch fault ⇒ gate still asks
- [x] deny does not re-queue (existing semantics guarded)
- [ ] CI green (orchestrator-tests) — the merge gate

## Rollout note
No migration, no new route (route-manifest untouched). Behavior change is authorization-only on endpoints with no current frontend consumers; board-task grant/deny flows keep working for workspace owners/admins — which prod's ~1-user workspaces all are.

🤖 Generated with [Claude Code](https://claude.com/claude-code)