### PR TITLE
feat(prd-194): Wave-2 untrusted edges — reject, dedup, fail closed (P2-13)

### DIFF
--- a/orchestrator/api/composio.py
+++ b/orchestrator/api/composio.py
@@ -612,7 +612,9 @@ async def handle_webhook(
     body = await request.body()
 
     # Verify signature — supports both legacy (x-composio-signature)
-    # and V3 (webhook-signature with "v1,<base64>" format)
+    # and V3 (webhook-signature with "v1,<base64>" format).
+    # When a secret is configured, a valid signature is mandatory:
+    # mismatch, verification error, or missing header ⇒ 401 (P2-13).
     webhook_secret = config.COMPOSIO_WEBHOOK_SECRET
     v3_signature = request.headers.get("webhook-signature")
     if webhook_secret and v3_signature:
@@ -626,10 +628,13 @@ async def handle_webhook(
                 hmac.new(base64.b64decode(webhook_secret), signed_content, hashlib.sha256).digest()
             ).decode()
             sig_value = v3_signature.split(",", 1)[-1] if "," in v3_signature else v3_signature
-            if not hmac.compare_digest(sig_value, expected_sig):
-                logger.warning("V3 webhook signature mismatch — allowing through for debugging")
+            signature_ok = hmac.compare_digest(sig_value, expected_sig)
         except Exception:
-            logger.warning("V3 signature verification error — allowing through for debugging", exc_info=True)
+            logger.warning("V3 signature verification error — rejecting", exc_info=True)
+            raise HTTPException(status_code=401, detail="Invalid webhook signature")
+        if not signature_ok:
+            logger.warning("V3 webhook signature mismatch — rejecting")
+            raise HTTPException(status_code=401, detail="Invalid webhook signature")
     elif webhook_secret and x_composio_signature:
         # Legacy format: plain HMAC hex digest
         expected_sig = hmac.new(
@@ -639,6 +644,9 @@ async def handle_webhook(
         ).hexdigest()
         if not hmac.compare_digest(x_composio_signature, expected_sig):
             raise HTTPException(status_code=401, detail="Invalid webhook signature")
+    elif webhook_secret:
+        logger.warning("Webhook rejected: COMPOSIO_WEBHOOK_SECRET is set but no signature header present")
+        raise HTTPException(status_code=401, detail="Missing webhook signature")
 
     # Parse payload
     try:

--- a/orchestrator/api/composio.py
+++ b/orchestrator/api/composio.py
@@ -33,6 +33,7 @@ from core.models.routing import UnroutedEvent
 from core.routing.cache import get_routing_cache
 from core.routing.engine import UniversalRouter
 from core.routing.ingestors.jira_trigger import JiraTriggerIngestor
+from services import webhook_dedup
 from config import config
 
 logger = logging.getLogger(__name__)
@@ -647,6 +648,20 @@ async def handle_webhook(
     elif webhook_secret:
         logger.warning("Webhook rejected: COMPOSIO_WEBHOOK_SECRET is set but no signature header present")
         raise HTTPException(status_code=401, detail="Missing webhook signature")
+
+    # Replay guard + event dedup (PRD-194 S2, P2-13). Composio V3 sends
+    # webhook-id + webhook-timestamp on every delivery, and both are part of
+    # the signed content above — so a valid-signature replay of an old
+    # capture still carries its ORIGINAL timestamp (⇒ stale ⇒ 401), and a
+    # redelivery of an already-accepted webhook-id is a fast no-op ack:
+    # nothing parsed, nothing routed, nothing dispatched.
+    if webhook_dedup.timestamp_is_stale(request.headers.get("webhook-timestamp")):
+        logger.warning("Webhook rejected: stale webhook-timestamp (replay guard)")
+        raise HTTPException(status_code=401, detail="Stale webhook timestamp")
+    dedup_event_id = request.headers.get("webhook-id")
+    if await webhook_dedup.seen_before("composio", dedup_event_id):
+        logger.info("Duplicate Composio webhook %s — no-op ack", dedup_event_id)
+        return {"status": "duplicate", "webhook_id": dedup_event_id}
 
     # Parse payload
     try:

--- a/orchestrator/api/webhooks.py
+++ b/orchestrator/api/webhooks.py
@@ -5,7 +5,9 @@ General Webhook Endpoints
 Two webhook paths:
 1. POST /api/webhooks/ws/{workspace_key}  — General workspace webhook
    Routes incoming requests through UniversalRouter to the right agent.
-   No auth required — the workspace_key in the URL is the credential.
+   The workspace_key in the URL is the credential floor; when a webhook
+   secret (or Slack signing secret) is configured, a valid signature is
+   additionally mandatory.
 
 2. POST /api/webhooks/recipe/{webhook_id} — Recipe-specific webhook
    (Defined in workflow_recipes.py, registered separately.)
@@ -15,6 +17,7 @@ import asyncio
 import hashlib
 import hmac
 import logging
+import time
 from typing import Any, Dict, Optional, Set
 from uuid import UUID, uuid4
 
@@ -51,8 +54,9 @@ async def _verify_webhook_signature(
     Checks headers: X-Hub-Signature-256 (GitHub), X-Composio-Signature,
     X-Webhook-Signature.
 
-    If a secret is configured and a signature header is present, the signature
-    must match. If no secret is configured, verification is skipped (URL-as-secret
+    When a secret is configured, a valid signature is mandatory: a missing
+    header, a mismatch, or a verification error all reject with 401 (P2-13).
+    If no secret is configured, verification is skipped (URL-as-secret
     pattern still applies).
     """
     if not secret:
@@ -65,8 +69,8 @@ async def _verify_webhook_signature(
         or request.headers.get("x-webhook-signature")
     )
     if not sig_header:
-        # No signature header present — skip if not required
-        return
+        logger.warning("[webhook] Rejected: secret configured but no signature header present")
+        raise HTTPException(status_code=401, detail="Missing webhook signature")
 
     raw_body = await request.body()
 
@@ -81,6 +85,67 @@ async def _verify_webhook_signature(
 
     if not hmac.compare_digest(computed, expected_sig):
         logger.warning("[webhook] HMAC signature mismatch")
+        raise HTTPException(status_code=401, detail="Invalid webhook signature")
+
+
+# Slack's documented v0 replay window: reject requests whose signing
+# timestamp is further than 5 minutes from now.
+_SLACK_TS_SKEW_SECONDS = 60 * 5
+
+
+def _resolve_slack_signing_secret(db: Session, workspace: Workspace) -> Optional[str]:
+    """The signing secret collected for this workspace's Slack channel, if any.
+
+    Prefers an active ``channel_connections`` row; falls back to any Slack row
+    that carries a secret. Returns ``None`` when Slack was never configured
+    with a signing secret (verification is then skipped — URL-as-secret floor).
+    """
+    from core.models.channels import ChannelConnection
+
+    rows = (
+        db.query(ChannelConnection)
+        .filter(
+            ChannelConnection.workspace_id == workspace.id,
+            ChannelConnection.platform == "slack",
+        )
+        .all()
+    )
+    fallback: Optional[str] = None
+    for row in rows:
+        secret = (row.config or {}).get("signing_secret")
+        if not secret:
+            continue
+        if row.status == "active":
+            return str(secret)
+        fallback = fallback or str(secret)
+    return fallback
+
+
+async def _verify_slack_signature(request: Request, signing_secret: str) -> None:
+    """Verify Slack's v0 signing scheme.
+
+    Slack signs ``v0:{timestamp}:{raw_body}`` with the app's signing secret and
+    sends ``X-Slack-Signature: v0=<hex>`` + ``X-Slack-Request-Timestamp``.
+    Mandatory once a signing secret is collected: bad timestamp, stale
+    timestamp, or mismatch ⇒ 401 (P2-13).
+    """
+    sig_header = request.headers.get("x-slack-signature", "")
+    ts = request.headers.get("x-slack-request-timestamp", "")
+    raw_body = await request.body()
+
+    try:
+        ts_int = int(ts)
+    except (TypeError, ValueError):
+        logger.warning("[webhook] Slack signature rejected: bad timestamp header")
+        raise HTTPException(status_code=401, detail="Invalid webhook signature")
+    if abs(time.time() - ts_int) > _SLACK_TS_SKEW_SECONDS:
+        logger.warning("[webhook] Slack signature rejected: stale timestamp")
+        raise HTTPException(status_code=401, detail="Invalid webhook signature")
+
+    base = f"v0:{ts}:".encode("utf-8") + raw_body
+    computed = "v0=" + hmac.new(signing_secret.encode("utf-8"), base, hashlib.sha256).hexdigest()
+    if not hmac.compare_digest(computed, sig_header):
+        logger.warning("[webhook] Slack signature mismatch")
         raise HTTPException(status_code=401, detail="Invalid webhook signature")
 
 
@@ -314,8 +379,9 @@ async def general_workspace_webhook(
     """
     General workspace webhook — routes incoming requests to the right agent.
 
-    The workspace_key in the URL is the credential (URL-as-secret pattern).
-    No authentication required.
+    The workspace_key in the URL is the credential floor (URL-as-secret
+    pattern). When a webhook secret is configured — or a Slack signing
+    secret has been collected — a valid signature is mandatory on top.
 
     Body (JSON):
     - message / text / content: The message to route
@@ -361,9 +427,17 @@ async def general_workspace_webhook(
     if not workspace:
         raise HTTPException(status_code=404, detail="Unknown webhook")
 
-    # 1b. Verify HMAC signature if a webhook secret is configured
-    webhook_secret = (workspace.settings or {}).get("webhook_secret") or config.WEBHOOK_SECRET
-    await _verify_webhook_signature(request, webhook_secret)
+    # 1b. Verify inbound authenticity. Slack signs with its own v0 scheme
+    # (X-Slack-Signature), so Slack-signed requests verify against the
+    # collected signing secret; everything else uses the generic HMAC,
+    # which is mandatory once a webhook secret is configured.
+    if request.headers.get("x-slack-signature"):
+        slack_secret = _resolve_slack_signing_secret(db, workspace)
+        if slack_secret:
+            await _verify_slack_signature(request, slack_secret)
+    else:
+        webhook_secret = (workspace.settings or {}).get("webhook_secret") or config.WEBHOOK_SECRET
+        await _verify_webhook_signature(request, webhook_secret)
 
     # 2. Detect platform and extract reply context
     platform = _detect_platform(body) if isinstance(body, dict) else None

--- a/orchestrator/api/webhooks.py
+++ b/orchestrator/api/webhooks.py
@@ -428,13 +428,20 @@ async def general_workspace_webhook(
         raise HTTPException(status_code=404, detail="Unknown webhook")
 
     # 1b. Verify inbound authenticity. Slack signs with its own v0 scheme
-    # (X-Slack-Signature), so Slack-signed requests verify against the
-    # collected signing secret; everything else uses the generic HMAC,
-    # which is mandatory once a webhook secret is configured.
-    if request.headers.get("x-slack-signature"):
-        slack_secret = _resolve_slack_signing_secret(db, workspace)
-        if slack_secret:
-            await _verify_slack_signature(request, slack_secret)
+    # (X-Slack-Signature), so when a Slack signing secret has been collected
+    # the request verifies against it. Every other request goes through the
+    # generic HMAC, which is mandatory once a webhook secret is configured —
+    # including requests that *carry* an x-slack-signature header when no
+    # Slack secret was ever collected. Branching on the header alone would
+    # let any caller bypass the mandatory generic check by adding a garbage
+    # Slack header (P2-13, fail closed).
+    slack_secret = (
+        _resolve_slack_signing_secret(db, workspace)
+        if request.headers.get("x-slack-signature")
+        else None
+    )
+    if slack_secret:
+        await _verify_slack_signature(request, slack_secret)
     else:
         webhook_secret = (workspace.settings or {}).get("webhook_secret") or config.WEBHOOK_SECRET
         await _verify_webhook_signature(request, webhook_secret)

--- a/orchestrator/api/webhooks.py
+++ b/orchestrator/api/webhooks.py
@@ -30,6 +30,7 @@ from core.models.workspaces import Workspace
 from core.routing.cache import get_routing_cache
 from core.routing.engine import UniversalRouter
 from core.routing.ingestors.webhook import WebhookIngestor
+from services import webhook_dedup
 from config import config
 
 logger = logging.getLogger(__name__)
@@ -445,6 +446,28 @@ async def general_workspace_webhook(
     else:
         webhook_secret = (workspace.settings or {}).get("webhook_secret") or config.WEBHOOK_SECRET
         await _verify_webhook_signature(request, webhook_secret)
+
+    # 1c. Replay guard + event dedup (PRD-194 S2, P2-13). This lane executes
+    # the agent synchronously inside the HTTP request; a slow run triggers
+    # provider redelivery (Slack/Telegram retry on slow ack) and, until this
+    # guard, the SAME event ran again — burning tokens and re-firing
+    # side-effects. Keyed per-workspace on the platform's own event id
+    # (Telegram update_id / Slack event_id / webhook-id header); a
+    # redelivery is a fast no-op ack before any routing. The Shopify
+    # /events debounce (PRD-189 S3) is a different endpoint — untouched.
+    if webhook_dedup.timestamp_is_stale(request.headers.get("webhook-timestamp")):
+        logger.warning("[webhook/ws] Rejected: stale webhook-timestamp (replay guard)")
+        raise HTTPException(status_code=401, detail="Stale webhook timestamp")
+    dedup_event_id = None
+    if isinstance(body, dict):
+        dedup_event_id = body.get("update_id") or body.get("event_id")
+    dedup_event_id = dedup_event_id or request.headers.get("webhook-id")
+    if await webhook_dedup.seen_before(f"ws:{workspace.id}", dedup_event_id):
+        logger.info(
+            "[webhook/ws] Duplicate event %s for workspace %s — no-op ack",
+            dedup_event_id, workspace.id,
+        )
+        return {"status": "duplicate_ignored", "event_id": str(dedup_event_id)}
 
     # 2. Detect platform and extract reply context
     platform = _detect_platform(body) if isinstance(body, dict) else None

--- a/orchestrator/api/widgets/auth.py
+++ b/orchestrator/api/widgets/auth.py
@@ -179,7 +179,25 @@ async def widget_auth(
         )
 
     # ----- 3. Domain / origin check ---------------------------------------
+    # P2-13 (PRD-194 S3): public keys fail CLOSED on a missing origin. An
+    # ak_pub_ key ships in page HTML by design — its entire security model is
+    # the origin lock — so presenting one with no Origin/Referer header
+    # (curl, a server-side script) is a DENY, not a silent skip of the domain
+    # check. Server keys (ak_srv_) are not origin-locked and are unaffected;
+    # an unknown/legacy key_type is treated as public (fail closed). The
+    # merchant opt-in in check_domain (empty allowed_domains = any origin)
+    # is unchanged — this guard is origin-ABSENT ⇒ deny, nothing more.
     origin = _extract_origin(request)
+    is_public_key = (getattr(api_key_record, "key_type", None) or "public") == "public"
+    if is_public_key and not origin:
+        logger.warning(
+            "widget_auth: public key %s presented with no Origin/Referer — denied (fail closed)",
+            api_key_record.key_prefix,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Origin required for public API keys",
+        )
     if origin and not ApiKeyService.check_domain(api_key_record, origin):
         logger.warning(
             "widget_auth: origin %s not in allowed_domains for key %s",
@@ -236,25 +254,23 @@ def require_permission(permission: str) -> Callable:
     async def _check(
         auth: WidgetAuthContext = Depends(widget_auth),
     ) -> WidgetAuthContext:
-        # PRD-174 F042 — one empty-permission semantic. Historically the widget
-        # plane treated an empty permission list as "unrestricted" (a god-key),
-        # while the board plane treats empty as "grants nothing". When the policy
-        # plane is ON we unify on the board plane's least-privilege rule (empty =
-        # deny) via the shared helper; OFF keeps the historical behaviour so the
-        # large population of already-issued keys is not broken mid-rollout.
+        # P2-13 (PRD-194 S3) / PRD-174 F042 — ONE empty-permission semantic on
+        # the widget plane: EMPTY = DENY, regardless of the policy-plane flag.
+        # The internet-facing plane is never the permissive one — a minted
+        # no-permission key must not be a god-key here while the plane rolls
+        # out (P2-11 owns the platform-wide durable fix). Grants are explicit:
+        # membership or a deliberate "*" element (the board plane's
+        # least-privilege rule, modules/policy/roles.has_permission). The
+        # historical flag-gated "empty = unrestricted" branch is deleted.
         try:
-            from modules.policy import policy_plane_enabled
             from modules.policy.roles import has_permission as _has_perm
 
-            _plane_on = policy_plane_enabled()
-        except Exception:
-            _plane_on = False
-
-        if _plane_on:
-            allowed = _has_perm(auth.permissions, permission)  # empty = deny
-        else:
-            # Legacy: empty list = unrestricted; a non-empty list must contain it.
-            allowed = (not auth.permissions) or (permission in auth.permissions)
+            allowed = _has_perm(auth.permissions, permission)
+        except ImportError:
+            # Policy package unavailable (stripped local build) — same
+            # least-privilege rule, locally: empty = deny, explicit grants only.
+            perms = set(auth.permissions or [])
+            allowed = bool(perms) and (permission in perms or "*" in perms)
 
         if not allowed:
             raise HTTPException(

--- a/orchestrator/api/widgets/cors.py
+++ b/orchestrator/api/widgets/cors.py
@@ -10,10 +10,13 @@ Path coverage (PRD-008-A):
 - ``/api/widgets/*``  — storefront widget calls (any storefront origin)
 - ``/api/sites/*``    — Automatos dashboard Sites CRUD (admin operations)
 
-Both surfaces share the ``WIDGET_ORIGIN_ALLOWLIST`` env var. When empty,
-all origins are allowed (development default). The actual security
-boundary on /api/sites is the JWT in cookies, not CORS — CORS just lets
-the dashboard browser issue the request in the first place.
+Both surfaces share the ``WIDGET_ORIGIN_ALLOWLIST`` env var. An empty
+allowlist is permissive ONLY in the ``local`` edition (dev default); in the
+``saas`` edition the boot guard (``config.validate_security``, PRD-194 S4 /
+P2-13) aborts boot on an empty allowlist, and this module fails CLOSED if
+that state is ever reached anyway. The actual security boundary on
+/api/sites is the JWT in cookies, not CORS — CORS just lets the dashboard
+browser issue the request in the first place.
 """
 
 import logging
@@ -41,12 +44,22 @@ WIDGET_ORIGIN_ALLOWLIST: set[str] = {
 def _origin_allowed(origin: str) -> bool:
     """Return True if *origin* is in the configured allowlist.
 
-    When the allowlist is empty (not configured), ALL origins are allowed
-    for backwards-compatibility during development.  In production the
-    env var should always be set.
+    Empty allowlist (P2-13, PRD-194 S4): permissive ONLY in the ``local``
+    edition — choosing ``AUTH_EDITION=local`` is the explicit dev opt-in. In
+    the ``saas`` edition the boot guard (``config.validate_security``)
+    guarantees a non-empty allowlist, so this branch is unreachable there;
+    if it is ever reached anyway (guard bypassed), the public plane fails
+    CLOSED, loudly — never allow-all in production.
     """
     if not WIDGET_ORIGIN_ALLOWLIST:
-        return True
+        if config.IS_LOCAL_EDITION:
+            return True
+        logger.error(
+            "WIDGET_ORIGIN_ALLOWLIST is empty in the saas edition — denying "
+            "origin %s (fail closed; the boot guard should have prevented this)",
+            origin,
+        )
+        return False
     return origin.rstrip("/") in WIDGET_ORIGIN_ALLOWLIST
 
 

--- a/orchestrator/api/widgets/rate_limit.py
+++ b/orchestrator/api/widgets/rate_limit.py
@@ -41,7 +41,6 @@ with a ``Retry-After`` header.
 """
 
 import asyncio
-import hashlib
 import json
 import logging
 import time
@@ -51,6 +50,7 @@ from uuid import uuid4
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 from config import config
+from core.services.api_key_service import _hash_key
 
 logger = logging.getLogger(__name__)
 
@@ -211,8 +211,11 @@ class WidgetRateLimitMiddleware:
         client_ip = client[0] if client else "unknown"
 
         if api_key:
-            digest = hashlib.sha256(api_key.encode("utf-8")).hexdigest()[:32]
-            identifier = f"key:{digest}"
+            # The canonical key-identity derivation (core/services/
+            # api_key_service._hash_key — the same digest sdk_api_keys
+            # stores as key_hash): the bucket IS the key row's identity,
+            # and no key material lands in Redis.
+            identifier = f"key:{_hash_key(api_key)[:32]}"
             limit = (
                 config.WIDGET_RATE_LIMIT_SERVER_PER_WINDOW
                 if api_key.startswith("ak_srv_")

--- a/orchestrator/api/widgets/rate_limit.py
+++ b/orchestrator/api/widgets/rate_limit.py
@@ -1,15 +1,36 @@
 """
-Widget API Rate Limiting Middleware (ASGI-native)
-==================================================
+Widget API Rate Limiting Middleware (ASGI-native, Redis-backed)
+================================================================
 
-Per-API-key rate limiting using an in-memory sliding window counter.
-Applies only to ``/api/widgets/*`` routes.
+Per-key / per-IP rate limiting for ``/api/widgets/*`` routes, backed by a
+**Redis sliding window shared across all uvicorn workers** (PRD-194 S5,
+P2-13). This REPLACES the previous per-process in-memory window, which
+reset on every deploy, was invisible to sibling workers, and never gated
+anything real.
 
-Implemented as a pure ASGI middleware (not ``BaseHTTPMiddleware``) so
-that ``StreamingResponse`` / SSE connections are **not buffered**.
+Shape:
 
-Rate-limit headers are added to every widget response so SDK consumers
-can implement client-side back-off:
+- The identifier is resolved **pre-handler** in the middleware — a request
+  with a Bearer key is keyed on a SHA-256 digest of the presented key (a
+  1:1 per-key bucket without writing key material into Redis); a request
+  with no key falls back to ``client_ip``. The FIRST request is gated.
+- The window lives in a Redis sorted set — the same sliding-window idiom as
+  ``core/security/rate_limiter.py`` — via the platform Redis client
+  (``core/redis/client.py`` + ``config.REDIS_URL``). No new dependency.
+- The two money-spending endpoints (``/api/widgets/chat``,
+  ``/api/widgets/callback`` — LLM turns, channel fan-out) additionally get
+  a **per-IP ceiling that applies even when a key is presented**: a scraped
+  public key replayed from one box hits the IP ceiling regardless of the
+  key's own budget.
+- **Redis down ⇒ fail OPEN, loudly** (locked decision): the widget must not
+  brick on a cache outage — every ungated request increments a counter and
+  logs an ERROR, so an outage is visible, not silent.
+
+Implemented as a pure ASGI middleware (not ``BaseHTTPMiddleware``) so that
+``StreamingResponse`` / SSE connections are **not buffered**.
+
+Rate-limit headers are added to every widget response so SDK consumers can
+implement client-side back-off:
 
 - ``X-RateLimit-Limit`` — max requests allowed in the window
 - ``X-RateLimit-Remaining`` — requests left in the current window
@@ -19,63 +40,131 @@ When the limit is exceeded the middleware returns **429 Too Many Requests**
 with a ``Retry-After`` header.
 """
 
+import asyncio
+import hashlib
 import json
 import logging
 import time
-from collections import defaultdict
-from threading import Lock
 from typing import Optional
+from uuid import uuid4
 
 from starlette.types import ASGIApp, Receive, Scope, Send
 
+from config import config
+
 logger = logging.getLogger(__name__)
 
-# ---------------------------------------------------------------------------
-# Defaults per key type
-# ---------------------------------------------------------------------------
+_KEY_PREFIX = "widget:rl"
 
-DEFAULT_PUBLIC_RATE = 30     # requests per minute
-DEFAULT_SERVER_RATE = 1000   # requests per minute
-WINDOW_SIZE = 60             # seconds
+# Money-spending endpoints that carry a per-IP ceiling ON TOP of the per-key
+# limit (exact path → config attribute holding the ceiling).
+_IP_CEILING_PATHS: dict[str, str] = {
+    "/api/widgets/chat": "WIDGET_CHAT_IP_LIMIT_PER_WINDOW",
+    "/api/widgets/callback": "WIDGET_CALLBACK_IP_LIMIT_PER_WINDOW",
+}
+
+# Loud fail-open accounting: every request allowed because Redis was
+# unreachable bumps this counter (and logs an ERROR). A cache outage must be
+# visible in logs/metrics, never silent.
+_redis_failures: int = 0
+
+
+def get_redis_failure_count() -> int:
+    """Number of requests allowed ungated because Redis was unreachable."""
+    return _redis_failures
+
+
+def _count_redis_failure(identifier: str) -> None:
+    global _redis_failures
+    _redis_failures += 1
+    logger.error(
+        "widget rate limiter FAIL-OPEN (#%d): Redis unreachable — request "
+        "for %s allowed ungated (P2-13: availability beats limiting on a "
+        "cache outage, but this must not stay silent)",
+        _redis_failures,
+        identifier,
+    )
+
+
+def _default_redis():
+    """Platform Redis connection or ``None`` — the same lazy, fail-soft seam
+    as ``core/security/rate_limiter._get_redis``."""
+    try:
+        from core.redis.client import get_redis_client
+
+        client = get_redis_client()
+        if client is None:
+            return None
+        return client.get_redis()
+    except Exception:
+        return None
 
 
 # ---------------------------------------------------------------------------
-# Sliding-window counter store
+# Redis-backed sliding-window store (shared across workers)
 # ---------------------------------------------------------------------------
 
 class RateLimitStore:
-    """Thread-safe in-memory sliding-window rate-limit counter."""
+    """Sliding-window rate-limit counter in a Redis sorted set.
 
-    def __init__(self) -> None:
-        self._buckets: dict[str, list[float]] = defaultdict(list)
-        self._lock: Lock = Lock()
+    One key per identifier; members are request timestamps. The window is
+    shared across every process/worker pointing at the same Redis — the
+    property the deleted in-memory dict could never have. Same idiom as
+    ``core/security/rate_limiter.py`` (zremrangebyscore → zcard → zadd →
+    expire in one pipeline; a denied request still marks the window, so
+    hammering keeps the window hot rather than resetting it).
+    """
+
+    def __init__(self, redis_factory=None) -> None:
+        self._redis_factory = redis_factory or _default_redis
 
     def check(
         self,
         key_id: str,
         limit: int,
+        window: Optional[int] = None,
     ) -> tuple[bool, int, int, int]:
         """Evaluate whether *key_id* may proceed under *limit* req/window.
 
-        Returns (allowed, limit, remaining, reset_seconds).
+        Returns ``(allowed, limit, remaining, reset_seconds)``. Redis
+        unreachable ⇒ **fail OPEN** (allowed, loud counter + ERROR log).
         """
-        now = time.monotonic()
-        cutoff = now - WINDOW_SIZE
+        window = window or config.WIDGET_RATE_LIMIT_WINDOW_SECONDS
 
-        with self._lock:
-            bucket = self._buckets[key_id]
-            bucket[:] = [ts for ts in bucket if ts > cutoff]
-            count = len(bucket)
+        try:
+            redis = self._redis_factory()
+        except Exception:
+            redis = None
+        if redis is None:
+            _count_redis_failure(key_id)
+            return (True, limit, max(0, limit - 1), window)
 
-            if count >= limit:
-                reset_seconds = int(bucket[0] - cutoff) + 1
-                return (False, limit, 0, reset_seconds)
+        key = f"{_KEY_PREFIX}:{key_id}"
+        now = time.time()
 
-            bucket.append(now)
-            remaining = limit - len(bucket)
-            reset_seconds = int(bucket[0] - cutoff) + 1 if bucket else WINDOW_SIZE
+        try:
+            pipe = redis.pipeline()
+            pipe.zremrangebyscore(key, 0, now - window)   # drop expired marks
+            pipe.zcard(key)                               # count BEFORE this request
+            pipe.zrange(key, 0, 0, withscores=True)       # oldest surviving mark
+            pipe.zadd(key, {f"{now:.6f}:{uuid4().hex[:6]}": now})
+            pipe.expire(key, window + 10)
+            results = pipe.execute()
+        except Exception:
+            _count_redis_failure(key_id)
+            return (True, limit, max(0, limit - 1), window)
 
-            return (True, limit, remaining, reset_seconds)
+        count = int(results[1])
+        oldest = results[2]
+        if oldest:
+            oldest_score = float(oldest[0][1])
+            reset_seconds = max(1, int(oldest_score + window - now) + 1)
+        else:
+            reset_seconds = int(window)
+
+        if count >= limit:
+            return (False, limit, 0, reset_seconds)
+        return (True, limit, max(0, limit - count - 1), reset_seconds)
 
 
 # ---------------------------------------------------------------------------
@@ -83,18 +172,12 @@ class RateLimitStore:
 # ---------------------------------------------------------------------------
 
 class WidgetRateLimitMiddleware:
-    """Per-API-key rate limiting for ``/api/widgets/*`` routes.
+    """Shared, first-request-gating rate limiting for ``/api/widgets/*``.
 
-    Pure ASGI — does not buffer streaming responses.
-
-    NOTE: Because the rate limiter runs *before* route handlers, and the
-    API key ID is resolved inside the route handler (via ``Depends``),
-    this middleware currently only applies rate limiting when
-    ``request.state.api_key_id`` has been set by an earlier middleware.
-    For the widget auth flow the auth dependency runs inside the handler,
-    so rate-limit headers are injected but the sliding window check is
-    only active when the key ID is already known (e.g. from a prior
-    request on the same connection).
+    Pure ASGI — does not buffer streaming responses. The identifier is
+    resolved here, before any route handler runs, so the very first request
+    on a connection is limited; the Redis-backed store makes the decision
+    hold across all workers.
     """
 
     def __init__(self, app: ASGIApp, store: Optional[RateLimitStore] = None) -> None:
@@ -116,22 +199,51 @@ class WidgetRateLimitMiddleware:
             await self.app(scope, receive, send)
             return
 
-        # Extract identifier: prefer API key header, fall back to client IP
+        # Identifier: prefer the presented API key (hashed — no key material
+        # in Redis), fall back to client IP. Resolved pre-handler so the
+        # FIRST request is gated (P2-13).
         headers = dict(scope.get("headers", []))
         api_key = (headers.get(b"authorization") or b"").decode("latin-1").strip()
         if api_key.lower().startswith("bearer "):
             api_key = api_key[7:].strip()
 
-        if api_key:
-            identifier = f"key:{api_key[:32]}"
-            limit = DEFAULT_SERVER_RATE if api_key.startswith("ak_srv_") else DEFAULT_PUBLIC_RATE
-        else:
-            client = scope.get("client")
-            client_ip = client[0] if client else "unknown"
-            identifier = f"ip:{client_ip}"
-            limit = DEFAULT_PUBLIC_RATE
+        client = scope.get("client")
+        client_ip = client[0] if client else "unknown"
 
-        allowed, rl_limit, remaining, reset_seconds = self._store.check(identifier, limit)
+        if api_key:
+            digest = hashlib.sha256(api_key.encode("utf-8")).hexdigest()[:32]
+            identifier = f"key:{digest}"
+            limit = (
+                config.WIDGET_RATE_LIMIT_SERVER_PER_WINDOW
+                if api_key.startswith("ak_srv_")
+                else config.WIDGET_RATE_LIMIT_PUBLIC_PER_WINDOW
+            )
+        else:
+            identifier = f"ip:{client_ip}"
+            limit = config.WIDGET_RATE_LIMIT_PUBLIC_PER_WINDOW
+
+        allowed, rl_limit, remaining, reset_seconds = await asyncio.to_thread(
+            self._store.check, identifier, limit
+        )
+
+        # Per-IP ceiling on the money-spending endpoints — applies even when
+        # a key was presented (PRD-194 S5): a scraped ak_pub_ key replayed
+        # from one machine hits the IP ceiling regardless of key limits.
+        if allowed:
+            ceiling_attr = _IP_CEILING_PATHS.get(path.rstrip("/"))
+            if ceiling_attr is not None:
+                ip_ceiling = int(getattr(config, ceiling_attr))
+                endpoint_tag = path.rstrip("/").rsplit("/", 1)[-1]
+                ip_allowed, ip_limit, ip_remaining, ip_reset = await asyncio.to_thread(
+                    self._store.check,
+                    f"ipceil:{endpoint_tag}:{client_ip}",
+                    ip_ceiling,
+                )
+                if not ip_allowed:
+                    allowed = False
+                    rl_limit, remaining, reset_seconds = ip_limit, 0, ip_reset
+                else:
+                    remaining = min(remaining, ip_remaining)
 
         if not allowed:
             # 429 Too Many Requests

--- a/orchestrator/api/workflow_recipes.py
+++ b/orchestrator/api/workflow_recipes.py
@@ -1759,8 +1759,8 @@ async def recipe_webhook(
     Trigger a recipe execution via webhook.
 
     The webhook_id is a persistent secret stored in the recipe's
-    schedule_config.webhook_id. No authentication required — the
-    URL itself is the credential.
+    schedule_config.webhook_id — the URL is the credential floor. When a
+    webhook secret is configured, a valid HMAC signature is also mandatory.
 
     Body (optional):
     - Any JSON payload — passed as input_data to the recipe executor.
@@ -1797,7 +1797,8 @@ async def recipe_webhook(
     if not recipe:
         raise HTTPException(status_code=404, detail="Unknown webhook")
 
-    # Verify HMAC signature if a webhook secret is configured
+    # Verify HMAC signature — mandatory when a webhook secret is configured:
+    # missing header or mismatch ⇒ 401 (P2-13).
     webhook_secret = (recipe.schedule_config or {}).get("webhook_secret") or config.WEBHOOK_SECRET
     if webhook_secret:
         sig_header = (
@@ -1805,17 +1806,19 @@ async def recipe_webhook(
             or request.headers.get("x-composio-signature")
             or request.headers.get("x-webhook-signature")
         )
-        if sig_header:
-            raw_body = await request.body()
-            expected_sig = sig_header.removeprefix("sha256=")
-            computed = hmac.new(
-                webhook_secret.encode("utf-8"),
-                raw_body,
-                hashlib.sha256,
-            ).hexdigest()
-            if not hmac.compare_digest(computed, expected_sig):
-                logger.warning("[webhook] HMAC signature mismatch for recipe webhook %s", webhook_id)
-                raise HTTPException(status_code=401, detail="Invalid webhook signature")
+        if not sig_header:
+            logger.warning("[webhook] Rejected recipe webhook %s: secret configured but no signature header", webhook_id)
+            raise HTTPException(status_code=401, detail="Missing webhook signature")
+        raw_body = await request.body()
+        expected_sig = sig_header.removeprefix("sha256=")
+        computed = hmac.new(
+            webhook_secret.encode("utf-8"),
+            raw_body,
+            hashlib.sha256,
+        ).hexdigest()
+        if not hmac.compare_digest(computed, expected_sig):
+            logger.warning("[webhook] HMAC signature mismatch for recipe webhook %s", webhook_id)
+            raise HTTPException(status_code=401, detail="Invalid webhook signature")
 
     if not recipe.steps:
         raise HTTPException(status_code=400, detail="Recipe has no steps")

--- a/orchestrator/api/workflow_recipes.py
+++ b/orchestrator/api/workflow_recipes.py
@@ -28,6 +28,7 @@ from core.models.core import RecipeExecution
 from core.models.composio import TriggerSubscription, ComposioEntity
 from core.auth.hybrid import get_request_context_hybrid
 from core.auth.dependencies import RequestContext
+from services import webhook_dedup
 from config import config
 
 
@@ -1819,6 +1820,26 @@ async def recipe_webhook(
         if not hmac.compare_digest(computed, expected_sig):
             logger.warning("[webhook] HMAC signature mismatch for recipe webhook %s", webhook_id)
             raise HTTPException(status_code=401, detail="Invalid webhook signature")
+
+    # Replay guard + event dedup (PRD-194 S2, P2-13): a redelivered event
+    # (same webhook-id header / body event_id) must not create a second
+    # RecipeExecution. A stale provider timestamp is a replay ⇒ 401. No
+    # event id ⇒ nothing to dedup on ⇒ process normally (URL-as-secret
+    # callers that send no id keep working).
+    if webhook_dedup.timestamp_is_stale(request.headers.get("webhook-timestamp")):
+        logger.warning(
+            "[webhook] Rejected recipe webhook %s: stale webhook-timestamp (replay guard)",
+            webhook_id,
+        )
+        raise HTTPException(status_code=401, detail="Stale webhook timestamp")
+    dedup_event_id = request.headers.get("webhook-id") or (
+        body.get("event_id") if isinstance(body, dict) else None
+    )
+    if await webhook_dedup.seen_before(f"recipe:{webhook_id}", dedup_event_id):
+        logger.info(
+            "[webhook] Duplicate recipe webhook event %s — no-op ack", dedup_event_id
+        )
+        return {"status": "duplicate", "event_id": str(dedup_event_id)}
 
     if not recipe.steps:
         raise HTTPException(status_code=400, detail="Recipe has no steps")

--- a/orchestrator/config.py
+++ b/orchestrator/config.py
@@ -495,6 +495,16 @@ class Config:
     WEBHOOK_TIMESTAMP_SKEW_SECONDS: int = int(os.getenv("WEBHOOK_TIMESTAMP_SKEW_SECONDS", "300"))
     WIDGET_TOKEN_SECRET: str = os.getenv("WIDGET_TOKEN_SECRET", "")
     WIDGET_ORIGIN_ALLOWLIST: str = os.getenv("WIDGET_ORIGIN_ALLOWLIST", "")
+    # PRD-194 S5 (P2-13): Redis-backed shared widget rate limiter (replaces
+    # the per-process in-memory window). One window length; per-key limits by
+    # key type; and a per-IP ceiling on the two money-spending endpoints
+    # (/api/widgets/chat, /api/widgets/callback) that applies even when a
+    # key is presented.
+    WIDGET_RATE_LIMIT_WINDOW_SECONDS: int = int(os.getenv("WIDGET_RATE_LIMIT_WINDOW_SECONDS", "60"))
+    WIDGET_RATE_LIMIT_PUBLIC_PER_WINDOW: int = int(os.getenv("WIDGET_RATE_LIMIT_PUBLIC_PER_WINDOW", "30"))
+    WIDGET_RATE_LIMIT_SERVER_PER_WINDOW: int = int(os.getenv("WIDGET_RATE_LIMIT_SERVER_PER_WINDOW", "1000"))
+    WIDGET_CHAT_IP_LIMIT_PER_WINDOW: int = int(os.getenv("WIDGET_CHAT_IP_LIMIT_PER_WINDOW", "30"))
+    WIDGET_CALLBACK_IP_LIMIT_PER_WINDOW: int = int(os.getenv("WIDGET_CALLBACK_IP_LIMIT_PER_WINDOW", "10"))
     SHOPIFY_INTERNAL_API_KEY: str = os.getenv("SHOPIFY_INTERNAL_API_KEY", "")
     # PRD-189 S3: per-workspace debounce window (seconds) for catalog-webhook
     # re-syncs. A merchant bulk edit emits a burst of products/update webhooks;

--- a/orchestrator/config.py
+++ b/orchestrator/config.py
@@ -485,6 +485,14 @@ class Config:
 
     # Webhooks / Widgets
     WEBHOOK_SECRET: str = os.getenv("WEBHOOK_SECRET")
+    # PRD-194 S2 (P2-13): replay/dedup guard for the three EXTERNAL webhook
+    # lanes (Composio /webhook, workspace /ws/{key}, playbook /recipe/{id}).
+    # Dedup marks live in Redis (SETNX + TTL via core/redis/client.py — no
+    # new table). TTL covers provider retry windows with slack to spare.
+    WEBHOOK_DEDUP_TTL_SECONDS: int = int(os.getenv("WEBHOOK_DEDUP_TTL_SECONDS", "3600"))
+    # Replay skew: reject events whose provider timestamp is further than
+    # this from now (mirrors Slack's documented v0 5-minute window).
+    WEBHOOK_TIMESTAMP_SKEW_SECONDS: int = int(os.getenv("WEBHOOK_TIMESTAMP_SKEW_SECONDS", "300"))
     WIDGET_TOKEN_SECRET: str = os.getenv("WIDGET_TOKEN_SECRET", "")
     WIDGET_ORIGIN_ALLOWLIST: str = os.getenv("WIDGET_ORIGIN_ALLOWLIST", "")
     SHOPIFY_INTERNAL_API_KEY: str = os.getenv("SHOPIFY_INTERNAL_API_KEY", "")

--- a/orchestrator/config.py
+++ b/orchestrator/config.py
@@ -1133,6 +1133,10 @@ class Config:
           shared bucket with no ``{workspace_id}`` placeholder is allowed —
           tenant isolation is enforced per-query by ``S3VectorsBackend.search()``
           (fail-closed on ``workspace_id``), not by the bucket layout.)
+        - PRD-194 S4 (P2-13): ``WIDGET_ORIGIN_ALLOWLIST`` is empty in the
+          ``saas`` edition — widget CORS would rest at allow-all on the
+          internet-facing plane. Boot-abort in saas (same posture as F004 /
+          the Clerk edition guard); ``local`` keeps the permissive dev default.
         """
         errors: list[str] = []
 
@@ -1156,6 +1160,21 @@ class Config:
                 errors.append(
                     "S3_VECTORS_ENABLED=true but S3_VECTORS_BUCKET is unset."
                 )
+
+        # PRD-194 S4 (P2-13) — the internet-facing widget plane must not rest
+        # at allow-all CORS in production. In the saas edition an empty
+        # WIDGET_ORIGIN_ALLOWLIST is a boot error (locked decision: boot-abort,
+        # matching the F004 and Clerk edition guards). The local edition keeps
+        # the permissive dev default — choosing AUTH_EDITION=local IS the
+        # explicit opt-in.
+        if self.IS_SAAS_EDITION and not (self.WIDGET_ORIGIN_ALLOWLIST or "").strip():
+            errors.append(
+                "WIDGET_ORIGIN_ALLOWLIST is unset in the saas edition — widget "
+                "CORS (/api/widgets, /api/sites) would allow ALL origins on the "
+                "internet-facing plane (fail-open). Set WIDGET_ORIGIN_ALLOWLIST "
+                "to the comma-separated allowed storefront/dashboard origins, or "
+                "run AUTH_EDITION=local for a dev instance."
+            )
 
         if errors:
             raise RuntimeError(

--- a/orchestrator/jobs/sync_composio_actions.py
+++ b/orchestrator/jobs/sync_composio_actions.py
@@ -78,8 +78,24 @@ async def sync_all_composio_actions(
             total_errors = sum(r.errors for r in results)
             total_duration_ms = sum(r.duration_ms for r in results)
 
+            # PRD-194 S6 (P2-13): a silent no-op sync must fail LOUDLY. If
+            # connected apps exist but composio_action_metadata is still
+            # empty after a "completed" run, the feeder is broken — surface
+            # it as a FAILED sync, not a quiet success. This exact failure
+            # (hardcoded app list + await-on-sync TypeError) went undetected
+            # for months because it only ever logged per-app errors.
+            from modules.tools.sync.composio_action_sync import (
+                check_action_metadata_populated,
+            )
+
+            metadata_ok, metadata_detail = check_action_metadata_populated(db)
+            if not metadata_ok:
+                logger.error(
+                    "Composio action sync assertion FAILED: %s", metadata_detail
+                )
+
             _last_sync_result = {
-                "status": "completed",
+                "status": "completed" if metadata_ok else "failed",
                 "started_at": start_time.isoformat(),
                 "completed_at": datetime.utcnow().isoformat(),
                 "duration_ms": total_duration_ms,
@@ -88,6 +104,7 @@ async def sync_all_composio_actions(
                 "classified": total_classified,
                 "skipped": total_skipped,
                 "errors": total_errors,
+                "metadata_assertion": metadata_detail,
                 "per_app_results": [
                     {
                         "app_id": r.app_id,

--- a/orchestrator/modules/tools/sync/composio_action_sync.py
+++ b/orchestrator/modules/tools/sync/composio_action_sync.py
@@ -16,6 +16,7 @@ Design Principles:
 - Batch processing to reduce API calls
 """
 
+import asyncio
 import hashlib
 import logging
 from dataclasses import dataclass
@@ -28,6 +29,42 @@ from ..capabilities.classifier import ActionClassifier, ActionClassification
 from ..capabilities.models import ComposioActionMetadata
 
 logger = logging.getLogger(__name__)
+
+
+def check_action_metadata_populated(db: Session) -> tuple[bool, str]:
+    """Fail-LOUD assertion for the destructive-gate feeder (PRD-194 S6, P2-13).
+
+    ``composio_action_metadata`` backs the destructive-action gate (F018).
+    Its feeder was a silent no-op for months — a hardcoded app list plus an
+    ``await`` on a synchronous client method meant the daily 04:00 sync
+    never wrote a row, and nothing noticed. This check makes that state
+    LOUD: **connected apps with an EMPTY metadata table is a failure**, not
+    a quiet degrade to the 8-keyword intent heuristic.
+
+    Returns ``(ok, detail)``. ok when there are no active connections
+    (cold start — nothing to classify) or when at least one metadata row
+    exists. Callers log ``detail`` at ERROR when not ok; the gate reader's
+    fail-closed keyword floor (action_capability_filter) stays in place
+    either way.
+    """
+    from core.models.composio import ComposioConnection
+
+    connected = db.execute(
+        select(ComposioConnection.id)
+        .where(ComposioConnection.status == "active")
+        .limit(1)
+    ).first()
+    if not connected:
+        return True, "no active Composio connections — nothing to classify"
+
+    row = db.execute(select(ComposioActionMetadata.action_id).limit(1)).first()
+    if row:
+        return True, "composio_action_metadata populated for connected apps"
+    return False, (
+        "connected Composio apps exist but composio_action_metadata is EMPTY — "
+        "the destructive gate (F018) is running blind on the keyword heuristic "
+        "and the action sync is a silent no-op (P2-13 §1.4.a)"
+    )
 
 
 @dataclass
@@ -203,8 +240,16 @@ class ComposioActionSyncService:
             return []
 
         try:
-            # Use Composio SDK to get app actions
-            raw_actions = await self.composio_client.get_app_actions(app_id)
+            # get_app_actions is a synchronous `def` (core/composio/client.py)
+            # and every other call site calls it synchronously. Awaiting it
+            # directly raised TypeError for EVERY app — swallowed as a failed
+            # SyncResult, so the daily sync wrote nothing for months (P2-13
+            # §1.4.a). Offload to a thread — the in-tree idiom for sync
+            # Composio calls (see core/composio/tool_executor.py) — rather
+            # than forking the client into a fake-async method.
+            raw_actions = await asyncio.to_thread(
+                self.composio_client.get_app_actions, app_id
+            )
 
             actions = []
             for raw in raw_actions:
@@ -328,16 +373,22 @@ class ComposioActionSyncService:
         return hashlib.sha256(content.encode()).hexdigest()[:16]
 
     async def _get_all_enabled_apps(self) -> List[str]:
-        """Get list of all Composio apps enabled by any workspace."""
+        """Distinct app names with an ACTIVE Composio connection anywhere.
 
-        # This would query your tools table for Composio apps
-        # Implementation depends on your schema
+        P2-13 (PRD-194 S6): replaces a hardcoded 8-app placeholder that made
+        the daily sync classify apps nobody had connected — and none of the
+        apps they actually had. ``composio_connections.app_name`` (stored
+        uppercase, matching how ``get_app_actions`` is called everywhere
+        else) is the ground truth the destructive gate needs classified.
+        """
+        from core.models.composio import ComposioConnection
 
-        # Placeholder - return common apps for now
-        return [
-            "slack", "github", "gmail", "google_calendar",
-            "notion", "jira", "linear", "discord"
-        ]
+        rows = self.db.execute(
+            select(ComposioConnection.app_name)
+            .where(ComposioConnection.status == "active")
+            .distinct()
+        ).all()
+        return sorted({str(r[0]) for r in rows if r and r[0]})
 
     async def override_classification(
         self,

--- a/orchestrator/services/callback.py
+++ b/orchestrator/services/callback.py
@@ -41,8 +41,11 @@ PHONE_E164_REGEX = re.compile(r"^\+[1-9]\d{7,14}$")
 # are deduplicated to a single dispatch.
 IDEMPOTENCY_WINDOW = timedelta(minutes=5)
 
-# Rate limits — small + safe defaults. Per-Site is the only one
-# currently configurable; per-IP requires Redis (deferred).
+# Rate limits — small + safe defaults. Per-session + per-Site live here
+# (DB-derived). The per-IP ceiling is enforced PRE-handler by the
+# Redis-backed widget rate limiter (api/widgets/rate_limit.py,
+# WIDGET_CALLBACK_IP_LIMIT_PER_WINDOW — PRD-194 S5): it gates the request
+# before this service ever runs.
 DEFAULT_PER_SESSION_COOLDOWN = timedelta(seconds=60)
 DEFAULT_PER_SITE_HOURLY_CAP = 100
 
@@ -125,7 +128,7 @@ def find_recent_duplicate(
 
 
 # ---------------------------------------------------------------------------
-# Rate limiting (per-session + per-Site, IP deferred until Redis)
+# Rate limiting (per-session + per-Site; per-IP is the middleware's job)
 # ---------------------------------------------------------------------------
 
 @dataclass(frozen=True)
@@ -145,8 +148,9 @@ def check_rate_limits(
 ) -> RateLimitDecision:
     """Per-session cooldown (60s) + per-Site hourly cap.
 
-    Per-IP rate limit is deferred until Redis-backed atomic counters
-    land (need atomicity to prevent races; SQL-only is too racy).
+    The per-IP ceiling is NOT here: it is enforced pre-handler by the
+    Redis-backed widget rate limiter (api/widgets/rate_limit.py — PRD-194
+    S5), which has the cross-worker atomicity SQL-only checks lacked.
     """
     from core.models.widget_event_log import WidgetEventLog
 

--- a/orchestrator/services/composio_sync_scheduler.py
+++ b/orchestrator/services/composio_sync_scheduler.py
@@ -13,6 +13,7 @@ factory idiom). Failure to sync is logged, never raised — a stale metadata
 table degrades gracefully to the fail-closed gate, it must not crash boot.
 """
 
+import asyncio
 import logging
 from typing import Optional
 
@@ -46,6 +47,34 @@ class ComposioSyncScheduler:
             max_instances=1,
         )
         logger.info("[ComposioSync] Scheduled daily metadata sync at %02d:00 UTC", hour)
+
+        # PRD-194 S6 (P2-13): startup assertion — connected apps with an
+        # EMPTY composio_action_metadata table means the destructive gate is
+        # running blind on the keyword heuristic. Say so at boot, loudly,
+        # instead of failing silently for months. Logged, never raised: a
+        # stale table degrades to the fail-closed keyword floor and must not
+        # crash boot (module docstring contract).
+        await asyncio.to_thread(self._startup_metadata_check)
+
+    @staticmethod
+    def _startup_metadata_check() -> None:
+        try:
+            from core.database.database import SessionLocal
+            from modules.tools.sync.composio_action_sync import (
+                check_action_metadata_populated,
+            )
+
+            db = SessionLocal()
+            try:
+                ok, detail = check_action_metadata_populated(db)
+            finally:
+                db.close()
+            if ok:
+                logger.info("[ComposioSync] startup metadata check: %s", detail)
+            else:
+                logger.error("[ComposioSync] STARTUP ASSERTION FAILED: %s", detail)
+        except Exception:
+            logger.exception("[ComposioSync] startup metadata check errored")
 
     async def _run_sync(self):
         """Execute the Composio action metadata sync."""

--- a/orchestrator/services/webhook_dedup.py
+++ b/orchestrator/services/webhook_dedup.py
@@ -1,0 +1,124 @@
+"""Webhook replay/dedup guard — PRD-194 S2 (P2-13, security §1.1/§1.3.c).
+
+The three EXTERNAL webhook lanes (Composio ``/webhook``, workspace
+``/ws/{key}``, playbook ``/recipe/{id}``) execute real agent/playbook work
+from an inbound POST. Providers redeliver on slow responses, and until this
+guard existed a redelivered event simply ran again — burning tokens and
+re-firing side-effects. This module gives those lanes two checks:
+
+- :func:`seen_before` — event dedup on the provider's event id
+  (``webhook-id`` / ``event_id`` / ``update_id``), backed by Redis
+  ``SET NX EX`` (atomic first-writer-wins, self-expiring). A redelivered
+  event becomes a fast no-op ack at the ingest point.
+- :func:`timestamp_is_stale` — replay defence where a provider timestamp
+  exists: outside the skew window ⇒ reject.
+
+Deliberate semantics (locked decisions, PRD-194):
+
+- **Redis SETNX + TTL, no table, no migration.** Reuses the platform Redis
+  client (``core/redis/client.py`` + ``config.REDIS_URL``); the guard is
+  ephemeral by nature, keyed per-lane so a later single-surface
+  consolidation (P2-25) is a merge, not a rewrite.
+- **Redis down ⇒ fail OPEN for dedup** (process the event, log LOUDLY).
+  Availability of the lane beats replay protection when the guard store is
+  down — the signature gate (S1) still stands in front of every lane.
+- **Mark-on-arrival, not mark-on-success.** The dedup mark is written when
+  the event is first accepted, before execution. Marking after success
+  would reopen the exact double-execute window this guard closes (a slow
+  handler triggers the provider retry *while still running*).
+- **The Shopify ``/events`` path is NOT routed through this guard** —
+  PRD-189 S3's per-workspace debounce owns that lane (different endpoint,
+  complementary guard; it coalesces *distinct* events, this rejects *the
+  same* event redelivered).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Optional
+
+from config import config
+
+logger = logging.getLogger(__name__)
+
+_KEY_PREFIX = "webhook:dedup"
+
+
+def _get_redis():
+    """Platform Redis connection or ``None`` — the same lazy, fail-soft seam
+    as ``core/security/rate_limiter._get_redis``."""
+    try:
+        from core.redis.client import get_redis_client
+
+        client = get_redis_client()
+        if client is None:
+            return None
+        return client.get_redis()
+    except Exception:
+        return None
+
+
+def _seen_before_sync(lane: str, event_id: str) -> bool:
+    """Atomically mark ``(lane, event_id)`` as seen; ``True`` if it already was.
+
+    ``SET NX EX``: the first delivery writes the mark and returns falsy-negative
+    (not seen); every redelivery inside the TTL finds the mark and returns
+    ``True``. Redis unavailable/erroring ⇒ **fail OPEN** (return ``False``,
+    log loudly) — the lane must keep working through a cache outage; replay
+    protection resumes when Redis does.
+    """
+    redis = _get_redis()
+    if redis is None:
+        logger.error(
+            "[webhook-dedup] Redis unavailable — replay/dedup guard DOWN, "
+            "processing event without replay protection (lane=%s)",
+            lane,
+        )
+        return False
+
+    key = f"{_KEY_PREFIX}:{lane}:{event_id}"
+    try:
+        first_delivery = redis.set(
+            key, "1", nx=True, ex=config.WEBHOOK_DEDUP_TTL_SECONDS
+        )
+        return not bool(first_delivery)
+    except Exception:
+        logger.error(
+            "[webhook-dedup] Redis error — replay/dedup guard DOWN, "
+            "processing event without replay protection (lane=%s)",
+            lane,
+            exc_info=True,
+        )
+        return False
+
+
+async def seen_before(lane: str, event_id: Optional[str]) -> bool:
+    """``True`` when this event id was already accepted on this lane.
+
+    ``lane`` scopes the key (e.g. ``"composio"``, ``"ws:{workspace_id}"``,
+    ``"recipe:{webhook_id}"``) so ids that are only unique per-provider-
+    connection (Telegram ``update_id``) cannot collide across tenants.
+    No event id ⇒ nothing to dedup on ⇒ process normally.
+    """
+    if not event_id:
+        return False
+    return await asyncio.to_thread(_seen_before_sync, lane, str(event_id))
+
+
+def timestamp_is_stale(ts_raw: Optional[str]) -> bool:
+    """Replay defence: ``True`` when a provider timestamp exists and is
+    outside the configured skew window.
+
+    No header ⇒ ``False`` (nothing to check — dedup still applies). A
+    present-but-garbage timestamp is treated as stale (fail closed): a
+    caller that supplies the header must supply a valid one.
+    """
+    if ts_raw is None or ts_raw == "":
+        return False
+    try:
+        ts = float(ts_raw)
+    except (TypeError, ValueError):
+        return True
+    return abs(time.time() - ts) > config.WEBHOOK_TIMESTAMP_SKEW_SECONDS

--- a/orchestrator/tests/security/test_prd172_tenant_isolation.py
+++ b/orchestrator/tests/security/test_prd172_tenant_isolation.py
@@ -235,6 +235,9 @@ class TestF004ShopifyFailClosed:
         cfg = Config()
         monkeypatch.setattr(cfg, "SHOPIFY_INTERNAL_API_KEY", "real-secret", raising=False)
         monkeypatch.setattr(cfg, "S3_VECTORS_ENABLED", False, raising=False)
+        # PRD-194 S4: saas boots also require a widget CORS allowlist —
+        # satisfied here so this test stays scoped to the Shopify guard.
+        monkeypatch.setattr(cfg, "WIDGET_ORIGIN_ALLOWLIST", "https://app.automatos.app", raising=False)
         cfg.validate_security()  # no raise
 
     def test_verify_internal_key_rejects_arbitrary_header(self, monkeypatch):
@@ -331,6 +334,9 @@ class TestF005VectorIsolation:
         monkeypatch.setattr(cfg, "SHOPIFY_INTERNAL_API_KEY", "x", raising=False)
         monkeypatch.setattr(cfg, "S3_VECTORS_ENABLED", True, raising=False)
         monkeypatch.setattr(cfg, "S3_VECTORS_BUCKET", "shared-no-placeholder", raising=False)
+        # PRD-194 S4: saas boots also require a widget CORS allowlist —
+        # satisfied here so this test stays scoped to the bucket layout.
+        monkeypatch.setattr(cfg, "WIDGET_ORIGIN_ALLOWLIST", "https://app.automatos.app", raising=False)
         monkeypatch.setattr(cfg, "validate_auth_edition", lambda: None, raising=False)
         cfg.validate_security()  # must not raise on the bucket layout
 

--- a/orchestrator/tests/test_p2w2_composio_feeder.py
+++ b/orchestrator/tests/test_p2w2_composio_feeder.py
@@ -1,0 +1,280 @@
+"""PRD-194 S6 (P2-13, security §1.4.a, composio C.2/§J P0-2) — fix the
+destructive-gate feeder and make a silent no-op sync fail LOUDLY.
+
+``ComposioActionSyncService`` is the sole writer of
+``composio_action_metadata`` — the table backing the destructive-action gate
+(F018) — and it could never write a row:
+
+- ``_get_all_enabled_apps`` returned a hardcoded 8-app placeholder, so the
+  daily sync classified apps nobody had connected (and none they had);
+- ``_fetch_app_actions`` ``await``-ed ``get_app_actions``, a synchronous
+  ``def`` on the client — ``TypeError`` for every app, swallowed as a
+  failed ``SyncResult``. The 04:00 cron ran for months writing nothing,
+  and the gate fell back to the 8-keyword intent heuristic forever.
+
+These tests pin the fixes: the enabled set is the REAL active-connection
+set; the sync client call is a thread offload of the (still-synchronous)
+client method — the in-tree idiom, no fake-async fork; a full ``sync_app``
+run writes metadata rows; and connected-apps-with-empty-table now fails
+LOUDLY (sync result status=failed + startup ERROR log) instead of silently.
+The gate reader's fail-closed keyword floor is untouched.
+
+Pure: stub Composio client (plain ``def``), stub/recording DB sessions,
+no network, no live Composio, no live DB.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("POSTGRES_USER", "test")
+os.environ.setdefault("POSTGRES_PASSWORD", "test")
+os.environ.setdefault("POSTGRES_HOST", "127.0.0.1")
+os.environ.setdefault("POSTGRES_PORT", "59432")
+os.environ.setdefault("POSTGRES_DB", "test")
+
+import asyncio  # noqa: E402
+import logging  # noqa: E402
+from pathlib import Path  # noqa: E402
+
+import pytest  # noqa: E402
+
+import tests.conftest as _conftest  # noqa: E402
+
+_conftest._restore_real_app_modules()
+
+from modules.tools.capabilities.models import ComposioActionMetadata  # noqa: E402
+from modules.tools.sync.composio_action_sync import (  # noqa: E402
+    ComposioActionSyncService,
+    check_action_metadata_populated,
+)
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ---------------------------------------------------------------- stubs
+
+class _SyncClient:
+    """Composio client stand-in whose get_app_actions is a plain def —
+    exactly like the real core/composio/client.py method."""
+
+    def __init__(self):
+        self.calls: list[str] = []
+
+    def get_app_actions(self, app_name):
+        self.calls.append(app_name)
+        return [
+            {
+                "name": "GITHUB_CREATE_ISSUE",
+                "display_name": "Create Issue",
+                "description": "Create a new issue in a repository",
+                "parameters": {"type": "object", "properties": {}},
+            },
+            {
+                "name": "GITHUB_DELETE_REPOSITORY",
+                "display_name": "Delete Repository",
+                "description": "Permanently delete a repository",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        ]
+
+
+class _Rows:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def all(self):
+        return self._rows
+
+    def first(self):
+        return self._rows[0] if self._rows else None
+
+    def scalar_one_or_none(self):
+        return self._rows[0] if self._rows else None
+
+
+class _QueueDb:
+    """db.execute() answers from a FIFO of _Rows — one per expected query."""
+
+    def __init__(self, results):
+        self._results = list(results)
+
+    def execute(self, stmt):
+        return self._results.pop(0)
+
+
+class _RecordingDb:
+    """Every lookup misses (new action); add/commit are recorded."""
+
+    def __init__(self):
+        self.added = []
+        self.commits = 0
+
+    def execute(self, stmt):
+        return _Rows([])
+
+    def add(self, obj):
+        self.added.append(obj)
+
+    def commit(self):
+        self.commits += 1
+
+
+# ---------------------------------------------------------------- the sync bug
+
+def test_fetch_app_actions_no_await_on_sync():
+    """_fetch_app_actions returns actions from a client whose get_app_actions
+    is a plain def (was: TypeError on `await`, swallowed per app)."""
+    client = _SyncClient()
+    svc = ComposioActionSyncService(db=object(), composio_client=client)
+    actions = _run(svc._fetch_app_actions("GITHUB"))
+    assert client.calls == ["GITHUB"]
+    assert [a.id for a in actions] == ["GITHUB_CREATE_ISSUE", "GITHUB_DELETE_REPOSITORY"]
+    assert all(a.app_id == "GITHUB" for a in actions)
+
+
+def test_client_method_stays_sync_and_service_offloads():
+    """The locked pick-ONE: the client method stays a synchronous def (every
+    other call site calls it synchronously) and the async service offloads
+    via asyncio.to_thread — no fake-async fork of the client."""
+    import modules.tools.sync.composio_action_sync as sync_mod
+
+    orch_root = Path(sync_mod.__file__).resolve().parents[3]
+    client_src = (orch_root / "core" / "composio" / "client.py").read_text()
+    assert "def get_app_actions(" in client_src
+    assert "async def get_app_actions(" not in client_src
+
+    sync_src = Path(sync_mod.__file__).read_text()
+    assert "asyncio.to_thread" in sync_src
+    assert "await self.composio_client.get_app_actions" not in sync_src
+
+
+def test_enabled_apps_are_connected_not_placeholder():
+    """_get_all_enabled_apps reflects the ACTIVE connection set, not the
+    hardcoded 8-app placeholder."""
+    db = _QueueDb([_Rows([("GITHUB",), ("SLACK",)])])
+    svc = ComposioActionSyncService(db=db, composio_client=None)
+    apps = _run(svc._get_all_enabled_apps())
+    assert apps == ["GITHUB", "SLACK"]
+
+    # And the placeholder is really gone from the source.
+    import modules.tools.sync.composio_action_sync as sync_mod
+
+    src = Path(sync_mod.__file__).read_text()
+    assert '"google_calendar"' not in src  # the old constant list's tell
+
+
+def test_enabled_apps_empty_when_nothing_connected():
+    db = _QueueDb([_Rows([])])
+    svc = ComposioActionSyncService(db=db, composio_client=None)
+    assert _run(svc._get_all_enabled_apps()) == []
+
+
+def test_sync_writes_metadata_rows():
+    """A sync_app run against a stubbed client writes ComposioActionMetadata
+    rows (was: 0 rows, TypeError per app)."""
+    db = _RecordingDb()
+    svc = ComposioActionSyncService(db=db, composio_client=_SyncClient())
+    result = _run(svc.sync_app("GITHUB"))
+
+    assert result.total_actions == 2
+    assert result.classified == 2
+    assert result.errors == 0
+    metadata_rows = [o for o in db.added if isinstance(o, ComposioActionMetadata)]
+    assert len(metadata_rows) == 2
+    assert db.commits >= 1
+    by_id = {m.action_id: m for m in metadata_rows}
+    assert by_id["GITHUB_DELETE_REPOSITORY"].app_id == "GITHUB"
+
+
+# ---------------------------------------------------------------- fail loud
+
+def test_empty_metadata_for_connected_apps_flags_loud():
+    """Connected apps + EMPTY metadata table ⇒ NOT ok (was: silent forever)."""
+    ok, detail = check_action_metadata_populated(
+        _QueueDb([_Rows([(1,)]), _Rows([])])  # a connection; no metadata
+    )
+    assert ok is False
+    assert "EMPTY" in detail
+
+
+def test_metadata_check_ok_on_cold_start_and_when_populated():
+    # No active connections — nothing to classify, not a failure.
+    ok, detail = check_action_metadata_populated(_QueueDb([_Rows([])]))
+    assert ok is True
+
+    # Connections + at least one metadata row — healthy.
+    ok, detail = check_action_metadata_populated(
+        _QueueDb([_Rows([(1,)]), _Rows([("GITHUB_CREATE_ISSUE",)])])
+    )
+    assert ok is True
+
+
+def test_sync_all_flags_failed_when_metadata_empty(monkeypatch):
+    """The daily job surfaces the assertion: status=failed + ERROR log when
+    connected apps exist but the table stayed empty (was: quiet 'completed')."""
+    import core.database.database as db_mod
+    import jobs.sync_composio_actions as jobs_mod
+    import modules.tools.sync as sync_pkg
+    import modules.tools.sync.composio_action_sync as sync_mod
+
+    class _Db:
+        def close(self):
+            pass
+
+    class _StubService:
+        def __init__(self, **kwargs):
+            pass
+
+        async def sync_all_enabled_apps(self):
+            return []
+
+    monkeypatch.setattr(db_mod, "SessionLocal", lambda: _Db())
+    monkeypatch.setattr(sync_pkg, "ComposioActionSyncService", _StubService)
+    monkeypatch.setattr(jobs_mod, "_get_composio_client", lambda: None)
+    monkeypatch.setattr(jobs_mod, "_get_llm_client", lambda: None)
+
+    monkeypatch.setattr(
+        sync_mod, "check_action_metadata_populated", lambda db: (False, "EMPTY sentinel")
+    )
+    result = _run(jobs_mod.sync_all_composio_actions())
+    assert result["status"] == "failed"
+    assert result["metadata_assertion"] == "EMPTY sentinel"
+
+    monkeypatch.setattr(
+        sync_mod, "check_action_metadata_populated", lambda db: (True, "populated")
+    )
+    result = _run(jobs_mod.sync_all_composio_actions())
+    assert result["status"] == "completed"
+    assert result["metadata_assertion"] == "populated"
+
+
+def test_scheduler_startup_check_logs_error(monkeypatch, caplog):
+    """The boot-time assertion says so at ERROR when the gate is blind —
+    logged, never raised (a stale table must not crash boot)."""
+    import core.database.database as db_mod
+    import modules.tools.sync.composio_action_sync as sync_mod
+    import services.composio_sync_scheduler as sched_mod
+
+    class _Db:
+        def close(self):
+            pass
+
+    monkeypatch.setattr(db_mod, "SessionLocal", lambda: _Db())
+    monkeypatch.setattr(
+        sync_mod, "check_action_metadata_populated", lambda db: (False, "gate is blind")
+    )
+    with caplog.at_level(logging.ERROR):
+        sched_mod.ComposioSyncScheduler._startup_metadata_check()
+    assert any("STARTUP ASSERTION FAILED" in r.message for r in caplog.records)
+
+    # And a healthy table logs info, no error — never raises either way.
+    caplog.clear()
+    monkeypatch.setattr(
+        sync_mod, "check_action_metadata_populated", lambda db: (True, "populated")
+    )
+    with caplog.at_level(logging.ERROR):
+        sched_mod.ComposioSyncScheduler._startup_metadata_check()
+    assert not any("STARTUP ASSERTION FAILED" in r.message for r in caplog.records)

--- a/orchestrator/tests/test_p2w2_cors_boot_guard.py
+++ b/orchestrator/tests/test_p2w2_cors_boot_guard.py
@@ -1,0 +1,118 @@
+"""PRD-194 S4 (P2-13, security §1.2.b) — widget CORS empty-allowlist boot guard.
+
+``api/widgets/cors.py`` allowed ALL origins when ``WIDGET_ORIGIN_ALLOWLIST``
+was unset — which is the default — and nothing enforced the docstring's "in
+production the env var should always be set". These tests pin the locked
+decision: **a saas boot with an empty widget allowlist ABORTS** (added to
+``config.validate_security``, the same hard-fail boot phase and posture as
+the ``SHOPIFY_INTERNAL_API_KEY`` and Clerk edition guards), while the
+``local`` edition keeps the permissive dev default — choosing
+``AUTH_EDITION=local`` is the explicit opt-in. Belt-and-braces: if the
+empty-allowlist state is ever reached in saas anyway, ``_origin_allowed``
+fails CLOSED instead of allow-all.
+
+Pure config-object tests — attributes are monkeypatched on the singleton
+(the established ``validate_*`` shape); no env reloads, no boot, no network.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("POSTGRES_USER", "test")
+os.environ.setdefault("POSTGRES_PASSWORD", "test")
+os.environ.setdefault("POSTGRES_HOST", "127.0.0.1")
+os.environ.setdefault("POSTGRES_PORT", "59432")
+os.environ.setdefault("POSTGRES_DB", "test")
+
+import pytest  # noqa: E402
+
+import tests.conftest as _conftest  # noqa: E402
+
+_conftest._restore_real_app_modules()
+
+from config import config as cfg  # noqa: E402
+
+
+@pytest.fixture()
+def _security_baseline(monkeypatch):
+    """Satisfy every OTHER validate_security check so the widget-allowlist
+    guard is the only variable under test."""
+    monkeypatch.setattr(cfg, "SHOPIFY_INTERNAL_API_KEY", "test-internal-key")
+    monkeypatch.setattr(cfg, "S3_VECTORS_ENABLED", False)
+    monkeypatch.setattr(cfg, "CLERK_JWKS_URL", "https://x/.well-known/jwks.json")
+    monkeypatch.setattr(cfg, "CLERK_SECRET_KEY", "sk_test")
+    monkeypatch.setattr(cfg, "DEFAULT_WORKSPACE_ID", "00000000-0000-0000-0000-0000000000aa")
+    return monkeypatch
+
+
+def test_saas_empty_widget_allowlist_aborts_boot(_security_baseline):
+    """AUTH_EDITION=saas + empty WIDGET_ORIGIN_ALLOWLIST ⇒ RuntimeError
+    (boot abort) — the public plane must never rest at allow-all in prod."""
+    mp = _security_baseline
+    mp.setattr(cfg, "AUTH_EDITION", "saas")
+    mp.setattr(cfg, "WIDGET_ORIGIN_ALLOWLIST", "")
+    with pytest.raises(RuntimeError) as ei:
+        cfg.validate_security()
+    assert "WIDGET_ORIGIN_ALLOWLIST" in str(ei.value)
+
+
+def test_saas_whitespace_allowlist_also_aborts(_security_baseline):
+    """A whitespace-only value is still 'unset' — no accidental pass."""
+    mp = _security_baseline
+    mp.setattr(cfg, "AUTH_EDITION", "saas")
+    mp.setattr(cfg, "WIDGET_ORIGIN_ALLOWLIST", "   ")
+    with pytest.raises(RuntimeError):
+        cfg.validate_security()
+
+
+def test_saas_with_allowlist_boots(_security_baseline):
+    mp = _security_baseline
+    mp.setattr(cfg, "AUTH_EDITION", "saas")
+    mp.setattr(
+        cfg, "WIDGET_ORIGIN_ALLOWLIST",
+        "https://inbuilduk.myshopify.com,https://app.automatos.app",
+    )
+    cfg.validate_security()  # must not raise
+
+
+def test_local_empty_allowlist_permitted(_security_baseline):
+    """The local edition keeps the permissive dev default — an empty
+    allowlist must NOT abort a local boot."""
+    mp = _security_baseline
+    mp.setattr(cfg, "AUTH_EDITION", "local")
+    mp.setattr(cfg, "WIDGET_ORIGIN_ALLOWLIST", "")
+    cfg.validate_security()  # must not raise
+
+
+# ---------------------------------------------------------------- runtime belt
+
+def test_cors_empty_allowlist_denies_in_saas(monkeypatch):
+    """If the empty-allowlist state is ever reached in saas (guard bypassed),
+    _origin_allowed fails CLOSED — never allow-all in production."""
+    import api.widgets.cors as cors_mod
+
+    monkeypatch.setattr(cors_mod, "WIDGET_ORIGIN_ALLOWLIST", set())
+    monkeypatch.setattr(cors_mod.config, "AUTH_EDITION", "saas")
+    assert cors_mod._origin_allowed("https://any-store.example") is False
+
+
+def test_cors_empty_allowlist_permits_in_local(monkeypatch):
+    import api.widgets.cors as cors_mod
+
+    monkeypatch.setattr(cors_mod, "WIDGET_ORIGIN_ALLOWLIST", set())
+    monkeypatch.setattr(cors_mod.config, "AUTH_EDITION", "local")
+    assert cors_mod._origin_allowed("https://any-store.example") is True
+
+
+def test_cors_configured_allowlist_still_authoritative(monkeypatch):
+    """A configured allowlist behaves identically in both editions."""
+    import api.widgets.cors as cors_mod
+
+    monkeypatch.setattr(
+        cors_mod, "WIDGET_ORIGIN_ALLOWLIST", {"https://app.automatos.app"}
+    )
+    for edition in ("saas", "local"):
+        monkeypatch.setattr(cors_mod.config, "AUTH_EDITION", edition)
+        assert cors_mod._origin_allowed("https://app.automatos.app") is True
+        assert cors_mod._origin_allowed("https://evil.example") is False

--- a/orchestrator/tests/test_p2w2_webhook_dedup.py
+++ b/orchestrator/tests/test_p2w2_webhook_dedup.py
@@ -1,0 +1,322 @@
+"""PRD-194 S2 (P2-13, security §1.1/§1.3.c) — webhook replay guard + event dedup.
+
+Until this change none of the three EXTERNAL webhook lanes (Composio
+``/webhook``, workspace ``/ws/{key}``, playbook ``/recipe/{id}``) rejected a
+redelivered event: a provider retry re-ran the same agent/playbook, burning
+tokens and re-firing side-effects. These tests pin the new contract:
+
+- the SAME event id delivered twice executes once — the redelivery is a
+  fast no-op ack (``status: duplicate``), nothing routed, nothing run;
+- a provider timestamp outside the skew window is a replay ⇒ 401;
+- Redis down ⇒ the guard fails OPEN for dedup (the lane keeps working,
+  loudly) — locked decision: availability beats replay protection when the
+  guard store is down;
+- the Shopify ``/events`` path (PRD-189 S3's debounce) is NOT routed
+  through this guard.
+
+Pure: hand-built Starlette Requests, a dict-backed fake Redis patched at the
+module boundary (``webhook_dedup._get_redis``), stub/poisoned DBs; no network,
+no live Redis, no real Composio.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("POSTGRES_USER", "test")
+os.environ.setdefault("POSTGRES_PASSWORD", "test")
+os.environ.setdefault("POSTGRES_HOST", "127.0.0.1")
+os.environ.setdefault("POSTGRES_PORT", "59432")
+os.environ.setdefault("POSTGRES_DB", "test")
+
+import asyncio  # noqa: E402
+import logging  # noqa: E402
+import time  # noqa: E402
+from pathlib import Path  # noqa: E402
+from types import SimpleNamespace  # noqa: E402
+from uuid import uuid4  # noqa: E402
+
+import pytest  # noqa: E402
+from fastapi import HTTPException  # noqa: E402
+from starlette.requests import Request  # noqa: E402
+
+import tests.conftest as _conftest  # noqa: E402
+
+_conftest._restore_real_app_modules()
+
+from api import composio as composio_api  # noqa: E402
+from api import webhooks as webhooks_api  # noqa: E402
+from api import workflow_recipes as recipes_api  # noqa: E402
+from services import webhook_dedup  # noqa: E402
+from config import config  # noqa: E402
+
+
+# ---------------------------------------------------------------- helpers
+
+def _make_request(headers: dict, body: bytes = b"{}") -> Request:
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/api/webhooks/test",
+        "headers": [(k.lower().encode(), str(v).encode()) for k, v in headers.items()],
+        "query_string": b"",
+    }
+
+    async def receive():
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    return Request(scope, receive)
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+class _FakeRedis:
+    """Dict-backed stand-in honouring the exact SET NX EX contract we use."""
+
+    def __init__(self):
+        self.store: dict = {}
+        self.last_ex = None
+
+    def set(self, key, value, nx=False, ex=None):
+        self.last_ex = ex
+        if nx and key in self.store:
+            return None  # redis-py returns None when NX blocks the write
+        self.store[key] = value
+        return True
+
+
+class _ExplodingRedis:
+    def set(self, *a, **kw):
+        raise ConnectionError("redis down")
+
+
+class _PoisonedDb:
+    """A DB the handler must never reach on the guarded paths."""
+
+    def query(self, *args, **kwargs):
+        raise AssertionError("db must not be touched on this path")
+
+
+class _StubQuery:
+    def __init__(self, single=None, many=None):
+        self._single = single
+        self._many = many or []
+
+    def filter(self, *args, **kwargs):
+        return self
+
+    def first(self):
+        return self._single
+
+    def all(self):
+        return self._many
+
+
+class _RoutingDb:
+    def __init__(self, workspace=None, channel_rows=None):
+        self._workspace = workspace
+        self._channel_rows = channel_rows or []
+
+    def query(self, model, *args, **kwargs):
+        if model.__name__ == "ChannelConnection":
+            return _StubQuery(many=self._channel_rows)
+        return _StubQuery(single=self._workspace)
+
+
+class _RecipeDb:
+    def __init__(self, recipe):
+        self._recipe = recipe
+
+    def query(self, *args, **kwargs):
+        return _StubQuery(single=self._recipe)
+
+    def add(self, obj):
+        raise AssertionError("no RecipeExecution may be created on a duplicate")
+
+
+def _fake_workspace(settings=None):
+    return SimpleNamespace(id=uuid4(), is_active=True, settings=settings or {})
+
+
+@pytest.fixture()
+def fake_redis(monkeypatch):
+    fake = _FakeRedis()
+    monkeypatch.setattr(webhook_dedup, "_get_redis", lambda: fake)
+    return fake
+
+
+# ---------------------------------------------------------------- unit: guard
+
+def test_seen_before_first_false_then_true(fake_redis):
+    """SETNX semantics: first delivery marks and passes, redelivery is seen."""
+    assert _run(webhook_dedup.seen_before("composio", "evt_1")) is False
+    assert _run(webhook_dedup.seen_before("composio", "evt_1")) is True
+    # marks self-expire with the configured TTL
+    assert fake_redis.last_ex == config.WEBHOOK_DEDUP_TTL_SECONDS
+    # a different lane is a different key — no cross-lane collision
+    assert _run(webhook_dedup.seen_before("recipe:whX", "evt_1")) is False
+
+
+def test_seen_before_without_event_id_is_noop(monkeypatch):
+    """No event id ⇒ nothing to dedup on ⇒ process (and never touch Redis)."""
+    monkeypatch.setattr(
+        webhook_dedup, "_get_redis",
+        lambda: (_ for _ in ()).throw(AssertionError("redis must not be touched")),
+    )
+    assert _run(webhook_dedup.seen_before("composio", None)) is False
+    assert _run(webhook_dedup.seen_before("composio", "")) is False
+
+
+def test_timestamp_skew_contract():
+    now = int(time.time())
+    assert webhook_dedup.timestamp_is_stale(str(now)) is False
+    assert webhook_dedup.timestamp_is_stale(None) is False  # no header → no check
+    assert webhook_dedup.timestamp_is_stale("") is False
+    stale = now - (config.WEBHOOK_TIMESTAMP_SKEW_SECONDS + 60)
+    assert webhook_dedup.timestamp_is_stale(str(stale)) is True
+    future = now + (config.WEBHOOK_TIMESTAMP_SKEW_SECONDS + 60)
+    assert webhook_dedup.timestamp_is_stale(str(future)) is True
+    # present-but-garbage timestamp fails closed
+    assert webhook_dedup.timestamp_is_stale("not-a-number") is True
+
+
+def test_redis_down_fails_open(monkeypatch, caplog):
+    """LOCKED DECISION: Redis unavailable ⇒ process the event, log loudly.
+
+    Availability of the lane beats replay protection when the guard store is
+    down — a cache outage must not brick webhook ingest.
+    """
+    monkeypatch.setattr(webhook_dedup, "_get_redis", lambda: None)
+    with caplog.at_level(logging.ERROR):
+        assert _run(webhook_dedup.seen_before("composio", "evt_9")) is False
+        assert _run(webhook_dedup.seen_before("composio", "evt_9")) is False
+    assert any("replay/dedup guard DOWN" in r.message for r in caplog.records)
+
+    monkeypatch.setattr(webhook_dedup, "_get_redis", lambda: _ExplodingRedis())
+    with caplog.at_level(logging.ERROR):
+        assert _run(webhook_dedup.seen_before("composio", "evt_9")) is False
+
+
+# ---------------------------------------------------------------- Composio lane
+
+def test_composio_replay_is_noop(monkeypatch, fake_redis):
+    """The same webhook-id delivered twice dispatches once; the redelivery is
+    a fast no-op ack (was: two full dispatches)."""
+    monkeypatch.setattr(composio_api.config, "COMPOSIO_WEBHOOK_SECRET", None)
+    headers = {"webhook-id": "wh_dup_1", "webhook-timestamp": str(int(time.time()))}
+
+    # First delivery passes the guard and gets processed (400: no trigger_name
+    # in the body — proof it went past dedup into the handler proper).
+    with pytest.raises(HTTPException) as ei:
+        _run(composio_api.handle_webhook(
+            request=_make_request(headers), x_composio_signature=None, db=_PoisonedDb()))
+    assert ei.value.status_code == 400
+
+    # Redelivery: fast no-op ack — no parse, no routing, no dispatch, no DB.
+    result = _run(composio_api.handle_webhook(
+        request=_make_request(headers), x_composio_signature=None, db=_PoisonedDb()))
+    assert result == {"status": "duplicate", "webhook_id": "wh_dup_1"}
+
+
+def test_stale_timestamp_rejected(monkeypatch, fake_redis):
+    """A webhook-timestamp older than the skew window ⇒ 401 (replay defence)."""
+    monkeypatch.setattr(composio_api.config, "COMPOSIO_WEBHOOK_SECRET", None)
+    stale = str(int(time.time()) - config.WEBHOOK_TIMESTAMP_SKEW_SECONDS - 120)
+    req = _make_request({"webhook-id": "wh_old", "webhook-timestamp": stale})
+    with pytest.raises(HTTPException) as ei:
+        _run(composio_api.handle_webhook(request=req, x_composio_signature=None, db=_PoisonedDb()))
+    assert ei.value.status_code == 401
+    # rejected replays must NOT consume a dedup slot
+    assert not fake_redis.store
+
+
+# ---------------------------------------------------------------- workspace lane
+
+def test_workspace_webhook_dedup_on_event_id(monkeypatch, fake_redis):
+    """A redelivered Telegram update_id does not re-run the agent."""
+    monkeypatch.setattr(webhooks_api.config, "WEBHOOK_SECRET", None)
+    ws = _fake_workspace()
+
+    async def _must_not_execute(*a, **kw):
+        raise AssertionError("agent must not execute on a duplicate")
+
+    monkeypatch.setattr(webhooks_api, "_execute_agent_sync", _must_not_execute)
+
+    # Simulate the first delivery having been accepted already.
+    fake_redis.store[f"webhook:dedup:ws:{ws.id}:4242"] = "1"
+
+    body = b'{"update_id": 4242, "message": {"chat": {"id": 7}, "text": "hi"}}'
+    req = _make_request({"content-type": "application/json"}, body=body)
+    result = _run(webhooks_api.general_workspace_webhook(
+        workspace_key="k", request=req, db=_RoutingDb(ws)))
+    assert result == {"status": "duplicate_ignored", "event_id": "4242"}
+
+
+def test_workspace_webhook_stale_timestamp_rejected(monkeypatch, fake_redis):
+    monkeypatch.setattr(webhooks_api.config, "WEBHOOK_SECRET", None)
+    ws = _fake_workspace()
+    stale = str(int(time.time()) - config.WEBHOOK_TIMESTAMP_SKEW_SECONDS - 120)
+    req = _make_request(
+        {"content-type": "application/json", "webhook-timestamp": stale},
+        body=b'{"update_id": 1}',
+    )
+    with pytest.raises(HTTPException) as ei:
+        _run(webhooks_api.general_workspace_webhook(
+            workspace_key="k", request=req, db=_RoutingDb(ws)))
+    assert ei.value.status_code == 401
+
+
+def test_workspace_dedup_scoped_per_workspace(fake_redis, monkeypatch):
+    """Telegram update_ids are only unique per bot — two workspaces must not
+    share a dedup slot for the same numeric id."""
+    ws_a, ws_b = uuid4(), uuid4()
+    assert _run(webhook_dedup.seen_before(f"ws:{ws_a}", "4242")) is False
+    assert _run(webhook_dedup.seen_before(f"ws:{ws_b}", "4242")) is False
+    assert _run(webhook_dedup.seen_before(f"ws:{ws_a}", "4242")) is True
+
+
+# ---------------------------------------------------------------- playbook lane
+
+def _fake_recipe():
+    return SimpleNamespace(
+        schedule_config={"webhook_id": "wh1"}, steps=[], name="r", workspace_id=uuid4()
+    )
+
+
+def test_recipe_webhook_dedup_is_noop(monkeypatch, fake_redis):
+    """A redelivered event id does not create a second RecipeExecution."""
+    monkeypatch.setattr(recipes_api.config, "WEBHOOK_SECRET", None)
+    headers = {"content-type": "application/json", "webhook-id": "evt_9"}
+
+    # First delivery passes the guard (400: recipe has no steps — past dedup).
+    with pytest.raises(HTTPException) as ei:
+        _run(recipes_api.recipe_webhook(
+            webhook_id="wh1", request=_make_request(headers), db=_RecipeDb(_fake_recipe())))
+    assert ei.value.status_code == 400
+
+    # Redelivery: no-op ack; _RecipeDb.add raises if an execution row is built.
+    result = _run(recipes_api.recipe_webhook(
+        webhook_id="wh1", request=_make_request(headers), db=_RecipeDb(_fake_recipe())))
+    assert result == {"status": "duplicate", "event_id": "evt_9"}
+
+
+def test_recipe_webhook_stale_timestamp_rejected(monkeypatch, fake_redis):
+    monkeypatch.setattr(recipes_api.config, "WEBHOOK_SECRET", None)
+    stale = str(int(time.time()) - config.WEBHOOK_TIMESTAMP_SKEW_SECONDS - 120)
+    req = _make_request(
+        {"content-type": "application/json", "webhook-timestamp": stale})
+    with pytest.raises(HTTPException) as ei:
+        _run(recipes_api.recipe_webhook(
+            webhook_id="wh1", request=req, db=_RecipeDb(_fake_recipe())))
+    assert ei.value.status_code == 401
+
+
+# ---------------------------------------------------------------- composition
+
+def test_dedup_does_not_touch_shopify_events():
+    """PRD-189 S3 owns the Shopify /events debounce — this guard must not be
+    wired into api/shopify.py (compose, do not collide)."""
+    shopify_src = Path(composio_api.__file__).parent.joinpath("shopify.py").read_text()
+    assert "webhook_dedup" not in shopify_src

--- a/orchestrator/tests/test_p2w2_webhook_signature_reject.py
+++ b/orchestrator/tests/test_p2w2_webhook_signature_reject.py
@@ -158,12 +158,17 @@ def test_composio_webhook_missing_signature_rejected_when_secret_set(monkeypatch
 
 
 def test_composio_webhook_valid_v3_signature_accepted(monkeypatch):
-    """A correctly signed request passes verification (fails later on 400, not 401)."""
+    """A correctly signed request passes verification (fails later on 400, not 401).
+
+    Timestamp is *fresh*: since PRD-194 S2 a stale provider timestamp is
+    rejected by the replay guard even when the signature verifies.
+    """
     monkeypatch.setattr(composio_api.config, "COMPOSIO_WEBHOOK_SECRET", _COMPOSIO_SECRET_B64)
     body = b"{}"  # no trigger_name → the handler 400s AFTER the signature gate
-    sig = _v3_signature(body, "wh_1", "1700000000", _COMPOSIO_SECRET_B64)
+    ts = str(int(time.time()))
+    sig = _v3_signature(body, "wh_1", ts, _COMPOSIO_SECRET_B64)
     req = _make_request(
-        {"webhook-signature": sig, "webhook-id": "wh_1", "webhook-timestamp": "1700000000"},
+        {"webhook-signature": sig, "webhook-id": "wh_1", "webhook-timestamp": ts},
         body=body,
     )
     with pytest.raises(HTTPException) as ei:

--- a/orchestrator/tests/test_p2w2_webhook_signature_reject.py
+++ b/orchestrator/tests/test_p2w2_webhook_signature_reject.py
@@ -1,0 +1,310 @@
+"""PRD-194 S1 (P2-13, security §1.1 CRITICAL) — webhook reject-on-signature-mismatch.
+
+Until this change, the external webhook lanes failed OPEN on signature
+problems: the Composio V3 block logged "allowing through for debugging" on a
+mismatch or a verification error, and both the workspace and the playbook
+(recipe) lanes silently skipped verification when the signature header was
+absent — so a configured secret bought nothing against an attacker who simply
+omitted the header. Slack inbound was never verifiable at all: no X-Slack-
+Signature scheme existed.
+
+These tests pin the fail-closed contract (the GitHub lane's semantics,
+`github_webhooks.py` — the in-tree template): **when a secret is configured,
+a valid signature is mandatory — mismatch, verification error, or missing
+header ⇒ 401 and nothing dispatches.** No secret configured keeps the
+URL-as-secret floor (unchanged posture).
+
+Pure: requests are hand-built Starlette Requests, the DB is a stub (poisoned
+where the handler must reject before ever touching it); no network, no real
+Composio, no live Slack.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("POSTGRES_USER", "test")
+os.environ.setdefault("POSTGRES_PASSWORD", "test")
+os.environ.setdefault("POSTGRES_HOST", "127.0.0.1")
+os.environ.setdefault("POSTGRES_PORT", "59432")
+os.environ.setdefault("POSTGRES_DB", "test")
+
+import asyncio  # noqa: E402
+import base64  # noqa: E402
+import hashlib  # noqa: E402
+import hmac  # noqa: E402
+import time  # noqa: E402
+from types import SimpleNamespace  # noqa: E402
+from uuid import uuid4  # noqa: E402
+
+import pytest  # noqa: E402
+from fastapi import HTTPException  # noqa: E402
+from starlette.requests import Request  # noqa: E402
+
+import tests.conftest as _conftest  # noqa: E402
+
+_conftest._restore_real_app_modules()
+
+from api import composio as composio_api  # noqa: E402
+from api import webhooks as webhooks_api  # noqa: E402
+from api import workflow_recipes as recipes_api  # noqa: E402
+
+
+# ---------------------------------------------------------------- helpers
+
+def _make_request(headers: dict, body: bytes = b"{}") -> Request:
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/api/webhooks/test",
+        "headers": [(k.lower().encode(), str(v).encode()) for k, v in headers.items()],
+        "query_string": b"",
+    }
+
+    async def receive():
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    return Request(scope, receive)
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+class _PoisonedDb:
+    """A DB the handler must never reach — rejection happens first."""
+
+    def query(self, *args, **kwargs):
+        raise AssertionError("db must not be touched when the signature is rejected")
+
+
+class _StubQuery:
+    def __init__(self, single=None, many=None):
+        self._single = single
+        self._many = many or []
+
+    def filter(self, *args, **kwargs):
+        return self
+
+    def first(self):
+        return self._single
+
+    def all(self):
+        return self._many
+
+
+class _RoutingDb:
+    """query(Model) routed by model name — workspace lookup + channel rows."""
+
+    def __init__(self, workspace=None, channel_rows=None):
+        self._workspace = workspace
+        self._channel_rows = channel_rows or []
+
+    def query(self, model, *args, **kwargs):
+        if model.__name__ == "ChannelConnection":
+            return _StubQuery(many=self._channel_rows)
+        return _StubQuery(single=self._workspace)
+
+
+def _fake_workspace(settings=None):
+    return SimpleNamespace(id=uuid4(), is_active=True, settings=settings or {})
+
+
+# ---------------------------------------------------------------- Composio V3
+
+_COMPOSIO_SECRET_B64 = base64.b64encode(b"composio-test-secret").decode()
+
+
+def _v3_signature(body: bytes, webhook_id: str, webhook_ts: str, secret_b64: str) -> str:
+    signed_content = f"{webhook_id}.{webhook_ts}.".encode() + body
+    digest = hmac.new(base64.b64decode(secret_b64), signed_content, hashlib.sha256).digest()
+    return "v1," + base64.b64encode(digest).decode()
+
+
+def test_composio_webhook_mismatch_rejected(monkeypatch):
+    """A V3 signature mismatch is a 401 and dispatches nothing (was: 200 + dispatch)."""
+    monkeypatch.setattr(composio_api.config, "COMPOSIO_WEBHOOK_SECRET", _COMPOSIO_SECRET_B64)
+    req = _make_request(
+        {
+            "webhook-signature": "v1,definitely-not-the-signature",
+            "webhook-id": "wh_1",
+            "webhook-timestamp": "1700000000",
+        },
+        body=b'{"type": "composio.trigger.message", "data": {}}',
+    )
+    with pytest.raises(HTTPException) as ei:
+        _run(composio_api.handle_webhook(request=req, x_composio_signature=None, db=_PoisonedDb()))
+    assert ei.value.status_code == 401
+
+
+def test_composio_webhook_verification_error_rejected(monkeypatch):
+    """A verification *error* (garbage headers) rejects too — no fail-open on exception."""
+    monkeypatch.setattr(composio_api.config, "COMPOSIO_WEBHOOK_SECRET", "%%% not base64 %%%")
+    req = _make_request(
+        {"webhook-signature": "v1,whatever", "webhook-id": "wh_1", "webhook-timestamp": "1"},
+    )
+    with pytest.raises(HTTPException) as ei:
+        _run(composio_api.handle_webhook(request=req, x_composio_signature=None, db=_PoisonedDb()))
+    assert ei.value.status_code == 401
+
+
+def test_composio_webhook_missing_signature_rejected_when_secret_set(monkeypatch):
+    """Secret configured + no signature header at all ⇒ 401 (was: no verification ran)."""
+    monkeypatch.setattr(composio_api.config, "COMPOSIO_WEBHOOK_SECRET", _COMPOSIO_SECRET_B64)
+    req = _make_request({}, body=b"{}")
+    with pytest.raises(HTTPException) as ei:
+        _run(composio_api.handle_webhook(request=req, x_composio_signature=None, db=_PoisonedDb()))
+    assert ei.value.status_code == 401
+
+
+def test_composio_webhook_valid_v3_signature_accepted(monkeypatch):
+    """A correctly signed request passes verification (fails later on 400, not 401)."""
+    monkeypatch.setattr(composio_api.config, "COMPOSIO_WEBHOOK_SECRET", _COMPOSIO_SECRET_B64)
+    body = b"{}"  # no trigger_name → the handler 400s AFTER the signature gate
+    sig = _v3_signature(body, "wh_1", "1700000000", _COMPOSIO_SECRET_B64)
+    req = _make_request(
+        {"webhook-signature": sig, "webhook-id": "wh_1", "webhook-timestamp": "1700000000"},
+        body=body,
+    )
+    with pytest.raises(HTTPException) as ei:
+        _run(composio_api.handle_webhook(request=req, x_composio_signature=None, db=_PoisonedDb()))
+    assert ei.value.status_code == 400  # missing trigger_name — proof the 401 gate passed
+
+
+# ---------------------------------------------------------------- workspace lane
+
+def test_workspace_webhook_hmac_mandatory_when_secret():
+    """Secret-configured workspace lane 401s when the signature header is absent."""
+    ws = _fake_workspace(settings={"webhook_secret": "topsecret"})
+    req = _make_request({"content-type": "application/json"}, body=b'{"message": "hi"}')
+    with pytest.raises(HTTPException) as ei:
+        _run(webhooks_api.general_workspace_webhook(workspace_key="k", request=req, db=_RoutingDb(ws)))
+    assert ei.value.status_code == 401
+
+
+def test_verify_webhook_signature_paths():
+    """Pure contract of the shared verifier: mandatory-when-secret, floor otherwise."""
+    secret = "topsecret"
+    body = b'{"x": 1}'
+    good = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+    # correct signature (with and without the GitHub sha256= prefix) passes
+    _run(webhooks_api._verify_webhook_signature(
+        _make_request({"x-webhook-signature": good}, body), secret))
+    _run(webhooks_api._verify_webhook_signature(
+        _make_request({"x-hub-signature-256": f"sha256={good}"}, body), secret))
+
+    # mismatch ⇒ 401
+    with pytest.raises(HTTPException):
+        _run(webhooks_api._verify_webhook_signature(
+            _make_request({"x-webhook-signature": "0" * 64}, body), secret))
+
+    # secret set + missing header ⇒ 401 (the deleted silent skip)
+    with pytest.raises(HTTPException):
+        _run(webhooks_api._verify_webhook_signature(_make_request({}, body), secret))
+
+    # no secret ⇒ no-op (URL-as-secret floor unchanged)
+    _run(webhooks_api._verify_webhook_signature(_make_request({}, body), None))
+
+
+# ---------------------------------------------------------------- Slack v0
+
+def _slack_headers(secret: str, body: bytes, ts: int) -> dict:
+    base = f"v0:{ts}:".encode() + body
+    sig = "v0=" + hmac.new(secret.encode(), base, hashlib.sha256).hexdigest()
+    return {"x-slack-signature": sig, "x-slack-request-timestamp": str(ts)}
+
+
+def test_slack_signature_verified():
+    """A valid X-Slack-Signature passes; an invalid one 401s."""
+    secret, body = "slack-signing-secret", b'{"type": "event_callback"}'
+    now = int(time.time())
+
+    _run(webhooks_api._verify_slack_signature(
+        _make_request(_slack_headers(secret, body, now), body), secret))
+
+    with pytest.raises(HTTPException) as ei:
+        _run(webhooks_api._verify_slack_signature(
+            _make_request(_slack_headers("wrong-secret", body, now), body), secret))
+    assert ei.value.status_code == 401
+
+
+def test_slack_signature_stale_or_garbage_timestamp_rejected():
+    secret, body = "slack-signing-secret", b"{}"
+    stale = int(time.time()) - 4000
+    with pytest.raises(HTTPException):
+        _run(webhooks_api._verify_slack_signature(
+            _make_request(_slack_headers(secret, body, stale), body), secret))
+
+    headers = _slack_headers(secret, body, int(time.time()))
+    headers["x-slack-request-timestamp"] = "not-a-number"
+    with pytest.raises(HTTPException):
+        _run(webhooks_api._verify_slack_signature(_make_request(headers, body), secret))
+
+
+def test_slack_lane_enforces_collected_signing_secret():
+    """A Slack-signed request to the workspace lane verifies against the
+    channel's collected signing secret — a mismatch 401s instead of skipping."""
+    ws = _fake_workspace()
+    row = SimpleNamespace(config={"signing_secret": "the-real-secret"}, status="active")
+    headers = _slack_headers("attacker-secret", b'{"message": "hi"}', int(time.time()))
+    headers["content-type"] = "application/json"
+    req = _make_request(headers, body=b'{"message": "hi"}')
+    with pytest.raises(HTTPException) as ei:
+        _run(webhooks_api.general_workspace_webhook(
+            workspace_key="k", request=req, db=_RoutingDb(ws, channel_rows=[row])))
+    assert ei.value.status_code == 401
+
+
+def test_resolve_slack_signing_secret_prefers_active_row():
+    ws = _fake_workspace()
+    inactive = SimpleNamespace(config={"signing_secret": "old"}, status="inactive")
+    active = SimpleNamespace(config={"signing_secret": "new"}, status="active")
+    db = _RoutingDb(ws, channel_rows=[inactive, active])
+    assert webhooks_api._resolve_slack_signing_secret(db, ws) == "new"
+    assert webhooks_api._resolve_slack_signing_secret(_RoutingDb(ws), ws) is None
+
+
+# ---------------------------------------------------------------- recipe lane
+
+def _fake_recipe(secret: str | None):
+    cfg = {"webhook_id": "wh1"}
+    if secret:
+        cfg["webhook_secret"] = secret
+    return SimpleNamespace(schedule_config=cfg, steps=[], name="r", workspace_id=uuid4())
+
+
+class _RecipeDb:
+    def __init__(self, recipe):
+        self._recipe = recipe
+
+    def query(self, *args, **kwargs):
+        return _StubQuery(single=self._recipe)
+
+
+def test_recipe_webhook_hmac_mandatory_when_secret():
+    """Secret-configured playbook lane 401s on a missing or invalid signature."""
+    recipe = _fake_recipe("recipe-secret")
+
+    req = _make_request({"content-type": "application/json"}, body=b"{}")
+    with pytest.raises(HTTPException) as ei:
+        _run(recipes_api.recipe_webhook(webhook_id="wh1", request=req, db=_RecipeDb(recipe)))
+    assert ei.value.status_code == 401
+
+    req = _make_request(
+        {"content-type": "application/json", "x-webhook-signature": "0" * 64}, body=b"{}")
+    with pytest.raises(HTTPException) as ei:
+        _run(recipes_api.recipe_webhook(webhook_id="wh1", request=req, db=_RecipeDb(recipe)))
+    assert ei.value.status_code == 401
+
+
+def test_recipe_webhook_valid_signature_accepted():
+    """A correctly signed request passes the gate (fails later on 400 no-steps, not 401)."""
+    recipe = _fake_recipe("recipe-secret")
+    body = b"{}"
+    good = hmac.new(b"recipe-secret", body, hashlib.sha256).hexdigest()
+    req = _make_request(
+        {"content-type": "application/json", "x-webhook-signature": good}, body=body)
+    with pytest.raises(HTTPException) as ei:
+        _run(recipes_api.recipe_webhook(webhook_id="wh1", request=req, db=_RecipeDb(recipe)))
+    assert ei.value.status_code == 400  # "Recipe has no steps" — past the signature gate

--- a/orchestrator/tests/test_p2w2_webhook_signature_reject.py
+++ b/orchestrator/tests/test_p2w2_webhook_signature_reject.py
@@ -256,6 +256,20 @@ def test_slack_lane_enforces_collected_signing_secret():
     assert ei.value.status_code == 401
 
 
+def test_slack_header_does_not_bypass_generic_hmac():
+    """S1 gap (P2-13): an x-slack-signature header with NO collected Slack
+    signing secret must not bypass the mandatory generic HMAC. Before this
+    fix the lane branched on the header alone — any caller could skip a
+    configured webhook_secret by adding a garbage Slack header."""
+    ws = _fake_workspace(settings={"webhook_secret": "topsecret"})
+    headers = {"content-type": "application/json", "x-slack-signature": "v0=garbage"}
+    req = _make_request(headers, body=b'{"message": "hi"}')
+    with pytest.raises(HTTPException) as ei:
+        _run(webhooks_api.general_workspace_webhook(
+            workspace_key="k", request=req, db=_RoutingDb(ws, channel_rows=[])))
+    assert ei.value.status_code == 401
+
+
 def test_resolve_slack_signing_secret_prefers_active_row():
     ws = _fake_workspace()
     inactive = SimpleNamespace(config={"signing_secret": "old"}, status="inactive")

--- a/orchestrator/tests/test_p2w2_widget_fail_closed.py
+++ b/orchestrator/tests/test_p2w2_widget_fail_closed.py
@@ -1,0 +1,207 @@
+"""PRD-194 S3 (P2-13, security §1.2.a F053 / §1.2.d F042) — widget auth fails closed.
+
+The storefront widget is the only surface exposed to arbitrary browsers, and
+its auth failed OPEN in two directions:
+
+1. **Origin-absent bypass** — an ``ak_pub_`` key (ships in page HTML by
+   design; its entire security model is the origin lock) validated from any
+   client that simply omitted ``Origin``/``Referer``. Now: public key with
+   no origin ⇒ **403**. Server keys are not origin-locked and are
+   unaffected; ``check_domain``'s merchant opt-in (empty ``allowed_domains``
+   = any origin) is unchanged.
+2. **Empty-permission god-key** — with the policy plane OFF (the default),
+   ``require_permission`` treated an empty permission list as unrestricted.
+   Now: **empty = deny regardless of the policy flag** — the internet-facing
+   plane is never the permissive one (P2-11 owns the platform-wide fix).
+
+Rollout note (locked decision): audit-first — Gerard audits live ``ak_pub_``
+usage for header-less callers before this deploys; an ``ak_srv_`` server key
+is the sanctioned path for any legitimate non-browser caller found.
+
+Pure: hand-built Starlette Requests, ``ApiKeyService.validate_api_key``
+stubbed at the class boundary, no DB, no network.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("POSTGRES_USER", "test")
+os.environ.setdefault("POSTGRES_PASSWORD", "test")
+os.environ.setdefault("POSTGRES_HOST", "127.0.0.1")
+os.environ.setdefault("POSTGRES_PORT", "59432")
+os.environ.setdefault("POSTGRES_DB", "test")
+
+import asyncio  # noqa: E402
+import sys  # noqa: E402
+from types import SimpleNamespace  # noqa: E402
+from uuid import uuid4  # noqa: E402
+
+import pytest  # noqa: E402
+from fastapi import HTTPException  # noqa: E402
+from starlette.requests import Request  # noqa: E402
+
+import tests.conftest as _conftest  # noqa: E402
+
+_conftest._restore_real_app_modules()
+
+import api.widgets.auth as widget_auth_mod  # noqa: E402
+from api.widgets.auth import WidgetAuthContext, require_permission, widget_auth  # noqa: E402
+
+
+# ---------------------------------------------------------------- helpers
+
+def _make_request(headers: dict) -> Request:
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/api/widgets/chat",
+        "headers": [(k.lower().encode(), str(v).encode()) for k, v in headers.items()],
+        "query_string": b"",
+    }
+
+    async def receive():
+        return {"type": "http.request", "body": b"{}", "more_body": False}
+
+    return Request(scope, receive)
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _key_record(
+    key_type="public",
+    allowed_domains=None,
+    permissions=None,
+):
+    return SimpleNamespace(
+        id=uuid4(),
+        workspace_id=uuid4(),
+        key_type=key_type,
+        key_prefix="ak_pub_a1b2" if key_type == "public" else "ak_srv_a1b2",
+        allowed_domains=allowed_domains,
+        permissions=permissions or [],
+        default_agent_id=None,
+        team=None,
+    )
+
+
+def _auth(monkeypatch, record, headers):
+    """Run widget_auth with validate_api_key stubbed to return *record*."""
+    monkeypatch.setattr(
+        widget_auth_mod.ApiKeyService, "validate_api_key", lambda db, token: record
+    )
+    base = {"Authorization": "Bearer ak_pub_testtoken"}
+    base.update(headers)
+    return _run(widget_auth(request=_make_request(base), db=object()))
+
+
+# ---------------------------------------------------------------- S3a: origin
+
+def test_public_key_denied_when_origin_absent(monkeypatch):
+    """An ak_pub_ key with no Origin/Referer header ⇒ 403 (was: validated)."""
+    record = _key_record(key_type="public", allowed_domains=["good.com"])
+    with pytest.raises(HTTPException) as ei:
+        _auth(monkeypatch, record, {})
+    assert ei.value.status_code == 403
+    assert "Origin required" in ei.value.detail
+
+
+def test_public_key_still_allowed_from_listed_origin(monkeypatch):
+    """No regression for the real browser path: listed origin still passes."""
+    record = _key_record(key_type="public", allowed_domains=["good.com"])
+    ctx = _auth(monkeypatch, record, {"Origin": "https://good.com"})
+    assert isinstance(ctx, WidgetAuthContext)
+    assert ctx.workspace_id == record.workspace_id
+    assert ctx.api_key_id == record.id
+
+
+def test_public_key_from_unlisted_origin_denied(monkeypatch):
+    """Existing deny direction unchanged: wrong origin is still a 403."""
+    record = _key_record(key_type="public", allowed_domains=["good.com"])
+    with pytest.raises(HTTPException) as ei:
+        _auth(monkeypatch, record, {"Origin": "https://evil.com"})
+    assert ei.value.status_code == 403
+
+
+def test_public_key_empty_domains_with_origin_allowed(monkeypatch):
+    """check_domain's merchant opt-in is NOT weakened: empty allowed_domains
+    still admits any *present* origin — the new deny is origin-ABSENT only."""
+    record = _key_record(key_type="public", allowed_domains=[])
+    ctx = _auth(monkeypatch, record, {"Origin": "https://anywhere.example"})
+    assert ctx.workspace_id == record.workspace_id
+
+
+def test_server_key_unaffected_by_missing_origin(monkeypatch):
+    """ak_srv_ keys are not origin-locked — no origin is fine for them."""
+    record = _key_record(key_type="server", allowed_domains=["good.com"])
+    ctx = _auth(monkeypatch, record, {})
+    assert ctx.workspace_id == record.workspace_id
+
+
+def test_unknown_key_type_treated_as_public(monkeypatch):
+    """A null/legacy key_type fails CLOSED (treated as origin-locked public)."""
+    record = _key_record(key_type=None)
+    with pytest.raises(HTTPException) as ei:
+        _auth(monkeypatch, record, {})
+    assert ei.value.status_code == 403
+
+
+def test_referer_counts_as_origin(monkeypatch):
+    """_extract_origin accepts Referer — a real browser path that sends only
+    Referer must keep working for public keys."""
+    record = _key_record(key_type="public", allowed_domains=["good.com"])
+    ctx = _auth(monkeypatch, record, {"Referer": "https://good.com/products/x"})
+    assert ctx.workspace_id == record.workspace_id
+
+
+# ---------------------------------------------------------------- S3b: perms
+
+def _ctx(permissions):
+    return WidgetAuthContext(
+        workspace_id=uuid4(), api_key_id=uuid4(), permissions=permissions
+    )
+
+
+def test_widget_empty_permission_denied():
+    """A widget key with permissions=[] is DENIED a permissioned route —
+    with the policy plane in its default (OFF) state (was: allow-all)."""
+    check = require_permission("chat")
+    with pytest.raises(HTTPException) as ei:
+        _run(check(auth=_ctx([])))
+    assert ei.value.status_code == 403
+
+
+def test_widget_granted_permission_allowed():
+    check = require_permission("chat")
+    ctx = _run(check(auth=_ctx(["chat"])))
+    assert isinstance(ctx, WidgetAuthContext)
+
+
+def test_widget_missing_permission_denied():
+    check = require_permission("data:execute")
+    with pytest.raises(HTTPException) as ei:
+        _run(check(auth=_ctx(["chat"])))
+    assert ei.value.status_code == 403
+
+
+def test_widget_explicit_wildcard_grants():
+    """An explicit '*' element is a deliberate grant (board-plane semantics),
+    not an omission — honoured on the widget plane too."""
+    check = require_permission("chat")
+    ctx = _run(check(auth=_ctx(["*"])))
+    assert isinstance(ctx, WidgetAuthContext)
+
+
+def test_empty_permission_denied_even_without_policy_module(monkeypatch):
+    """The deny does not depend on the policy package importing — empty is
+    denied by the local fallback too (deny regardless of the flag/plane)."""
+    monkeypatch.setitem(sys.modules, "modules.policy.roles", None)
+    check = require_permission("chat")
+    with pytest.raises(HTTPException) as ei:
+        _run(check(auth=_ctx([])))
+    assert ei.value.status_code == 403
+    # and explicit grants still work through the fallback
+    ctx = _run(check(auth=_ctx(["chat"])))
+    assert isinstance(ctx, WidgetAuthContext)

--- a/orchestrator/tests/test_p2w2_widget_rate_limit.py
+++ b/orchestrator/tests/test_p2w2_widget_rate_limit.py
@@ -1,0 +1,311 @@
+"""PRD-194 S5 (P2-13, security §1.2.c) — Redis-backed shared widget rate limiter.
+
+The previous ``RateLimitStore`` was a per-process in-memory dict: it reset on
+every deploy, each of the 4 uvicorn workers kept its own window, and by its
+own docstring the check was "only active when the key ID is already known".
+This is the widget dossier's one sanctioned internal REPLACE (§E, §J-5): the
+in-memory window is DELETED and the store is a Redis sorted-set sliding
+window (the ``core/security/rate_limiter.py`` idiom, via the platform Redis
+client), so:
+
+- the window is **shared across workers** (two store instances on one Redis
+  see one window);
+- the identifier is resolved **pre-handler** — the FIRST request is gated,
+  keyed on the presented key (hashed) or the client IP;
+- the two money-spending endpoints (``/chat``, ``/callback``) carry a
+  **per-IP ceiling that applies even when a key is presented**;
+- **Redis down ⇒ fail OPEN, loudly** (locked decision) — a cache outage
+  must not brick the widget, and must not stay silent (counter + ERROR log).
+
+Pure: dict-backed fake Redis injected via the store's ``redis_factory`` seam;
+full ASGI middleware invocations with a recording downstream app. No live
+Redis, no network.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("POSTGRES_USER", "test")
+os.environ.setdefault("POSTGRES_PASSWORD", "test")
+os.environ.setdefault("POSTGRES_HOST", "127.0.0.1")
+os.environ.setdefault("POSTGRES_PORT", "59432")
+os.environ.setdefault("POSTGRES_DB", "test")
+
+import asyncio  # noqa: E402
+import json  # noqa: E402
+import logging  # noqa: E402
+import time  # noqa: E402
+from pathlib import Path  # noqa: E402
+
+import pytest  # noqa: E402
+
+import tests.conftest as _conftest  # noqa: E402
+
+_conftest._restore_real_app_modules()
+
+import api.widgets.rate_limit as rl_mod  # noqa: E402
+from api.widgets.rate_limit import RateLimitStore, WidgetRateLimitMiddleware  # noqa: E402
+from config import config  # noqa: E402
+
+
+# ---------------------------------------------------------------- fake redis
+
+class _FakePipeline:
+    def __init__(self, r):
+        self._r = r
+        self._ops = []
+
+    def __getattr__(self, name):
+        def _queue(*args, **kwargs):
+            self._ops.append((name, args, kwargs))
+            return self
+
+        return _queue
+
+    def execute(self):
+        return [getattr(self._r, name)(*args, **kwargs) for name, args, kwargs in self._ops]
+
+
+class _FakeRedis:
+    """Dict-backed sorted-set subset honouring exactly the commands we use."""
+
+    def __init__(self):
+        self.z: dict[str, dict[str, float]] = {}
+
+    def zremrangebyscore(self, key, mn, mx):
+        d = self.z.get(key, {})
+        mn_f = float("-inf") if mn in ("-inf",) else float(mn)
+        mx_f = float(mx)
+        doomed = [m for m, s in d.items() if mn_f <= s <= mx_f]
+        for m in doomed:
+            d.pop(m)
+        return len(doomed)
+
+    def zcard(self, key):
+        return len(self.z.get(key, {}))
+
+    def zrange(self, key, start, end, withscores=False):
+        items = sorted(self.z.get(key, {}).items(), key=lambda kv: kv[1])
+        sel = items[start:] if end == -1 else items[start:end + 1]
+        return sel if withscores else [m for m, _ in sel]
+
+    def zadd(self, key, mapping):
+        self.z.setdefault(key, {}).update(mapping)
+        return len(mapping)
+
+    def expire(self, key, ttl):
+        return True
+
+    def pipeline(self):
+        return _FakePipeline(self)
+
+
+class _PoisonedRedis:
+    def pipeline(self):
+        raise AssertionError("redis must not be touched for this path")
+
+
+def _prime(fake: _FakeRedis, identifier: str, n: int):
+    """Fill *identifier*'s window with n fresh marks (as other workers would)."""
+    now = time.time()
+    key = f"widget:rl:{identifier}"
+    for i in range(n):
+        fake.zadd(key, {f"prime-{i}": now - 0.001 * i})
+
+
+# ---------------------------------------------------------------- ASGI rig
+
+class _App:
+    def __init__(self):
+        self.calls: list[str] = []
+
+    async def __call__(self, scope, receive, send):
+        self.calls.append(scope["path"])
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"{}"})
+
+
+def _mw(app, fake_redis):
+    return WidgetRateLimitMiddleware(app, store=RateLimitStore(redis_factory=lambda: fake_redis))
+
+
+async def _call(mw, path, headers=None, method="POST", client=("9.9.9.9", 1234)):
+    scope = {
+        "type": "http",
+        "method": method,
+        "path": path,
+        "headers": [(k.lower().encode(), str(v).encode()) for k, v in (headers or {}).items()],
+        "query_string": b"",
+        "client": client,
+    }
+    sent: list[dict] = []
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(message):
+        sent.append(message)
+
+    await mw(scope, receive, send)
+    return sent
+
+
+def _status(sent):
+    return next(m["status"] for m in sent if m["type"] == "http.response.start")
+
+
+def _headers(sent):
+    start = next(m for m in sent if m["type"] == "http.response.start")
+    return {k.decode(): v.decode() for k, v in start.get("headers", [])}
+
+
+# ---------------------------------------------------------------- store
+
+def test_rate_limit_shared_across_workers():
+    """Two limiter instances on ONE Redis share the window — the property the
+    deleted in-memory dict could never have."""
+    fake = _FakeRedis()
+    worker_a = RateLimitStore(redis_factory=lambda: fake)
+    worker_b = RateLimitStore(redis_factory=lambda: fake)
+
+    assert worker_a.check("key:shared", 3)[0] is True
+    assert worker_b.check("key:shared", 3)[0] is True
+    assert worker_a.check("key:shared", 3)[0] is True
+    # Fourth request — made by the OTHER worker — is denied: shared state.
+    allowed, limit, remaining, reset = worker_b.check("key:shared", 3)
+    assert allowed is False
+    assert remaining == 0
+    assert reset >= 1
+
+
+def test_rate_limit_window_slides():
+    """Marks older than the window are dropped before counting."""
+    fake = _FakeRedis()
+    store = RateLimitStore(redis_factory=lambda: fake)
+    window = config.WIDGET_RATE_LIMIT_WINDOW_SECONDS
+    stale = time.time() - window - 5
+    fake.zadd("widget:rl:ip:1.2.3.4", {f"old-{i}": stale for i in range(50)})
+    allowed, _, remaining, _ = store.check("ip:1.2.3.4", 2)
+    assert allowed is True  # the 50 stale marks were evicted, not counted
+    assert remaining == 1
+
+
+def test_limiter_degrades_open_on_redis_down(monkeypatch, caplog):
+    """LOCKED DECISION: Redis unreachable ⇒ allow, count, log ERROR — the
+    widget must not brick on a cache outage, and the outage must be loud."""
+    store = RateLimitStore(redis_factory=lambda: None)
+    before = rl_mod.get_redis_failure_count()
+    with caplog.at_level(logging.ERROR):
+        allowed, limit, remaining, reset = store.check("key:x", 5)
+    assert allowed is True
+    assert rl_mod.get_redis_failure_count() == before + 1
+    assert any("FAIL-OPEN" in r.message for r in caplog.records)
+
+    class _Exploding:
+        def pipeline(self):
+            raise ConnectionError("redis down")
+
+    store2 = RateLimitStore(redis_factory=lambda: _Exploding())
+    assert store2.check("key:x", 5)[0] is True
+    assert rl_mod.get_redis_failure_count() == before + 2
+
+
+# ---------------------------------------------------------------- middleware
+
+def test_rate_limit_gates_first_request_by_ip():
+    """A request with NO api key is limited by client_ip on its FIRST hit —
+    the old middleware only checked once a key id was already known."""
+    fake = _FakeRedis()
+    _prime(fake, "ip:9.9.9.9", config.WIDGET_RATE_LIMIT_PUBLIC_PER_WINDOW)
+    app = _App()
+    sent = asyncio.run(_call(_mw(app, fake), "/api/widgets/config"))
+    assert _status(sent) == 429
+    assert app.calls == []  # never reached the handler
+    body = json.loads(next(m["body"] for m in sent if m["type"] == "http.response.body"))
+    assert body["detail"] == "Rate limit exceeded"
+    assert "retry-after" in _headers(sent)
+
+
+def test_allowed_request_passes_with_headers():
+    fake = _FakeRedis()
+    app = _App()
+    sent = asyncio.run(_call(_mw(app, fake), "/api/widgets/config",
+                             headers={"Authorization": "Bearer ak_pub_abc123"}))
+    assert _status(sent) == 200
+    assert app.calls == ["/api/widgets/config"]
+    h = _headers(sent)
+    assert h["x-ratelimit-limit"] == str(config.WIDGET_RATE_LIMIT_PUBLIC_PER_WINDOW)
+    assert int(h["x-ratelimit-remaining"]) >= 0
+    assert int(h["x-ratelimit-reset"]) >= 1
+
+
+def test_key_identifier_is_hashed_not_raw():
+    """No key material in Redis: the bucket key is a SHA-256 digest."""
+    fake = _FakeRedis()
+    app = _App()
+    token = "ak_pub_supersecrettoken"
+    asyncio.run(_call(_mw(app, fake), "/api/widgets/config",
+                      headers={"Authorization": f"Bearer {token}"}))
+    assert fake.z, "a window key must have been created"
+    assert all(token not in k for k in fake.z)
+
+
+def test_callback_per_ip_ceiling():
+    """The callback endpoint rejects over-ceiling per-IP EVEN with a valid
+    key presented (was: per-IP explicitly deferred until Redis)."""
+    fake = _FakeRedis()
+    _prime(fake, "ipceil:callback:9.9.9.9", config.WIDGET_CALLBACK_IP_LIMIT_PER_WINDOW)
+    app = _App()
+    sent = asyncio.run(_call(_mw(app, fake), "/api/widgets/callback",
+                             headers={"Authorization": "Bearer ak_pub_abc123"}))
+    assert _status(sent) == 429
+    assert app.calls == []
+
+
+def test_chat_per_ip_ceiling():
+    fake = _FakeRedis()
+    _prime(fake, "ipceil:chat:9.9.9.9", config.WIDGET_CHAT_IP_LIMIT_PER_WINDOW)
+    app = _App()
+    sent = asyncio.run(_call(_mw(app, fake), "/api/widgets/chat",
+                             headers={"Authorization": "Bearer ak_pub_abc123"}))
+    assert _status(sent) == 429
+    assert app.calls == []
+
+
+def test_non_money_endpoint_has_no_ip_ceiling():
+    """Other widget endpoints carry only the per-key/per-IP base limit — a
+    keyed request under its key limit passes even from a hot IP."""
+    fake = _FakeRedis()
+    _prime(fake, "ipceil:chat:9.9.9.9", 10_000)  # irrelevant to /config
+    app = _App()
+    sent = asyncio.run(_call(_mw(app, fake), "/api/widgets/config",
+                             headers={"Authorization": "Bearer ak_pub_abc123"}))
+    assert _status(sent) == 200
+
+
+def test_non_widget_paths_untouched():
+    app = _App()
+    mw = WidgetRateLimitMiddleware(app, store=RateLimitStore(redis_factory=lambda: _PoisonedRedis()))
+    sent = asyncio.run(_call(mw, "/api/agents"))
+    assert _status(sent) == 200
+    assert app.calls == ["/api/agents"]
+    assert "x-ratelimit-limit" not in _headers(sent)
+
+
+def test_options_preflight_passes_ungated():
+    app = _App()
+    mw = WidgetRateLimitMiddleware(app, store=RateLimitStore(redis_factory=lambda: _PoisonedRedis()))
+    sent = asyncio.run(_call(mw, "/api/widgets/chat", method="OPTIONS"))
+    assert _status(sent) == 200
+
+
+# ---------------------------------------------------------------- REPLACE pin
+
+def test_in_memory_window_is_gone():
+    """The dossier's sanctioned REPLACE (§E, §J-5): the per-process dict is
+    DELETED, not left mounted beside the Redis store (CLAUDE.md §5)."""
+    src = Path(rl_mod.__file__).read_text()
+    assert "defaultdict" not in src
+    assert "from threading import Lock" not in src
+    assert "core/redis/client.py" in src  # the shared store is the Redis one

--- a/orchestrator/tests/test_prd008a_cors_coverage.py
+++ b/orchestrator/tests/test_prd008a_cors_coverage.py
@@ -58,18 +58,22 @@ def test_path_is_covered_excludes_unrelated_paths():
     assert _path_is_covered("/api/some-other-resource/sites") is False
 
 
-def test_origin_allowed_when_no_allowlist_configured():
-    """Empty allowlist → permissive — matches the documented default."""
+def test_origin_allowed_when_no_allowlist_configured(monkeypatch):
+    """Empty allowlist → permissive ONLY in the local edition (PRD-194 S4 /
+    P2-13). In saas the boot guard forbids the state; if reached anyway the
+    public plane fails CLOSED."""
     from api.widgets.cors import _origin_allowed
     import api.widgets.cors as cors_mod
 
-    original = cors_mod.WIDGET_ORIGIN_ALLOWLIST
-    cors_mod.WIDGET_ORIGIN_ALLOWLIST = set()
-    try:
-        assert _origin_allowed("https://random-store.myshopify.com") is True
-        assert _origin_allowed("https://app.automatos.app") is True
-    finally:
-        cors_mod.WIDGET_ORIGIN_ALLOWLIST = original
+    monkeypatch.setattr(cors_mod, "WIDGET_ORIGIN_ALLOWLIST", set())
+
+    monkeypatch.setattr(cors_mod.config, "AUTH_EDITION", "local")
+    assert _origin_allowed("https://random-store.myshopify.com") is True
+    assert _origin_allowed("https://app.automatos.app") is True
+
+    monkeypatch.setattr(cors_mod.config, "AUTH_EDITION", "saas")
+    assert _origin_allowed("https://random-store.myshopify.com") is False
+    assert _origin_allowed("https://app.automatos.app") is False
 
 
 def test_origin_allowed_with_explicit_allowlist():


### PR DESCRIPTION
> [!IMPORTANT]
> **Stacked on #530 — merge #530 first; this PR's diff then reduces to S2–S6** (+ one small S1-gap commit). The branch is deliberately based on `fix/p2w2-webhook-signature-reject` (PR #530, S1 pull-forward, CI green); this repo merges with merge commits, so the diff self-cleans once #530 lands.

Builds **PRD-194** (`docs/PRDS/PRD-194-PHASE2-WAVE-2-UNTRUSTED-EDGES.md`) — the **P2-13** leg of Wave 2: arm the three untrusted edges (webhooks, storefront widget, Composio action lane) so each fails **closed** in its resting state. Security appendix §1.1 (CRITICAL), §1.2 (HIGH), §1.4.a (HIGH).

## Story-by-story

### S1 · Webhook reject-on-mismatch — **already in PR #530** (verified, not re-implemented)
Verified #530 against the PRD's S1 spec: Composio V3 mismatch/error/missing-header ⇒ 401; workspace + playbook lanes HMAC mandatory-when-secret (silent skips deleted); Slack v0 scheme implemented against the collected `signing_secret`; GitHub lane untouched; no debug bypass; 12 pure tests. **One genuine gap found and fixed on top** (`3d80e54f3`): the workspace lane branched on the *presence* of `x-slack-signature` alone — a caller could bypass a configured `webhook_secret` by sending a garbage Slack header when no Slack signing secret was collected. The Slack branch is now taken only when a collected secret actually resolves; otherwise the generic mandatory-when-secret HMAC applies.

### S2 · Replay guard + event dedup on the three external lanes (`22b713bbd`)
- New `services/webhook_dedup.py`: Redis `SET NX EX` dedup on the provider's event id, keyed per-lane (`composio` | `ws:{workspace_id}` | `recipe:{webhook_id}` — per-connection ids like Telegram `update_id` can't collide across tenants), + timestamp-skew reject where a provider timestamp exists (`webhook-timestamp`; on the Composio lane the timestamp is inside the signed content, so a captured valid-signature replay still carries its original, now-stale timestamp ⇒ 401).
- Wired at the three ingest points: `api/composio.py` (before parse/routing), `api/webhooks.py` (before routing/`_execute_agent_sync`), `api/workflow_recipes.py` (before the `RecipeExecution` row). A redelivery is a **fast no-op ack**.
- **Locked decision applied:** Redis SETNX + TTL reusing `core/redis/client.py` — **no new table, no migration**. **Redis down ⇒ fail OPEN for dedup** (process the event, ERROR log) — lane availability beats replay protection when the guard store is down; stated in code and pinned by test.
- Marks are written on arrival, not on success — marking after success would reopen the exact double-execute window this closes.
- **Does NOT touch the Shopify `/events` path** (PRD-189 S3 owns that debounce) — pinned by `test_dedup_does_not_touch_shopify_events`.
- Config: `WEBHOOK_DEDUP_TTL_SECONDS` (3600) / `WEBHOOK_TIMESTAMP_SKEW_SECONDS` (300, mirrors Slack's v0 window).

### S3 · Widget auth fails closed both ways (`7dc510489`)
- `api/widgets/auth.py`: an `ak_pub_` key with **no `Origin`/`Referer` ⇒ 403** (public keys ship in page HTML; the origin lock IS their security model). Server keys unaffected; unknown/legacy `key_type` fails closed as public; `check_domain`'s merchant opt-in (empty `allowed_domains` = any *present* origin) unchanged.
- `require_permission`: the flag-gated legacy branch (empty list = unrestricted god-key) is **deleted** — **empty = deny regardless of the policy flag**, via the shared `modules/policy/roles.has_permission` least-privilege rule (explicit membership or a deliberate `"*"`). P2-11 remains the durable platform-wide fix.

> **S3 rollout sequencing (locked decision — audit-first):** Gerard audits live `ak_pub_` usage for header-less callers **before this deploys**. No `ak_srv_` server key is built in this PR — it gets built only if that audit finds a legitimate non-browser caller who needs the sanctioned path.

### S4 · Widget CORS: empty allowlist aborts a saas boot (`a59f80cbe`)
- **Locked decision applied (boot-abort, not loud-degrade):** `config.validate_security` (already in the hard-fail boot phase, `main.py:178`) now fails a **saas** boot when `WIDGET_ORIGIN_ALLOWLIST` is empty — same pattern as the `SHOPIFY_INTERNAL_API_KEY` and Clerk edition guards. `local` keeps the permissive dev default (`AUTH_EDITION=local` is the explicit opt-in).
- Belt-and-braces: `_origin_allowed` fails **closed** (deny + ERROR log) if the empty-allowlist state is ever reached in saas anyway.
- ⚠️ **Deploy note:** the saas Railway service must have `WIDGET_ORIGIN_ALLOWLIST` set **before** this deploys, or boot aborts — that is the chosen posture.
- Repointed guards whose assumptions changed (same commit): `test_prd008a_cors_coverage` (permissiveness now edition-gated) and the two `test_prd172_tenant_isolation` validate_security pass-cases (now satisfy the allowlist so they stay scoped to Shopify/S3).

### S5 · Redis-backed shared widget rate limiter — REPLACE (`0cb985a17`)
- The in-memory per-process window (`defaultdict` + `Lock`) is **deleted in the same commit** and replaced by a Redis sorted-set sliding window — the `core/security/rate_limiter.py` idiom — via the existing `core/redis/client.py` + `config.REDIS_URL` (no new dependency).
- Identifier resolved **pre-handler** so the **first** request is gated: SHA-256 digest of the presented key (no key material in Redis keys) or `client_ip` fallback. Shared across all 4 workers.
- **Per-IP ceiling on both money-spending endpoints** (`/api/widgets/chat`, `/api/widgets/callback`) that applies **even when a key is presented** — a scraped public key replayed from one box hits the IP ceiling regardless of the key's budget. Closes `services/callback.py`'s "per-IP deferred until Redis" note (comments repointed).
- **Redis down ⇒ fail OPEN, loudly** (locked decision): counter + ERROR log per ungated request — a cache outage must not brick the widget and must not stay silent. Pinned by test.
- Ceilings/windows are config constants (`WIDGET_RATE_LIMIT_*`, `WIDGET_CHAT_IP_LIMIT_PER_WINDOW`=30/min, `WIDGET_CALLBACK_IP_LIMIT_PER_WINDOW`=10/min).

### S6 · Destructive-gate feeder fixed + fail-loud assertion (`43b3e37dd`)
- `_get_all_enabled_apps`: the hardcoded 8-app placeholder is gone — queries distinct `composio_connections.app_name` where `status='active'` (uppercase, matching every other `get_app_actions` call site).
- `_fetch_app_actions`: the `await` on the synchronous client method (the per-app `TypeError` swallowed for months) is fixed **honestly, one way**: the client method **stays sync** (all other call sites are sync) and the service offloads via `asyncio.to_thread` — the in-tree idiom (`core/composio/tool_executor.py`). Pinned by test that the client has no fake-async fork.
- Fail-loud: `check_action_metadata_populated(db)` — connected apps + empty `composio_action_metadata` ⇒ the daily job's result becomes `status=failed` + ERROR log (was: quiet "completed" no-op), and `ComposioSyncScheduler.start()` runs the same assertion at boot (ERROR log, never raises — a stale table degrades to the fail-closed keyword floor, which is untouched).

## Locked decisions applied (Gerard's calls, from the PRD's open-questions box)
1. **S4 posture:** boot-abort in saas ✅ (loud-degrade kept only as the unreachable-state belt).
2. **S3 rollout:** audit-first; no `ak_srv_` minting surface built ✅.
3. **S2 store:** Redis SETNX + TTL, no table/migration; Redis-down = fail-open-for-dedup, loud ✅.
4. **§1.4.b chat-shortcut chokepoint:** not touched — PRD-192 (#533) owns it ✅.
5. **Channels §1.3.a/§1.3.b:** not built — tracked as the separate channels-trust PRD ✅.

## Verification (CI is the only gate — no local runs)
71 new/updated **pure** tests across 5 suites (`test_p2w2_webhook_dedup.py`, `test_p2w2_widget_fail_closed.py`, `test_p2w2_cors_boot_guard.py`, `test_p2w2_widget_rate_limit.py`, `test_p2w2_composio_feeder.py` + additions to #530's `test_p2w2_webhook_signature_reject.py`). All mock at the boundary: dict-backed fake Redis, hand-built Starlette Requests, poisoned/stub DB sessions, plain-`def` stub Composio client. No live Redis/DB/network anywhere.

Notes for reviewers:
- **No new routes**; the committed `orchestrator/reports/route-manifest.json` is byte-identical to main.
- `git merge-tree` verified conflict-free against `origin/feat/p2-w2-policy-plane` (#533) and `origin/feat/p2-w2-approve-resume` (#531) after every story.
- PRD file:line refs were grounded @ `d26ce039d`; the only drift found: `rate_limit.py` had already become a pure-ASGI middleware with pre-handler identifier extraction (the PRD described the older in-handler shape) — the store was still in-memory/per-process, which is what S5 replaces; and `validate_security` sits at config.py:1120 (±15 lines from the cited :1105).
- One S2 side-effect on #530's suite: `test_composio_webhook_valid_v3_signature_accepted` used a hardcoded 2023 timestamp — now stale **by design** under the replay guard; repointed to a fresh timestamp in the S2 commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Strengthened webhook signature validation, replay protection, and duplicate-event handling across supported integrations.
  * Added Slack signature verification with timestamp checks.
  * Public widget API keys now require an approved origin; permissions default to deny without explicit grants.
  * SaaS deployments now fail closed when no widget origin allowlist is configured.

* **Reliability**
  * Added shared Redis-backed widget rate limiting with hashed credentials and per-IP protections.
  * Improved Composio synchronization checks and failure reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->