### PR TITLE
feat(prd-193): Wave-2 approve → grant → resume — the ask finally has a yes (P2-12)

### DIFF
--- a/frontend/components/chatbot/chat.tsx
+++ b/frontend/components/chatbot/chat.tsx
@@ -226,6 +226,25 @@ export function Chat({
           } as any)
         }
 
+        // PRD-193 S3 (P2-12): tool approval card — a confirmation-gated
+        // action asked, the S1 gate attached a grant; the human approves or
+        // denies right here (Approve resumes the execution server-side, S4).
+        if (toolData.tool_approval && toolData.tool_approval.grant_id != null) {
+          const ta = toolData.tool_approval
+          addWidget({
+            type: 'tool_approval',
+            title: 'Action approval needed',
+            data: { ...ta },
+            metadata: {
+              source: { type: 'tool', name: ta.action || 'platform_action' },
+              createdAt: new Date(),
+              conversationId: id,
+            },
+            state: 'ready',
+            createdAt: new Date().toISOString(),
+          } as any)
+        }
+
         // Create widgets for database results
         if (toolData.database_results && Array.isArray(toolData.database_results)) {
           toolData.database_results.forEach((dbResult: any) => {

--- a/frontend/components/widgets/ToolApprovalWidget/index.tsx
+++ b/frontend/components/widgets/ToolApprovalWidget/index.tsx
@@ -1,0 +1,206 @@
+'use client'
+
+/**
+ * ToolApprovalWidget (PRD-193 S3, P2-12)
+ *
+ * In-chat card for a confirmation-gated tool call awaiting approval: the
+ * action, a human-readable params digest, permission level, AI-Act oversight
+ * tier + rationale, and Approve / Deny wired to the PRD-181 approval-grant
+ * API (its first frontend consumer). Cloned from MissionApprovalWidget —
+ * shared presentation, different behaviour (a grant is granted/denied; a
+ * mission is PATCHed) — deliberately NOT generalised (revisit on a third card).
+ *
+ * Approving resumes the interrupted execution server-side (PRD-193 S4); the
+ * card reflects the executed result honestly — a failed resume is shown as a
+ * failure, never a fake success.
+ */
+
+import { useState } from 'react'
+import { Check, ShieldAlert, ShieldCheck, X } from 'lucide-react'
+import { WidgetBase } from '../WidgetBase'
+import { registerWidget } from '../registry'
+import { Button } from '@/components/ui/button'
+import { useDenyApproval, useGrantApproval } from '@/hooks/use-approval-grants-api'
+import type { ToolApprovalWidgetData, WidgetBaseProps, WidgetDefinition } from '../types'
+import { toast } from 'sonner'
+
+/**
+ * Human-readable label for an oversight tier (clone of the mission card's —
+ * presentation only, kept local per the no-premature-abstraction call).
+ * Exported for tests.
+ */
+export function oversightTierLabel(tier?: string): string {
+  switch (tier) {
+    case 'monitor':
+      return 'Monitored'
+    case 'human_on_the_loop':
+      return 'Human on the loop'
+    case 'human_in_the_loop':
+      return 'Human approval required'
+    default:
+      return 'Human approval required'
+  }
+}
+
+interface ExecutedResult {
+  success?: boolean
+  error?: string | null
+  requires_confirmation?: boolean
+  resumed_via?: string
+}
+
+/** Post-approve outcome line — honest about what actually happened (S4). */
+export function executedOutcomeLine(executed?: ExecutedResult | null): string {
+  if (!executed) return 'Approved.'
+  if (executed.resumed_via === 'board_task_requeue') {
+    return 'Approved — the blocked task was re-queued and will complete under this grant.'
+  }
+  if (executed.requires_confirmation) {
+    return 'Approved, but the action asked for confirmation again — check the pending approvals.'
+  }
+  if (executed.success) return 'Approved — the action ran.'
+  return `Approved, but execution failed: ${executed.error || 'unknown error'}`
+}
+
+export function ToolApprovalWidget({
+  title,
+  data,
+  metadata,
+  isActive,
+  isLoading,
+  error,
+  onClose,
+  onMaximize,
+  onRefresh,
+}: WidgetBaseProps<ToolApprovalWidgetData>) {
+  const grantApproval = useGrantApproval()
+  const denyApproval = useDenyApproval()
+  const [done, setDone] = useState<'approved' | 'denied' | null>(null)
+  const [outcome, setOutcome] = useState<string>('')
+
+  const busy = grantApproval.isLoading || denyApproval.isLoading
+  const paramEntries = Object.entries(data.params || {})
+
+  const handleApprove = async () => {
+    try {
+      const res = await grantApproval.mutateAsync({ id: data.grant_id })
+      const executed = (res?.grant?.details as { executed_result?: ExecutedResult } | undefined)
+        ?.executed_result
+      const line = executedOutcomeLine(executed)
+      setOutcome(line)
+      setDone('approved')
+      if (executed && executed.success === false) {
+        toast.error(line)
+      } else {
+        toast.success(line)
+      }
+    } catch {
+      toast.error('Failed to approve the action')
+    }
+  }
+
+  const handleDeny = async () => {
+    try {
+      await denyApproval.mutateAsync({ id: data.grant_id })
+      setOutcome('Denied — the action will not run.')
+      setDone('denied')
+      toast.info('Action denied')
+    } catch {
+      toast.error('Failed to deny the action')
+    }
+  }
+
+  return (
+    <WidgetBase
+      title={title || 'Action approval needed'}
+      icon={<ShieldCheck className="h-4 w-4" />}
+      metadata={metadata}
+      isActive={isActive}
+      isLoading={isLoading}
+      error={error}
+      onClose={onClose}
+      onMaximize={onMaximize}
+      onRefresh={onRefresh}
+    >
+      <div className="flex flex-col gap-3 p-3">
+        <div>
+          <p className="text-sm font-medium break-all">{data.action}</p>
+          {data.message && (
+            <p className="text-xs text-muted-foreground mt-0.5">{data.message}</p>
+          )}
+          {data.permission_level && (
+            <p className="text-[10px] uppercase tracking-wide text-muted-foreground mt-1">
+              {data.permission_level}
+            </p>
+          )}
+        </div>
+
+        {/* AI-Act oversight banner — clone of the mission card's presentation. */}
+        {(data.risk_tier || data.oversight_rationale) && (
+          <div
+            className="flex items-start gap-2 rounded border border-amber-300 bg-amber-50 px-2 py-1.5 dark:border-amber-800 dark:bg-amber-950/40"
+            role="note"
+            aria-label="Human oversight"
+          >
+            <ShieldAlert className="mt-0.5 h-3.5 w-3.5 shrink-0 text-amber-600" />
+            <div className="min-w-0">
+              <p className="text-[11px] font-medium text-amber-800 dark:text-amber-300">
+                {oversightTierLabel(data.risk_tier)}
+                {data.risk_class ? ` · ${data.risk_class.replace(/_/g, ' ')}` : ''}
+              </p>
+              {data.oversight_rationale && (
+                <p className="mt-0.5 text-[10px] text-amber-700 dark:text-amber-400">
+                  {data.oversight_rationale}
+                </p>
+              )}
+            </div>
+          </div>
+        )}
+
+        {/* The exact call being approved — key/value digest, never raw JSON. */}
+        {paramEntries.length > 0 && (
+          <dl className="space-y-0.5 max-h-40 overflow-y-auto rounded border border-border bg-muted/40 px-2 py-1.5">
+            {paramEntries.map(([key, value]) => (
+              <div key={key} className="flex items-baseline gap-2 text-xs">
+                <dt className="shrink-0 font-mono text-muted-foreground">{key}</dt>
+                <dd className="min-w-0 truncate font-mono" title={String(value)}>
+                  {String(value)}
+                </dd>
+              </div>
+            ))}
+          </dl>
+        )}
+
+        {done ? (
+          <p className="text-sm text-muted-foreground" role="status">
+            {outcome}
+          </p>
+        ) : (
+          <div className="flex gap-2">
+            <Button size="sm" disabled={busy} onClick={handleApprove} className="flex-1">
+              <Check className="h-4 w-4 mr-1" />{' '}
+              {grantApproval.isLoading ? 'Approving…' : 'Approve & run'}
+            </Button>
+            <Button size="sm" variant="outline" disabled={busy} onClick={handleDeny}>
+              <X className="h-4 w-4 mr-1" /> Deny
+            </Button>
+          </div>
+        )}
+      </div>
+    </WidgetBase>
+  )
+}
+
+export const ToolApprovalWidgetDef: WidgetDefinition<ToolApprovalWidgetData> = {
+  type: 'tool_approval',
+  displayName: 'Action Approval',
+  description: 'Approve or deny a confirmation-gated tool call',
+  icon: ShieldCheck,
+  component: ToolApprovalWidget,
+  defaultSize: { width: 5, height: 4 },
+  minSize: { width: 4, height: 3 },
+  capabilities: ['refreshable'],
+}
+
+// Register the widget (importing this module auto-registers it)
+registerWidget(ToolApprovalWidgetDef)

--- a/frontend/components/widgets/__tests__/tool-approval-widget.test.tsx
+++ b/frontend/components/widgets/__tests__/tool-approval-widget.test.tsx
@@ -80,7 +80,7 @@ describe('ToolApprovalWidget — PRD-193 S3', () => {
       },
     })
     const user = userEvent.setup()
-    render(<ToolApprovalWidget id="w2" data={data()} metadata={metadata} />)
+    render(<ToolApprovalWidget id="w2" title="Action approval needed" data={data()} metadata={metadata} />)
 
     await user.click(screen.getByRole('button', { name: /approve & run/i }))
 
@@ -99,7 +99,7 @@ describe('ToolApprovalWidget — PRD-193 S3', () => {
       },
     })
     const user = userEvent.setup()
-    render(<ToolApprovalWidget id="w3" data={data()} metadata={metadata} />)
+    render(<ToolApprovalWidget id="w3" title="Action approval needed" data={data()} metadata={metadata} />)
 
     await user.click(screen.getByRole('button', { name: /approve & run/i }))
 
@@ -111,7 +111,7 @@ describe('ToolApprovalWidget — PRD-193 S3', () => {
   it('deny fires the deny mutation and renders the refusal', async () => {
     denyMutateAsync.mockResolvedValue({ grant: { id: 42, status: 'denied' } })
     const user = userEvent.setup()
-    render(<ToolApprovalWidget id="w4" data={data()} metadata={metadata} />)
+    render(<ToolApprovalWidget id="w4" title="Action approval needed" data={data()} metadata={metadata} />)
 
     await user.click(screen.getByRole('button', { name: /deny/i }))
 
@@ -126,6 +126,7 @@ describe('ToolApprovalWidget — PRD-193 S3', () => {
     render(
       <ToolApprovalWidget
         id="w5"
+        title="Action approval needed"
         data={data({ risk_tier: undefined, risk_class: undefined, oversight_rationale: undefined })}
         metadata={metadata}
       />,

--- a/frontend/components/widgets/__tests__/tool-approval-widget.test.tsx
+++ b/frontend/components/widgets/__tests__/tool-approval-widget.test.tsx
@@ -1,0 +1,143 @@
+/**
+ * PRD-193 S3 (P2-12) — the in-chat tool-approval card (frontend half).
+ *
+ * The backend `tool_approval` payload carries the gated action, a params
+ * digest, and the AI-Act oversight fields. This pins the widget: it renders
+ * the oversight tier + rationale and the params digest, Approve fires the
+ * grant mutation (the PRD-181 grant API's first frontend consumer), Deny
+ * fires the deny mutation and renders the refusal, and a failed resume is
+ * reported honestly — never as a fake success.
+ *
+ * Mirrors mission-approval-oversight.test.tsx (the card this one clones).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+const grantMutateAsync = vi.fn()
+const denyMutateAsync = vi.fn()
+
+vi.mock('@/hooks/use-approval-grants-api', () => ({
+  useGrantApproval: () => ({ isLoading: false, mutateAsync: grantMutateAsync }),
+  useDenyApproval: () => ({ isLoading: false, mutateAsync: denyMutateAsync }),
+}))
+
+import {
+  ToolApprovalWidget,
+  executedOutcomeLine,
+  oversightTierLabel,
+} from '../ToolApprovalWidget'
+import type { ToolApprovalWidgetData, WidgetMetadata } from '../types'
+
+const metadata: WidgetMetadata = {
+  source: { type: 'tool', name: 'platform_delete_document' },
+  createdAt: new Date(),
+}
+
+function data(overrides?: Partial<ToolApprovalWidgetData>): ToolApprovalWidgetData {
+  return {
+    grant_id: 42,
+    action: 'platform_delete_document',
+    message: 'This action (destructive) requires confirmation.',
+    permission_level: 'destructive',
+    params: { document_id: 7 },
+    risk_tier: 'human_in_the_loop',
+    risk_class: 'destructive',
+    oversight_rationale:
+      'Destructive: deletes data. A human must approve before it runs.',
+    requires_approval: true,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  grantMutateAsync.mockReset()
+  denyMutateAsync.mockReset()
+})
+
+describe('ToolApprovalWidget — PRD-193 S3', () => {
+  it('renders the action, oversight tier + rationale, and the params digest', () => {
+    render(<ToolApprovalWidget id="w1" title="Action approval needed" data={data()} metadata={metadata} />)
+
+    expect(screen.getByText('platform_delete_document')).toBeInTheDocument()
+    // Oversight banner (clone of the mission card presentation).
+    expect(screen.getByText(/Human approval required/)).toBeInTheDocument()
+    expect(screen.getByText(/deletes data/)).toBeInTheDocument()
+    expect(screen.getByRole('note', { name: /human oversight/i })).toBeInTheDocument()
+    // The human sees exactly what they are approving.
+    expect(screen.getByText('document_id')).toBeInTheDocument()
+    expect(screen.getByText('7')).toBeInTheDocument()
+  })
+
+  it('approve fires the grant mutation and reflects the executed result', async () => {
+    grantMutateAsync.mockResolvedValue({
+      grant: {
+        id: 42,
+        status: 'revoked',
+        details: { executed_result: { success: true } },
+      },
+    })
+    const user = userEvent.setup()
+    render(<ToolApprovalWidget id="w2" data={data()} metadata={metadata} />)
+
+    await user.click(screen.getByRole('button', { name: /approve & run/i }))
+
+    expect(grantMutateAsync).toHaveBeenCalledWith({ id: 42 })
+    await waitFor(() =>
+      expect(screen.getByRole('status')).toHaveTextContent(/the action ran/i),
+    )
+  })
+
+  it('a failed resume is reported as a failure — never a fake success', async () => {
+    grantMutateAsync.mockResolvedValue({
+      grant: {
+        id: 42,
+        status: 'revoked',
+        details: { executed_result: { success: false, error: 'boom' } },
+      },
+    })
+    const user = userEvent.setup()
+    render(<ToolApprovalWidget id="w3" data={data()} metadata={metadata} />)
+
+    await user.click(screen.getByRole('button', { name: /approve & run/i }))
+
+    await waitFor(() =>
+      expect(screen.getByRole('status')).toHaveTextContent(/execution failed: boom/i),
+    )
+  })
+
+  it('deny fires the deny mutation and renders the refusal', async () => {
+    denyMutateAsync.mockResolvedValue({ grant: { id: 42, status: 'denied' } })
+    const user = userEvent.setup()
+    render(<ToolApprovalWidget id="w4" data={data()} metadata={metadata} />)
+
+    await user.click(screen.getByRole('button', { name: /deny/i }))
+
+    expect(denyMutateAsync).toHaveBeenCalledWith({ id: 42 })
+    expect(grantMutateAsync).not.toHaveBeenCalled()
+    await waitFor(() =>
+      expect(screen.getByRole('status')).toHaveTextContent(/will not run/i),
+    )
+  })
+
+  it('renders no oversight banner when no risk fields are present', () => {
+    render(
+      <ToolApprovalWidget
+        id="w5"
+        data={data({ risk_tier: undefined, risk_class: undefined, oversight_rationale: undefined })}
+        metadata={metadata}
+      />,
+    )
+    expect(screen.queryByRole('note', { name: /human oversight/i })).not.toBeInTheDocument()
+  })
+
+  it('maps oversight tiers and executed outcomes to honest copy', () => {
+    expect(oversightTierLabel('human_in_the_loop')).toBe('Human approval required')
+    expect(oversightTierLabel(undefined)).toBe('Human approval required')
+
+    expect(executedOutcomeLine({ success: true })).toMatch(/action ran/i)
+    expect(executedOutcomeLine({ success: false, error: 'nope' })).toMatch(/failed: nope/i)
+    expect(executedOutcomeLine({ resumed_via: 'board_task_requeue' })).toMatch(/re-queued/i)
+    expect(executedOutcomeLine({ requires_confirmation: true })).toMatch(/asked for confirmation again/i)
+  })
+})

--- a/frontend/components/widgets/__tests__/tool-approval-widget.test.tsx
+++ b/frontend/components/widgets/__tests__/tool-approval-widget.test.tsx
@@ -59,7 +59,9 @@ describe('ToolApprovalWidget — PRD-193 S3', () => {
   it('renders the action, oversight tier + rationale, and the params digest', () => {
     render(<ToolApprovalWidget id="w1" title="Action approval needed" data={data()} metadata={metadata} />)
 
-    expect(screen.getByText('platform_delete_document')).toBeInTheDocument()
+    // The action name appears in the card body (WidgetBase also badges the
+    // widget's source name with the same text — hence getAllByText).
+    expect(screen.getAllByText('platform_delete_document').length).toBeGreaterThan(0)
     // Oversight banner (clone of the mission card presentation).
     expect(screen.getByText(/Human approval required/)).toBeInTheDocument()
     expect(screen.getByText(/deletes data/)).toBeInTheDocument()

--- a/frontend/components/widgets/index.ts
+++ b/frontend/components/widgets/index.ts
@@ -51,6 +51,9 @@ export { FileWidget, FileWidgetDef } from './FileWidget'
 // PRD-163 S4: Mission plan approval card
 export { MissionApprovalWidget, MissionApprovalWidgetDef } from './MissionApprovalWidget'
 
+// PRD-193 S3 (P2-12): Tool-call approval card (confirmation-gated actions)
+export { ToolApprovalWidget, ToolApprovalWidgetDef } from './ToolApprovalWidget'
+
 // PRD-66: Coding Canvas Widget (workspace file browser + Monaco editor)
 export { CodingCanvasWidget, CodingCanvasWidgetDef } from './CodingCanvasWidget'
 

--- a/frontend/components/widgets/types.ts
+++ b/frontend/components/widgets/types.ts
@@ -31,6 +31,8 @@ export type WidgetType =
   | 'coding_canvas'  // Monaco-based workspace file browser + editor
   // PRD-163 S4: in-chat mission plan approval card
   | 'mission_approval'  // Approve/reject an auto-created mission plan
+  // PRD-193 S3 (P2-12): in-chat tool approval card (confirmation-gated action)
+  | 'tool_approval'  // Approve/deny a gated tool call via its approval grant
 
 export interface MissionApprovalTask {
   title: string
@@ -53,6 +55,25 @@ export interface MissionApprovalWidgetData {
   approval_deadline_at?: string
   // PRD-181 S5 (EU-AI-Act Art.14): the autonomy risk tier + why a human is in
   // the loop, shown on the card so the approver sees the risk classification.
+  risk_tier?: 'monitor' | 'human_on_the_loop' | 'human_in_the_loop'
+  risk_class?: string
+  oversight_rationale?: string
+  requires_approval?: boolean
+}
+
+/**
+ * PRD-193 S3 (P2-12): a confirmation-gated tool call awaiting approval.
+ * The card clones the mission-approval presentation but acts on the PRD-181
+ * approval-grant API (grant/deny) — they share presentation, not behaviour.
+ */
+export interface ToolApprovalWidgetData {
+  grant_id: number
+  action: string
+  message?: string
+  permission_level?: string
+  /** Human-readable digest of the model-provided params (server plumbing stripped). */
+  params?: Record<string, unknown>
+  // PRD-181 S5 (EU-AI-Act Art.14) oversight fields, as on the mission card.
   risk_tier?: 'monitor' | 'human_on_the_loop' | 'human_in_the_loop'
   risk_class?: string
   oversight_rationale?: string

--- a/frontend/hooks/use-approval-grants-api.ts
+++ b/frontend/hooks/use-approval-grants-api.ts
@@ -1,0 +1,79 @@
+/**
+ * Approval-grant React Query hooks — PRD-193 S3 (P2-12).
+ *
+ * First frontend consumer of the PRD-181 approval-grant API. Shape mirrors
+ * use-missions-api.ts (useApproveMission): a POST mutation per decision,
+ * invalidating the grants list so the P2-15 Command Center approvals queue
+ * stays fresh once it lands.
+ *
+ * No new backend routes — /api/v1/approval-grants shipped with PRD-181.
+ */
+
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { apiClient } from '@/lib/api-client'
+
+// ── Query Keys ────────────────────────────────────────────────
+
+export const approvalGrantQueryKeys = {
+  all: ['approval-grants'] as const,
+}
+
+// ── Types (PRD-181 ApprovalGrant.to_dict shape) ───────────────
+
+export interface ApprovalGrantRecord {
+  id: number
+  workspace_id: string | null
+  subject_type: string
+  subject_id: string
+  tool_name: string | null
+  risk_tier: string | null
+  agent_id: number | null
+  status: 'pending' | 'granted' | 'revoked' | 'expired' | 'denied' | string
+  reason: string | null
+  requested_at: string | null
+  expires_at: string | null
+  granted_at: string | null
+  granted_by: string | null
+  revoked_at: string | null
+  revoked_by: string | null
+  /** PRD-193 S4: params snapshot + executed_result land here on resume. */
+  details?: Record<string, unknown>
+}
+
+export interface ApprovalGrantResponse {
+  grant: ApprovalGrantRecord
+}
+
+// ── Grant (approve) ───────────────────────────────────────────
+
+export function useGrantApproval() {
+  const queryClient = useQueryClient()
+
+  return useMutation<ApprovalGrantResponse, Error, { id: number }>({
+    mutationFn: ({ id }) =>
+      apiClient.request<ApprovalGrantResponse>(`/api/v1/approval-grants/${id}/grant`, {
+        method: 'POST',
+        body: {} as unknown as BodyInit,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: approvalGrantQueryKeys.all })
+    },
+  })
+}
+
+// ── Deny ──────────────────────────────────────────────────────
+
+export function useDenyApproval() {
+  const queryClient = useQueryClient()
+
+  return useMutation<ApprovalGrantResponse, Error, { id: number }>({
+    mutationFn: ({ id }) =>
+      apiClient.request<ApprovalGrantResponse>(`/api/v1/approval-grants/${id}/deny`, {
+        method: 'POST',
+        body: {} as unknown as BodyInit,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: approvalGrantQueryKeys.all })
+    },
+  })
+}

--- a/orchestrator/api/approval_grants.py
+++ b/orchestrator/api/approval_grants.py
@@ -94,7 +94,9 @@ async def grant_approval(
         raise HTTPException(status_code=422, detail=f"Grant is not pending (status: {grant.status})")
 
     grant_grant(grant, granted_by=_actor_ref(ctx))
-    _requeue_subject(db, grant)
+    # PRD-193 S4: for tool_call subjects this re-dispatches the stored call
+    # (consume-then-execute inside this one transaction boundary).
+    await _requeue_subject(db, grant)
     db.commit()
     _audit(db, ctx, "approval_grant:granted", grant)
     return {"grant": grant.to_dict()}
@@ -139,29 +141,145 @@ async def revoke_approval(
     return {"grant": grant.to_dict()}
 
 
-def _requeue_subject(db: Session, grant: ApprovalGrant) -> None:
-    """On grant, return a blocked board task to the dispatch queue."""
+async def _requeue_subject(db: Session, grant: ApprovalGrant) -> None:
+    """On grant, resume the blocked subject.
+
+    - ``board_task``: return the blocked task to the dispatch queue (unchanged).
+    - ``tool_call`` (PRD-193 S4, P2-12): re-dispatch the stored call through
+      the spine — or, for board-originated asks, ride the existing board
+      re-queue so the re-run completes into the now-active grant (S2).
+    """
+    from core.models.approval_grants import SUBJECT_TOOL_CALL
+
+    if grant.subject_type == SUBJECT_TOOL_CALL:
+        await _resume_tool_call(db, grant)
+        return
     if grant.subject_type != SUBJECT_BOARD_TASK:
         return
+    _requeue_blocked_task(db, grant.workspace_id, grant.subject_id)
+
+
+def _requeue_blocked_task(db: Session, workspace_id: Any, task_id: Any) -> bool:
+    """Return a BLOCKED board task to the dispatch queue. True iff re-queued.
+
+    Extracted unchanged from the board branch of ``_requeue_subject`` so the
+    PRD-193 S4 board linkage (a ``tool_call`` grant carrying
+    ``details.board_task_id``) resumes through the SAME code path.
+    """
     try:
-        task = db.query(BoardTask).get(int(grant.subject_id))
+        task = db.query(BoardTask).get(int(task_id))
     except (TypeError, ValueError):
-        return
+        return False
     if task is None or task.status != "blocked":
-        return
+        return False
     task.status = "assigned"
     task.blocked_at = None
     task.blocked_reason = None
     try:
         from services.board_dispatcher import notify_task_available
 
-        notify_task_available(db, workspace_id=grant.workspace_id, task_id=task.id)
+        notify_task_available(db, workspace_id=workspace_id, task_id=task.id)
     except Exception:
         logger.warning("[approval_grants.api] notify_task_available failed", exc_info=True)
+    return True
+
+
+async def _resume_tool_call(db: Session, grant: ApprovalGrant) -> None:
+    """PRD-193 S4 (P2-12): approving must complete the work, not just flip a row.
+
+    Board-originated asks (``details.board_task_id`` present + task still
+    blocked) resume via the EXISTING board re-queue — the task re-run retries
+    the call and meets the now-active grant (S2), so nothing double-executes
+    (locked decision 4: lean board linkage). Everything else re-dispatches the
+    stored call directly through ``UnifiedToolExecutor.execute_tool`` — the
+    same spine the original call would have taken, so telemetry, the policy
+    seam, and outcome capture all fire; nothing is exempted by being approved.
+
+    The outcome summary lands on ``details.executed_result`` (returned in the
+    grant response so the S3 card swaps to its executed state). Fail LOUD but
+    contained: a failing re-dispatch surfaces as an honest failure on the
+    grant — never a fake success (tool-runtime dossier C.3), and never an
+    exception out of the grant endpoint.
+    """
+    from datetime import datetime, timezone
+
+    details = dict(grant.details) if isinstance(grant.details, dict) else {}
+
+    board_task_id = details.get("board_task_id")
+    if board_task_id is not None and _requeue_blocked_task(
+        db, grant.workspace_id, board_task_id
+    ):
+        grant.details = {
+            **details,
+            "executed_result": {
+                "resumed_via": "board_task_requeue",
+                "board_task_id": board_task_id,
+                "executed_at": datetime.now(timezone.utc).isoformat(),
+            },
+        }
+        return
+
+    action = details.get("action") or grant.tool_name
+    params = details.get("params")
+    params = dict(params) if isinstance(params, dict) else {}
+    caller_context = details.get("caller_context")
+    caller_context = dict(caller_context) if isinstance(caller_context, dict) else None
+
+    if not action:
+        grant.details = {
+            **details,
+            "executed_result": {
+                "success": False,
+                "error": "grant carries no stored action to resume",
+                "executed_at": datetime.now(timezone.utc).isoformat(),
+            },
+        }
+        return
+
+    try:
+        from modules.tools.execution.unified_executor import UnifiedToolExecutor
+
+        executor = UnifiedToolExecutor(db)
+        raw = await executor.execute_tool(
+            tool_name=str(action),
+            parameters=params,
+            agent_id=int(grant.agent_id or 0),
+            workspace_id=grant.workspace_id,
+            trace_id=f"grant-resume-{grant.id}",
+            caller_context=caller_context,
+        )
+        raw = raw if isinstance(raw, dict) else {}
+        ok = bool(raw.get("success"))
+        summary: Dict[str, Any] = {
+            "success": ok,
+            "error": (str(raw.get("error"))[:500] if (not ok and raw.get("error")) else None),
+            "requires_confirmation": bool(raw.get("requires_confirmation")),
+            "executed_at": datetime.now(timezone.utc).isoformat(),
+        }
+    except Exception as exc:
+        logger.error(
+            "[approval_grants.api] tool_call resume failed for grant %s",
+            grant.id, exc_info=True,
+        )
+        summary = {
+            "success": False,
+            "error": str(exc)[:500],
+            "requires_confirmation": False,
+            "executed_at": datetime.now(timezone.utc).isoformat(),
+        }
+    grant.details = {**details, "executed_result": summary}
 
 
 def _fail_subject(db: Session, grant: ApprovalGrant) -> None:
-    """On deny, fail a blocked board task (the human refused the action)."""
+    """On deny, fail the blocked subject (the human refused the action)."""
+    from core.models.approval_grants import SUBJECT_TOOL_CALL
+
+    if grant.subject_type == SUBJECT_TOOL_CALL:
+        # PRD-193 S4: a denied tool call is a no-op execution — the grant's
+        # DENIED status is the record; the S3 card renders the refusal; the
+        # model sees it via context on the next turn. (A blocked board task,
+        # if any, keeps its own board_task-subject grant lifecycle.)
+        return
     if grant.subject_type != SUBJECT_BOARD_TASK:
         return
     try:

--- a/orchestrator/consumers/chatbot/service.py
+++ b/orchestrator/consumers/chatbot/service.py
@@ -1446,8 +1446,14 @@ class StreamingChatService:
             llm_context = truncate_to_token_budget(llm_context, _TOOL_RESULT_TOKEN_BUDGET)
 
             # Frontend data emission (widget tool-data).
+            # PRD-193 S3 (P2-12): an approval ask (success=False +
+            # requires_confirmation) still carries the tool_approval card —
+            # the human must see it live even though the tool did not run.
             frontend_data = result.get("frontend_data", {})
-            if result.get("success") and frontend_data:
+            _is_approval_ask = bool(
+                (result.get("raw_result") or {}).get("requires_confirmation")
+            )
+            if frontend_data and (result.get("success") or _is_approval_ask):
                 tool_data.update(frontend_data)
                 await sse_queue.put(self.streaming_handler.format_aisdk_tool_data(frontend_data))
 

--- a/orchestrator/core/models/approval_grants.py
+++ b/orchestrator/core/models/approval_grants.py
@@ -116,4 +116,8 @@ class ApprovalGrant(Base):
             "granted_by": self.granted_by,
             "revoked_at": self.revoked_at.isoformat() if self.revoked_at else None,
             "revoked_by": self.revoked_by,
+            # PRD-193 S4 (P2-12): the tool_call snapshot (action + params
+            # digest source) and the resume outcome (details.executed_result)
+            # — the S3 card and the P2-15 approvals queue read these.
+            "details": self.details or {},
         }

--- a/orchestrator/core/services/notification_dispatcher.py
+++ b/orchestrator/core/services/notification_dispatcher.py
@@ -48,6 +48,7 @@ VALID_EVENT_TYPES: frozenset[str] = frozenset(
         "task_complete",
         "task_failed",
         "task_sla_breach",
+        "approval_pending",
         "mission_plan_ready",
         "mission_step_complete",
         "mission_complete",

--- a/orchestrator/modules/agents/factory/agent_factory.py
+++ b/orchestrator/modules/agents/factory/agent_factory.py
@@ -1043,6 +1043,20 @@ class AgentFactory:
                         {"field_context": context}
                         if context and context.get("field_id") else None
                     )
+                    # PRD-193 S1/S4 (P2-12): a confirmation ask fired on a
+                    # board-task run must link its grant back to the task
+                    # (details.board_task_id), so the grant API's existing
+                    # board re-queue resumes the run into the now-active
+                    # grant. api/board_tasks passes source/task_id in context.
+                    if (
+                        context
+                        and context.get("source") == "board_task"
+                        and context.get("task_id") is not None
+                    ):
+                        _field_caller_context = {
+                            **(_field_caller_context or {}),
+                            "board_task_id": context.get("task_id"),
+                        }
 
                     async def _agent_tool_cb(name, args, call_id, ws_id):
                         # SLACK empty-params guard.

--- a/orchestrator/modules/memory/tool_outcome_capture.py
+++ b/orchestrator/modules/memory/tool_outcome_capture.py
@@ -104,6 +104,31 @@ def build_tool_outcome(
     app = str(params.get("app_name") or result.get("app") or "platform")
     success = bool(result.get("success"))
 
+    if result.get("requires_confirmation"):
+        # PRD-193 S5 (P2-12): an ask is an ASK — neither a failure nor a
+        # success. The confirmation gate returning requires_confirmation
+        # daily must not become failure-spam in memory (the exact noise
+        # class PRD-187 S2 cleaned up). Deduped per (workspace, app, action)
+        # like every other outcome.
+        signature = "ask:awaiting_approval"
+        fact = f"Tool {action} ({app}) is awaiting human approval before it can run."
+        outcome_hash = _content_hash(workspace_id, app, action, signature)
+        return {
+            "fact": fact,
+            "type": TOOL_OUTCOME_TYPE,
+            "importance": 0.3,
+            "metadata": {
+                "category": TOOL_OUTCOME_TYPE,
+                "importance": 0.3,
+                "app": app,
+                "action": action,
+                "error_class": "",
+                "outcome": "ask",
+                "success": False,
+                "outcome_hash": outcome_hash,
+            },
+        }
+
     if success:
         if not _is_notable_success(result):
             return None  # noise gate: trivial success → no memory

--- a/orchestrator/modules/tools/discovery/platform_executor.py
+++ b/orchestrator/modules/tools/discovery/platform_executor.py
@@ -638,6 +638,12 @@ class PlatformActionExecutor:
         if not handler:
             return {"success": False, "error": f"Unknown platform action: {action_name}"}
 
+        # PRD-193 S2 (P2-12): when a human grant authorises this exact call,
+        # its id is recorded here so the execution is audit-marked as
+        # grant-authorised — distinct from the full-autonomy dial skipping
+        # the gate.
+        approved_via_grant_id: Optional[int] = None
+
         # Permission check for write/destructive actions (fail-closed)
         try:
             from modules.tools.discovery import get_action_registry
@@ -709,35 +715,54 @@ class PlatformActionExecutor:
                     }
 
             if action_def and action_def.requires_confirmation and not full_autonomy:
-                # PRD-193 S1 (P2-12): the ask is no longer a dead end — issue
-                # (or reuse) a PENDING tool_call ApprovalGrant and return the
-                # ask WITH the grant attached, so a human can finally say yes.
-                # Fail-safe: any fault in the grant machinery returns the plain
-                # ask (the ask is the floor — never an exception, never an
-                # execution).
+                # PRD-193 S1/S2 (P2-12): the ask is no longer a dead end.
+                # S2 — consult FIRST: an authorising grant on this exact
+                # subject key (GRANTED + unexpired + params-hash equality)
+                # opens the gate; destructive grants are retired on use
+                # (single-use). Anything else — pending, expired, revoked,
+                # denied, params drift, or ANY error in the consult — falls
+                # through to the ask (fail closed; the ask is the floor).
+                # S1 — otherwise issue (or reuse) a PENDING tool_call
+                # ApprovalGrant and return the ask WITH the grant attached,
+                # so a human finally has something to say yes to.
                 from modules.tools.execution import tool_grants
 
-                ask = {
-                    "success": False,
-                    "requires_confirmation": True,
-                    "action": action_name,
-                    "permission_level": action_def.permission_level,
-                    "message": (
-                        f"This action ({action_def.permission_level}) requires confirmation. "
-                        f"Action: {action_name} — {action_def.description[:100]}"
-                    ),
-                    "params": params,
-                }
-                return tool_grants.attach_ask_grant(
+                _grant = tool_grants.consume_tool_grant(
                     self.db,
                     self.workspace_id,
                     action=action_name,
                     params=params,
-                    ask=ask,
                     permission_level=action_def.permission_level,
-                    description=action_def.description,
-                    caller_context=caller_context,
                 )
+                if _grant is not None:
+                    approved_via_grant_id = getattr(_grant, "id", None)
+                    logger.info(
+                        "[PlatformExecutor] '%s' authorised by approval grant %s "
+                        "— proceeding (workspace=%s)",
+                        action_name, approved_via_grant_id, self.workspace_id,
+                    )
+                else:
+                    ask = {
+                        "success": False,
+                        "requires_confirmation": True,
+                        "action": action_name,
+                        "permission_level": action_def.permission_level,
+                        "message": (
+                            f"This action ({action_def.permission_level}) requires confirmation. "
+                            f"Action: {action_name} — {action_def.description[:100]}"
+                        ),
+                        "params": params,
+                    }
+                    return tool_grants.attach_ask_grant(
+                        self.db,
+                        self.workspace_id,
+                        action=action_name,
+                        params=params,
+                        ask=ask,
+                        permission_level=action_def.permission_level,
+                        description=action_def.description,
+                        caller_context=caller_context,
+                    )
         except Exception as e:
             # Fail-closed: if we can't verify permissions, require confirmation
             logger.warning(
@@ -973,6 +998,13 @@ class PlatformActionExecutor:
                 and isinstance(result, dict)
             ):
                 result = {**result, "autonomous": True}
+            # PRD-193 S2: a grant-authorised execution records WHICH grant
+            # said yes (router_decision->>'approved_via_grant_id' via the
+            # same universal telemetry hook) — distinct from the dial-skip
+            # marker above. Attribution must be honest: approved is not
+            # autonomous.
+            if approved_via_grant_id is not None and isinstance(result, dict):
+                result = {**result, "approved_via_grant_id": approved_via_grant_id}
             return result
         except Exception as e:
             logger.error(f"[PlatformExecutor] {action_name} failed: {e}", exc_info=True)

--- a/orchestrator/modules/tools/discovery/platform_executor.py
+++ b/orchestrator/modules/tools/discovery/platform_executor.py
@@ -709,7 +709,15 @@ class PlatformActionExecutor:
                     }
 
             if action_def and action_def.requires_confirmation and not full_autonomy:
-                return {
+                # PRD-193 S1 (P2-12): the ask is no longer a dead end — issue
+                # (or reuse) a PENDING tool_call ApprovalGrant and return the
+                # ask WITH the grant attached, so a human can finally say yes.
+                # Fail-safe: any fault in the grant machinery returns the plain
+                # ask (the ask is the floor — never an exception, never an
+                # execution).
+                from modules.tools.execution import tool_grants
+
+                ask = {
                     "success": False,
                     "requires_confirmation": True,
                     "action": action_name,
@@ -720,13 +728,23 @@ class PlatformActionExecutor:
                     ),
                     "params": params,
                 }
+                return tool_grants.attach_ask_grant(
+                    self.db,
+                    self.workspace_id,
+                    action=action_name,
+                    params=params,
+                    ask=ask,
+                    permission_level=action_def.permission_level,
+                    description=action_def.description,
+                    caller_context=caller_context,
+                )
         except Exception as e:
             # Fail-closed: if we can't verify permissions, require confirmation
             logger.warning(
                 "[PlatformExecutor] Registry lookup failed for %s: %s — requiring confirmation",
                 action_name, e,
             )
-            return {
+            ask = {
                 "success": False,
                 "requires_confirmation": True,
                 "action": action_name,
@@ -737,6 +755,25 @@ class PlatformActionExecutor:
                 ),
                 "params": params,
             }
+            # PRD-193 S1: the fail-closed ask gets the grant loop too (best
+            # effort — the same surface resolves it if/when the registry
+            # heals). NOTE: no grant is CONSUMED on this path — the permission
+            # stack could not be verified, so nothing may execute here.
+            try:
+                from modules.tools.execution import tool_grants
+
+                return tool_grants.attach_ask_grant(
+                    self.db,
+                    self.workspace_id,
+                    action=action_name,
+                    params=params,
+                    ask=ask,
+                    permission_level=None,
+                    description=None,
+                    caller_context=caller_context,
+                )
+            except Exception:  # pragma: no cover - attach_ask_grant never raises
+                return ask
 
         # PRD-140 Phase 1 — hierarchy permission check. Runs before the
         # rate limiter so denied calls don't spend rate-limit budget.

--- a/orchestrator/modules/tools/execution/telemetry.py
+++ b/orchestrator/modules/tools/execution/telemetry.py
@@ -137,7 +137,9 @@ async def write_telemetry(
             error_message=result.get("error") if status == "error" else None,
             execution_time_ms=execution_time_ms,
             router_decision=_build_router_decision(
-                ctx, autonomous=result.get("autonomous") is True
+                ctx,
+                autonomous=result.get("autonomous") is True,
+                approved_via_grant_id=result.get("approved_via_grant_id"),
             ),
             intent_cluster_id=ctx.get("intent_cluster_id"),
             routing_source=ctx.get("routing_source"),
@@ -157,7 +159,9 @@ async def write_telemetry(
 
 
 def _build_router_decision(
-    ctx: Dict[str, Any], autonomous: bool = False
+    ctx: Dict[str, Any],
+    autonomous: bool = False,
+    approved_via_grant_id: Optional[Any] = None,
 ) -> Optional[Dict[str, Any]]:
     """Extract routing metadata from caller_context into router_decision JSONB."""
     decision = {}
@@ -165,6 +169,11 @@ def _build_router_decision(
         # PRD-143: confirmation was skipped by the full-autonomy dial — the
         # distinct, queryable audit marker (router_decision->>'autonomous').
         decision["autonomous"] = True
+    if approved_via_grant_id is not None:
+        # PRD-193 S2: this execution was authorised by a specific human
+        # approval grant — queryable and DISTINCT from the dial-skip marker
+        # (router_decision->>'approved_via_grant_id').
+        decision["approved_via_grant_id"] = approved_via_grant_id
     sel = ctx.get("selection_outcome")
     if isinstance(sel, dict) and sel:
         # PRD-143 S14: per-dispatch selection outcome (narrowed/hit/fallback)

--- a/orchestrator/modules/tools/execution/tool_grants.py
+++ b/orchestrator/modules/tools/execution/tool_grants.py
@@ -292,6 +292,64 @@ def attach_ask_grant(
 
 
 # ---------------------------------------------------------------------------
+# Consume at the yes (S2)
+# ---------------------------------------------------------------------------
+
+def consume_tool_grant(
+    db: Any,
+    workspace_id: UUID | str,
+    *,
+    action: str,
+    params: Any,
+    permission_level: Optional[str] = None,
+) -> Optional[Any]:
+    """Return the authorising grant for this exact call, or ``None``.
+
+    Authorising = GRANTED + unexpired (``is_authorising``) + ``params_hash``
+    equality (the grant authorises *the* call, not the tool). Destructive
+    grants are single-use: retired here, on use, via ``revoke_grant`` with
+    ``revoked_by="system:consumed"`` — reuse of the existing lifecycle, no new
+    status, no schema change (locked decision 1). Write-class grants stay
+    GRANTED for their TTL window per call-key.
+
+    Never raises; any error ⇒ ``None`` ⇒ the ask stands. Fail-closed is the
+    whole point — this gate fronts deletes / member removal / system settings.
+    """
+    try:
+        from core.models.approval_grants import SUBJECT_TOOL_CALL
+        from core.services.approval_grants import (
+            find_active_grant,
+            is_authorising,
+            revoke_grant,
+        )
+        from modules.policy.policy_document import RISK_DESTRUCTIVE
+
+        subject_id = tool_call_subject_id(workspace_id, action, params)
+        grant = find_active_grant(
+            db, workspace_id, subject_type=SUBJECT_TOOL_CALL, subject_id=subject_id
+        )
+        if grant is None or not is_authorising(grant):
+            return None
+
+        details = grant.details if isinstance(grant.details, dict) else {}
+        if details.get("params_hash") != params_hash(params):
+            # Params drifted from what the human approved — that is a new ask.
+            return None
+
+        stored_risk = grant.risk_tier or _risk_class_for(action, permission_level)
+        if stored_risk == RISK_DESTRUCTIVE:
+            # Single-use: the yes covered exactly one execution.
+            revoke_grant(grant, revoked_by=GRANT_CONSUMED_BY)
+        return grant
+    except Exception:
+        logger.warning(
+            "[tool_grants] grant consult failed for %s — failing closed to the ask",
+            action, exc_info=True,
+        )
+        return None
+
+
+# ---------------------------------------------------------------------------
 # Non-chat-lane notification (S5) — fire-and-forget, never blocks the ask
 # ---------------------------------------------------------------------------
 
@@ -368,6 +426,7 @@ __all__ = [
     "GRANT_CONSUMED_BY",
     "attach_ask_grant",
     "canonical_params",
+    "consume_tool_grant",
     "enrich_ask_with_grant",
     "issue_tool_grant",
     "params_hash",

--- a/orchestrator/modules/tools/execution/tool_grants.py
+++ b/orchestrator/modules/tools/execution/tool_grants.py
@@ -1,0 +1,375 @@
+"""PRD-193 (P2-12) — tool-call approval grants: the ask finally has a "yes".
+
+One shared seam between the confirmation gate and the PRD-181 grant substrate:
+
+* ``tool_call_subject_id`` / ``params_hash`` — the deterministic call key. The
+  hash covers the canonical **model-provided** params only (server-injected
+  ``_``-prefixed plumbing like ``_agent_id`` is stripped), so the ask, the
+  human's approval, and the retried call all land on the SAME subject.
+* ``issue_tool_grant``   — at the ask, create (or reuse) a PENDING
+  ``ApprovalGrant`` scoped ``tool_call`` and announce it to the workspace's
+  humans on non-chat lanes (chat sees the S3 card live — no double-notify).
+* ``attach_ask_grant``   — enrich the executor's ask return with ``grant_id``,
+  ``risk_class`` and the AI-Act oversight fields the S3 card renders.
+* ``consume_tool_grant`` — immediately before the confirmation return, resolve
+  an authorising grant for the same subject: GRANTED + unexpired + params-hash
+  equality ⇒ the gate opens. Destructive grants are single-use — retired on use
+  via ``revoke_grant(..., revoked_by="system:consumed")`` (locked decision:
+  destructive ⇒ single-use exact-params; write-class ⇒ TTL window per call-key
+  on the existing 24h ``APPROVAL_GRANT_TTL_SECONDS``).
+
+Fail-safe posture (the whole point of this gate): every error on the issue or
+consult side lands on the ask — never an exception, never an execution. This
+module therefore never raises into the executor.
+
+Subject-first by design: PRD-192's policy-plane ``ask`` verdicts route through
+this same seam later (workspace + action + canonical params — no per-surface
+fork). Reuses PRD-181's model/service wholesale: no new table, no migration,
+no new config key.
+"""
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+from typing import Any, Dict, Optional, Set
+from uuid import UUID
+
+logger = logging.getLogger(__name__)
+
+# Actor ref recorded when a single-use (destructive) grant is retired on use.
+GRANT_CONSUMED_BY = "system:consumed"
+
+# Strong refs to fire-and-forget notification tasks (the board_approval /
+# api/webhooks.py background-task idiom) so the loop cannot GC them mid-flight.
+_NOTIFY_TASKS: Set["asyncio.Task"] = set()
+
+# caller_context keys snapshotted into ``details`` so the S4 resume re-dispatch
+# reproduces the original call's identity/telemetry posture — nothing more.
+_CALLER_SNAPSHOT_KEYS = (
+    "user_id",
+    "system_role",
+    "workspace_role",
+    "conversation_id",
+    "turn_id",
+)
+
+
+# ---------------------------------------------------------------------------
+# The deterministic call key (pure)
+# ---------------------------------------------------------------------------
+
+def canonical_params(params: Any) -> Dict[str, Any]:
+    """The model-provided view of a call's params.
+
+    Server-injected plumbing (``_agent_id``, ``_agent_name``, ``_created_by``,
+    …) is stripped so the ask and the retry produce the same key regardless of
+    which lane injected what.
+    """
+    if not isinstance(params, dict):
+        return {}
+    return {k: v for k, v in params.items() if not str(k).startswith("_")}
+
+
+def params_hash(params: Any) -> str:
+    """Stable hash of the canonical params (sorted-key JSON, sha256)."""
+    canon = canonical_params(params)
+    try:
+        raw = json.dumps(canon, sort_keys=True, default=str)
+    except Exception:  # pragma: no cover - json.default=str makes this rare
+        raw = str(sorted(canon.items(), key=lambda kv: str(kv[0])))
+    return hashlib.sha256(raw.encode("utf-8", "ignore")).hexdigest()
+
+
+def tool_call_subject_id(workspace_id: UUID | str, action: str, params: Any) -> str:
+    """Deterministic ``subject_id`` for a tool call: workspace + action + params.
+
+    Human-readable prefix (the action) + digest — fits the 255-char column and
+    keeps the P2-15 approvals queue debuggable.
+    """
+    digest = hashlib.sha256(
+        "|".join([str(workspace_id), str(action or ""), params_hash(params)]).encode(
+            "utf-8", "ignore"
+        )
+    ).hexdigest()
+    return f"{action}:{digest[:32]}"
+
+
+def _risk_class_for(action: str, permission_level: Optional[str]) -> str:
+    """Pure risk classification (policy_document.classify_action), fail-safe."""
+    try:
+        from modules.policy.policy_document import classify_action
+
+        return classify_action(action, permission_level=permission_level)
+    except Exception:  # pragma: no cover - classifier is pure; import guard only
+        logger.warning("[tool_grants] risk classification failed for %s", action, exc_info=True)
+        return "destructive" if permission_level == "destructive" else "internal_write"
+
+
+def _lane_for(caller_context: Optional[Dict[str, Any]]) -> str:
+    """Coarse lane marker for the details snapshot + notification routing.
+
+    Chat threads ``conversation_id`` (consumers/chatbot build_tool_caller_context);
+    board runs thread ``board_task_id``; everything else is the agent lane
+    (heartbeat / scheduled / mission).
+    """
+    ctx = caller_context or {}
+    if ctx.get("conversation_id"):
+        return "chat"
+    if ctx.get("board_task_id") is not None:
+        return "board"
+    return "agent"
+
+
+# ---------------------------------------------------------------------------
+# Issue at the ask (S1)
+# ---------------------------------------------------------------------------
+
+def issue_tool_grant(
+    db: Any,
+    workspace_id: UUID | str,
+    *,
+    action: str,
+    params: Any,
+    permission_level: Optional[str] = None,
+    description: Optional[str] = None,
+    caller_context: Optional[Dict[str, Any]] = None,
+) -> Optional[Any]:
+    """Create (or reuse) the PENDING ``tool_call`` grant for this exact call.
+
+    Returns the grant, or ``None`` on any failure — the caller returns the ask
+    either way (the ask is the floor). Never raises. Caller owns the txn
+    (mirrors the PRD-181 service: stage + flush, never commit).
+    """
+    try:
+        from core.models.approval_grants import SUBJECT_TOOL_CALL
+        from core.services.approval_grants import create_grant, find_pending_grant
+
+        subject_id = tool_call_subject_id(workspace_id, action, params)
+
+        existing = find_pending_grant(
+            db, workspace_id, subject_type=SUBJECT_TOOL_CALL, subject_id=subject_id
+        )
+        if existing is not None:
+            # Idempotent ask: the pending row (already announced on creation)
+            # is the actionable thing — no grant spam, no re-notify.
+            return existing
+
+        ctx = caller_context or {}
+        agent_id: Optional[int] = None
+        raw_agent = params.get("_agent_id") if isinstance(params, dict) else None
+        try:
+            agent_id = int(raw_agent) if raw_agent is not None else None
+        except (TypeError, ValueError):
+            agent_id = None
+
+        risk_class = _risk_class_for(action, permission_level)
+        lane = _lane_for(caller_context)
+
+        grant = create_grant(
+            db,
+            workspace_id,
+            subject_type=SUBJECT_TOOL_CALL,
+            subject_id=subject_id,
+            tool_name=action,
+            risk_tier=risk_class,
+            agent_id=agent_id,
+            reason=(
+                f"Confirmation required before running {action}: "
+                f"{(description or 'gated platform action')[:200]}"
+            ),
+        )
+
+        caller_snapshot = {
+            k: ctx.get(k) for k in _CALLER_SNAPSHOT_KEYS if ctx.get(k) is not None
+        }
+        details: Dict[str, Any] = {
+            "action": action,
+            "params": canonical_params(params),
+            "params_hash": params_hash(params),
+            "lane": lane,
+            "action_description": (description or "")[:300],
+        }
+        if caller_snapshot:
+            details["caller_context"] = caller_snapshot
+        if ctx.get("conversation_id"):
+            details["conversation_id"] = ctx.get("conversation_id")
+        if ctx.get("turn_id"):
+            details["turn_id"] = ctx.get("turn_id")
+        if ctx.get("board_task_id") is not None:
+            details["board_task_id"] = ctx.get("board_task_id")
+        grant.details = details
+
+        # PRD-193 S5: an ask that fires with nobody watching must not be
+        # silent — announce the fresh pending grant on non-chat lanes (chat
+        # renders the S3 card live in the conversation; don't double-notify).
+        if lane != "chat":
+            _notify_approval_pending(grant, workspace_id)
+
+        return grant
+    except Exception:
+        logger.warning(
+            "[tool_grants] grant issuance failed for %s (ask still returned)",
+            action, exc_info=True,
+        )
+        return None
+
+
+def enrich_ask_with_grant(ask: Dict[str, Any], grant: Any, *, risk_class: str) -> Dict[str, Any]:
+    """Return the ask WITH the grant + AI-Act oversight fields attached (pure).
+
+    Field names mirror the PRD-163/181 mission card payload (``risk_class`` /
+    ``risk_tier`` / ``oversight_rationale`` / ``requires_approval``) so the S3
+    ``tool_approval`` card renders through the same presentation.
+    """
+    oversight: Dict[str, Any]
+    try:
+        from modules.policy.ai_act import OversightTier, oversight_for_risk
+
+        mapping = oversight_for_risk(risk_class)
+        oversight = mapping.to_dict()
+        if mapping.tier != OversightTier.HUMAN_IN_THE_LOOP:
+            # A gated ask awaiting approval is human-in-the-loop by definition
+            # (the write-class gated actions classify on-the-loop) — floor the
+            # tier so the card never implies "no human oversight", the same
+            # posture as the mission card's ``_mission_oversight``. The true
+            # risk_class is kept; the rationale states the gated-ask reality.
+            oversight["tier"] = OversightTier.HUMAN_IN_THE_LOOP.value
+            oversight["rationale"] = (
+                "This action is confirmation-gated: a human must approve it "
+                "before it runs."
+            )
+            oversight["requires_approval"] = True
+    except Exception:  # pragma: no cover - pure import; guard only
+        oversight = {
+            "risk_class": risk_class or "unknown",
+            "tier": "human_in_the_loop",
+            "rationale": "This action requires human approval before it runs.",
+            "requires_approval": True,
+        }
+    return {
+        **ask,
+        "grant_id": getattr(grant, "id", None),
+        "risk_class": oversight.get("risk_class", risk_class),
+        "risk_tier": oversight.get("tier"),
+        "oversight_rationale": oversight.get("rationale"),
+        "requires_approval": True,
+    }
+
+
+def attach_ask_grant(
+    db: Any,
+    workspace_id: UUID | str,
+    *,
+    action: str,
+    params: Any,
+    ask: Dict[str, Any],
+    permission_level: Optional[str] = None,
+    description: Optional[str] = None,
+    caller_context: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Issue the grant and return the enriched ask; on ANY failure return the
+    ask unchanged. The single fail-safe entry the confirmation gate calls."""
+    try:
+        grant = issue_tool_grant(
+            db,
+            workspace_id,
+            action=action,
+            params=params,
+            permission_level=permission_level,
+            description=description,
+            caller_context=caller_context,
+        )
+        if grant is None:
+            return ask
+        return enrich_ask_with_grant(
+            ask, grant, risk_class=_risk_class_for(action, permission_level)
+        )
+    except Exception:  # pragma: no cover - issue/enrich already guard; belt & braces
+        logger.warning("[tool_grants] ask enrichment failed for %s", action, exc_info=True)
+        return ask
+
+
+# ---------------------------------------------------------------------------
+# Non-chat-lane notification (S5) — fire-and-forget, never blocks the ask
+# ---------------------------------------------------------------------------
+
+def _notify_approval_pending(grant: Any, workspace_id: UUID | str) -> None:
+    """Schedule the ``approval_pending`` notification without blocking the gate.
+
+    Mirrors ``services/board_approval``: dispatched off-transaction on the
+    running loop with its own session; no loop (pure unit tests, sync callers)
+    ⇒ skip silently. A dispatch fault never reaches the executor.
+    """
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return
+    try:
+        task = loop.create_task(
+            _dispatch_approval_pending(
+                str(workspace_id),
+                grant_id=getattr(grant, "id", None),
+                tool_name=getattr(grant, "tool_name", None),
+                risk_tier=getattr(grant, "risk_tier", None),
+                reason=getattr(grant, "reason", None),
+            )
+        )
+        _NOTIFY_TASKS.add(task)
+        task.add_done_callback(_NOTIFY_TASKS.discard)
+    except Exception:  # pragma: no cover - create_task on a live loop
+        logger.warning("[tool_grants] approval_pending scheduling failed", exc_info=True)
+
+
+async def _dispatch_approval_pending(
+    workspace_id: str,
+    *,
+    grant_id: Any,
+    tool_name: Optional[str],
+    risk_tier: Optional[str],
+    reason: Optional[str],
+) -> None:
+    """Dispatch ``approval_pending`` through the canonical notification seam.
+
+    Owns its session: by the time the loop runs this, the creating caller's
+    transaction is finished (and its session may be closed). The grant id rides
+    ``link_id`` so the P2-15 approvals queue has a deep-link target.
+    """
+    from core.database.database import SessionLocal
+    from core.services.notification_dispatcher import NotificationDispatcher
+
+    db = SessionLocal()
+    try:
+        message = reason or f"A gated action ({tool_name or 'platform action'}) is awaiting approval."
+        if risk_tier:
+            message = f"{message} [risk: {risk_tier}]"
+        await NotificationDispatcher(db, workspace_id).dispatch(
+            event_type="approval_pending",
+            title=f"Approval needed: {tool_name or 'platform action'}",
+            message=message,
+            link_type="approval_grant",
+            link_id=str(grant_id) if grant_id is not None else None,
+            status="action_required",
+        )
+    except Exception:
+        logger.warning(
+            "[tool_grants] approval_pending dispatch failed for grant %s",
+            grant_id, exc_info=True,
+        )
+    finally:
+        try:
+            db.close()
+        except Exception:  # pragma: no cover
+            pass
+
+
+__all__ = [
+    "GRANT_CONSUMED_BY",
+    "attach_ask_grant",
+    "canonical_params",
+    "enrich_ask_with_grant",
+    "issue_tool_grant",
+    "params_hash",
+    "tool_call_subject_id",
+]

--- a/orchestrator/modules/tools/execution/tool_grants.py
+++ b/orchestrator/modules/tools/execution/tool_grants.py
@@ -281,7 +281,10 @@ def attach_ask_grant(
             description=description,
             caller_context=caller_context,
         )
-        if grant is None:
+        # A grant without a usable integer id cannot power the card — the
+        # grant/deny endpoints key on it. Degraded stores (or fakes) that
+        # yield id-less rows get the plain prose ask, never a dead card.
+        if grant is None or not isinstance(getattr(grant, "id", None), int):
             return ask
         return enrich_ask_with_grant(
             ask, grant, risk_class=_risk_class_for(action, permission_level)

--- a/orchestrator/modules/tools/formatting/result_formatter.py
+++ b/orchestrator/modules/tools/formatting/result_formatter.py
@@ -791,7 +791,54 @@ class ToolResultFormatter:
                     "requires_approval": True,
                 }
 
+        # PRD-193 S3 (P2-12): a confirmation ask that carries a grant surfaces
+        # the in-chat tool-approval card — the human's affordance beside the
+        # S15 prose (which stays the model's view). Result-shape driven, not a
+        # tool_name branch: any gated action (direct platform_* call or the
+        # platform_execute meta-dispatch) gets the card when the S1 gate
+        # attached a grant. Mirrors the mission_approval payload above.
+        if result.get("requires_confirmation") and result.get("grant_id") is not None:
+            frontend_data["tool_approval"] = {
+                "grant_id": result.get("grant_id"),
+                "action": result.get("action") or tool_name,
+                "message": result.get("message", ""),
+                "permission_level": result.get("permission_level"),
+                # The human must see exactly what they are approving — a
+                # key/value digest of the model-provided params, never a raw
+                # dump of server plumbing.
+                "params": ToolResultFormatter._tool_params_digest(result.get("params")),
+                # AI-Act oversight fields (attached by the S1 gate; floored
+                # fail-safe here so the card never implies "no oversight").
+                "risk_class": result.get("risk_class") or "unknown",
+                "risk_tier": result.get("risk_tier") or "human_in_the_loop",
+                "oversight_rationale": result.get("oversight_rationale") or (
+                    "This action requires human approval before it runs."
+                ),
+                "requires_approval": True,
+            }
+
         return frontend_data
+
+    @staticmethod
+    def _tool_params_digest(params: Any) -> Dict[str, Any]:
+        """PRD-193 S3: human-readable digest of a gated call's params.
+
+        Server-injected ``_``-prefixed plumbing is dropped; long values are
+        truncated. The approver sees the tool's real arguments (target ids,
+        keys, values) — not a raw JSON dump.
+        """
+        if not isinstance(params, dict):
+            return {}
+        digest: Dict[str, Any] = {}
+        for key, value in params.items():
+            if str(key).startswith("_"):
+                continue
+            if isinstance(value, (int, float, bool)) or value is None:
+                digest[str(key)] = value
+                continue
+            text = value if isinstance(value, str) else str(value)
+            digest[str(key)] = (text[:117] + "…") if len(text) > 120 else text
+        return digest
     
     @staticmethod
     def format_for_llm(result: Dict[str, Any], tool_name: str, max_chars: int = 20000) -> str:

--- a/orchestrator/modules/tools/tool_router.py
+++ b/orchestrator/modules/tools/tool_router.py
@@ -923,9 +923,24 @@ class ToolRouter:
                 else error
             )
             logger.warning(f"[tool-trace {trace_id}] {tool_name} failed: {error}")
+            # PRD-193 S3 (P2-12): an approval ask is not an opaque failure —
+            # when the S1 gate attached a grant, emit the tool_approval card
+            # payload so the HUMAN gets an affordance beside the S15 prose
+            # (which stays the model's view, above). Best-effort: a formatter
+            # fault never changes the envelope shape.
+            ask_frontend_data: Dict[str, Any] = {}
+            if result.get("requires_confirmation") and result.get("grant_id") is not None:
+                try:
+                    ask_frontend_data = self.formatter.format_for_frontend(result, tool_name)
+                except Exception:
+                    logger.debug(
+                        f"[tool-trace {trace_id}] tool_approval card formatting skipped",
+                        exc_info=True,
+                    )
+                    ask_frontend_data = {}
             envelope = {
                 "success": False,
-                "frontend_data": {},
+                "frontend_data": ask_frontend_data,
                 "llm_context": f"Tool {tool_name} failed: {llm_error}",
                 "raw_result": result,
                 "fatal_error": fatal_error,

--- a/orchestrator/tests/test_p2w2_ask_notification.py
+++ b/orchestrator/tests/test_p2w2_ask_notification.py
@@ -1,0 +1,241 @@
+"""PRD-193 S5 (P2-12) — surface the ask beyond the open chat + loop hygiene.
+
+An ask that fires on a board/heartbeat/scheduled run with nobody watching must
+not be silent — the exact failure class P2-02 closed for playbooks. The fresh
+pending grant dispatches an ``approval_pending`` notification on non-chat
+lanes (chat sees the S3 card live — no double-notify).
+
+EVENT-VOCABULARY NOTE (deliberate deviation from the PRD text): the PRD names
+``approval_requested``; PR #531 already shipped ``approval_pending`` for
+exactly this concept (pending grant → tell the workspace's humans). One event
+type per concept — this PRD REUSES ``approval_pending`` rather than minting a
+rival (reuse-don't-fork; deviation stated in the PR body).
+
+Loop hygiene pinned here too:
+  - the ask outcome is typed as an ASK in memory, not failure-spam
+    (``tool_outcome_capture`` — the noise class PRD-187 S2 cleaned up);
+  - same-turn duplicate suppression stands (correct: ask-spam guard), while a
+    fresh tracker per loop run means the post-grant retry is NOT dedup-blocked
+    — pinned so a future shared-tracker refactor can't silently resurrect the
+    dossier's dedup dead-end.
+"""
+from __future__ import annotations
+
+import asyncio
+import importlib.util as _ilu
+import os
+import sys as _sys
+import uuid
+
+import pytest
+
+os.environ.setdefault("POSTGRES_USER", "test")
+os.environ.setdefault("POSTGRES_PASSWORD", "test")
+os.environ.setdefault("POSTGRES_HOST", "127.0.0.1")
+os.environ.setdefault("POSTGRES_PORT", "59432")
+os.environ.setdefault("POSTGRES_DB", "test")
+
+
+def _camelot_unlocatable() -> bool:  # pragma: no cover - env-dependent
+    try:
+        return _ilu.find_spec("camelot") is None
+    except ValueError:
+        return False
+
+
+if _camelot_unlocatable():  # pragma: no cover - env-dependent
+    import types as _types
+
+    _sys.modules.setdefault("camelot", _types.ModuleType("camelot"))
+
+from modules.tools.execution import tool_grants
+
+pytestmark = pytest.mark.asyncio
+
+
+class _Query:
+    def __init__(self, rows):
+        self._rows = list(rows)
+
+    def filter(self, *conds):
+        rows = self._rows
+        for cond in conds:
+            key = cond.left.key
+            value = getattr(cond.right, "value", None)
+            rows = [r for r in rows if str(getattr(r, key, None)) == str(value)]
+        return _Query(rows)
+
+    def order_by(self, *args):
+        return _Query(list(reversed(self._rows)))
+
+    def first(self):
+        return self._rows[0] if self._rows else None
+
+    def all(self):
+        return list(self._rows)
+
+
+class _FakeSession:
+    def __init__(self):
+        self.rows = []
+
+    def add(self, obj):
+        if getattr(obj, "id", None) is None:
+            obj.id = len(self.rows) + 1
+        self.rows.append(obj)
+
+    def flush(self):
+        pass
+
+    def query(self, model):
+        return _Query([r for r in self.rows if isinstance(r, model)])
+
+
+@pytest.fixture()
+def dispatched(monkeypatch):
+    """Record every scheduled approval_pending dispatch (no real session/IO)."""
+    calls = []
+
+    async def _record(workspace_id, **kwargs):
+        calls.append({"workspace_id": workspace_id, **kwargs})
+
+    monkeypatch.setattr(tool_grants, "_dispatch_approval_pending", _record)
+    return calls
+
+
+def _issue(db, ws, caller_context):
+    return tool_grants.issue_tool_grant(
+        db, ws,
+        action="platform_delete_document",
+        params={"document_id": 7},
+        permission_level="destructive",
+        description="Delete a document permanently.",
+        caller_context=caller_context,
+    )
+
+
+# ===========================================================================
+# 1. The event is registered — reusing #531's approval_pending (see docstring)
+# ===========================================================================
+
+async def test_approval_requested_event_registered():
+    """Mirror of test_prd163_async_planning's registration pin — the dispatcher
+    must accept the approval event so a silent-lane ask actually delivers.
+    (Named per the PRD's test list; asserts the REUSED ``approval_pending``.)"""
+    from core.services.notification_dispatcher import VALID_EVENT_TYPES
+
+    assert "approval_pending" in VALID_EVENT_TYPES
+
+
+# ===========================================================================
+# 2. Non-chat lanes notify; chat does not double-notify
+# ===========================================================================
+
+async def test_agent_lane_ask_notifies(dispatched):
+    db = _FakeSession()
+    ws = uuid.uuid4()
+    grant = _issue(db, ws, caller_context=None)  # heartbeat/agent lane
+    await asyncio.sleep(0)  # let the fire-and-forget task run
+
+    assert len(dispatched) == 1
+    call = dispatched[0]
+    assert call["workspace_id"] == str(ws)
+    assert call["grant_id"] == grant.id
+    assert call["tool_name"] == "platform_delete_document"
+
+
+async def test_board_lane_ask_notifies(dispatched):
+    db = _FakeSession()
+    grant = _issue(db, uuid.uuid4(), caller_context={"board_task_id": 77})
+    await asyncio.sleep(0)
+
+    assert len(dispatched) == 1
+    assert dispatched[0]["grant_id"] == grant.id
+
+
+async def test_chat_lane_ask_does_not_double_notify(dispatched):
+    db = _FakeSession()
+    _issue(db, uuid.uuid4(), caller_context={"conversation_id": "c-1", "turn_id": "t-1"})
+    await asyncio.sleep(0)
+
+    assert dispatched == []  # the S3 card is live in the conversation
+
+
+async def test_reused_pending_grant_does_not_renotify(dispatched):
+    """The idempotent re-ask reuses the pending row — announced once, on
+    creation, exactly like the board_approval reuse branch."""
+    db = _FakeSession()
+    ws = uuid.uuid4()
+    first = _issue(db, ws, caller_context=None)
+    second = _issue(db, ws, caller_context=None)
+    await asyncio.sleep(0)
+
+    assert first.id == second.id
+    assert len(dispatched) == 1
+
+
+# ===========================================================================
+# 3. The ask is typed as an ASK in memory — not failure-spam
+# ===========================================================================
+
+async def test_ask_not_captured_as_failure():
+    from modules.memory.tool_outcome_capture import build_tool_outcome
+
+    rec = build_tool_outcome(
+        tool_name="platform_delete_document",
+        parameters={},
+        result={
+            "success": False,
+            "requires_confirmation": True,
+            "grant_id": 42,
+            "message": "This action (destructive) requires confirmation.",
+        },
+        workspace_id="ws-1",
+    )
+    assert rec is not None, "the ask IS a notable outcome — typed, not dropped"
+    assert rec["metadata"]["outcome"] == "ask"
+    assert rec["metadata"]["error_class"] == ""
+    assert "failed" not in rec["fact"].lower()
+    assert "awaiting human approval" in rec["fact"]
+
+    # A genuine failure still classifies as a failure (unchanged behaviour).
+    fail = build_tool_outcome(
+        tool_name="platform_delete_document",
+        parameters={},
+        result={"success": False, "error": "boom"},
+        workspace_id="ws-1",
+    )
+    assert "failed" in fail["fact"]
+    assert fail["metadata"].get("outcome") != "ask"
+
+
+# ===========================================================================
+# 4. Loop hygiene: same-turn dedup stands; the post-grant retry is not blocked
+# ===========================================================================
+
+async def test_granted_retry_not_dedup_blocked():
+    from modules.tools.execution.tool_execution_tracker import ToolExecutionTracker
+    from modules.tools.execution.tool_loop import ToolLoopExecutor
+
+    args = {"document_id": 7}
+
+    # Same-turn duplicate suppression is CORRECT (the ask-spam guard) …
+    turn1 = ToolExecutionTracker()
+    assert turn1.should_skip_execution("platform_delete_document", args)[0] is False
+    turn1.record_execution("platform_delete_document", args)
+    assert turn1.should_skip_execution("platform_delete_document", args)[0] is True
+
+    # … but the NEXT run's tracker is fresh, so the granted retry executes.
+    turn2 = ToolExecutionTracker()
+    assert turn2.should_skip_execution("platform_delete_document", args)[0] is False
+
+    # Pin the loop executor's fresh-tracker-per-instance default so a future
+    # shared-tracker refactor can't silently resurrect the dedup dead-end.
+    async def _cb(*a, **k):  # pragma: no cover - never invoked
+        return {}
+
+    loop_a = ToolLoopExecutor(llm_callback=_cb, tool_callback=_cb)
+    loop_b = ToolLoopExecutor(llm_callback=_cb, tool_callback=_cb)
+    assert loop_a.tracker is not loop_b.tracker
+    loop_a.tracker.record_execution("platform_delete_document", args)
+    assert loop_b.tracker.should_skip_execution("platform_delete_document", args)[0] is False

--- a/orchestrator/tests/test_p2w2_grant_resume.py
+++ b/orchestrator/tests/test_p2w2_grant_resume.py
@@ -1,0 +1,358 @@
+"""PRD-193 S4 (P2-12) — approving must complete the work, not just flip a row.
+
+The grant API's subject dispatch — board-only until now — gains the
+``tool_call`` branch: on grant, re-dispatch the stored call through the spine
+(``UnifiedToolExecutor.execute_tool`` — telemetry, the policy seam, and
+outcome capture all fire on the resumed execution); on deny, end it honestly
+(the DENIED status is the record; nothing executes). Board-originated asks
+(``details.board_task_id``) resume through the EXISTING board re-queue — the
+re-run then meets the now-active grant (S2) and completes (locked decision 4:
+lean board linkage, no J2 mid-run pause).
+
+Guarantees pinned here:
+  1. ``test_grant_resumes_tool_call``       — re-dispatch carries the stored
+     params + workspace + caller context + server-minted agent identity; the
+     outcome summary lands on ``details.executed_result``.
+  2. ``test_deny_does_not_execute``         — deny leaves the executor untouched
+     and the grant DENIED.
+  3. ``test_resume_failure_is_honest``      — a failing (or raising) re-dispatch
+     surfaces as a failure on the grant — never a fake success (dossier C.3).
+  4. ``test_board_linked_ask_requeues_task``— a grant carrying board_task_id
+     re-queues the blocked task (mirror of the existing board branch) and does
+     NOT double-dispatch.
+  5. Board-linked but not blocked ⇒ direct re-dispatch still completes the work.
+  6. ``to_dict`` exposes ``details`` so the card can render the executed state.
+
+Pure: fake session, real ApprovalGrant/BoardTask model objects, executor and
+board notifier mocked at their boundaries. No DB / network.
+"""
+from __future__ import annotations
+
+import importlib.util as _ilu
+import os
+import sys as _sys
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+os.environ.setdefault("POSTGRES_USER", "test")
+os.environ.setdefault("POSTGRES_PASSWORD", "test")
+os.environ.setdefault("POSTGRES_HOST", "127.0.0.1")
+os.environ.setdefault("POSTGRES_PORT", "59432")
+os.environ.setdefault("POSTGRES_DB", "test")
+
+
+def _camelot_unlocatable() -> bool:  # pragma: no cover - env-dependent
+    try:
+        return _ilu.find_spec("camelot") is None
+    except ValueError:
+        return False
+
+
+if _camelot_unlocatable():  # pragma: no cover - env-dependent
+    import types as _types
+
+    _sys.modules.setdefault("camelot", _types.ModuleType("camelot"))
+
+from core.models.approval_grants import ApprovalGrant, GrantStatus, SUBJECT_TOOL_CALL
+from core.models.core import BoardTask
+from core.services.approval_grants import deny_grant, grant_grant
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# Fake session — .query(Model).get(pk) plus the list shape the service uses.
+# ---------------------------------------------------------------------------
+
+class _Query:
+    def __init__(self, rows):
+        self._rows = list(rows)
+
+    def get(self, pk):
+        for r in self._rows:
+            if getattr(r, "id", None) == pk:
+                return r
+        return None
+
+    def filter(self, *conds):
+        return self
+
+    def order_by(self, *a):
+        return self
+
+    def first(self):
+        return self._rows[0] if self._rows else None
+
+    def all(self):
+        return list(self._rows)
+
+
+class _FakeSession:
+    def __init__(self):
+        self.rows = []
+
+    def add(self, obj):
+        if getattr(obj, "id", None) is None:
+            obj.id = len(self.rows) + 1
+        self.rows.append(obj)
+
+    def flush(self):
+        pass
+
+    def query(self, model):
+        return _Query([r for r in self.rows if isinstance(r, model)])
+
+
+def _tool_call_grant(
+    db: _FakeSession,
+    *,
+    workspace_id=None,
+    action: str = "platform_delete_document",
+    params: dict | None = None,
+    board_task_id=None,
+    agent_id: int = 9,
+) -> ApprovalGrant:
+    params = {"document_id": 7} if params is None else params
+    details = {
+        "action": action,
+        "params": params,
+        "params_hash": "h",
+        "lane": "chat" if board_task_id is None else "board",
+        "caller_context": {"user_id": "user_clerk_1", "conversation_id": "c-1"},
+    }
+    if board_task_id is not None:
+        details["board_task_id"] = board_task_id
+    grant = ApprovalGrant(
+        workspace_id=workspace_id or uuid.uuid4(),
+        subject_type=SUBJECT_TOOL_CALL,
+        subject_id=f"{action}:deadbeef",
+        tool_name=action,
+        risk_tier="destructive",
+        agent_id=agent_id,
+        status=GrantStatus.PENDING.value,
+        details=details,
+    )
+    db.add(grant)
+    grant_grant(grant, granted_by="user:1")
+    return grant
+
+
+def _blocked_task(db: _FakeSession, task_id: int = 77) -> BoardTask:
+    task = BoardTask(
+        title="probe task",
+        status="blocked",
+        workspace_id=uuid.uuid4(),
+    )
+    task.id = task_id
+    db.rows.append(task)
+    return task
+
+
+# ===========================================================================
+# 1. Grant ⇒ re-dispatch through the spine with the stored call
+# ===========================================================================
+
+async def test_grant_resumes_tool_call():
+    from api.approval_grants import _requeue_subject
+
+    db = _FakeSession()
+    grant = _tool_call_grant(db)
+
+    executor = AsyncMock()
+    executor.execute_tool = AsyncMock(return_value={"success": True, "deleted": True})
+
+    with patch(
+        "modules.tools.execution.unified_executor.UnifiedToolExecutor",
+        return_value=executor,
+    ) as executor_cls:
+        await _requeue_subject(db, grant)
+
+    executor_cls.assert_called_once_with(db)
+    kwargs = executor.execute_tool.await_args.kwargs
+    assert kwargs["tool_name"] == "platform_delete_document"
+    assert kwargs["parameters"] == {"document_id": 7}
+    assert kwargs["workspace_id"] == grant.workspace_id
+    assert kwargs["agent_id"] == 9  # the server-minted identity, re-threaded
+    assert kwargs["caller_context"] == {
+        "user_id": "user_clerk_1",
+        "conversation_id": "c-1",
+    }
+
+    executed = (grant.details or {}).get("executed_result")
+    assert executed is not None, "the outcome summary must land on the grant"
+    assert executed["success"] is True
+    assert executed.get("error") is None
+    # No board side effects for a chat-lane grant.
+    assert all(not isinstance(r, BoardTask) for r in db.rows)
+
+
+# ===========================================================================
+# 2. Deny is honest: nothing executes, the DENIED row is the record
+# ===========================================================================
+
+async def test_deny_does_not_execute():
+    from api.approval_grants import _fail_subject
+
+    db = _FakeSession()
+    grant = _tool_call_grant(db)
+    deny_grant(grant, revoked_by="user:1")
+
+    with patch(
+        "modules.tools.execution.unified_executor.UnifiedToolExecutor"
+    ) as executor_cls:
+        _fail_subject(db, grant)
+
+    executor_cls.assert_not_called()
+    assert grant.status == GrantStatus.DENIED.value
+    assert "executed_result" not in (grant.details or {})
+
+
+# ===========================================================================
+# 3. A failed resume surfaces as a failure — never a fake success
+# ===========================================================================
+
+async def test_resume_failure_is_honest():
+    from api.approval_grants import _requeue_subject
+
+    # (a) executor returns errors-as-data
+    db = _FakeSession()
+    grant = _tool_call_grant(db)
+    executor = AsyncMock()
+    executor.execute_tool = AsyncMock(return_value={"success": False, "error": "boom"})
+    with patch(
+        "modules.tools.execution.unified_executor.UnifiedToolExecutor",
+        return_value=executor,
+    ):
+        await _requeue_subject(db, grant)
+    executed = grant.details["executed_result"]
+    assert executed["success"] is False
+    assert "boom" in (executed.get("error") or "")
+
+    # (b) executor raises — still an honest failure on the grant, no exception
+    db2 = _FakeSession()
+    grant2 = _tool_call_grant(db2)
+    executor2 = AsyncMock()
+    executor2.execute_tool = AsyncMock(side_effect=RuntimeError("spine down"))
+    with patch(
+        "modules.tools.execution.unified_executor.UnifiedToolExecutor",
+        return_value=executor2,
+    ):
+        await _requeue_subject(db2, grant2)
+    executed2 = grant2.details["executed_result"]
+    assert executed2["success"] is False
+    assert "spine down" in (executed2.get("error") or "")
+
+
+async def test_resume_reask_is_reported_not_faked():
+    """If the re-dispatch hits the gate again (e.g. consumption raced), the
+    summary says so — the card must not claim the action ran."""
+    from api.approval_grants import _requeue_subject
+
+    db = _FakeSession()
+    grant = _tool_call_grant(db)
+    executor = AsyncMock()
+    executor.execute_tool = AsyncMock(
+        return_value={"success": False, "requires_confirmation": True, "grant_id": 99}
+    )
+    with patch(
+        "modules.tools.execution.unified_executor.UnifiedToolExecutor",
+        return_value=executor,
+    ):
+        await _requeue_subject(db, grant)
+    executed = grant.details["executed_result"]
+    assert executed["success"] is False
+    assert executed["requires_confirmation"] is True
+
+
+# ===========================================================================
+# 4. Board linkage — the EXISTING re-queue resumes board-originated asks
+# ===========================================================================
+
+async def test_board_linked_ask_requeues_task():
+    from api.approval_grants import _requeue_subject
+
+    db = _FakeSession()
+    task = _blocked_task(db, task_id=77)
+    grant = _tool_call_grant(db, board_task_id=77)
+
+    executor = AsyncMock()
+    with patch(
+        "modules.tools.execution.unified_executor.UnifiedToolExecutor",
+        return_value=executor,
+    ) as executor_cls, patch(
+        "services.board_dispatcher.notify_task_available"
+    ) as notify:
+        await _requeue_subject(db, grant)
+
+    # Mirror of the existing board branch: blocked → assigned + re-notified.
+    assert task.status == "assigned"
+    assert task.blocked_at is None and task.blocked_reason is None
+    notify.assert_called_once()
+    # The re-run executes into the now-active grant — no direct double-dispatch.
+    executor_cls.assert_not_called()
+    executed = grant.details["executed_result"]
+    assert executed["resumed_via"] == "board_task_requeue"
+    assert executed["board_task_id"] == 77
+
+
+async def test_board_linked_but_unblocked_falls_through_to_dispatch():
+    """The task already finished (the ask ended its run) — the human's yes
+    must still complete the WORK: direct re-dispatch through the spine."""
+    from api.approval_grants import _requeue_subject
+
+    db = _FakeSession()
+    task = _blocked_task(db, task_id=77)
+    task.status = "done"
+    grant = _tool_call_grant(db, board_task_id=77)
+
+    executor = AsyncMock()
+    executor.execute_tool = AsyncMock(return_value={"success": True})
+    with patch(
+        "modules.tools.execution.unified_executor.UnifiedToolExecutor",
+        return_value=executor,
+    ):
+        await _requeue_subject(db, grant)
+
+    assert task.status == "done"  # untouched
+    executor.execute_tool.assert_awaited_once()
+    assert grant.details["executed_result"]["success"] is True
+
+
+# ===========================================================================
+# 5. Existing board-task subject behaviour is unchanged (regression pin)
+# ===========================================================================
+
+async def test_board_task_subject_branch_unchanged():
+    from api.approval_grants import _requeue_subject
+    from core.models.approval_grants import SUBJECT_BOARD_TASK
+
+    db = _FakeSession()
+    task = _blocked_task(db, task_id=55)
+    grant = ApprovalGrant(
+        workspace_id=uuid.uuid4(),
+        subject_type=SUBJECT_BOARD_TASK,
+        subject_id="55",
+        status=GrantStatus.PENDING.value,
+    )
+    db.add(grant)
+    grant_grant(grant, granted_by="user:1")
+
+    with patch("services.board_dispatcher.notify_task_available") as notify:
+        await _requeue_subject(db, grant)
+
+    assert task.status == "assigned"
+    notify.assert_called_once()
+
+
+# ===========================================================================
+# 6. The card can see the executed state (to_dict exposes details)
+# ===========================================================================
+
+async def test_grant_to_dict_exposes_details():
+    db = _FakeSession()
+    grant = _tool_call_grant(db)
+    grant.details = {**grant.details, "executed_result": {"success": True}}
+    payload = grant.to_dict()
+    assert payload["details"]["executed_result"]["success"] is True

--- a/orchestrator/tests/test_p2w2_tool_approval_card.py
+++ b/orchestrator/tests/test_p2w2_tool_approval_card.py
@@ -1,0 +1,165 @@
+"""PRD-193 S3 (P2-12) — the in-chat tool-approval card (backend payload).
+
+A confirmation ask that carries a grant must surface a ``tool_approval``
+card payload from ``format_for_frontend`` — grant id, action, human-readable
+params digest, permission level, and the AI-Act oversight fields — mirroring
+the PRD-163/181 ``mission_approval`` card. The S15 prose stays the model's
+view; the card is the human's.
+
+Result-shape driven, not tool_name driven: direct ``platform_*`` calls and
+the ``platform_execute`` meta-dispatch both get the card. No grant ⇒ no card
+(prose-only, exactly today's behaviour). The frontend half
+(ToolApprovalWidget) is covered by a vitest test.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import types
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+for _k in ("POSTGRES_USER", "POSTGRES_PASSWORD", "POSTGRES_DB"):
+    os.environ.setdefault(_k, "test")
+os.environ.setdefault("POSTGRES_HOST", "localhost")
+os.environ.setdefault("POSTGRES_PORT", "5432")
+sys.modules.setdefault("camelot", types.ModuleType("camelot"))
+
+_ORCH = Path(__file__).resolve().parents[1]
+if str(_ORCH) not in sys.path:
+    sys.path.insert(0, str(_ORCH))
+
+
+def _ask_result(**overrides):
+    base = {
+        "success": False,
+        "requires_confirmation": True,
+        "action": "platform_delete_document",
+        "permission_level": "destructive",
+        "message": (
+            "This action (destructive) requires confirmation. "
+            "Action: platform_delete_document — Delete a document permanently."
+        ),
+        "params": {"document_id": 7, "_agent_id": 9, "_agent_name": "Scribe"},
+        # attached by the S1 gate
+        "grant_id": 42,
+        "risk_class": "destructive",
+        "risk_tier": "human_in_the_loop",
+        "oversight_rationale": "Destructive: deletes data. A human must approve before it runs.",
+        "requires_approval": True,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_formatter_emits_tool_approval_card():
+    from modules.tools.formatting.result_formatter import ToolResultFormatter
+
+    fd = ToolResultFormatter.format_for_frontend(_ask_result(), "platform_delete_document")
+
+    card = fd["tool_approval"]
+    assert card["grant_id"] == 42
+    assert card["action"] == "platform_delete_document"
+    assert card["permission_level"] == "destructive"
+    assert card["message"].startswith("This action (destructive)")
+    # The digest shows the model-provided params; server plumbing is stripped.
+    assert card["params"] == {"document_id": 7}
+    # AI-Act oversight fields for the approver.
+    assert card["risk_class"] == "destructive"
+    assert card["risk_tier"] == "human_in_the_loop"
+    assert "human must approve" in card["oversight_rationale"]
+    assert card["requires_approval"] is True
+
+
+def test_card_works_for_platform_execute_dispatch():
+    """The meta-dispatch lane reports tool_name=platform_execute — the card
+    still names the REAL action (carried on the ask result)."""
+    from modules.tools.formatting.result_formatter import ToolResultFormatter
+
+    fd = ToolResultFormatter.format_for_frontend(_ask_result(), "platform_execute")
+    assert fd["tool_approval"]["action"] == "platform_delete_document"
+    assert fd["tool_approval"]["grant_id"] == 42
+
+
+def test_no_card_without_grant():
+    """A grant-less ask (grant machinery faulted — the fail-safe floor) stays
+    prose-only: no half-card the human cannot act on."""
+    from modules.tools.formatting.result_formatter import ToolResultFormatter
+
+    ask = _ask_result()
+    for k in ("grant_id", "risk_class", "risk_tier", "oversight_rationale"):
+        ask.pop(k, None)
+    fd = ToolResultFormatter.format_for_frontend(ask, "platform_delete_document")
+    assert "tool_approval" not in fd
+
+
+def test_no_card_on_success():
+    from modules.tools.formatting.result_formatter import ToolResultFormatter
+
+    fd = ToolResultFormatter.format_for_frontend(
+        {"success": True, "documents": []}, "platform_delete_document"
+    )
+    assert "tool_approval" not in fd
+
+
+def test_oversight_fields_floor_fail_safe():
+    """A card missing its oversight fields (older/degraded ask shape) must
+    still never imply 'no human oversight'."""
+    from modules.tools.formatting.result_formatter import ToolResultFormatter
+
+    ask = _ask_result()
+    ask.pop("risk_class", None)
+    ask.pop("risk_tier", None)
+    ask.pop("oversight_rationale", None)
+    fd = ToolResultFormatter.format_for_frontend(ask, "platform_delete_document")
+    card = fd["tool_approval"]
+    assert card["risk_tier"] == "human_in_the_loop"
+    assert card["oversight_rationale"]
+    assert card["requires_approval"] is True
+
+
+def test_params_digest_truncates_long_values():
+    from modules.tools.formatting.result_formatter import ToolResultFormatter
+
+    digest = ToolResultFormatter._tool_params_digest(
+        {"key": "x" * 500, "n": 3, "flag": True, "none": None, "_agent_id": 9}
+    )
+    assert digest["n"] == 3 and digest["flag"] is True and digest["none"] is None
+    assert "_agent_id" not in digest
+    assert len(digest["key"]) <= 120
+
+
+@pytest.mark.asyncio
+async def test_router_failure_envelope_carries_ask_card():
+    """The tool-router failure path emits the card's frontend_data for an ask
+    that carries a grant — and stays empty for grant-less failures. The S15
+    prose remains the model's channel either way."""
+    from modules.tools.tool_router import ToolRouter
+
+    router = ToolRouter()
+    ask = _ask_result()
+
+    with patch(
+        "modules.tools.tool_router.execute_tool", new=AsyncMock(return_value=ask)
+    ), patch.object(ToolRouter, "_record_tool_signal", lambda *a, **k: None):
+        envelope = await router.execute_and_format(
+            "platform_delete_document", {"document_id": 7}, agent_id=1
+        )
+
+    assert envelope["success"] is False
+    assert envelope["frontend_data"]["tool_approval"]["grant_id"] == 42
+    # S15 stays: the ask message reaches the model as ever.
+    assert "requires confirmation" in envelope["llm_context"].lower()
+
+    # Grant-less ask (fail-safe floor) ⇒ prose-only, no card payload.
+    bare = {k: v for k, v in ask.items() if k != "grant_id"}
+    with patch(
+        "modules.tools.tool_router.execute_tool", new=AsyncMock(return_value=bare)
+    ), patch.object(ToolRouter, "_record_tool_signal", lambda *a, **k: None):
+        envelope2 = await router.execute_and_format(
+            "platform_delete_document", {"document_id": 7}, agent_id=1
+        )
+    assert envelope2["frontend_data"] == {}
+    assert "requires confirmation" in envelope2["llm_context"].lower()

--- a/orchestrator/tests/test_p2w2_tool_grant_consume.py
+++ b/orchestrator/tests/test_p2w2_tool_grant_consume.py
@@ -1,0 +1,408 @@
+"""PRD-193 S2 (P2-12) — consume an authorising grant: the gate finally has a yes.
+
+Immediately before the confirmation return, the executor consults for an
+authorising ``tool_call`` grant on the same deterministic subject key:
+GRANTED + unexpired (``is_authorising``) + params-hash equality ⇒ proceed to
+the handler; anything else ⇒ the ask stands. Locked decisions applied:
+destructive grants are SINGLE-USE (retired on use via
+``revoke_grant(revoked_by="system:consumed")``); write-class grants stay
+GRANTED for their TTL window per call-key.
+
+Guarantees pinned here:
+  1. ``test_granted_call_executes``            — an active, params-matching grant
+     lets the gated action reach its handler; no ``requires_confirmation`` in
+     the result; the result is audit-marked ``approved_via_grant_id``.
+  2. ``test_params_drift_reasks``              — same tool, different params ⇒
+     a new ask (the grant authorises *the* call, not the tool).
+  3. ``test_expired_revoked_denied_reask``     — each non-authorising status ⇒ ask.
+  4. ``test_destructive_grant_is_single_use``  — the second identical call after
+     a consumed grant ⇒ new ask; the spent grant reads revoked-by
+     ``system:consumed``.
+  5. ``test_write_class_grant_reusable_within_ttl`` — write-class grants keep
+     authorising inside the TTL window (no consumption).
+  6. ``test_consult_error_fails_closed``       — a raising lookup ⇒ the ask,
+     never execution.
+  7. ``test_grant_execution_audited``          — the telemetry audit marker
+     carries the grant id, distinct from the full-autonomy ``autonomous`` flag.
+
+Pure: fake session (evaluates the service's equality filters), fake registry,
+mocked rate limiter, muted notification seam. No DB / network / Redis.
+"""
+from __future__ import annotations
+
+import importlib.util as _ilu
+import os
+import sys as _sys
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+os.environ.setdefault("POSTGRES_USER", "test")
+os.environ.setdefault("POSTGRES_PASSWORD", "test")
+os.environ.setdefault("POSTGRES_HOST", "127.0.0.1")
+os.environ.setdefault("POSTGRES_PORT", "59432")
+os.environ.setdefault("POSTGRES_DB", "test")
+
+
+def _camelot_unlocatable() -> bool:  # pragma: no cover - env-dependent
+    try:
+        return _ilu.find_spec("camelot") is None
+    except ValueError:
+        return False
+
+
+if _camelot_unlocatable():  # pragma: no cover - env-dependent
+    import types as _types
+
+    _sys.modules.setdefault("camelot", _types.ModuleType("camelot"))
+
+from core.models.approval_grants import ApprovalGrant, GrantStatus
+from core.services.approval_grants import deny_grant, grant_grant, revoke_grant
+from modules.tools.discovery.action_registry import ActionDefinition
+from modules.tools.discovery.platform_executor import PlatformActionExecutor
+from modules.tools.execution import tool_grants
+
+pytestmark = pytest.mark.asyncio
+
+
+_DESTRUCTIVE_ACTION = "platform_delete_document"
+_WRITE_ACTION = "platform_update_system_setting"
+_MEMBER_CTX = {"user_id": "user_clerk_1", "workspace_role": "member"}
+
+
+# ---------------------------------------------------------------------------
+# Fake session — list-backed, evaluates the grant service's equality filters.
+# ---------------------------------------------------------------------------
+
+class _Query:
+    def __init__(self, rows):
+        self._rows = list(rows)
+
+    def filter(self, *conds):
+        rows = self._rows
+        for cond in conds:
+            key = cond.left.key
+            value = getattr(cond.right, "value", None)
+            rows = [r for r in rows if str(getattr(r, key, None)) == str(value)]
+        return _Query(rows)
+
+    def order_by(self, *args):
+        return _Query(list(reversed(self._rows)))
+
+    def first(self):
+        return self._rows[0] if self._rows else None
+
+    def all(self):
+        return list(self._rows)
+
+
+class _FakeSession:
+    def __init__(self):
+        self.rows = []
+
+    def add(self, obj):
+        if getattr(obj, "id", None) is None:
+            obj.id = len(self.rows) + 1
+        self.rows.append(obj)
+
+    def flush(self):
+        pass
+
+    def query(self, model):
+        return _Query([r for r in self.rows if isinstance(r, model)])
+
+
+# ---------------------------------------------------------------------------
+# Executor harness
+# ---------------------------------------------------------------------------
+
+def _action(name: str, **overrides) -> ActionDefinition:
+    kwargs = dict(
+        name=name,
+        description="PRD-193 gate probe.",
+        category="documents",
+        parameters={"type": "object", "properties": {}, "required": []},
+        permission_level="destructive",
+        requires_confirmation=True,
+    )
+    kwargs.update(overrides)
+    return ActionDefinition(**kwargs)
+
+
+class _FakeRegistry:
+    def __init__(self, *defs: ActionDefinition):
+        self._defs = {d.name: d for d in defs}
+
+    def get(self, name: str):
+        return self._defs.get(name)
+
+
+_REGISTRY = _FakeRegistry(
+    _action(_DESTRUCTIVE_ACTION),
+    _action(_WRITE_ACTION, permission_level="write", category="workspace"),
+)
+
+
+def _executor(db: _FakeSession) -> PlatformActionExecutor:
+    return PlatformActionExecutor(db, uuid.uuid4())
+
+
+def _gate_patches():
+    return (
+        patch("modules.tools.discovery.get_action_registry", return_value=_REGISTRY),
+        patch.object(PlatformActionExecutor, "_full_autonomy", return_value=False),
+        patch("core.security.rate_limiter.check_rate_limit", new=AsyncMock(return_value=None)),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _mute_notifications(monkeypatch):
+    async def _noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(tool_grants, "_dispatch_approval_pending", _noop)
+
+
+def _seed_granted(
+    db: _FakeSession,
+    ex: PlatformActionExecutor,
+    action: str,
+    params: dict,
+    *,
+    permission_level: str = "destructive",
+) -> ApprovalGrant:
+    """Seed a GRANTED grant exactly as S1 issuance + a human grant would."""
+    grant = tool_grants.issue_tool_grant(
+        db, ex.workspace_id,
+        action=action, params=params,
+        permission_level=permission_level,
+        description="probe", caller_context=dict(_MEMBER_CTX),
+    )
+    assert grant is not None, "seed failed — issuance broken"
+    grant_grant(grant, granted_by="user:1")
+    return grant
+
+
+# ===========================================================================
+# 1. The yes: an authorising grant opens the gate
+# ===========================================================================
+
+async def test_granted_call_executes():
+    db = _FakeSession()
+    ex = _executor(db)
+    grant = _seed_granted(db, ex, _DESTRUCTIVE_ACTION, {"document_id": 7})
+
+    sentinel = AsyncMock(return_value={"success": True, "_sentinel": "handler-ran"})
+    ex._handlers[_DESTRUCTIVE_ACTION] = sentinel
+
+    p1, p2, p3 = _gate_patches()
+    with p1, p2, p3:
+        result = await ex.execute(_DESTRUCTIVE_ACTION, {"document_id": 7}, dict(_MEMBER_CTX))
+
+    sentinel.assert_awaited_once()
+    assert result.get("success") is True
+    assert result.get("_sentinel") == "handler-ran"
+    assert "requires_confirmation" not in result
+    # S2 audit marking: WHICH grant authorised it — and it is not "autonomous".
+    assert result.get("approved_via_grant_id") == grant.id
+    assert result.get("autonomous") is None
+
+
+# ===========================================================================
+# 2. The grant authorises THE call, not the tool
+# ===========================================================================
+
+async def test_params_drift_reasks():
+    db = _FakeSession()
+    ex = _executor(db)
+    _seed_granted(db, ex, _DESTRUCTIVE_ACTION, {"document_id": 7})
+
+    sentinel = AsyncMock(return_value={"success": True})
+    ex._handlers[_DESTRUCTIVE_ACTION] = sentinel
+
+    p1, p2, p3 = _gate_patches()
+    with p1, p2, p3:
+        result = await ex.execute(_DESTRUCTIVE_ACTION, {"document_id": 8}, dict(_MEMBER_CTX))
+
+    sentinel.assert_not_awaited()
+    assert result["success"] is False
+    assert result["requires_confirmation"] is True
+
+
+async def test_params_hash_mismatch_reasks_even_on_same_subject():
+    """Belt-and-braces: a stored grant whose details hash does not match the
+    incoming call must not authorise it, even if the subject row was found."""
+    db = _FakeSession()
+    ex = _executor(db)
+    grant = _seed_granted(db, ex, _DESTRUCTIVE_ACTION, {"document_id": 7})
+    grant.details = {**(grant.details or {}), "params_hash": "tampered"}
+
+    sentinel = AsyncMock(return_value={"success": True})
+    ex._handlers[_DESTRUCTIVE_ACTION] = sentinel
+
+    p1, p2, p3 = _gate_patches()
+    with p1, p2, p3:
+        result = await ex.execute(_DESTRUCTIVE_ACTION, {"document_id": 7}, dict(_MEMBER_CTX))
+
+    sentinel.assert_not_awaited()
+    assert result["requires_confirmation"] is True
+
+
+# ===========================================================================
+# 3. Non-authorising statuses re-ask
+# ===========================================================================
+
+async def test_expired_revoked_denied_reask():
+    for mutate in (
+        lambda g: setattr(g, "expires_at", datetime.now(timezone.utc) - timedelta(seconds=5)),
+        lambda g: revoke_grant(g, revoked_by="user:1"),
+        lambda g: deny_grant(g, revoked_by="user:1"),
+    ):
+        db = _FakeSession()
+        ex = _executor(db)
+        grant = _seed_granted(db, ex, _DESTRUCTIVE_ACTION, {"document_id": 7})
+        mutate(grant)
+
+        sentinel = AsyncMock(return_value={"success": True})
+        ex._handlers[_DESTRUCTIVE_ACTION] = sentinel
+
+        p1, p2, p3 = _gate_patches()
+        with p1, p2, p3:
+            result = await ex.execute(
+                _DESTRUCTIVE_ACTION, {"document_id": 7}, dict(_MEMBER_CTX)
+            )
+
+        sentinel.assert_not_awaited()
+        assert result["success"] is False
+        assert result["requires_confirmation"] is True, (
+            f"status={grant.status!r} must NOT authorise"
+        )
+
+
+async def test_pending_grant_does_not_authorise():
+    """A PENDING grant blocks — only a live GRANTED one opens the gate."""
+    db = _FakeSession()
+    ex = _executor(db)
+    tool_grants.issue_tool_grant(
+        db, ex.workspace_id,
+        action=_DESTRUCTIVE_ACTION, params={"document_id": 7},
+        permission_level="destructive", caller_context=dict(_MEMBER_CTX),
+    )
+
+    sentinel = AsyncMock(return_value={"success": True})
+    ex._handlers[_DESTRUCTIVE_ACTION] = sentinel
+
+    p1, p2, p3 = _gate_patches()
+    with p1, p2, p3:
+        result = await ex.execute(_DESTRUCTIVE_ACTION, {"document_id": 7}, dict(_MEMBER_CTX))
+
+    sentinel.assert_not_awaited()
+    assert result["requires_confirmation"] is True
+    # And no second pending row was spammed (S1 idempotency, re-checked here).
+    pendings = [
+        r for r in db.rows
+        if isinstance(r, ApprovalGrant) and r.status == GrantStatus.PENDING.value
+    ]
+    assert len(pendings) == 1
+
+
+# ===========================================================================
+# 4. Locked decision 1 — destructive ⇒ single-use, exact params
+# ===========================================================================
+
+async def test_destructive_grant_is_single_use():
+    db = _FakeSession()
+    ex = _executor(db)
+    grant = _seed_granted(db, ex, _DESTRUCTIVE_ACTION, {"document_id": 7})
+
+    sentinel = AsyncMock(return_value={"success": True})
+    ex._handlers[_DESTRUCTIVE_ACTION] = sentinel
+
+    p1, p2, p3 = _gate_patches()
+    with p1, p2, p3:
+        first = await ex.execute(_DESTRUCTIVE_ACTION, {"document_id": 7}, dict(_MEMBER_CTX))
+        second = await ex.execute(_DESTRUCTIVE_ACTION, {"document_id": 7}, dict(_MEMBER_CTX))
+
+    sentinel.assert_awaited_once()  # the yes covered exactly one execution
+    assert first.get("approved_via_grant_id") == grant.id
+    # The spent grant is retired via the EXISTING lifecycle — no new status.
+    assert grant.status == GrantStatus.REVOKED.value
+    assert grant.revoked_by == tool_grants.GRANT_CONSUMED_BY
+    # The identical retry is a fresh ask (new pending grant attached).
+    assert second["requires_confirmation"] is True
+    assert second.get("grant_id") not in (None, grant.id)
+
+
+async def test_write_class_grant_reusable_within_ttl():
+    """Locked decision 1: the 3 write-class actions get a TTL-window grant per
+    call-key — repeated identical calls inside the window keep executing."""
+    db = _FakeSession()
+    ex = _executor(db)
+    grant = _seed_granted(
+        db, ex, _WRITE_ACTION, {"key": "rag_rerank_enabled", "value": "true"},
+        permission_level="write",
+    )
+
+    sentinel = AsyncMock(return_value={"success": True})
+    ex._handlers[_WRITE_ACTION] = sentinel
+
+    p1, p2, p3 = _gate_patches()
+    with p1, p2, p3:
+        first = await ex.execute(
+            _WRITE_ACTION, {"key": "rag_rerank_enabled", "value": "true"}, dict(_MEMBER_CTX)
+        )
+        second = await ex.execute(
+            _WRITE_ACTION, {"key": "rag_rerank_enabled", "value": "true"}, dict(_MEMBER_CTX)
+        )
+
+    assert sentinel.await_count == 2
+    assert grant.status == GrantStatus.GRANTED.value  # not consumed
+    assert first.get("approved_via_grant_id") == grant.id
+    assert second.get("approved_via_grant_id") == grant.id
+
+
+# ===========================================================================
+# 5. Fail closed: a raising consult lands on the ask, never execution
+# ===========================================================================
+
+async def test_consult_error_fails_closed(monkeypatch):
+    db = _FakeSession()
+    ex = _executor(db)
+    _seed_granted(db, ex, _DESTRUCTIVE_ACTION, {"document_id": 7})
+
+    import core.services.approval_grants as grant_service
+
+    def _boom(*a, **k):
+        raise RuntimeError("lookup exploded")
+
+    monkeypatch.setattr(grant_service, "find_active_grant", _boom)
+
+    sentinel = AsyncMock(return_value={"success": True})
+    ex._handlers[_DESTRUCTIVE_ACTION] = sentinel
+
+    p1, p2, p3 = _gate_patches()
+    with p1, p2, p3:
+        result = await ex.execute(_DESTRUCTIVE_ACTION, {"document_id": 7}, dict(_MEMBER_CTX))
+
+    sentinel.assert_not_awaited()
+    assert result["success"] is False
+    assert result["requires_confirmation"] is True, "errors land on the ask"
+
+
+# ===========================================================================
+# 6. Attribution is honest and queryable
+# ===========================================================================
+
+async def test_grant_execution_audited():
+    """The telemetry audit marker carries the grant id, distinct from the
+    full-autonomy dial's ``autonomous`` flag."""
+    from modules.tools.execution.telemetry import _build_router_decision
+
+    decision = _build_router_decision({}, autonomous=False, approved_via_grant_id=7)
+    assert decision == {"approved_via_grant_id": 7}
+
+    dial = _build_router_decision({}, autonomous=True)
+    assert dial == {"autonomous": True}
+    assert "approved_via_grant_id" not in dial

--- a/orchestrator/tests/test_p2w2_tool_grant_issue.py
+++ b/orchestrator/tests/test_p2w2_tool_grant_issue.py
@@ -307,6 +307,32 @@ async def test_grant_issue_failure_still_asks(monkeypatch):
     sentinel.assert_not_awaited()
 
 
+async def test_idless_grant_degrades_to_plain_ask(monkeypatch):
+    """A grant row without a usable integer id cannot power the card — the
+    grant/deny endpoints key on it — so the ask degrades to plain prose,
+    never a dead card. (Also keeps MagicMock-db journey suites from leaking a
+    non-serialisable grant_id into SSE tool-data frames.)"""
+    import core.services.approval_grants as grant_service
+
+    class _IdlessGrant:
+        id = None  # a degraded store that never minted a primary key
+
+    monkeypatch.setattr(
+        grant_service, "find_pending_grant", lambda *a, **k: _IdlessGrant()
+    )
+
+    db = _FakeSession()
+    ex = _executor(db)
+    registry = _FakeRegistry(_action(_DESTRUCTIVE_ACTION))
+    p_registry, p_autonomy = _gate_patches(registry)
+
+    with p_registry, p_autonomy:
+        result = await ex.execute(_DESTRUCTIVE_ACTION, {"document_id": 7}, dict(_MEMBER_CTX))
+
+    assert result["requires_confirmation"] is True
+    assert "grant_id" not in result
+
+
 # ===========================================================================
 # 5. The registry-miss fail-closed ask carries a grant too (best-effort)
 # ===========================================================================

--- a/orchestrator/tests/test_p2w2_tool_grant_issue.py
+++ b/orchestrator/tests/test_p2w2_tool_grant_issue.py
@@ -1,0 +1,330 @@
+"""PRD-193 S1 (P2-12) — issue a durable grant at the ask.
+
+The confirmation gate must stop returning a dead-end: when a
+``requires_confirmation`` action fires, ``PlatformActionExecutor.execute``
+issues (or reuses) a PENDING ``ApprovalGrant`` scoped ``tool_call`` and returns
+the ask WITH the grant attached (``grant_id`` + risk class + AI-Act oversight
+fields), so there is finally something a human can act on.
+
+Guarantees pinned here:
+  1. ``test_ask_issues_pending_tool_grant``   — ask ⇒ one pending grant scoped
+     (workspace, tool_call, deterministic subject_id, tool_name, risk_tier),
+     ask carries grant_id / risk_class / oversight fields.
+  2. ``test_repeat_ask_reuses_pending_grant`` — same call twice ⇒ ONE pending row.
+  3. ``test_deny_paths_issue_no_grant``       — su-gate and admin-deny returns
+     create nothing (a deny is not an ask).
+  4. ``test_grant_issue_failure_still_asks``  — grant creation raising ⇒ the ask
+     is still returned (the ask is the floor: never an exception, never an
+     execution).
+  5. Subject-key determinism — server-injected ``_``-prefixed params do not
+     perturb the call key (the ask and the retry must produce the same key).
+
+Pure: fake session (list-backed, evaluates the service's equality filters),
+fake registry, no DB / network / Redis. Notification dispatch is stubbed.
+"""
+from __future__ import annotations
+
+import importlib.util as _ilu
+import os
+import sys as _sys
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+os.environ.setdefault("POSTGRES_USER", "test")
+os.environ.setdefault("POSTGRES_PASSWORD", "test")
+os.environ.setdefault("POSTGRES_HOST", "127.0.0.1")
+os.environ.setdefault("POSTGRES_PORT", "59432")
+os.environ.setdefault("POSTGRES_DB", "test")
+
+
+def _camelot_unlocatable() -> bool:  # pragma: no cover - env-dependent
+    try:
+        return _ilu.find_spec("camelot") is None
+    except ValueError:
+        return False
+
+
+if _camelot_unlocatable():  # pragma: no cover - env-dependent
+    import types as _types
+
+    _sys.modules.setdefault("camelot", _types.ModuleType("camelot"))
+
+from core.models.approval_grants import ApprovalGrant, GrantStatus, SUBJECT_TOOL_CALL
+from modules.tools.discovery.action_registry import ActionDefinition
+from modules.tools.discovery.platform_executor import PlatformActionExecutor
+from modules.tools.execution import tool_grants
+
+pytestmark = pytest.mark.asyncio
+
+
+_DESTRUCTIVE_ACTION = "platform_delete_document"
+_MEMBER_CTX = {"user_id": "user_clerk_1", "workspace_role": "member"}
+
+
+# ---------------------------------------------------------------------------
+# Fake session — list-backed, evaluates the grant service's equality filters
+# (workspace_id / subject_type / subject_id / status) against stored rows.
+# ---------------------------------------------------------------------------
+
+class _Query:
+    def __init__(self, rows):
+        self._rows = list(rows)
+
+    def filter(self, *conds):
+        rows = self._rows
+        for cond in conds:
+            key = cond.left.key
+            value = getattr(cond.right, "value", None)
+            rows = [r for r in rows if str(getattr(r, key, None)) == str(value)]
+        return _Query(rows)
+
+    def order_by(self, *args):
+        return _Query(list(reversed(self._rows)))
+
+    def first(self):
+        return self._rows[0] if self._rows else None
+
+    def all(self):
+        return list(self._rows)
+
+
+class _FakeSession:
+    def __init__(self):
+        self.rows = []
+
+    def add(self, obj):
+        if getattr(obj, "id", None) is None:
+            obj.id = len(self.rows) + 1
+        self.rows.append(obj)
+
+    def flush(self):
+        pass
+
+    def query(self, model):
+        return _Query([r for r in self.rows if isinstance(r, model)])
+
+
+# ---------------------------------------------------------------------------
+# Executor harness (mirrors tests/test_prd143_su_executor_gate.py idiom)
+# ---------------------------------------------------------------------------
+
+def _action(name: str, **overrides) -> ActionDefinition:
+    kwargs = dict(
+        name=name,
+        description="PRD-193 gate probe: delete a document permanently.",
+        category="documents",
+        parameters={"type": "object", "properties": {}, "required": []},
+        permission_level="destructive",
+        requires_confirmation=True,
+    )
+    kwargs.update(overrides)
+    return ActionDefinition(**kwargs)
+
+
+class _FakeRegistry:
+    def __init__(self, *defs: ActionDefinition):
+        self._defs = {d.name: d for d in defs}
+
+    def get(self, name: str):
+        return self._defs.get(name)
+
+
+def _executor(db=None) -> PlatformActionExecutor:
+    ex = PlatformActionExecutor(db if db is not None else _FakeSession(), uuid.uuid4())
+    return ex
+
+
+def _gate_patches(registry: _FakeRegistry):
+    return (
+        patch("modules.tools.discovery.get_action_registry", return_value=registry),
+        patch.object(PlatformActionExecutor, "_full_autonomy", return_value=False),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _mute_notifications(monkeypatch):
+    """Keep issuance tests pure — the S5 dispatch seam is tested separately."""
+    async def _noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(tool_grants, "_dispatch_approval_pending", _noop)
+
+
+def _pending_grants(db: _FakeSession):
+    return [
+        r for r in db.rows
+        if isinstance(r, ApprovalGrant) and r.status == GrantStatus.PENDING.value
+    ]
+
+
+# ===========================================================================
+# 1. The ask issues a pending grant and returns it on the ask
+# ===========================================================================
+
+async def test_ask_issues_pending_tool_grant():
+    db = _FakeSession()
+    ex = _executor(db)
+    registry = _FakeRegistry(_action(_DESTRUCTIVE_ACTION))
+    p_registry, p_autonomy = _gate_patches(registry)
+
+    params = {"document_id": 7, "_agent_id": 9}
+    with p_registry, p_autonomy:
+        result = await ex.execute(_DESTRUCTIVE_ACTION, params, dict(_MEMBER_CTX))
+
+    # The ask still stands (fail-safe floor) …
+    assert result["success"] is False
+    assert result["requires_confirmation"] is True
+    assert result["action"] == _DESTRUCTIVE_ACTION
+
+    # … but it now carries the grant + risk + oversight fields for the card.
+    grants = _pending_grants(db)
+    assert len(grants) == 1, "the ask must stage exactly one pending grant"
+    grant = grants[0]
+    assert result.get("grant_id") == grant.id
+    assert result.get("risk_class") == "destructive"
+    assert result.get("risk_tier") == "human_in_the_loop"
+    assert result.get("oversight_rationale")
+
+    # Grant scoping: workspace + tool_call subject + deterministic key + risk.
+    assert str(grant.workspace_id) == str(ex.workspace_id)
+    assert grant.subject_type == SUBJECT_TOOL_CALL
+    assert grant.subject_id == tool_grants.tool_call_subject_id(
+        ex.workspace_id, _DESTRUCTIVE_ACTION, params
+    )
+    assert grant.tool_name == _DESTRUCTIVE_ACTION
+    assert grant.risk_tier == "destructive"
+    assert grant.agent_id == 9  # server-minted identity from _agent_id
+
+    # The details snapshot carries what resume (S4) needs.
+    details = grant.details or {}
+    assert details.get("action") == _DESTRUCTIVE_ACTION
+    assert details.get("params") == {"document_id": 7}  # model-provided only
+    assert details.get("params_hash") == tool_grants.params_hash(params)
+
+
+async def test_repeat_ask_reuses_pending_grant():
+    db = _FakeSession()
+    ex = _executor(db)
+    registry = _FakeRegistry(_action(_DESTRUCTIVE_ACTION))
+    p_registry, p_autonomy = _gate_patches(registry)
+
+    with p_registry, p_autonomy:
+        first = await ex.execute(_DESTRUCTIVE_ACTION, {"document_id": 7}, dict(_MEMBER_CTX))
+        second = await ex.execute(_DESTRUCTIVE_ACTION, {"document_id": 7}, dict(_MEMBER_CTX))
+
+    grants = _pending_grants(db)
+    assert len(grants) == 1, "an identical retry must not spam a second grant"
+    assert first["grant_id"] == second["grant_id"] == grants[0].id
+
+
+async def test_different_params_issue_distinct_grants():
+    """The grant authorises *the* call, not the tool — a different target is a
+    different subject key and a different pending row."""
+    db = _FakeSession()
+    ex = _executor(db)
+    registry = _FakeRegistry(_action(_DESTRUCTIVE_ACTION))
+    p_registry, p_autonomy = _gate_patches(registry)
+
+    with p_registry, p_autonomy:
+        a = await ex.execute(_DESTRUCTIVE_ACTION, {"document_id": 7}, dict(_MEMBER_CTX))
+        b = await ex.execute(_DESTRUCTIVE_ACTION, {"document_id": 8}, dict(_MEMBER_CTX))
+
+    assert len(_pending_grants(db)) == 2
+    assert a["grant_id"] != b["grant_id"]
+
+
+# ===========================================================================
+# 2. Subject-key determinism (ask == retry, server plumbing stripped)
+# ===========================================================================
+
+async def test_subject_key_ignores_server_injected_params():
+    ws = uuid.uuid4()
+    bare = tool_grants.tool_call_subject_id(ws, _DESTRUCTIVE_ACTION, {"document_id": 7})
+    injected = tool_grants.tool_call_subject_id(
+        ws, _DESTRUCTIVE_ACTION,
+        {"document_id": 7, "_agent_id": 9, "_agent_name": "Scribe"},
+    )
+    assert bare == injected
+    # And the key is workspace- and params-sensitive.
+    assert bare != tool_grants.tool_call_subject_id(ws, _DESTRUCTIVE_ACTION, {"document_id": 8})
+    assert bare != tool_grants.tool_call_subject_id(uuid.uuid4(), _DESTRUCTIVE_ACTION, {"document_id": 7})
+
+
+# ===========================================================================
+# 3. Deny paths issue nothing — a deny is not an ask
+# ===========================================================================
+
+async def test_deny_paths_issue_no_grant():
+    db = _FakeSession()
+    ex = _executor(db)
+    registry = _FakeRegistry(
+        _action("platform_su_probe", super_admin_only=True, requires_confirmation=False,
+                permission_level="read"),
+        _action("platform_admin_probe", admin_only=True, requires_confirmation=False,
+                permission_level="read"),
+    )
+    p_registry, p_autonomy = _gate_patches(registry)
+
+    with p_registry, p_autonomy:
+        su = await ex.execute("platform_su_probe", {}, dict(_MEMBER_CTX))
+        admin = await ex.execute("platform_admin_probe", {}, dict(_MEMBER_CTX))
+
+    assert su.get("permission_denied") is True
+    assert admin.get("permission_denied") is True
+    assert su.get("grant_id") is None and admin.get("grant_id") is None
+    assert db.rows == [], "deny paths must not stage grants"
+
+
+# ===========================================================================
+# 4. Fail-safe floor: grant machinery raising still returns the ask
+# ===========================================================================
+
+async def test_grant_issue_failure_still_asks(monkeypatch):
+    db = _FakeSession()
+    ex = _executor(db)
+    registry = _FakeRegistry(_action(_DESTRUCTIVE_ACTION))
+    p_registry, p_autonomy = _gate_patches(registry)
+
+    def _boom(*a, **k):
+        raise RuntimeError("grant store down")
+
+    import core.services.approval_grants as grant_service
+
+    monkeypatch.setattr(grant_service, "create_grant", _boom)
+    monkeypatch.setattr(grant_service, "find_pending_grant", _boom)
+
+    sentinel = AsyncMock(return_value={"success": True})
+    ex._handlers[_DESTRUCTIVE_ACTION] = sentinel
+
+    with p_registry, p_autonomy:
+        result = await ex.execute(_DESTRUCTIVE_ACTION, {"document_id": 7}, dict(_MEMBER_CTX))
+
+    assert result["success"] is False
+    assert result["requires_confirmation"] is True, "the ask is the floor"
+    assert result.get("grant_id") is None
+    sentinel.assert_not_awaited()
+
+
+# ===========================================================================
+# 5. The registry-miss fail-closed ask carries a grant too (best-effort)
+# ===========================================================================
+
+async def test_registry_miss_ask_still_returns_and_carries_grant():
+    db = _FakeSession()
+    ex = _executor(db)
+    ex._handlers["platform_mystery"] = AsyncMock(return_value={"success": True})
+
+    with patch(
+        "modules.tools.discovery.get_action_registry",
+        side_effect=RuntimeError("registry unavailable"),
+    ):
+        result = await ex.execute("platform_mystery", {"x": 1}, dict(_MEMBER_CTX))
+
+    assert result["success"] is False
+    assert result["requires_confirmation"] is True
+    ex._handlers["platform_mystery"].assert_not_awaited()
+    # Best-effort grant on the fail-closed ask (the same surface resolves it).
+    assert len(_pending_grants(db)) == 1
+    assert result.get("grant_id") == _pending_grants(db)[0].id

--- a/orchestrator/tests/test_p2w2_tool_grant_issue.py
+++ b/orchestrator/tests/test_p2w2_tool_grant_issue.py
@@ -265,6 +265,13 @@ async def test_deny_paths_issue_no_grant():
         _action("platform_admin_probe", admin_only=True, requires_confirmation=False,
                 permission_level="read"),
     )
+    # The executor resolves the handler BEFORE the permission gates — stub
+    # both probes so the call reaches the su/admin gates (and prove the
+    # handlers are never awaited on a deny).
+    su_handler = AsyncMock(return_value={"success": True})
+    admin_handler = AsyncMock(return_value={"success": True})
+    ex._handlers["platform_su_probe"] = su_handler
+    ex._handlers["platform_admin_probe"] = admin_handler
     p_registry, p_autonomy = _gate_patches(registry)
 
     with p_registry, p_autonomy:
@@ -273,6 +280,8 @@ async def test_deny_paths_issue_no_grant():
 
     assert su.get("permission_denied") is True
     assert admin.get("permission_denied") is True
+    su_handler.assert_not_awaited()
+    admin_handler.assert_not_awaited()
     assert su.get("grant_id") is None and admin.get("grant_id") is None
     assert db.rows == [], "deny paths must not stage grants"
 


### PR DESCRIPTION
PRD-193 (Phase-2 Wave-2, review id **P2-12**): the confirmation gate stops being a dead end. Twelve months of `requires_confirmation` returns had no consult path, no card, and no resume — the only "yes" was the full-autonomy dial (which silently elevates to admin). This PR wires the three already-built pieces together: PRD-181's grant substrate, PRD-163's approval-card presentation, and the board lane's resume pattern. **Zero schema growth, zero new config keys, zero new routes** (`route-manifest.json` untouched; `approval_grants` + its API are PRD-181's, reused wholesale).

## Story-by-story

- **S1 — issue a durable grant at the ask** (`7085180ac`): new `modules/tools/execution/tool_grants.py` — deterministic call key (workspace + action + canonical **model-provided** params; server-injected `_`-prefixed plumbing stripped so ask and retry agree), `issue_tool_grant` (find-pending-then-create, details snapshot for resume: params, params_hash, lane, conversation/turn ids, `board_task_id` when threaded, caller snapshot), `attach_ask_grant` (fail-safe enrichment). Both executor ask returns (confirmation + registry-miss fail-closed) now carry `grant_id`, `risk_class`, and AI-Act oversight fields. **The ask is the floor**: any fault in the grant machinery returns the plain ask — never an exception, never an execution. Deny paths (su/admin) issue nothing.
- **S2 — consume an authorising grant** (`a63bff6ed`): immediately before the ask, the executor consults the same subject key — GRANTED + unexpired + **params-hash equality** ⇒ proceed to the handler; pending/expired/revoked/denied/params-drift/any-error ⇒ the ask stands (fail closed). Execution is audit-marked `approved_via_grant_id`, persisted via the universal telemetry hook (`router_decision->>'approved_via_grant_id'`) — distinct from the dial's `autonomous` marker.
- **S3 — the in-chat `tool_approval` card** (`2cda698cb`): `format_for_frontend` emits `tool_approval` when a result carries `requires_confirmation` + `grant_id` (result-shape driven — direct `platform_*` calls and the `platform_execute` meta-dispatch both get it). The S15 prose **stays** the model's view. Frontend: `ToolApprovalWidget` cloned from `MissionApprovalWidget` (shared presentation, different behaviour — deliberately not generalised), registered in `widgets/types.ts`/`index.ts`, mapped in `chat.tsx`, wired via new `useGrantApproval`/`useDenyApproval` hooks (mirroring `useApproveMission`) to the **existing** grant API — its first frontend consumer.
- **S4 — resume the interrupted execution** (`83d02bcfa`): `_requeue_subject` gains the `tool_call` branch — on grant, the stored call re-dispatches through `UnifiedToolExecutor.execute_tool` scoped to the grant's workspace (telemetry, the policy seam, and outcome capture all fire; nothing is exempted by being approved), consume-then-execute inside the grant endpoint's one transaction. Board-originated asks (`details.board_task_id`, task still blocked) resume via the **existing** board re-queue (extracted unchanged into `_requeue_blocked_task`) — the re-run meets the now-active grant; no double-dispatch. Outcome lands on `details.executed_result` and returns in the grant response (`to_dict` now exposes `details`) so the card swaps to its executed state. A failed/re-asking resume is reported honestly — never a fake success. Deny is a no-op execution.
- **S5 — notification + loop hygiene** (`49e0e221e`): fresh pending tool grants on **non-chat lanes** dispatch `approval_pending` (grant id as `link_id`, `link_type=approval_grant` — P2-15's deep-link target); chat doesn't double-notify (the card is live). The ask outcome is typed as an **ask** in `tool_outcome_capture` (never failure-spam); same-turn dedup stands while the fresh-tracker-per-run behaviour is pinned so the post-grant retry can never be dedup-blocked.

## Locked decisions applied
1. **TTL/scope**: destructive ⇒ single-use, exact-params — retired on use via `revoke_grant(revoked_by="system:consumed")` (existing lifecycle, no new status/schema). The 3 write-class actions ⇒ TTL-window per call-key on the existing 24h `APPROVAL_GRANT_TTL_SECONDS`. No standing per-tool grants.
2. **Gated set**: all 8 destructive + all 3 write-class stay gated (incl. `platform_cancel_scheduled_task`). Nothing flipped to auto — the grant path is generic by flag, zero per-action code.
3. **`platform_get_system_health`**: untouched — stays su-only, outside the grant mechanism.
4. **Agent-lane depth**: lean board linkage only (grant → existing board re-queue → re-run completes into the now-active grant). No J2 mid-run pause / agent-callback honesty folded in.
5. **Composio F018 asks**: left prose-only — not folded into the grant surface this wave.

## Event-vocabulary deviation (deliberate)
The PRD text says add **`approval_requested`**. PR #531 already shipped **`approval_pending`** for exactly this concept (pending grant → tell workspace admins). One event type per concept — this PR **reuses `approval_pending`** rather than minting a rival (reuse-don't-fork). The `VALID_EVENT_TYPES` line is added here only because this base predates #531; it is byte-identical at the identical position, so the two PRs merge as one line.

## Coordination notes (#531 / #533 / #530)
- Verified via `git merge-tree --write-tree` against both open heads: **clean merges both ways, zero conflicts.**
- **#531**: `api/approval_grants.py` endpoint signatures + module docstring untouched; my changes are the `_requeue_subject`/`_fail_subject` region, one `await` on the `grant_approval` body line (required — resume rides an async spine), and a lazy `SUBJECT_TOOL_CALL` import inside the function so #531's import-block hunk context stays byte-identical. `services/board_approval.py` untouched.
- **#533 (PRD-192)**: `modules/policy/*`, `unified_executor.py` untouched. Three files listed under PRD-192's umbrella needed minimal touches **outside #533's diff hunks** for this feature to work end-to-end (CLAUDE.md §12), each verified conflict-free: `consumers/chatbot/service.py` (the `frontend_data` emission gate — an ask is success=False, so the card was structurally undeliverable without it; 1 conditional), `tool_router.py` (failure-path `frontend_data` for grant-carrying asks — the S15 prose region `:912-916` untouched, F018 lane untouched), `agent_factory.py` (thread `board_task_id` into the tool caller-context — 10 lines above #533's `_agent_tool_cb` hunk; #533's `_cb_caller_context` spread preserves the key post-merge). The wiring where PRD-192's plane `ask` calls `issue_tool_grant` remains PRD-192's side to add — `tool_grants.py` is subject-first for exactly that.
- **#530**: webhook signature files untouched.

## Verification
Test-first throughout; all tests pure (fake sessions evaluating the service's real filters, executors/notifiers mocked at their boundaries — no DB/network/Redis). 5 new backend suites (`test_p2w2_tool_grant_issue|consume|approval_card|grant_resume|ask_notification.py`, 33 tests) + 1 vitest suite (`tool-approval-widget.test.tsx`). No migration (PRD-181's table is live). CI is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added in-chat approval cards for confirmation-gated actions, including action details, parameters, risk information, and oversight guidance.
  * Added Approve and Deny controls with clear execution outcomes and notifications.
  * Approved actions now resume execution, while denied actions remain blocked.
  * Added approval tracking, notifications, audit metadata, and safe handling for failed or changed requests.

* **Bug Fixes**
  * Confirmation requests now appear even when the initial tool attempt reports a failure.
  * Execution failures and re-approval requirements are reported accurately instead of being treated as successful.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->