### PR TITLE
feat(prd-202): adopt the Agent Skills open standard — trigger-based L2 activation + L3 worker execution

### DIFF
--- a/orchestrator/alembic/versions/prd202_s1_skill_l1_trigger_backfill.py
+++ b/orchestrator/alembic/versions/prd202_s1_skill_l1_trigger_backfill.py
@@ -1,0 +1,58 @@
+"""PRD-202 S1 (P2-21) — persist each skill's description as its L1 trigger text
+
+The Agent Skills open standard loads a skill's ``name`` + ``description`` on
+every turn (L1), and its body only when the ``description`` matches the task
+(L2 on trigger). For that to work the ``description`` must live where the L1
+loader reads it — ``skill_metadata`` (the JSONB the loader treats as L1) — not
+only on the ``description`` column.
+
+This is a pure, idempotent DATA backfill: for every skill that has a
+``description`` but whose ``skill_metadata`` lacks a ``description`` key, copy it
+in. It writes no schema and touches no ``skill_source`` string — the canonical
+provenance scheme (:mod:`modules.agents.services.skill_source_scheme`) *resolves*
+legacy values at read time, so no risky reshape of the overloaded git join key
+is needed here (that repair is the Q3 data-pass, Gerard's cadence call).
+
+Chain: onto the mainline tip ``prd196_audit_logs_ws_created_idx`` (which already
+carries PRD-191's agent_skills unique/priority work — untouched here). The
+deploy entrypoint runs ``alembic upgrade heads`` on boot, so this self-applies.
+
+Revision ID: prd202_s1_skill_l1_trigger_backfill
+Revises: prd196_audit_logs_ws_created_idx
+Create Date: 2026-07-14
+"""
+from alembic import op
+
+revision = "prd202_s1_skill_l1_trigger_backfill"
+down_revision = "prd196_audit_logs_ws_created_idx"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Postgres JSONB: seed skill_metadata.description from the description column
+    # wherever it is missing. jsonb_set on a coalesced '{}' handles NULL metadata.
+    op.execute(
+        """
+        UPDATE skills
+        SET skill_metadata = jsonb_set(
+            COALESCE(skill_metadata, '{}'::jsonb),
+            '{description}',
+            to_jsonb(description),
+            true
+        )
+        WHERE description IS NOT NULL
+          AND description <> ''
+          AND (
+            skill_metadata IS NULL
+            OR NOT (skill_metadata ? 'description')
+            OR COALESCE(skill_metadata->>'description', '') = ''
+          )
+        """
+    )
+
+
+def downgrade() -> None:
+    # Data-only enrichment; nothing structural to reverse. The L1 loader also
+    # falls back to the description column, so a downgrade is a no-op.
+    pass

--- a/orchestrator/config.py
+++ b/orchestrator/config.py
@@ -553,6 +553,23 @@ class Config:
     WORKER_INTERNAL_URL: str = os.getenv("WORKER_INTERNAL_URL", "http://localhost:8081")
     WORKER_INTERNAL_TOKEN: str = os.getenv("WORKER_INTERNAL_TOKEN", "")
 
+    # PRD-202 S2 (Q4): the small set of "core" skills that stay always-L2 — their
+    # full body renders every turn because they are an agent's core operating
+    # manual (Auto's platform-management), not an optional capability. Every
+    # OTHER attached skill renders only its L1 metadata (~50-100 tokens) and
+    # loads its body on trigger via the load_skill tool. Comma-separated names.
+    SKILL_CORE_ALWAYS_ON = [
+        s.strip()
+        for s in os.getenv("SKILL_CORE_ALWAYS_ON", "platform-management").split(",")
+        if s.strip()
+    ]
+
+    # PRD-202 S3: L3 skill-script execution caps (via the workspace worker only).
+    # Wall-clock cap (seconds) and output-size cap (chars) — the worker is the
+    # isolation boundary; only the script OUTPUT (capped) enters context.
+    SKILL_SCRIPT_TIMEOUT_SECONDS: int = int(os.getenv("SKILL_SCRIPT_TIMEOUT_SECONDS", "60"))
+    SKILL_SCRIPT_OUTPUT_MAX_CHARS: int = int(os.getenv("SKILL_SCRIPT_OUTPUT_MAX_CHARS", "20000"))
+
     # Task Reconciliation (Symphony-inspired stall detection)
     TASK_STALL_TIMEOUT_SECONDS: int = int(os.getenv("TASK_STALL_TIMEOUT_SECONDS", "300"))  # 5 min
     TASK_PENDING_TIMEOUT_SECONDS: int = int(os.getenv("TASK_PENDING_TIMEOUT_SECONDS", "120"))  # 2 min

--- a/orchestrator/core/services/skill_l3_execution.py
+++ b/orchestrator/core/services/skill_l3_execution.py
@@ -1,0 +1,102 @@
+"""
+L3 script-execution enablement (PRD-202 S4)
+===========================================
+
+The Agent Skills open standard has no governance. Automatos keeps import/read of
+a skill (L1 + L2) always-allowed once scanned, but gates **running** its bundled
+scripts (L3) behind an explicit, per-workspace, workspace-admin enablement —
+**import != executable**.
+
+Enablement is stored on ``workspace.settings["skills_l3_enabled"]`` (a list of
+skill ids) — no new table, mirroring the ``auto_autonomy`` settings pattern —
+and every enable/disable is written to ``SkillAuditLog``.
+
+Pure DB helpers (no worker, no network): the caller owns the transaction.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, List
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+_SETTINGS_KEY = "skills_l3_enabled"
+
+
+def _enabled_ids(settings: dict) -> List[int]:
+    raw = (settings or {}).get(_SETTINGS_KEY) or []
+    out: List[int] = []
+    for v in raw:
+        try:
+            out.append(int(v))
+        except (TypeError, ValueError):
+            continue
+    return out
+
+
+def is_l3_execution_enabled(db: Session, workspace_id: UUID | str, skill_id: int) -> bool:
+    """True iff this workspace has explicitly enabled L3 execution for the skill."""
+    from core.models.workspaces import Workspace
+
+    ws = db.query(Workspace).filter(Workspace.id == workspace_id).first()
+    if ws is None:
+        return False
+    return int(skill_id) in _enabled_ids(ws.settings or {})
+
+
+def set_l3_execution_enabled(
+    db: Session,
+    workspace_id: UUID | str,
+    skill_id: int,
+    enabled: bool,
+    *,
+    actor: str = "admin",
+) -> List[int]:
+    """Enable/disable L3 execution for a skill in this workspace, audited.
+
+    Caller owns the transaction — this stages the settings change, writes a
+    ``SkillAuditLog`` row, and flushes. Returns the updated enabled-id list.
+    Raises ValueError if the workspace is missing.
+    """
+    from core.models.core import SkillAuditLog
+    from core.models.workspaces import Workspace
+
+    ws = db.query(Workspace).filter(Workspace.id == workspace_id).first()
+    if ws is None:
+        raise ValueError(f"workspace {workspace_id} not found")
+
+    settings = dict(ws.settings or {})
+    ids = set(_enabled_ids(settings))
+    skill_id = int(skill_id)
+
+    if enabled:
+        ids.add(skill_id)
+    else:
+        ids.discard(skill_id)
+
+    settings[_SETTINGS_KEY] = sorted(ids)
+    # Reassign the whole dict so SQLAlchemy detects the JSON mutation.
+    ws.settings = settings
+
+    db.add(SkillAuditLog(
+        skill_id=skill_id,
+        action="l3_enable" if enabled else "l3_disable",
+        action_details={
+            "workspace_id": str(workspace_id),
+            "enabled": bool(enabled),
+            "actor": actor,
+        },
+        status="success",
+        user_id=actor,
+    ))
+    db.flush()
+
+    logger.info(
+        "[skill-l3] workspace=%s skill=%s L3 execution %s by %s",
+        workspace_id, skill_id, "ENABLED" if enabled else "DISABLED", actor,
+    )
+    return sorted(ids)

--- a/orchestrator/modules/agents/services/skill_loader.py
+++ b/orchestrator/modules/agents/services/skill_loader.py
@@ -1011,8 +1011,12 @@ class SkillLoader:
                 logger.warning(f"Skill not found: {skill_name}")
                 return None
 
-            # Runtime freshness check for builtin-core skills
-            if skill.skill_source == "builtin-core":
+            # Runtime freshness check for builtin skills. PRD-202 S1: resolve
+            # the provenance through the canonical scheme so BOTH the legacy
+            # tags (``builtin-core``/``builtin-seeds``) and the canonical
+            # ``builtin:<name>`` form match — no bare-string compare survives.
+            from modules.agents.services.skill_source_scheme import scheme_of
+            if scheme_of(skill.skill_source) == "builtin":
                 core_content = self._refresh_builtin_if_stale(skill, db)
                 if core_content:
                     self.core_content_cache[skill_name] = core_content

--- a/orchestrator/modules/agents/services/skill_portability.py
+++ b/orchestrator/modules/agents/services/skill_portability.py
@@ -284,6 +284,40 @@ async def import_standard_skill_folder(
 
 
 # ---------------------------------------------------------------------------
+# Bundle read — for L3 worker materialization (S3)
+# ---------------------------------------------------------------------------
+
+def collect_skill_bundle(filesystem_path: Optional[str]) -> Dict[str, str]:
+    """Return ``{relative_path: text_content}`` for a skill's bundled files.
+
+    Walks the skill's on-disk directory (``filesystem_path`` — what
+    ``get_skill_script_path`` resolves against) and returns every classifiable
+    script/resource file's text, EXCLUDING ``SKILL.md`` (the L2 body is the DB's
+    job, not the worker's). This is the bundle S3 materializes into the
+    workspace worker so a script's sibling files resolve at run time.
+    """
+    bundle: Dict[str, str] = {}
+    if not filesystem_path:
+        return bundle
+    root = Path(filesystem_path)
+    if not root.exists() or not root.is_dir():
+        return bundle
+    for path in sorted(root.rglob("*")):
+        if not path.is_file():
+            continue
+        rel = path.relative_to(root)
+        if rel.name.lower() == "skill.md":
+            continue
+        if _classify_file(rel) is None:
+            continue
+        try:
+            bundle[str(rel)] = path.read_text(encoding="utf-8")
+        except Exception:
+            logger.warning("[skill-bundle] could not read %s (skipped)", rel, exc_info=True)
+    return bundle
+
+
+# ---------------------------------------------------------------------------
 # Export — Skill row -> standard folder
 # ---------------------------------------------------------------------------
 

--- a/orchestrator/modules/agents/services/skill_portability.py
+++ b/orchestrator/modules/agents/services/skill_portability.py
@@ -1,0 +1,357 @@
+"""
+Spec-conformant skill import / export (PRD-202 S1)
+==================================================
+
+Aligns the in-house skill schema with the **Agent Skills open standard** so
+that:
+
+* any standard-conformant folder — a ``SKILL.md`` with ``name`` + ``description``
+  frontmatter, optional ``scripts/`` and resource files — **imports** cleanly to
+  a ``Skill`` row (+ ``SkillFile`` index rows), with the frontmatter
+  ``description`` persisted as the **L1 trigger text**; and
+* any ``Skill`` row **exports** back to that same folder shape (portable out —
+  an external runner would accept it).
+
+The DB stays the source of truth (the standard has no tenancy — that is
+Automatos's addition). Provenance is written in the canonical ``scheme:ref``
+form via :mod:`skill_source_scheme`. Every import runs the 2-stage security
+scanner (S4) — static always, the LLM stage ON for third-party/external
+sources — and auto-blocks on a critical finding.
+
+Reuses (not re-implements): ``parse_yaml_frontmatter`` (the frontmatter reader
+the loader already ships), the scanner's ``scan_skill_content`` (quick_scan +
+optional llm_security_scan — no new scanner, dossier E), and the canonical
+provenance scheme.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import yaml
+
+from modules.agents.services.skill_source_scheme import (
+    canonicalize_skill_source,
+    is_external_source,
+)
+
+logger = logging.getLogger(__name__)
+
+# Files whose parent dir is one of these are L3 resources (load on demand).
+_L3_SCRIPT_DIR = "scripts"
+_L3_RESOURCE_DIRS = ("scripts", "examples", "data", "resources", "references", "assets")
+
+# Frontmatter keys that are skill-schema columns, not free metadata.
+_STRUCTURED_KEYS = {"name", "description", "version", "tags", "category", "type", "skill_type"}
+
+
+# ---------------------------------------------------------------------------
+# Scan verdict (S4 rides this path) — thin wrapper over the existing scanner.
+# ---------------------------------------------------------------------------
+
+async def scan_skill_for_import(
+    content: str,
+    filename: str,
+    *,
+    run_llm_scan: bool,
+) -> Dict[str, Any]:
+    """Run the 2-stage scanner on skill content and return a verdict dict.
+
+    Static ``quick_scan`` always runs; the LLM stage runs only when
+    ``run_llm_scan`` (third-party/external sources). A critical static finding
+    auto-blocks (mirrors ``scan_plugin``'s critical-static short-circuit) — the
+    LLM stage is not consulted because the verdict is already terminal.
+
+    Returns ``{"verdict": "passed"|"blocked"|"review", "findings": [...],
+    "llm_stage_run": bool}``.
+    """
+    from core.services.plugin_security_scanner import quick_scan
+
+    static_findings = quick_scan(content, filename=filename)
+    critical = [f for f in static_findings if f.severity == "critical"]
+    findings_payload = [
+        {"type": f.type, "severity": f.severity, "line": f.line, "description": f.description}
+        for f in static_findings
+    ]
+
+    if critical:
+        return {"verdict": "blocked", "findings": findings_payload, "llm_stage_run": False}
+
+    if not run_llm_scan:
+        # Trusted hot path (builtin / workspace-authored): static-only.
+        return {"verdict": "passed", "findings": findings_payload, "llm_stage_run": False}
+
+    # External source: LLM stage ON (dossier ClawHub incident D.3).
+    from core.services.plugin_security_scanner import llm_security_scan
+
+    llm = await llm_security_scan({filename: content})
+    if llm.status == "failed":
+        verdict = "review"
+    elif llm.risk_score >= 70:
+        verdict = "blocked"
+    elif llm.risk_score >= 20:
+        verdict = "review"
+    else:
+        verdict = "passed"
+    return {"verdict": verdict, "findings": findings_payload, "llm_stage_run": True}
+
+
+# ---------------------------------------------------------------------------
+# Import — standard folder -> Skill (+ SkillFile) rows
+# ---------------------------------------------------------------------------
+
+def _find_skill_md(folder: Path) -> Optional[Path]:
+    """Locate the SKILL.md at the folder root (case-insensitive)."""
+    if not folder.exists() or not folder.is_dir():
+        return None
+    for child in folder.iterdir():
+        if child.is_file() and child.name.lower() == "skill.md":
+            return child
+    return None
+
+
+def _classify_file(rel_path: Path) -> Optional[tuple[str, int]]:
+    """Return (file_type, load_level) for a bundled file, or None to skip."""
+    if rel_path.name.lower() == "skill.md":
+        return ("core", 2)
+    parent = rel_path.parent.name
+    if parent == _L3_SCRIPT_DIR:
+        return ("script", 3)
+    if parent in _L3_RESOURCE_DIRS:
+        return ("example" if parent in ("examples", "data") else "resource", 3)
+    if rel_path.suffix.lower() == ".md":
+        return ("resource", 3)
+    return None
+
+
+def _index_bundle_files(db, skill_id: int, skill_dir: Path) -> List[Dict[str, Any]]:
+    """Create SkillFile index rows for every bundled file. Returns their specs."""
+    from core.models.core import SkillFile
+
+    db.query(SkillFile).filter(SkillFile.skill_id == skill_id).delete()
+
+    indexed: List[Dict[str, Any]] = []
+    for path in sorted(skill_dir.rglob("*")):
+        if not path.is_file():
+            continue
+        rel = path.relative_to(skill_dir)
+        classified = _classify_file(rel)
+        if classified is None:
+            continue
+        file_type, load_level = classified
+        try:
+            raw = path.read_text(encoding="utf-8")
+            size = len(raw.encode("utf-8"))
+            tokens = len(raw) // 4
+        except Exception:
+            size, tokens = 0, 0
+        db.add(SkillFile(
+            skill_id=skill_id,
+            file_path=str(rel),
+            file_type=file_type,
+            load_level=load_level,
+            file_size_bytes=size,
+            estimated_tokens=tokens,
+        ))
+        indexed.append({"file_path": str(rel), "file_type": file_type, "load_level": load_level})
+    return indexed
+
+
+async def import_standard_skill_folder(
+    db,
+    folder_path: str,
+    *,
+    source_scheme: str,
+    source_ref: Optional[str] = None,
+    workspace_id: Optional[Any] = None,
+    actor: str = "import",
+    run_llm_scan: Optional[bool] = None,
+) -> Dict[str, Any]:
+    """Import a spec-conformant skill folder into a ``Skill`` (+ ``SkillFile``) rows.
+
+    Args:
+        db: SQLAlchemy session.
+        folder_path: Path to the skill folder (contains ``SKILL.md``).
+        source_scheme: Canonical provenance scheme (git|plugin|builtin|workspace).
+        source_ref: Origin id (git source name, plugin slug, ...).
+        workspace_id: Owning workspace (None = marketplace/global).
+        actor: Who initiated the import (audit).
+        run_llm_scan: Force LLM scan on/off; default derives from the scheme
+            (external → on).
+
+    Returns a result dict with ``success``, ``skill_id``, ``name``, ``verdict``.
+    A critical scanner finding blocks the import (no row is written).
+    """
+    from core.models.core import Skill
+    from modules.agents.services.skill_loader import parse_yaml_frontmatter
+
+    folder = Path(folder_path)
+    skill_md = _find_skill_md(folder)
+    if skill_md is None:
+        return {"success": False, "error": f"No SKILL.md found in {folder_path}"}
+
+    content = skill_md.read_text(encoding="utf-8")
+    yaml_data, body = parse_yaml_frontmatter(content)
+    yaml_data = yaml_data or {}
+
+    name = (yaml_data.get("name") or folder.name or "").strip()
+    description = (yaml_data.get("description") or "").strip()
+    if not name:
+        return {"success": False, "error": "SKILL.md frontmatter missing required 'name'"}
+    if not description:
+        return {"success": False, "error": "SKILL.md frontmatter missing required 'description' (the L1 trigger text)"}
+
+    skill_source = canonicalize_skill_source(source_scheme, source_ref)
+
+    # --- Security scan (S4 rides the import path) ---
+    external = run_llm_scan if run_llm_scan is not None else is_external_source(skill_source)
+    scan = await scan_skill_for_import(content, filename=f"{name}/SKILL.md", run_llm_scan=external)
+    if scan["verdict"] == "blocked":
+        logger.warning("[skill-import] BLOCKED '%s' — critical/high-risk findings", name)
+        return {
+            "success": False,
+            "verdict": "blocked",
+            "findings": scan["findings"],
+            "error": f"Skill '{name}' blocked by the security scanner — fix the flagged patterns and re-import.",
+        }
+
+    # description IS the L1 trigger text — persist it on the column AND into the
+    # skill_metadata JSONB (which load_skill_metadata reads as L1).
+    skill_metadata = dict(yaml_data)
+    skill_metadata["description"] = description
+    skill_metadata["security_scan"] = {
+        "verdict": scan["verdict"],
+        "llm_stage_run": scan["llm_stage_run"],
+        "scanned_by": actor,
+    }
+
+    existing = (
+        db.query(Skill)
+        .filter(
+            Skill.name == name,
+            Skill.skill_source == skill_source,
+            Skill.workspace_id == workspace_id,
+        )
+        .first()
+    )
+
+    if existing:
+        existing.description = description
+        existing.prompt_template = body
+        existing.skill_version = str(yaml_data.get("version", existing.skill_version or "1.0.0"))
+        existing.tags = yaml_data.get("tags", existing.tags)
+        existing.category = yaml_data.get("category") or existing.category or "general"
+        existing.filesystem_path = str(folder)
+        existing.skill_metadata = skill_metadata
+        existing.is_active = True
+        skill = existing
+    else:
+        skill = Skill(
+            name=name,
+            description=description,
+            skill_type=yaml_data.get("skill_type") or yaml_data.get("type") or "technical",
+            category=yaml_data.get("category") or "general",
+            skill_version=str(yaml_data.get("version", "1.0.0")),
+            skill_source=skill_source,
+            prompt_template=body,
+            filesystem_path=str(folder),
+            tags=yaml_data.get("tags", []),
+            skill_metadata=skill_metadata,
+            workspace_id=workspace_id,
+            is_active=True,
+        )
+        db.add(skill)
+        db.flush()
+
+    indexed = _index_bundle_files(db, skill.id, folder)
+    db.commit()
+
+    logger.info(
+        "[skill-import] imported '%s' (id=%s, source=%s, %d bundled files, verdict=%s)",
+        name, skill.id, skill_source, len(indexed), scan["verdict"],
+    )
+    return {
+        "success": True,
+        "skill_id": skill.id,
+        "name": name,
+        "skill_source": skill_source,
+        "description": description,
+        "verdict": scan["verdict"],
+        "bundled_files": indexed,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Export — Skill row -> standard folder
+# ---------------------------------------------------------------------------
+
+def _build_frontmatter(skill) -> Dict[str, Any]:
+    """Assemble the standard frontmatter dict from a Skill row (name+description first)."""
+    fm: Dict[str, Any] = {
+        "name": getattr(skill, "name", None),
+        "description": getattr(skill, "description", None) or "",
+    }
+    version = getattr(skill, "skill_version", None)
+    if version:
+        fm["version"] = version
+    tags = getattr(skill, "tags", None)
+    if tags:
+        fm["tags"] = list(tags)
+    category = getattr(skill, "category", None)
+    if category:
+        fm["category"] = category
+    # Carry any extra author metadata that isn't a structured column, minus
+    # internal bookkeeping we don't export.
+    meta = getattr(skill, "skill_metadata", None)
+    if isinstance(meta, dict):
+        for k, v in meta.items():
+            if k in _STRUCTURED_KEYS or k in ("security_scan", "forked_from_skill_id"):
+                continue
+            fm.setdefault(k, v)
+    return fm
+
+
+def export_skill_to_folder(db, skill, dest_dir: str) -> str:
+    """Emit a standard skill folder from a ``Skill`` row.
+
+    Writes ``<dest_dir>/<name>/SKILL.md`` (frontmatter with name + description +
+    body) and copies any bundled ``scripts/``/resource files that live under the
+    skill's ``filesystem_path``. Returns the emitted skill-folder path. An
+    external Agent-Skills runner would accept the result.
+    """
+    name = getattr(skill, "name", None) or "skill"
+    out_dir = Path(dest_dir) / name
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    frontmatter = _build_frontmatter(skill)
+    fm_yaml = yaml.safe_dump(frontmatter, sort_keys=False, allow_unicode=True).strip()
+    body = getattr(skill, "prompt_template", None) or ""
+    skill_md = f"---\n{fm_yaml}\n---\n\n{body.strip()}\n"
+    (out_dir / "SKILL.md").write_text(skill_md, encoding="utf-8")
+
+    # Copy the L3 bundle (scripts + resources) from the on-disk source, if any.
+    src_path = getattr(skill, "filesystem_path", None)
+    copied = 0
+    if src_path:
+        src = Path(src_path)
+        if src.exists() and src.is_dir():
+            for path in sorted(src.rglob("*")):
+                if not path.is_file():
+                    continue
+                rel = path.relative_to(src)
+                if rel.name.lower() == "skill.md":
+                    continue  # already emitted from the DB body (source of truth)
+                if _classify_file(rel) is None:
+                    continue
+                target = out_dir / rel
+                target.parent.mkdir(parents=True, exist_ok=True)
+                try:
+                    target.write_bytes(path.read_bytes())
+                    copied += 1
+                except Exception:
+                    logger.warning("[skill-export] could not copy %s", rel, exc_info=True)
+
+    logger.info("[skill-export] exported '%s' to %s (%d bundled files)", name, out_dir, copied)
+    return str(out_dir)

--- a/orchestrator/modules/agents/services/skill_source_scheme.py
+++ b/orchestrator/modules/agents/services/skill_source_scheme.py
@@ -1,0 +1,123 @@
+"""
+Canonical ``skill_source`` provenance scheme (PRD-202 S1)
+========================================================
+
+The Agent Skills open standard has no tenancy/provenance model — that is
+Automatos's addition. Historically the ``Skill.skill_source`` column carried an
+*incoherent* mix of values (dossier agents-skills J4/D.1):
+
+    git-imported      -> ``str(source_id)``      (a bare numeric id, e.g. "5")
+    plugin-materialized -> ``plugin:<slug>``     (already scheme-shaped)
+    builtin-seeded    -> ``builtin-core`` / ``builtin-seeds``
+    workspace-authored -> ``workspace-user`` / ``workspace-fork``
+
+This module is the single source of truth for that provenance: one canonical
+``scheme:ref`` vocabulary over the four origins the platform actually has —
+``git`` / ``plugin`` / ``builtin`` / ``workspace``.
+
+Two pure functions:
+
+* ``canonicalize_skill_source(...)`` — produce a canonical ``scheme:ref`` string
+  for a NEW write (import/export/create paths use this).
+* ``parse_skill_source(value)`` — resolve ANY value (canonical OR legacy) to a
+  ``(scheme, ref)`` pair, so provenance *resolves* regardless of whether the row
+  has been backfilled yet. Callers that branch on origin (e.g. the loader's
+  builtin freshness check) go through this, never a bare string compare.
+
+No DB, no I/O — safe to import anywhere.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+# The fixed provenance vocabulary. Every skill originates from exactly one.
+CANONICAL_SKILL_SOURCE_SCHEMES: Tuple[str, ...] = ("git", "plugin", "builtin", "workspace")
+
+_SCHEME_SEP = ":"
+
+# Legacy (pre-PRD-202) provenance strings mapped to their canonical (scheme, ref).
+# Kept so ``parse_skill_source`` resolves un-backfilled rows without a reshape.
+_LEGACY_EXACT = {
+    "builtin-core": ("builtin", "core"),
+    "builtin-seeds": ("builtin", "seeds"),
+    "workspace-user": ("workspace", "user"),
+    "workspace-fork": ("workspace", "fork"),
+}
+
+
+def _norm(value: Optional[str]) -> str:
+    return (value or "").strip()
+
+
+def parse_skill_source(value: Optional[str]) -> Tuple[str, str]:
+    """Resolve any ``skill_source`` value to a canonical ``(scheme, ref)``.
+
+    Handles three shapes:
+
+    * canonical ``scheme:ref`` (e.g. ``git:anthropic-official``) — returned as-is;
+    * legacy exact tags (``builtin-core`` etc.) via the compatibility map;
+    * a bare numeric id (the legacy git shape ``"5"``) → ``("git", "5")``.
+
+    Unknown / empty values resolve to ``("unknown", "")`` — callers treat that as
+    "no recognised origin" (never as a match for a real scheme).
+    """
+    raw = _norm(value)
+    if not raw:
+        return ("unknown", "")
+
+    # Canonical scheme:ref already?
+    if _SCHEME_SEP in raw:
+        scheme, ref = raw.split(_SCHEME_SEP, 1)
+        scheme = scheme.strip().lower()
+        ref = ref.strip()
+        if scheme in CANONICAL_SKILL_SOURCE_SCHEMES:
+            return (scheme, ref)
+        return ("unknown", raw)
+
+    # Legacy exact tag?
+    lowered = raw.lower()
+    if lowered in _LEGACY_EXACT:
+        return _LEGACY_EXACT[lowered]
+
+    # Legacy git shape: a bare numeric SkillSource id.
+    if raw.isdigit():
+        return ("git", raw)
+
+    return ("unknown", raw)
+
+
+def canonicalize_skill_source(
+    scheme: str,
+    ref: Optional[str] = None,
+) -> str:
+    """Build a canonical ``scheme:ref`` provenance string for a NEW write.
+
+    ``scheme`` must be one of :data:`CANONICAL_SKILL_SOURCE_SCHEMES`. ``ref`` is
+    the origin identifier (a git source name, plugin slug, builtin name, or
+    workspace kind). Whitespace is trimmed; a missing ref yields a bare
+    ``scheme:`` (still resolvable).
+    """
+    s = _norm(scheme).lower()
+    if s not in CANONICAL_SKILL_SOURCE_SCHEMES:
+        raise ValueError(
+            f"Unknown skill_source scheme '{scheme}'. "
+            f"Expected one of {CANONICAL_SKILL_SOURCE_SCHEMES}."
+        )
+    r = _norm(ref)
+    return f"{s}{_SCHEME_SEP}{r}" if r else f"{s}{_SCHEME_SEP}"
+
+
+def scheme_of(value: Optional[str]) -> str:
+    """Convenience: the canonical scheme of any ``skill_source`` value."""
+    return parse_skill_source(value)[0]
+
+
+def is_external_source(value: Optional[str]) -> bool:
+    """True for third-party / external provenance (git, plugin).
+
+    ``builtin`` (the platform's own) and ``workspace`` (the user's own) are
+    trusted; ``git`` and ``plugin`` arrive from outside and get the LLM scan
+    stage ON at import (S4, dossier ClawHub incident D.3).
+    """
+    return scheme_of(value) in ("git", "plugin")

--- a/orchestrator/modules/context/sections/skills.py
+++ b/orchestrator/modules/context/sections/skills.py
@@ -1,8 +1,22 @@
 """
-SkillsSection — SKILL.md content for the agent's assigned skill.
+SkillsSection — trigger-based skill activation for the agent's prompt.
 
-Priority 4. Renders the agent's assigned SKILL.md content for all
-execution paths (chatbot, task, heartbeat, recipe).
+Priority 4. PRD-202 S2: the per-skill prompt-cost cut.
+
+Each turn this renders, for the agent's attached skills:
+
+  * **L1 metadata only** — ``name`` + ``description`` (~50-100 tokens/skill) —
+    for every non-core skill, plus a one-line instruction that the model may
+    pull a skill's full body when the task matches its description (via the
+    ``load_skill`` tool). The body is NOT pre-paid.
+  * the **full L2 body** ONLY for the small ``core`` always-on set
+    (``config.SKILL_CORE_ALWAYS_ON`` — Auto's ``platform-management``), which is
+    an agent's core operating manual, not an optional capability (Q4).
+
+This replaces the old always-inject render (every attached skill's full body
+every turn, uncapped-primary + a 5,000-token aux budget). That path — and the
+aux budget — are **deleted**, not flagged: an attached-but-irrelevant skill no
+longer taxes every turn with thousands of tokens.
 """
 
 from __future__ import annotations
@@ -14,27 +28,27 @@ from modules.context.sections.base import BaseSection, SectionContext
 
 logger = logging.getLogger(__name__)
 
+# Fail-safe default when config cannot be imported (e.g. isolated unit tests).
+# The authoritative source is config.SKILL_CORE_ALWAYS_ON.
+_DEFAULT_CORE_ALWAYS_ON = ("platform-management",)
+
 
 class SkillsSection(BaseSection):
-    """SKILL.md content for the agent's assigned skill(s).
+    """Trigger-based skill activation: L1 metadata always, L2 body on demand.
 
-    Loads the ``prompt_template`` field from the agent's active skills
-    (via the ``agent_skills`` many-to-many relationship on the Agent model).
-
-    PRD-137 Fix #5: the primary skill (highest-priority active skill) is
-    rendered uncapped. Auxiliary skills share an aux budget. This stops
-    Auto's 11K-token platform-management SKILL.md being truncated to 3K.
+    Auto's ``platform-management`` (the ``core`` set) stays always-L2; every
+    other attached skill contributes only its L1 metadata each turn and loads
+    its body when the model calls ``load_skill`` (matched on the description).
     """
 
     name: str = "skills"
     priority: int = 4
-    # Primary skill is uncapped. Auxiliary skills share this budget.
-    aux_max_tokens: int = 5000
-    # Class-level max_tokens kept None so legacy callers don't truncate.
+    # No aux budget: non-core skills render L1 metadata only (tiny), so there is
+    # nothing large to cap. Class-level max_tokens stays None (legacy callers).
     max_tokens: Optional[int] = None
 
     async def render(self, ctx: SectionContext) -> str:
-        """Load and return skill content for the agent."""
+        """Load and return skill content for the agent (never raises)."""
         try:
             return self._build(ctx)
         except Exception:
@@ -42,7 +56,7 @@ class SkillsSection(BaseSection):
             return ""
 
     # ------------------------------------------------------------------
-    # Internal helpers
+    # Build
     # ------------------------------------------------------------------
 
     def _build(self, ctx: SectionContext) -> str:
@@ -50,22 +64,77 @@ class SkillsSection(BaseSection):
         if agent is None:
             return ""
 
-        # Agent.skills is a relationship loaded via agent_skills association table
         skills = getattr(agent, "skills", None)
         if not skills:
             return ""
 
-        # Filter to active skills only
         active_skills = [s for s in skills if getattr(s, "is_active", True)]
         if not active_skills:
             return ""
 
-        # PRD-191 S4 (closes F054): Agent.skills arrives ordered by the REAL
-        # attachment-level priority (agent_skills.priority DESC — model
-        # order_by). The old sort keyed on a phantom Skill.priority attribute
-        # that no column backed, so the uncapped-primary slot was load order.
-        # PRD-191 S2: never render the same body twice — dedup by id, then by
-        # (name, content_hash), keeping the first (= highest-priority) instance.
+        active_skills = self._dedup(active_skills)
+        core_names = self._core_always_on_names()
+
+        core_bodies: list[str] = []
+        l1_entries: list[str] = []
+        activated_core: list[str] = []
+        offered_l1: list[str] = []
+
+        for s in active_skills:
+            name = getattr(s, "name", None) or "skill"
+            # Full L2 body renders ONLY for the core always-on set — never
+            # unconditionally. Every other skill is L1 + load_skill trigger.
+            if name in core_names:
+                body = self._core_skill_body(s, ctx)
+                if body:
+                    core_bodies.append(body)
+                    activated_core.append(name)
+            else:
+                l1_entries.append(self._l1_metadata_line(s))
+                offered_l1.append(name)
+
+        parts: list[str] = []
+        if core_bodies:
+            parts.append("\n\n---\n\n".join(core_bodies))
+        if l1_entries:
+            parts.append(self._render_l1_catalog(l1_entries))
+
+        skill_tool_names = self._extract_skill_tool_names(active_skills)
+        if skill_tool_names:
+            parts.append(
+                "## Using Your Skill Tools\n"
+                f"You have access to: {', '.join(skill_tool_names)}\n"
+                "When your task requires capabilities provided by these tools, "
+                "you MUST use them via function calling. "
+                "Analyze your task, check if any tools match, and CALL them — "
+                "do not just describe what you would do."
+            )
+
+        if not parts:
+            return ""
+
+        # Skill-activation signal (S2 measurement): which skills stayed always-on
+        # (core) vs were offered at L1 this turn. The cost delta / activation rate
+        # (§7) is read from these.
+        logger.info(
+            "[skills] activation: core_always_on=%s l1_offered=%s (ws=%s)",
+            activated_core, offered_l1, getattr(ctx, "workspace_id", None),
+        )
+
+        return "\n\n".join(parts)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _dedup(active_skills: list) -> list:
+        """PRD-191 S2 (held): never present the same skill twice.
+
+        Dedup by id, then by (name, content_hash), keeping the first (=
+        highest-priority — Agent.skills arrives ordered by the real
+        agent_skills.priority) instance.
+        """
         seen_ids = set()
         seen_bodies = set()
         deduped = []
@@ -80,39 +149,40 @@ class SkillsSection(BaseSection):
                 seen_ids.add(sid)
             seen_bodies.add(body_key)
             deduped.append(s)
-        active_skills = deduped
+        return deduped
 
-        primary_text = self._get_skill_content(active_skills[0], ctx)
-        aux_texts = [
-            txt for txt in (self._get_skill_content(s, ctx) for s in active_skills[1:])
-            if txt
-        ]
+    @staticmethod
+    def _core_always_on_names() -> set:
+        """The core always-L2 skill names (Q4). Config is authoritative."""
+        try:
+            from config import config
 
-        if not primary_text and not aux_texts:
-            return ""
+            names = getattr(config, "SKILL_CORE_ALWAYS_ON", None)
+            if names:
+                return set(names)
+        except Exception:
+            pass
+        return set(_DEFAULT_CORE_ALWAYS_ON)
 
-        aux_combined = "\n\n---\n\n".join(aux_texts) if aux_texts else ""
-        if aux_combined and self.aux_max_tokens:
-            aux_combined = self.truncate(aux_combined, self.aux_max_tokens)
+    @staticmethod
+    def _l1_metadata_line(skill) -> str:
+        """One L1 line: name + description (~50-100 tokens), NOT the body."""
+        name = getattr(skill, "name", None) or "skill"
+        desc = getattr(skill, "description", None)
+        desc = desc.strip() if isinstance(desc, str) else ""
+        return f"- **{name}**: {desc}" if desc else f"- **{name}**"
 
-        if primary_text and aux_combined:
-            combined = primary_text + "\n\n---\n\n" + aux_combined
-        else:
-            combined = primary_text or aux_combined
-
-        # Skill tool usage instructions
-        skill_tool_names = self._extract_skill_tool_names(active_skills)
-        if skill_tool_names:
-            combined += (
-                "\n\n## Using Your Skill Tools\n"
-                f"You have access to: {', '.join(skill_tool_names)}\n"
-                "When your task requires capabilities provided by these tools, "
-                "you MUST use them via function calling. "
-                "Analyze your task, check if any tools match, and CALL them — "
-                "do not just describe what you would do."
-            )
-
-        return combined
+    @staticmethod
+    def _render_l1_catalog(entries: list[str]) -> str:
+        """The L1 catalog + the load_skill trigger instruction."""
+        return (
+            "## Available Skills\n"
+            "These skills are attached to you. Only their names and descriptions "
+            "are loaded now — NOT their full instructions. When your task matches "
+            "a skill's description, call `load_skill(name=\"<skill-name>\")` to "
+            "load that skill's full instructions for this turn.\n"
+            + "\n".join(entries)
+        )
 
     @staticmethod
     def _extract_skill_tool_names(skills) -> list[str]:
@@ -129,21 +199,19 @@ class SkillsSection(BaseSection):
         return names
 
     @staticmethod
-    def _get_skill_content(skill, ctx: SectionContext) -> str:
-        """Extract skill content from the skill record.
+    def _core_skill_body(skill, ctx: SectionContext) -> str:
+        """Full L2 body for a CORE always-on skill only.
 
-        Tries ``prompt_template`` first (the SKILL.md body stored in DB).
-        Falls back to loading via SkillLoader if available and prompt_template
-        is empty.
+        Reads ``prompt_template`` (the SKILL.md body in the DB); falls back to
+        the loader's ``load_skill_core`` only when the template is empty and a
+        real session is available. Never called for non-core skills.
         """
-        # Primary: prompt_template field on the Skill model
         content = getattr(skill, "prompt_template", None)
         if content and str(content).strip():
             return str(content).strip()
 
-        # Fallback: use SkillLoader singleton if available
         skill_name = getattr(skill, "name", None)
-        if skill_name and ctx.db_session is not None:
+        if skill_name and getattr(ctx, "db_session", None) is not None:
             try:
                 from modules.agents.services.skill_loader import get_skill_loader
 
@@ -153,9 +221,8 @@ class SkillsSection(BaseSection):
                     return str(loaded).strip()
             except Exception:
                 logger.warning(
-                    "SkillLoader fallback failed for skill %s",
+                    "SkillLoader fallback failed for core skill %s",
                     skill_name,
                     exc_info=True,
                 )
-
         return ""

--- a/orchestrator/modules/context/sections/skills.py
+++ b/orchestrator/modules/context/sections/skills.py
@@ -179,8 +179,9 @@ class SkillsSection(BaseSection):
             "## Available Skills\n"
             "These skills are attached to you. Only their names and descriptions "
             "are loaded now — NOT their full instructions. When your task matches "
-            "a skill's description, call `load_skill(name=\"<skill-name>\")` to "
-            "load that skill's full instructions for this turn.\n"
+            "a skill's description, call the `platform_load_skill` action "
+            "(name=\"<skill-name>\") to load that skill's full instructions for "
+            "this turn.\n"
             + "\n".join(entries)
         )
 

--- a/orchestrator/modules/tools/discovery/actions_skills.py
+++ b/orchestrator/modules/tools/discovery/actions_skills.py
@@ -21,7 +21,101 @@ from .action_registry import ActionDefinition, ActionRegistry
 
 
 def register_skills_actions(registry: ActionRegistry) -> None:
-    """Register skill read/create/update/delete tools."""
+    """Register skill read/create/update/delete + runtime (load/run/enable) tools."""
+
+    # PRD-202 S2: trigger-based L2 activation. Attached skills are listed at L1
+    # (name + description) only; the model calls load_skill to pull a skill's
+    # full body into context when its task matches the description.
+    registry.register(ActionDefinition(
+        name="load_skill",
+        description=(
+            "Load a skill's full instructions (its SKILL.md body) into your "
+            "context for THIS turn. Your attached skills are shown with only "
+            "their name and description until you load them — call this when "
+            "your current task matches a skill's description and you need its "
+            "detailed step-by-step instructions. Returns the skill's full body."
+        ),
+        category="skills",
+        parameters={
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Exact skill name to load (from the 'Available Skills' list in your prompt).",
+                },
+            },
+            "required": ["name"],
+        },
+        permission_level="read",
+        tags=["skills", "load", "progressive-disclosure", "l2"],
+        examples=[
+            "load the growth-hacker skill",
+            "load_skill data-analysis",
+            "pull the full instructions for the sql skill",
+        ],
+    ))
+
+    # PRD-202 S3: L3 script execution via the workspace worker (sandboxed,
+    # per-workspace, token-gated). Only the script OUTPUT enters context.
+    registry.register(ActionDefinition(
+        name="run_skill_script",
+        description=(
+            "Run one of a skill's bundled scripts in the sandboxed workspace "
+            "worker and return only its OUTPUT (stdout/stderr) — the script "
+            "source never enters your context. Use for a skill's executable "
+            "helpers (data crunching, format conversion, generation). The "
+            "skill's L3 scripts must be enabled for this workspace by an admin "
+            "first (import/read is always allowed; running is opt-in)."
+        ),
+        category="skills",
+        parameters={
+            "type": "object",
+            "properties": {
+                "skill": {"type": "string", "description": "Skill name whose script to run."},
+                "script": {"type": "string", "description": "Script filename within the skill's scripts/ bundle (e.g. 'convert.py')."},
+                "args": {"type": "string", "description": "Optional command-line arguments passed to the script."},
+                "interpreter": {"type": "string", "description": "Optional interpreter (default inferred from extension: .py->python, .sh->bash, .js->node)."},
+            },
+            "required": ["skill", "script"],
+        },
+        permission_level="write",
+        tags=["skills", "script", "execute", "l3", "worker"],
+        examples=[
+            "run the convert.py script from the docx skill",
+            "run_skill_script skill=analytics script=summarize.py args='--period 7d'",
+        ],
+    ))
+
+    # PRD-202 S4: workspace-admin enablement gate for L3 execution. Importing /
+    # reading a skill is always allowed once scanned; running its scripts needs
+    # explicit per-workspace enablement (scanner-pass required, audited).
+    registry.register(ActionDefinition(
+        name="platform_set_skill_script_execution",
+        description=(
+            "Enable or disable L3 script execution for a skill in this "
+            "workspace (workspace-admin action, audited). Importing and reading "
+            "a skill is always allowed once scanned — but running its bundled "
+            "scripts is inert until enabled here. Enabling re-runs the security "
+            "scanner and refuses if the skill has critical findings."
+        ),
+        category="skills",
+        parameters={
+            "type": "object",
+            "properties": {
+                "skill_id": {"type": "integer", "description": "Skill id to enable/disable script execution for. Either skill_id or skill_name."},
+                "skill_name": {"type": "string", "description": "Skill name (used when skill_id is not known)."},
+                "enabled": {"type": "boolean", "description": "true to enable L3 script execution, false to disable."},
+            },
+            "required": ["enabled"],
+        },
+        permission_level="write",
+        admin_only=True,
+        tags=["skills", "governance", "l3", "enablement", "admin"],
+        examples=[
+            "enable script execution for the analytics skill",
+            "turn off L3 scripts for skill 42",
+        ],
+    ))
 
     registry.register(ActionDefinition(
         name="platform_get_skill_content",

--- a/orchestrator/modules/tools/discovery/actions_skills.py
+++ b/orchestrator/modules/tools/discovery/actions_skills.py
@@ -27,7 +27,7 @@ def register_skills_actions(registry: ActionRegistry) -> None:
     # (name + description) only; the model calls load_skill to pull a skill's
     # full body into context when its task matches the description.
     registry.register(ActionDefinition(
-        name="load_skill",
+        name="platform_load_skill",
         description=(
             "Load a skill's full instructions (its SKILL.md body) into your "
             "context for THIS turn. Your attached skills are shown with only "
@@ -58,7 +58,7 @@ def register_skills_actions(registry: ActionRegistry) -> None:
     # PRD-202 S3: L3 script execution via the workspace worker (sandboxed,
     # per-workspace, token-gated). Only the script OUTPUT enters context.
     registry.register(ActionDefinition(
-        name="run_skill_script",
+        name="platform_run_skill_script",
         description=(
             "Run one of a skill's bundled scripts in the sandboxed workspace "
             "worker and return only its OUTPUT (stdout/stderr) — the script "
@@ -109,7 +109,9 @@ def register_skills_actions(registry: ActionRegistry) -> None:
             "required": ["enabled"],
         },
         permission_level="write",
-        admin_only=True,
+        # PRD-143 Rev 2 emptied the admin_only tier (it was a platform-wide no-op)
+        # — governance here is workspace-scope + audit (SkillAuditLog) + the
+        # write-permission/autonomy gate, same as every other skill-governance write.
         tags=["skills", "governance", "l3", "enablement", "admin"],
         examples=[
             "enable script execution for the analytics skill",

--- a/orchestrator/modules/tools/discovery/handlers_skill_runtime.py
+++ b/orchestrator/modules/tools/discovery/handlers_skill_runtime.py
@@ -1,0 +1,299 @@
+"""
+Skill-runtime handlers (PRD-202)
+================================
+
+The runtime side of the Agent Skills loading model, distinct from the CRUD
+edit handlers in ``handlers_skills.py``:
+
+  * ``load_skill``  (S2) — trigger-based L2 activation. The prompt lists attached
+    skills at L1 (name + description) only; the model calls this to pull a
+    skill's full body into context for a turn.
+  * ``run_skill_script`` (S3) — L3 script execution via the WORKSPACE WORKER.
+    Materializes the skill's bundle into the worker filesystem and runs the
+    script there (sandboxed, per-workspace, token-gated); only the OUTPUT
+    returns to context — never the script source.
+  * ``set_skill_script_execution`` (S4) — workspace-admin enablement gate for
+    L3. Import/read a skill freely; run its scripts only after an admin enables
+    it (scanner-pass required, audited). Import != executable.
+
+All handlers share the platform-tool signature ``(db, workspace_id, params)``
+and are workspace-scoped: the executor passes the calling agent's workspace_id
+and these refuse to touch skills outside that boundary.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Shared: resolve a workspace-visible skill by name or id
+# ---------------------------------------------------------------------------
+
+def _resolve_visible_skill(db: Session, workspace_id, name: str = "", skill_id=None):
+    """Return the workspace-visible skill (own fork or global/marketplace).
+
+    Prefers a workspace-owned row over a global one of the same name.
+    """
+    from core.models.core import Skill
+
+    query = db.query(Skill).filter(Skill.is_active == True)  # noqa: E712
+    if skill_id:
+        query = query.filter(Skill.id == skill_id)
+    elif name:
+        query = query.filter(Skill.name.ilike(name))
+    else:
+        return None
+
+    query = query.filter(
+        (Skill.workspace_id.is_(None)) | (Skill.workspace_id == workspace_id)
+    )
+    # Workspace-owned fork wins over the global original of the same name.
+    return query.order_by(Skill.workspace_id.isnot(None).desc()).first()
+
+
+# ---------------------------------------------------------------------------
+# S2 — load_skill: trigger-based L2 activation
+# ---------------------------------------------------------------------------
+
+async def load_skill(db: Session, workspace_id: UUID, params: Dict[str, Any]) -> Dict[str, Any]:
+    """Load a skill's full L2 body into context for this turn (trigger).
+
+    The prompt lists attached skills at L1 (name + description); the model calls
+    this when its task matches a skill's description. Returns the SKILL.md body.
+    """
+    name = (params.get("name") or params.get("skill_name") or "").strip()
+    if not name:
+        return {"success": False, "error": "Provide the skill 'name' to load."}
+
+    skill = _resolve_visible_skill(db, workspace_id, name=name)
+    if not skill:
+        return {
+            "success": False,
+            "error": f"Skill '{name}' not found or not available to this workspace.",
+        }
+
+    body = skill.prompt_template
+    if not body or not str(body).strip():
+        try:
+            from modules.agents.services.skill_loader import get_skill_loader
+
+            body = get_skill_loader(db).load_skill_core(skill.name, db=db)
+        except Exception:
+            logger.warning("[load_skill] loader fallback failed for '%s'", skill.name, exc_info=True)
+            body = None
+
+    if not body or not str(body).strip():
+        return {"success": False, "error": f"Skill '{skill.name}' has no loadable instructions."}
+
+    logger.info("[load_skill] activated '%s' (id=%s) for ws=%s", skill.name, skill.id, workspace_id)
+    return {
+        "success": True,
+        "skill": skill.name,
+        "skill_id": skill.id,
+        "content": str(body).strip(),
+        "message": (
+            f"Loaded skill '{skill.name}'. Its full instructions are now in "
+            "context for this turn — follow them for the current task."
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# S3 — run_skill_script: L3 execution via the workspace worker
+# ---------------------------------------------------------------------------
+
+def _infer_interpreter(script_rel: str) -> str:
+    s = script_rel.lower()
+    if s.endswith(".py"):
+        return "python"
+    if s.endswith(".sh"):
+        return "bash"
+    if s.endswith(".js"):
+        return "node"
+    return "python"
+
+
+def _safe_name(name: str) -> str:
+    import re
+
+    return re.sub(r"[^A-Za-z0-9._-]", "_", name)[:100] or "skill"
+
+
+def _cap(text: Optional[str], limit: int) -> str:
+    if not text:
+        return ""
+    text = str(text)
+    if len(text) <= limit:
+        return text
+    return text[:limit] + f"\n…[truncated, {len(text) - limit} more chars]"
+
+
+async def run_skill_script(db: Session, workspace_id: UUID, params: Dict[str, Any]) -> Dict[str, Any]:
+    """Run a skill's bundled script in the workspace worker; return OUTPUT only.
+
+    Materializes the skill's ``SkillFile`` bundle into the per-workspace worker
+    filesystem and invokes ``WorkspaceClient.exec_command`` — the existing
+    sandboxed, per-workspace, ``WORKER_INTERNAL_TOKEN``-gated, wall-clock-capped
+    exec path (NOT the in-process ActionExecutor). Only stdout/stderr return to
+    context; the script source never does. Gated on per-workspace L3 enablement
+    (S4): import/read is free, running is opt-in.
+    """
+    import shlex
+
+    from config import config
+    from core.services.skill_l3_execution import is_l3_execution_enabled
+    from core.workspace_client import WorkspaceClient
+    from modules.agents.services.skill_portability import collect_skill_bundle
+
+    skill_name = (params.get("skill") or params.get("skill_name") or params.get("name") or "").strip()
+    script = (params.get("script") or "").strip()
+    args = params.get("args") or ""
+    interpreter = (params.get("interpreter") or "").strip()
+
+    if not skill_name:
+        return {"success": False, "error": "Provide the 'skill' whose script to run."}
+    if not script:
+        return {"success": False, "error": "Provide the 'script' filename to run."}
+
+    skill = _resolve_visible_skill(db, workspace_id, name=skill_name)
+    if not skill:
+        return {"success": False, "error": f"Skill '{skill_name}' not found or not available to this workspace."}
+
+    # --- S4 gate: L3 execution must be enabled for this skill in this workspace ---
+    if not is_l3_execution_enabled(db, workspace_id, skill.id):
+        return {
+            "success": False,
+            "error": (
+                f"L3 script execution is not enabled for skill '{skill.name}' in this workspace. "
+                "A workspace admin must enable it first (platform_set_skill_script_execution) — "
+                "importing/reading a skill is always allowed, but running its scripts is opt-in."
+            ),
+            "enablement_required": True,
+        }
+
+    bundle = collect_skill_bundle(getattr(skill, "filesystem_path", None))
+    if not bundle:
+        return {"success": False, "error": f"Skill '{skill.name}' has no bundled scripts to run."}
+
+    # Resolve the script within the bundle (scripts/<name> or <name>).
+    script_rel = None
+    for candidate in (f"scripts/{script}", script):
+        if candidate in bundle:
+            script_rel = candidate
+            break
+    if script_rel is None:
+        return {
+            "success": False,
+            "error": f"Script '{script}' not found in skill '{skill.name}' bundle.",
+            "available_scripts": [p for p in bundle if p.startswith("scripts/") or p.endswith((".py", ".sh", ".js"))],
+        }
+
+    # --- Materialize the bundle into the worker filesystem (per-workspace jail) ---
+    client = WorkspaceClient(str(workspace_id))
+    base = f".skills/{_safe_name(skill.name)}"
+    for rel, content in bundle.items():
+        write = await client.write_file(f"{base}/{rel}", content)
+        if not write.get("success", False):
+            return {
+                "success": False,
+                "error": f"Failed to materialize skill bundle into the workspace worker: {write.get('error')}",
+            }
+
+    # --- Execute in the sandbox; only OUTPUT returns to context ---
+    interp = interpreter or _infer_interpreter(script_rel)
+    command = f"{interp} {shlex.quote(script_rel)}"
+    if args:
+        command += f" {args}"
+
+    logger.info("[run_skill_script] ws=%s skill='%s' script='%s' -> worker exec", workspace_id, skill.name, script_rel)
+    result = await client.exec_command(
+        command=command,
+        cwd=base,
+        timeout=config.SKILL_SCRIPT_TIMEOUT_SECONDS,
+    )
+
+    if not result.get("success", True) and "error" in result and "stdout" not in result:
+        # Transport/worker error (unreachable, etc.) — no script output produced.
+        return {"success": False, "skill": skill.name, "script": script_rel, "error": result.get("error")}
+
+    cap = config.SKILL_SCRIPT_OUTPUT_MAX_CHARS
+    return {
+        "success": True,
+        "skill": skill.name,
+        "script": script_rel,
+        "exit_code": result.get("exit_code", result.get("returncode")),
+        "stdout": _cap(result.get("stdout") or result.get("output"), cap),
+        "stderr": _cap(result.get("stderr"), cap),
+    }
+
+
+# ---------------------------------------------------------------------------
+# S4 — set_skill_script_execution: workspace-admin L3 enablement (audited)
+# ---------------------------------------------------------------------------
+
+async def set_skill_script_execution(db: Session, workspace_id: UUID, params: Dict[str, Any]) -> Dict[str, Any]:
+    """Enable/disable L3 script execution for a skill in this workspace (admin).
+
+    Enabling re-runs the security scanner on the skill body and refuses on a
+    critical finding (scanner-pass required). Every change is audited via
+    ``SkillAuditLog``. import/read stays free; running is what this gates.
+    """
+    from core.services.skill_l3_execution import set_l3_execution_enabled
+
+    if "enabled" not in params:
+        return {"success": False, "error": "Provide 'enabled' (true to enable L3 execution, false to disable)."}
+    enabled = bool(params.get("enabled"))
+    skill_id = params.get("skill_id")
+    skill_name = (params.get("skill_name") or params.get("skill") or "").strip()
+
+    skill = _resolve_visible_skill(db, workspace_id, name=skill_name, skill_id=skill_id)
+    if not skill:
+        return {"success": False, "error": "Skill not found or not available to this workspace."}
+
+    actor = str(params.get("_agent_name") or params.get("_agent_id") or "workspace-admin")
+
+    # Scanner-pass required at enable-time (import != executable).
+    if enabled:
+        try:
+            from core.services.plugin_security_scanner import quick_scan
+
+            findings = quick_scan(skill.prompt_template or "", filename=f"{skill.name}/SKILL.md")
+            critical = [f for f in findings if f.severity == "critical"]
+            if critical:
+                return {
+                    "success": False,
+                    "error": (
+                        f"Cannot enable L3 execution for '{skill.name}' — the security scanner "
+                        "found critical issues. Fix them and re-import before enabling."
+                    ),
+                    "findings": [{"severity": f.severity, "description": f.description, "line": f.line} for f in critical],
+                }
+        except Exception:
+            logger.warning("[set_skill_script_execution] scanner unavailable — refusing enable (fail-closed)", exc_info=True)
+            return {"success": False, "error": "Security scanner unavailable — refusing to enable L3 execution (fail-closed)."}
+
+    try:
+        enabled_ids = set_l3_execution_enabled(db, workspace_id, skill.id, enabled, actor=actor)
+        db.commit()
+    except ValueError as e:
+        db.rollback()
+        return {"success": False, "error": str(e)}
+
+    return {
+        "success": True,
+        "skill": skill.name,
+        "skill_id": skill.id,
+        "l3_execution_enabled": enabled,
+        "enabled_skill_ids": enabled_ids,
+        "message": (
+            f"L3 script execution {'ENABLED' if enabled else 'DISABLED'} for skill "
+            f"'{skill.name}' in this workspace."
+        ),
+    }

--- a/orchestrator/modules/tools/discovery/platform_executor.py
+++ b/orchestrator/modules/tools/discovery/platform_executor.py
@@ -393,8 +393,8 @@ class PlatformActionExecutor:
             "platform_update_skill": update_skill,
             "platform_delete_workspace_skill": delete_workspace_skill,
             # Skill runtime (PRD-202): L2 trigger-load / L3 worker exec / L3 enablement
-            "load_skill": load_skill,
-            "run_skill_script": run_skill_script,
+            "platform_load_skill": load_skill,
+            "platform_run_skill_script": run_skill_script,
             "platform_set_skill_script_execution": set_skill_script_execution,
             # Agent assignment (PRD-71)
             "platform_assign_tool_to_agent": assign_tool_to_agent,

--- a/orchestrator/modules/tools/discovery/platform_executor.py
+++ b/orchestrator/modules/tools/discovery/platform_executor.py
@@ -123,6 +123,11 @@ from modules.tools.discovery.handlers_skills import (
     update_skill,
     delete_workspace_skill,
 )
+from modules.tools.discovery.handlers_skill_runtime import (  # PRD-202 S2/S3/S4
+    load_skill,
+    run_skill_script,
+    set_skill_script_execution,
+)
 from modules.tools.discovery.handlers_board_tasks import (
     create_board_task,
     list_board_tasks,
@@ -387,6 +392,10 @@ class PlatformActionExecutor:
             "platform_create_workspace_skill": create_workspace_skill,
             "platform_update_skill": update_skill,
             "platform_delete_workspace_skill": delete_workspace_skill,
+            # Skill runtime (PRD-202): L2 trigger-load / L3 worker exec / L3 enablement
+            "load_skill": load_skill,
+            "run_skill_script": run_skill_script,
+            "platform_set_skill_script_execution": set_skill_script_execution,
             # Agent assignment (PRD-71)
             "platform_assign_tool_to_agent": assign_tool_to_agent,
             "platform_assign_skill_to_agent": assign_skill_to_agent,

--- a/orchestrator/tests/test_context/test_service.py
+++ b/orchestrator/tests/test_context/test_service.py
@@ -294,7 +294,12 @@ class TestBuildContextChatbot:
     @pytest.mark.asyncio
     async def test_chatbot_skills_in_prompt(
         self, agent, mock_db, messages, mock_platform_actions, mock_memory, mock_tools_full    ):
-        """Skill content (SKILL.md) appears in system prompt."""
+        """PRD-202 S2: the skill's L1 metadata (name) appears in the system prompt.
+
+        The fixture skill ('sentinel') is not in the core always-on set, so its
+        full body is trigger-loaded (load_skill), not pre-injected — the section
+        contributes L1 metadata (name + description) instead.
+        """
         svc = ContextService(mock_db)
         result = await svc.build_context(
             mode=ContextMode.CHATBOT,
@@ -302,7 +307,7 @@ class TestBuildContextChatbot:
             workspace_id="ws_test",
             messages=messages,
         )
-        assert "SENTINEL" in result.system_prompt
+        assert "sentinel" in result.system_prompt  # L1 metadata (name)
         assert "skills" in result.sections_included
 
 

--- a/orchestrator/tests/test_p2w1_agent_skills_repair.py
+++ b/orchestrator/tests/test_p2w1_agent_skills_repair.py
@@ -186,13 +186,15 @@ def test_skills_section_dedupes_identical_bodies():
 
 def test_skills_section_first_skill_is_primary_by_arrival_order():
     # Agent.skills arrives pre-ordered by attachment priority (model order_by);
-    # the section must respect that order — first in, uncapped primary.
+    # the section must respect that order. PRD-202 S2 supersedes the full-body
+    # "primary" render with L1 metadata for non-core skills — so the ordering
+    # invariant is now asserted on the L1 catalog (names in arrival order).
     hi = _skill(1, "hi-priority", "HI-BODY unique-hi")
     lo = _skill(2, "lo-priority", "LO-BODY unique-lo")
     out = _render([hi, lo])
-    assert out.index("HI-BODY") < out.index("LO-BODY")
+    assert out.index("hi-priority") < out.index("lo-priority")
     flipped = _render([lo, hi])
-    assert flipped.index("LO-BODY") < flipped.index("HI-BODY")
+    assert flipped.index("lo-priority") < flipped.index("hi-priority")
 
 
 def test_skills_section_phantom_priority_sort_is_gone():

--- a/orchestrator/tests/test_prd202_s1_skill_portability.py
+++ b/orchestrator/tests/test_prd202_s1_skill_portability.py
@@ -1,0 +1,273 @@
+"""PRD-202 S1 (P2-21) — spec-conformant SKILL.md schema + import/export.
+
+Pins:
+1. The canonical ``skill_source`` provenance scheme resolves every value —
+   canonical ``scheme:ref`` AND legacy tags (``builtin-core``, bare git ids).
+2. A standard-conformant folder imports to a ``Skill`` (+ ``SkillFile``) rows
+   with the frontmatter ``description`` persisted as the L1 trigger text.
+3. A ``Skill`` row exports back to a standard folder an external runner accepts.
+4. import(export(skill)) round-trips name / description / body.
+
+All pure — fixture folders on a tmp dir, an in-memory fake session; no git,
+no network, no LLM (the ``workspace`` scheme is trusted → static-only scan on
+clean fixtures returns no findings).
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import pathlib
+import sys
+from types import SimpleNamespace
+
+for _k, _v in {
+    "POSTGRES_USER": "test", "POSTGRES_PASSWORD": "test",
+    "POSTGRES_HOST": "localhost", "POSTGRES_PORT": "5432", "POSTGRES_DB": "test",
+}.items():
+    os.environ.setdefault(_k, _v)
+
+_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from modules.agents.services.skill_source_scheme import (  # noqa: E402
+    CANONICAL_SKILL_SOURCE_SCHEMES,
+    canonicalize_skill_source,
+    is_external_source,
+    parse_skill_source,
+    scheme_of,
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. Canonical provenance scheme resolves
+# ---------------------------------------------------------------------------
+
+def test_skill_source_scheme_canonical_resolves_legacy_and_canonical():
+    # Legacy exact tags
+    assert parse_skill_source("builtin-core") == ("builtin", "core")
+    assert parse_skill_source("builtin-seeds") == ("builtin", "seeds")
+    assert parse_skill_source("workspace-user") == ("workspace", "user")
+    assert parse_skill_source("workspace-fork") == ("workspace", "fork")
+    # Legacy git shape: a bare numeric SkillSource id
+    assert parse_skill_source("5") == ("git", "5")
+    # Already-canonical scheme:ref
+    assert parse_skill_source("plugin:jira-admin") == ("plugin", "jira-admin")
+    assert parse_skill_source("git:anthropic-official") == ("git", "anthropic-official")
+    # Unknown / empty
+    assert parse_skill_source("") == ("unknown", "")
+    assert parse_skill_source(None) == ("unknown", "")
+
+
+def test_canonicalize_round_trips_through_parse():
+    for scheme in CANONICAL_SKILL_SOURCE_SCHEMES:
+        value = canonicalize_skill_source(scheme, "some-ref")
+        assert value == f"{scheme}:some-ref"
+        assert parse_skill_source(value) == (scheme, "some-ref")
+        assert scheme_of(value) == scheme
+
+
+def test_canonicalize_rejects_unknown_scheme():
+    try:
+        canonicalize_skill_source("ftp", "x")
+        assert False, "expected ValueError for an unknown scheme"
+    except ValueError:
+        pass
+
+
+def test_is_external_source_only_git_and_plugin():
+    assert is_external_source("git:anthropic-official") is True
+    assert is_external_source("plugin:jira") is True
+    assert is_external_source("5") is True  # legacy git
+    assert is_external_source("builtin-core") is False
+    assert is_external_source("workspace:user") is False
+    assert is_external_source("workspace-fork") is False
+
+
+# ---------------------------------------------------------------------------
+# In-memory fake session (no DB)
+# ---------------------------------------------------------------------------
+
+class _FakeQuery:
+    def filter(self, *a, **k):
+        return self
+
+    def first(self):
+        return None  # every import here is a fresh insert
+
+    def delete(self):
+        return 0
+
+    def all(self):
+        return []
+
+
+class _FakeSession:
+    def __init__(self):
+        self.added = []
+        self._next_id = 0
+
+    def query(self, *a, **k):
+        return _FakeQuery()
+
+    def add(self, obj):
+        self.added.append(obj)
+        if getattr(obj, "id", None) is None:
+            self._next_id += 1
+            obj.id = self._next_id
+
+    def flush(self):
+        for o in self.added:
+            if getattr(o, "id", None) is None:
+                self._next_id += 1
+                o.id = self._next_id
+
+    def commit(self):
+        pass
+
+    def skills(self):
+        return [o for o in self.added if type(o).__name__ == "Skill"]
+
+    def skill_files(self):
+        return [o for o in self.added if type(o).__name__ == "SkillFile"]
+
+
+def _write_standard_folder(root: pathlib.Path, *, name="my-skill", description="Does a specific thing well", body="# My Skill\n\nStep one, step two.") -> pathlib.Path:
+    folder = root / name
+    (folder / "scripts").mkdir(parents=True, exist_ok=True)
+    (folder / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: {description}\nversion: 2.1.0\ntags:\n  - alpha\n---\n\n{body}\n",
+        encoding="utf-8",
+    )
+    (folder / "scripts" / "run.py").write_text("print('hello from skill script')\n", encoding="utf-8")
+    (folder / "reference.md").write_text("# Reference\n\nExtra detail.\n", encoding="utf-8")
+    return folder
+
+
+# ---------------------------------------------------------------------------
+# 2. Import: standard folder -> Skill (+ SkillFile) with description as L1
+# ---------------------------------------------------------------------------
+
+def test_import_standard_skill_folder_persists_description_as_l1(tmp_path):
+    from modules.agents.services.skill_portability import import_standard_skill_folder
+
+    folder = _write_standard_folder(tmp_path)
+    db = _FakeSession()
+
+    result = asyncio.run(import_standard_skill_folder(
+        db, str(folder),
+        source_scheme="workspace", source_ref="user",
+        workspace_id=None,
+    ))
+
+    assert result["success"] is True, result
+    skills = db.skills()
+    assert len(skills) == 1
+    skill = skills[0]
+    assert skill.name == "my-skill"
+    # description is the L1 trigger text — on the column AND in the JSONB the
+    # L1 loader reads.
+    assert skill.description == "Does a specific thing well"
+    assert skill.skill_metadata["description"] == "Does a specific thing well"
+    # L2 body lives in prompt_template
+    assert "# My Skill" in skill.prompt_template
+    # provenance is canonical
+    assert skill.skill_source == "workspace:user"
+    assert parse_skill_source(skill.skill_source) == ("workspace", "user")
+
+    # L3 bundle indexed: the script + the resource, not skipped
+    files = {f.file_path: f for f in db.skill_files()}
+    assert any(p.endswith("run.py") for p in files), files
+    script = next(f for p, f in files.items() if p.endswith("run.py"))
+    assert script.load_level == 3 and script.file_type == "script"
+
+
+def test_import_rejects_folder_without_description(tmp_path):
+    from modules.agents.services.skill_portability import import_standard_skill_folder
+
+    folder = tmp_path / "bad-skill"
+    folder.mkdir()
+    (folder / "SKILL.md").write_text("---\nname: bad-skill\n---\n\n# Body\n", encoding="utf-8")
+    db = _FakeSession()
+
+    result = asyncio.run(import_standard_skill_folder(
+        db, str(folder), source_scheme="workspace", source_ref="user",
+    ))
+    assert result["success"] is False
+    assert "description" in result["error"].lower()
+
+
+# ---------------------------------------------------------------------------
+# 3. Export: Skill row -> standard folder
+# ---------------------------------------------------------------------------
+
+def test_export_skill_emits_standard_folder(tmp_path):
+    from modules.agents.services.skill_portability import export_skill_to_folder
+
+    # A skill with an on-disk bundle (scripts/) to copy out.
+    src = tmp_path / "src"
+    (src / "scripts").mkdir(parents=True)
+    (src / "scripts" / "run.py").write_text("print('x')\n", encoding="utf-8")
+
+    skill = SimpleNamespace(
+        name="exported-skill",
+        description="An exportable capability",
+        prompt_template="# Exported\n\nBody text.",
+        skill_version="1.4.0",
+        tags=["beta"],
+        category="analytics",
+        skill_metadata={"description": "An exportable capability", "author": "vector"},
+        filesystem_path=str(src),
+    )
+
+    out = export_skill_to_folder(None, skill, str(tmp_path / "out"))
+    out_dir = pathlib.Path(out)
+
+    skill_md = (out_dir / "SKILL.md").read_text(encoding="utf-8")
+    assert skill_md.startswith("---")
+    assert "name: exported-skill" in skill_md
+    assert "description: An exportable capability" in skill_md
+    assert "# Exported" in skill_md  # body present
+    # internal bookkeeping is NOT exported
+    assert "security_scan" not in skill_md
+    # bundled script copied into the standard scripts/ dir
+    assert (out_dir / "scripts" / "run.py").read_text(encoding="utf-8") == "print('x')\n"
+
+
+# ---------------------------------------------------------------------------
+# 4. Round-trip: import(export(skill)) preserves name / description / body
+# ---------------------------------------------------------------------------
+
+def test_import_export_roundtrips(tmp_path):
+    from modules.agents.services.skill_portability import (
+        export_skill_to_folder,
+        import_standard_skill_folder,
+    )
+
+    src = tmp_path / "src"
+    (src / "scripts").mkdir(parents=True)
+    (src / "scripts" / "run.py").write_text("print('roundtrip')\n", encoding="utf-8")
+    original = SimpleNamespace(
+        name="roundtrip-skill",
+        description="Round trips cleanly",
+        prompt_template="# Roundtrip\n\nContent.",
+        skill_version="3.0.0",
+        tags=["x"],
+        category="general",
+        skill_metadata={"description": "Round trips cleanly"},
+        filesystem_path=str(src),
+    )
+
+    exported_dir = export_skill_to_folder(None, original, str(tmp_path / "out"))
+
+    db = _FakeSession()
+    result = asyncio.run(import_standard_skill_folder(
+        db, exported_dir, source_scheme="workspace", source_ref="fork",
+    ))
+    assert result["success"] is True, result
+    reimported = db.skills()[0]
+    assert reimported.name == original.name
+    assert reimported.description == original.description
+    assert "# Roundtrip" in reimported.prompt_template
+    # the exported bundle survived the round trip and was re-indexed
+    assert any(f.file_path.endswith("run.py") for f in db.skill_files())

--- a/orchestrator/tests/test_prd202_s2_trigger_activation.py
+++ b/orchestrator/tests/test_prd202_s2_trigger_activation.py
@@ -182,4 +182,8 @@ def test_load_skill_registered_as_platform_action():
     from modules.tools.discovery.action_registry import get_action_registry
 
     reg = get_action_registry()
-    assert reg.get("load_skill") is not None, "load_skill must be a registered platform action"
+    # platform_-prefixed to satisfy the tool-reachability namespace invariant
+    # (test_tool_reachability): every registry action is platform_* / workspace_*.
+    assert reg.get("platform_load_skill") is not None, "platform_load_skill must be registered"
+    assert reg.get("platform_run_skill_script") is not None, "platform_run_skill_script must be registered"
+    assert reg.get("platform_set_skill_script_execution") is not None

--- a/orchestrator/tests/test_prd202_s2_trigger_activation.py
+++ b/orchestrator/tests/test_prd202_s2_trigger_activation.py
@@ -1,0 +1,185 @@
+"""PRD-202 S2 (P2-21) — trigger-based L2 activation.
+
+Pins:
+1. SkillsSection renders L1 metadata (name + description) for non-core skills —
+   NOT their full bodies (the per-skill prompt-cost cut).
+2. The load_skill tool injects a skill's L2 body (prompt_template) on trigger.
+3. An untriggered skill costs L1 only (the measured token delta).
+4. Source-grep guard: SkillsSection no longer renders full L2 bodies
+   unconditionally — the always-inject path (and the 5k aux budget) is gone.
+
+Pure/mocked — isolated section load with a fake estimator; the load_skill
+handler runs against a chainable mock session; no DB, no model.
+"""
+import asyncio
+import importlib.util
+import os
+import pathlib
+import sys
+import types
+from unittest.mock import MagicMock
+
+for _k, _v in {
+    "POSTGRES_USER": "test", "POSTGRES_PASSWORD": "test",
+    "POSTGRES_HOST": "localhost", "POSTGRES_PORT": "5432", "POSTGRES_DB": "test",
+}.items():
+    os.environ.setdefault(_k, _v)
+
+_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+_SKILLS_SRC = _ROOT / "modules" / "context" / "sections" / "skills.py"
+
+
+# ---------------------------------------------------------------------------
+# Isolated section load (fake estimator)
+# ---------------------------------------------------------------------------
+
+_estimator_stub = types.ModuleType("modules.context.estimator")
+
+
+class _FakeEstimator:
+    def estimate(self, text):
+        return len(text) // 4
+
+
+_estimator_stub.TokenEstimator = _FakeEstimator
+
+
+def _load_skills_section():
+    keys = (
+        "modules", "modules.context", "modules.context.estimator",
+        "modules.context.sections", "modules.context.sections.base",
+    )
+    saved = {k: sys.modules.get(k) for k in keys}
+    try:
+        for name in ("modules", "modules.context", "modules.context.sections"):
+            pkg = types.ModuleType(name)
+            pkg.__path__ = []
+            sys.modules[name] = pkg
+        sys.modules["modules.context.estimator"] = _estimator_stub
+        base = importlib.util.module_from_spec(importlib.util.spec_from_file_location(
+            "modules.context.sections.base", _ROOT / "modules/context/sections/base.py"))
+        sys.modules["modules.context.sections.base"] = base
+        base.__spec__.loader.exec_module(base)
+        skills = importlib.util.module_from_spec(importlib.util.spec_from_file_location(
+            "modules.context.sections.skills", _SKILLS_SRC))
+        skills.__spec__.loader.exec_module(skills)
+        return skills.SkillsSection, base.SectionContext
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                sys.modules.pop(k, None)
+            else:
+                sys.modules[k] = v
+
+
+def _skill(name, body, description="", sid=None):
+    s = MagicMock()
+    s.id = sid
+    s.name = name
+    s.prompt_template = body
+    s.description = description
+    s.is_active = True
+    s.tools_schema = None
+    s.content_hash = None
+    return s
+
+
+def _render(skills_list):
+    SkillsSection, SectionContext = _load_skills_section()
+    agent = MagicMock()
+    agent.skills = skills_list
+    ctx = SectionContext(agent=agent, workspace_id="ws_test")
+    return asyncio.run(SkillsSection().render(ctx))
+
+
+# ---------------------------------------------------------------------------
+# 1 + 3. L1-only render / token delta
+# ---------------------------------------------------------------------------
+
+def test_skills_section_renders_l1_only():
+    out = _render([_skill("growth", "FULL BODY " * 400, description="Growth playbooks")])
+    assert "growth" in out
+    assert "Growth playbooks" in out       # L1 description
+    assert "FULL BODY" not in out          # L2 body NOT pre-injected
+
+
+def test_untriggered_skill_costs_l1_only():
+    huge = "z" * 40000
+    out = _render([_skill("reporter", huge, description="Builds reports")])
+    assert huge not in out
+    assert len(out) < 2000  # L1-sized, not ~40k
+
+
+# ---------------------------------------------------------------------------
+# 2. load_skill injects the L2 body
+# ---------------------------------------------------------------------------
+
+def _mock_session_returning(skill):
+    q = MagicMock()
+    q.filter.return_value = q
+    q.order_by.return_value = q
+    q.first.return_value = skill
+    db = MagicMock()
+    db.query.return_value = q
+    return db
+
+
+def test_load_skill_tool_injects_l2_body():
+    from modules.tools.discovery.handlers_skill_runtime import load_skill
+
+    skill = MagicMock()
+    skill.id = 12
+    skill.name = "growth"
+    skill.prompt_template = "# Growth\n\nDetailed step-by-step body."
+    db = _mock_session_returning(skill)
+
+    result = asyncio.run(load_skill(db, "ws-1", {"name": "growth"}))
+    assert result["success"] is True
+    assert result["skill"] == "growth"
+    assert "Detailed step-by-step body." in result["content"]
+
+
+def test_load_skill_missing_name_errors():
+    from modules.tools.discovery.handlers_skill_runtime import load_skill
+
+    result = asyncio.run(load_skill(MagicMock(), "ws-1", {}))
+    assert result["success"] is False
+    assert "name" in result["error"].lower()
+
+
+def test_load_skill_not_found_errors():
+    from modules.tools.discovery.handlers_skill_runtime import load_skill
+
+    db = _mock_session_returning(None)
+    result = asyncio.run(load_skill(db, "ws-1", {"name": "nope"}))
+    assert result["success"] is False
+    assert "not found" in result["error"].lower()
+
+
+# ---------------------------------------------------------------------------
+# 4. Source-grep guard: no unconditional L2 render
+# ---------------------------------------------------------------------------
+
+def test_skills_section_no_unconditional_l2_render():
+    src = _SKILLS_SRC.read_text()
+    # the 5,000-token aux budget path is DELETED
+    assert "aux_max_tokens" not in src, "the superseded aux-budget path must be gone"
+    # PRD-191's phantom priority sort stays gone
+    assert 'getattr(s, "priority", 0)' not in src
+    # the old always-inject helper is gone (renamed/gated)
+    assert "_get_skill_content" not in src, "the unconditional L2 render helper must be gone"
+    # full-body render is now GATED by the core always-on set, not unconditional
+    assert "_core_always_on_names" in src, "the core-gate must exist"
+    assert "SKILL_CORE_ALWAYS_ON" in src, "core set must resolve from config"
+    # the L1 trigger instruction is wired
+    assert "load_skill" in src
+
+
+def test_load_skill_registered_as_platform_action():
+    from modules.tools.discovery.action_registry import get_action_registry
+
+    reg = get_action_registry()
+    assert reg.get("load_skill") is not None, "load_skill must be a registered platform action"

--- a/orchestrator/tests/test_prd202_s3_l3_worker_exec.py
+++ b/orchestrator/tests/test_prd202_s3_l3_worker_exec.py
@@ -1,0 +1,159 @@
+"""PRD-202 S3 (P2-21) — L3 script execution via the workspace worker.
+
+Pins:
+1. run_skill_script materializes the skill bundle into the worker and invokes
+   WorkspaceClient.exec_command (NOT the in-process ActionExecutor).
+2. Only the script OUTPUT (stdout/stderr) returns to context — never the source.
+3. A non-enabled skill's script is refused (S4 gate: import != executable).
+
+Pure/mocked — the workspace worker is mocked at the WorkspaceClient HTTP
+boundary; the bundle + enablement are stubbed; no live worker, no network.
+"""
+import asyncio
+import os
+import pathlib
+import sys
+from unittest.mock import AsyncMock, MagicMock
+
+for _k, _v in {
+    "POSTGRES_USER": "test", "POSTGRES_PASSWORD": "test",
+    "POSTGRES_HOST": "localhost", "POSTGRES_PORT": "5432", "POSTGRES_DB": "test",
+}.items():
+    os.environ.setdefault(_k, _v)
+
+_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+
+def _skill_session(skill):
+    q = MagicMock()
+    q.filter.return_value = q
+    q.order_by.return_value = q
+    q.first.return_value = skill
+    db = MagicMock()
+    db.query.return_value = q
+    return db
+
+
+def _fake_skill(name="docx", fs="/tmp/skills/docx"):
+    s = MagicMock()
+    s.id = 55
+    s.name = name
+    s.filesystem_path = fs
+    return s
+
+
+def _install_worker_mock(monkeypatch, exec_result):
+    """Patch WorkspaceClient at its source; return the mock client for asserts."""
+    import core.workspace_client as wc
+
+    client = MagicMock()
+    client.write_file = AsyncMock(return_value={"success": True})
+    client.exec_command = AsyncMock(return_value=exec_result)
+    monkeypatch.setattr(wc, "WorkspaceClient", MagicMock(return_value=client))
+    return client
+
+
+def _patch_bundle(monkeypatch, bundle):
+    import modules.agents.services.skill_portability as sp
+    monkeypatch.setattr(sp, "collect_skill_bundle", lambda _p: bundle)
+
+
+def _patch_enabled(monkeypatch, enabled):
+    import core.services.skill_l3_execution as l3
+    monkeypatch.setattr(l3, "is_l3_execution_enabled", lambda *a, **k: enabled)
+
+
+# ---------------------------------------------------------------------------
+# 1 + 2. worker exec + output-only
+# ---------------------------------------------------------------------------
+
+def test_run_skill_script_invokes_worker_exec(monkeypatch):
+    from modules.tools.discovery.handlers_skill_runtime import run_skill_script
+
+    _patch_enabled(monkeypatch, True)
+    _patch_bundle(monkeypatch, {"scripts/convert.py": "print('SECRET SOURCE do not leak')"})
+    client = _install_worker_mock(monkeypatch, {
+        "success": True, "stdout": "converted 3 files", "stderr": "", "exit_code": 0,
+    })
+    db = _skill_session(_fake_skill())
+
+    result = asyncio.run(run_skill_script(db, "ws-1", {"skill": "docx", "script": "convert.py"}))
+
+    assert result["success"] is True
+    # bundle materialized into the worker filesystem
+    assert client.write_file.await_count >= 1
+    # the sandboxed worker exec was invoked (not the in-process executor)
+    client.exec_command.assert_awaited_once()
+    call = client.exec_command.await_args
+    assert "scripts/convert.py" in call.kwargs["command"]
+    assert call.kwargs["command"].startswith("python ")
+    assert call.kwargs["cwd"] == ".skills/docx"
+
+
+def test_run_skill_script_returns_output_only(monkeypatch):
+    from modules.tools.discovery.handlers_skill_runtime import run_skill_script
+
+    _patch_enabled(monkeypatch, True)
+    _patch_bundle(monkeypatch, {"scripts/convert.py": "print('SECRET SOURCE do not leak')"})
+    _install_worker_mock(monkeypatch, {
+        "success": True, "stdout": "the output", "stderr": "a warning", "exit_code": 0,
+    })
+    db = _skill_session(_fake_skill())
+
+    result = asyncio.run(run_skill_script(db, "ws-1", {"skill": "docx", "script": "convert.py"}))
+
+    assert result["stdout"] == "the output"
+    assert result["stderr"] == "a warning"
+    # the script SOURCE never enters the result
+    blob = str(result)
+    assert "SECRET SOURCE" not in blob
+
+
+def test_run_skill_script_caps_output(monkeypatch):
+    from modules.tools.discovery.handlers_skill_runtime import run_skill_script
+
+    _patch_enabled(monkeypatch, True)
+    _patch_bundle(monkeypatch, {"scripts/x.py": "print('x')"})
+    _install_worker_mock(monkeypatch, {
+        "success": True, "stdout": "A" * 100000, "stderr": "", "exit_code": 0,
+    })
+    db = _skill_session(_fake_skill())
+
+    result = asyncio.run(run_skill_script(db, "ws-1", {"skill": "docx", "script": "x.py"}))
+    assert len(result["stdout"]) < 100000  # capped
+    assert "truncated" in result["stdout"]
+
+
+# ---------------------------------------------------------------------------
+# 3. enablement gate (S4)
+# ---------------------------------------------------------------------------
+
+def test_l3_execution_requires_enablement(monkeypatch):
+    from modules.tools.discovery.handlers_skill_runtime import run_skill_script
+
+    _patch_enabled(monkeypatch, False)  # NOT enabled for this workspace
+    _patch_bundle(monkeypatch, {"scripts/convert.py": "print('x')"})
+    client = _install_worker_mock(monkeypatch, {"success": True, "stdout": "x"})
+    db = _skill_session(_fake_skill())
+
+    result = asyncio.run(run_skill_script(db, "ws-1", {"skill": "docx", "script": "convert.py"}))
+
+    assert result["success"] is False
+    assert result.get("enablement_required") is True
+    # the worker was never touched — a disabled skill's script never runs
+    client.exec_command.assert_not_awaited()
+
+
+def test_run_skill_script_unknown_script_refused(monkeypatch):
+    from modules.tools.discovery.handlers_skill_runtime import run_skill_script
+
+    _patch_enabled(monkeypatch, True)
+    _patch_bundle(monkeypatch, {"scripts/convert.py": "print('x')"})
+    _install_worker_mock(monkeypatch, {"success": True, "stdout": "x"})
+    db = _skill_session(_fake_skill())
+
+    result = asyncio.run(run_skill_script(db, "ws-1", {"skill": "docx", "script": "missing.py"}))
+    assert result["success"] is False
+    assert "not found" in result["error"].lower()

--- a/orchestrator/tests/test_prd202_s4_governed_distribution.py
+++ b/orchestrator/tests/test_prd202_s4_governed_distribution.py
@@ -1,0 +1,236 @@
+"""PRD-202 S4 (P2-21) — tenanted, governed, scanned distribution.
+
+Pins:
+1. A spec-conformant folder import runs the 2-stage scanner (static always).
+2. Third-party/external provenance (git/plugin) forces the LLM stage ON; a
+   trusted source (workspace) stays static-only.
+3. L3 execution enablement is a workspace-admin action written to SkillAuditLog
+   (import != executable — running is opt-in, gated on a scanner-pass).
+
+Pure/mocked — fixture folder, fake session, the scanner's static + LLM stages
+stubbed; no network.
+"""
+import asyncio
+import os
+import pathlib
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+for _k, _v in {
+    "POSTGRES_USER": "test", "POSTGRES_PASSWORD": "test",
+    "POSTGRES_HOST": "localhost", "POSTGRES_PORT": "5432", "POSTGRES_DB": "test",
+}.items():
+    os.environ.setdefault(_k, _v)
+
+_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+class _FakeQuery:
+    def __init__(self, first=None):
+        self._first = first
+
+    def filter(self, *a, **k):
+        return self
+
+    def order_by(self, *a, **k):
+        return self
+
+    def first(self):
+        return self._first
+
+    def delete(self):
+        return 0
+
+
+class _FakeSession:
+    def __init__(self, first_by_model=None):
+        self.added = []
+        self._next_id = 0
+        self._first_by_model = first_by_model or {}
+
+    def query(self, model, *a, **k):
+        name = getattr(model, "__name__", "")
+        return _FakeQuery(self._first_by_model.get(name))
+
+    def add(self, obj):
+        self.added.append(obj)
+        if getattr(obj, "id", None) is None:
+            self._next_id += 1
+            try:
+                obj.id = self._next_id
+            except Exception:
+                pass
+
+    def flush(self):
+        for o in self.added:
+            if getattr(o, "id", None) is None:
+                self._next_id += 1
+                o.id = self._next_id
+
+    def commit(self):
+        pass
+
+    def rollback(self):
+        pass
+
+    def added_of(self, type_name):
+        return [o for o in self.added if type(o).__name__ == type_name]
+
+
+def _write_folder(root, name="scan-skill"):
+    folder = root / name
+    folder.mkdir(parents=True)
+    (folder / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: A clean importable skill\nversion: 1.0.0\n---\n\n# Body\n\nDo the thing.\n",
+        encoding="utf-8",
+    )
+    return folder
+
+
+def _patch_scanner(monkeypatch, static_findings=None):
+    """Spy the static stage; stub the LLM stage. Returns the two mocks."""
+    import core.services.plugin_security_scanner as scanner
+
+    quick = MagicMock(return_value=static_findings or [])
+    llm = AsyncMock(return_value=SimpleNamespace(status="passed", risk_score=0, findings=[]))
+    monkeypatch.setattr(scanner, "quick_scan", quick)
+    monkeypatch.setattr(scanner, "llm_security_scan", llm)
+    return quick, llm
+
+
+# ---------------------------------------------------------------------------
+# 1 + 2. two-stage scan on import; LLM stage forced for external sources
+# ---------------------------------------------------------------------------
+
+def test_standard_import_runs_two_stage_scan(monkeypatch, tmp_path):
+    from modules.agents.services.skill_portability import import_standard_skill_folder
+
+    quick, llm = _patch_scanner(monkeypatch)
+    folder = _write_folder(tmp_path)
+    db = _FakeSession()
+
+    result = asyncio.run(import_standard_skill_folder(
+        db, str(folder), source_scheme="workspace", source_ref="user",
+    ))
+    assert result["success"] is True
+    quick.assert_called()  # the static stage always runs on import
+
+
+def test_external_source_forces_llm_stage(monkeypatch, tmp_path):
+    from modules.agents.services.skill_portability import import_standard_skill_folder
+
+    quick, llm = _patch_scanner(monkeypatch)
+    folder = _write_folder(tmp_path, name="ext-skill")
+    db = _FakeSession()
+
+    # git provenance is third-party/external → LLM stage ON
+    asyncio.run(import_standard_skill_folder(
+        db, str(folder), source_scheme="git", source_ref="anthropic-official",
+    ))
+    llm.assert_awaited()  # the LLM stage ran for the external source
+
+
+def test_trusted_source_skips_llm_stage(monkeypatch, tmp_path):
+    from modules.agents.services.skill_portability import import_standard_skill_folder
+
+    quick, llm = _patch_scanner(monkeypatch)
+    folder = _write_folder(tmp_path, name="trusted-skill")
+    db = _FakeSession()
+
+    # workspace provenance is trusted → static only, LLM stage skipped
+    asyncio.run(import_standard_skill_folder(
+        db, str(folder), source_scheme="workspace", source_ref="user",
+    ))
+    llm.assert_not_awaited()
+
+
+def test_import_blocks_on_critical_static_finding(monkeypatch, tmp_path):
+    from modules.agents.services.skill_portability import import_standard_skill_folder
+
+    # NB: the "os.system" strings below are inert scanner-finding FIXTURES (test
+    # data describing what the scanner would flag) — no shell is invoked here.
+    critical = SimpleNamespace(type="dangerous_call", severity="critical", line=1, description="os.system")
+    _patch_scanner(monkeypatch, static_findings=[critical])
+    folder = _write_folder(tmp_path, name="bad-skill")
+    db = _FakeSession()
+
+    result = asyncio.run(import_standard_skill_folder(
+        db, str(folder), source_scheme="git", source_ref="x",
+    ))
+    assert result["success"] is False
+    assert result["verdict"] == "blocked"
+    assert db.added_of("Skill") == []  # nothing persisted on a block
+
+
+# ---------------------------------------------------------------------------
+# 3. L3 enablement is audited (SkillAuditLog)
+# ---------------------------------------------------------------------------
+
+def test_l3_enablement_is_audited():
+    from core.services.skill_l3_execution import set_l3_execution_enabled
+
+    ws = SimpleNamespace(settings={})
+    db = _FakeSession(first_by_model={"Workspace": ws})
+
+    set_l3_execution_enabled(db, "ws-1", 42, True, actor="owner-1")
+
+    audits = db.added_of("SkillAuditLog")
+    assert len(audits) == 1
+    assert audits[0].action == "l3_enable"
+    assert audits[0].skill_id == 42
+    # the enablement is persisted on the workspace settings
+    assert 42 in ws.settings["skills_l3_enabled"]
+
+    # disabling audits too, and removes the id
+    set_l3_execution_enabled(db, "ws-1", 42, False, actor="owner-1")
+    audits = db.added_of("SkillAuditLog")
+    assert audits[-1].action == "l3_disable"
+    assert 42 not in ws.settings["skills_l3_enabled"]
+
+
+def test_enable_refuses_when_scanner_flags_critical(monkeypatch):
+    from modules.tools.discovery.handlers_skill_runtime import set_skill_script_execution
+
+    critical = SimpleNamespace(severity="critical", description="os.system", line=3)
+    import core.services.plugin_security_scanner as scanner
+    monkeypatch.setattr(scanner, "quick_scan", MagicMock(return_value=[critical]))
+
+    skill = MagicMock()
+    skill.id = 7
+    skill.name = "risky"
+    skill.prompt_template = "# body with os.system(...)"
+    db = _FakeSession(first_by_model={"Skill": skill})
+
+    result = asyncio.run(set_skill_script_execution(db, "ws-1", {"skill_id": 7, "enabled": True}))
+    assert result["success"] is False
+    # a critical finding blocks enablement — import != executable, and not even
+    # enablable until the skill is clean
+    assert db.added_of("SkillAuditLog") == []
+
+
+def test_enable_succeeds_and_audits_when_clean(monkeypatch):
+    from modules.tools.discovery.handlers_skill_runtime import set_skill_script_execution
+
+    import core.services.plugin_security_scanner as scanner
+    monkeypatch.setattr(scanner, "quick_scan", MagicMock(return_value=[]))
+
+    skill = MagicMock()
+    skill.id = 9
+    skill.name = "clean"
+    skill.prompt_template = "# clean body"
+    ws = SimpleNamespace(settings={})
+    db = _FakeSession(first_by_model={"Skill": skill, "Workspace": ws})
+
+    result = asyncio.run(set_skill_script_execution(
+        db, "ws-1", {"skill_id": 9, "enabled": True, "_agent_name": "Auto"}
+    ))
+    assert result["success"] is True
+    assert result["l3_execution_enabled"] is True
+    assert db.added_of("SkillAuditLog")[-1].action == "l3_enable"

--- a/orchestrator/tests/test_skills_section.py
+++ b/orchestrator/tests/test_skills_section.py
@@ -13,10 +13,17 @@ Isolated module load (fake estimator) so skills.py runs without the full graph.
 """
 import asyncio
 import importlib.util
+import os
 import pathlib
 import sys
 import types
 from unittest.mock import MagicMock
+
+for _k, _v in {
+    "POSTGRES_USER": "test", "POSTGRES_PASSWORD": "test",
+    "POSTGRES_HOST": "localhost", "POSTGRES_PORT": "5432", "POSTGRES_DB": "test",
+}.items():
+    os.environ.setdefault(_k, _v)
 
 _ROOT = pathlib.Path(__file__).resolve().parents[1]
 

--- a/orchestrator/tests/test_skills_section.py
+++ b/orchestrator/tests/test_skills_section.py
@@ -1,4 +1,16 @@
-"""PRD-137 Fix #5: Primary skill not truncated, auxiliary skills capped."""
+"""PRD-202 S2: trigger-based L2 activation in SkillsSection.
+
+Supersedes the PRD-137 always-inject render (every attached skill's full body,
+uncapped-primary + 5k aux budget — both DELETED). New behavior:
+
+  * a ``core`` always-on skill (config.SKILL_CORE_ALWAYS_ON — platform-management)
+    renders its full L2 body every turn (Auto's operating manual, Q4);
+  * every OTHER attached skill renders only its L1 metadata (name + description)
+    plus a load_skill trigger instruction — its body is NOT pre-paid;
+  * PRD-191's dedup is preserved.
+
+Isolated module load (fake estimator) so skills.py runs without the full graph.
+"""
 import asyncio
 import importlib.util
 import pathlib
@@ -8,10 +20,6 @@ from unittest.mock import MagicMock
 
 _ROOT = pathlib.Path(__file__).resolve().parents[1]
 
-
-# ---------------------------------------------------------------------------
-# Stub estimator so base.py loads without the full module graph
-# ---------------------------------------------------------------------------
 
 _estimator_stub = types.ModuleType("modules.context.estimator")
 
@@ -25,13 +33,6 @@ _estimator_stub.TokenEstimator = _FakeEstimator
 
 
 def _load_sections_isolated():
-    """Load base.py + skills.py under a fake module graph, then restore.
-
-    The fakes only need to exist while the target files execute — the loaded
-    classes capture their dependencies at exec time. Restoring sys.modules
-    afterwards stops the fake ``modules`` package (with an emptied ``__path__``)
-    from leaking into the collection of sibling test modules. (PRD-142 W2-S2b.)
-    """
     _keys = (
         "modules",
         "modules.context",
@@ -41,9 +42,6 @@ def _load_sections_isolated():
     )
     _saved = {k: sys.modules.get(k) for k in _keys}
     try:
-        # Assign fresh fake packages — never mutate a real cached package's
-        # __path__ in place (setdefault + __path__=[] would corrupt the real
-        # ``modules`` package if it was already imported).
         for _name in ("modules", "modules.context", "modules.context.sections"):
             _pkg = types.ModuleType(_name)
             _pkg.__path__ = []
@@ -78,19 +76,19 @@ def _load_sections_isolated():
 
 SkillsSection, SectionContext = _load_sections_isolated()
 
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
+# The core always-on skill name (platform-management is the shipped default).
+CORE_SKILL = "platform-management"
 
 
-def _make_skill(name, content, is_active=True, tools_schema=None, priority=0):
+def _make_skill(name, content, description="", is_active=True, tools_schema=None, sid=None, content_hash=None):
     skill = MagicMock()
+    skill.id = sid
     skill.name = name
     skill.prompt_template = content
+    skill.description = description
     skill.is_active = is_active
     skill.tools_schema = tools_schema
-    skill.priority = priority
+    skill.content_hash = content_hash
     return skill
 
 
@@ -105,91 +103,90 @@ def _make_ctx(agent):
 
 
 def _render(section, ctx):
-    # asyncio.run() creates a fresh loop per call, so this is robust when a
-    # prior test in the same process already ran asyncio.run() (which leaves
-    # no current event loop on 3.10). get_event_loop() would raise there.
     return asyncio.run(section.render(ctx))
 
 
-# ── Primary skill not truncated ─────────────────────────────────────
+# ── Core skill: full L2 body always ─────────────────────────────────
 
 
-def test_single_large_skill_not_truncated():
-    """A single 11K-token skill should render fully (old cap was 3000)."""
-    large_content = "x" * 50000  # ~12,500 tokens at 4 chars/token
-    agent = _make_agent([_make_skill("platform-management", large_content)])
-    section = SkillsSection()
-    result = _render(section, _make_ctx(agent))
-    assert len(result) >= 50000
+def test_core_skill_renders_full_body():
+    large = "PLATFORM MANUAL " * 1000
+    agent = _make_agent([_make_skill(CORE_SKILL, large, description="core ops")])
+    result = _render(SkillsSection(), _make_ctx(agent))
+    assert result.count("PLATFORM MANUAL") == 1000  # uncapped, full body
 
 
-def test_primary_skill_content_preserved():
-    content = "# Platform Management\n\nFull skill content here with all sections."
-    agent = _make_agent([_make_skill("platform-management", content)])
-    section = SkillsSection()
-    result = _render(section, _make_ctx(agent))
-    assert content in result
+# ── Non-core skill: L1 metadata only (the cost cut) ─────────────────
 
 
-# ── Auxiliary skills capped ─────────────────────────────────────────
-
-
-def test_auxiliary_skills_truncated():
-    primary = _make_skill("primary-skill", "Primary content")
-    # aux_max_tokens=5000 → 20000 chars max
-    aux_content = "y" * 30000  # exceeds 5000 tokens
-    aux = _make_skill("aux-skill", aux_content)
-    agent = _make_agent([primary, aux])
-
-    section = SkillsSection()
-    result = _render(section, _make_ctx(agent))
-
-    assert "Primary content" in result
-    # The aux should be truncated to ~5000*4=20000 chars (±1 from boundary)
-    y_count = result.count("y")
-    assert y_count <= 20001
-    assert y_count < 30000  # definitely truncated from original
-
-
-def test_primary_not_truncated_even_with_aux():
-    primary_content = "p" * 50000
-    aux_content = "a" * 100
+def test_non_core_skill_renders_l1_only():
     agent = _make_agent([
-        _make_skill("big-primary", primary_content),
-        _make_skill("small-aux", aux_content),
+        _make_skill("growth-hacker", "SECRET BODY " * 500, description="Growth tactics and playbooks"),
     ])
+    result = _render(SkillsSection(), _make_ctx(agent))
+    # name + description present (L1), full body NOT
+    assert "growth-hacker" in result
+    assert "Growth tactics and playbooks" in result
+    assert "SECRET BODY" not in result
 
-    section = SkillsSection()
-    result = _render(section, _make_ctx(agent))
-    assert result.count("p") == 50000
-    assert "a" * 100 in result
+
+def test_l1_catalog_includes_load_skill_instruction():
+    agent = _make_agent([_make_skill("analytics", "body", description="Data analysis")])
+    result = _render(SkillsSection(), _make_ctx(agent))
+    assert "load_skill" in result  # the trigger instruction is present
 
 
-# ── No skills ──────────────────────────────────────────────────────
+def test_untriggered_skill_costs_l1_only():
+    """The token delta vs the old always-inject path: a big idle skill costs L1."""
+    huge_body = "x" * 40000  # ~10k tokens if inlined
+    agent = _make_agent([_make_skill("reporter", huge_body, description="Builds reports")])
+    result = _render(SkillsSection(), _make_ctx(agent))
+    # The rendered section is L1-sized (name+description+instruction), NOT ~40k.
+    assert len(result) < 2000
+    assert "x" * 40000 not in result
+
+
+def test_core_and_non_core_mixed():
+    agent = _make_agent([
+        _make_skill(CORE_SKILL, "CORE BODY HERE", description="core"),
+        _make_skill("side-skill", "SIDE BODY HERE", description="A side capability"),
+    ])
+    result = _render(SkillsSection(), _make_ctx(agent))
+    assert "CORE BODY HERE" in result       # core → full body
+    assert "SIDE BODY HERE" not in result    # non-core → L1 only
+    assert "side-skill" in result            # but its L1 metadata shows
+    assert "A side capability" in result
+
+
+# ── Dedup preserved (PRD-191) ───────────────────────────────────────
+
+
+def test_core_skill_deduped_by_id():
+    same = _make_skill(CORE_SKILL, "UNIQUE CORE " * 10, sid=7)
+    agent = _make_agent([same, same])
+    result = _render(SkillsSection(), _make_ctx(agent))
+    assert result.count("UNIQUE CORE") == 10  # rendered once, not twice
+
+
+# ── Empty / inactive ────────────────────────────────────────────────
 
 
 def test_no_skills_returns_empty():
-    agent = _make_agent([])
-    section = SkillsSection()
-    result = _render(section, _make_ctx(agent))
-    assert result == ""
+    assert _render(SkillsSection(), _make_ctx(_make_agent([]))) == ""
 
 
 def test_inactive_skills_excluded():
-    agent = _make_agent([_make_skill("dead", "content", is_active=False)])
-    section = SkillsSection()
-    result = _render(section, _make_ctx(agent))
-    assert result == ""
+    agent = _make_agent([_make_skill("dead", "content", description="x", is_active=False)])
+    assert _render(SkillsSection(), _make_ctx(agent)) == ""
 
 
-# ── Tool names from schema ──────────────────────────────────────────
+# ── Tool names block (kept) ─────────────────────────────────────────
 
 
 def test_skill_tool_names_included():
     schema = {"tools": [{"name": "search_knowledge"}, {"name": "write_file"}]}
-    agent = _make_agent([_make_skill("scout", "Scout skill", tools_schema=schema)])
-    section = SkillsSection()
-    result = _render(section, _make_ctx(agent))
+    agent = _make_agent([_make_skill("scout", "Scout skill", description="scout", tools_schema=schema)])
+    result = _render(SkillsSection(), _make_ctx(agent))
     assert "search_knowledge" in result
     assert "write_file" in result
     assert "Using Your Skill Tools" in result


### PR DESCRIPTION
## PRD-202 — Adopt the Agent Skills open standard (P2-21)

Spec: `docs/PRDS/PRD-202-PHASE2-WAVE-3-AGENT-SKILLS-STANDARD.md`. A **loading-model** PRD (Extension + Refactor, not a new engine): keep the DB as source of truth, adopt the standard's progressive-disclosure loading (L1-always / L2-on-trigger / L3-output-only), and run L3 scripts through the workspace worker that already exists.

### Stories

**S1 — Spec-conformant SKILL.md schema + import/export**
- `modules/agents/services/skill_source_scheme.py` — one canonical `skill_source` provenance scheme (`git:`/`plugin:`/`builtin:`/`workspace:`). `parse_skill_source` resolves **both** canonical `scheme:ref` and legacy tags (`builtin-core`, bare git ids like `"5"`), so provenance resolves without a risky reshape of the overloaded git join key.
- `modules/agents/services/skill_portability.py` — `import_standard_skill_folder` (conformant folder → `Skill` + `SkillFile` rows; frontmatter `description` persisted as **L1 trigger text** into `skill_metadata`) and `export_skill_to_folder` (row → standard folder an external runner accepts). Reuses `parse_yaml_frontmatter` + the existing scanner. No new table.
- `load_skill_core`'s builtin freshness check repointed to the scheme resolver — the bare-string `== "builtin-core"` compare is **deleted**.
- Migration `prd202_s1_skill_l1_trigger_backfill` — idempotent backfill of `skill_metadata.description`, chained onto the mainline tip `prd196` (carries PRD-191, untouched).

**S2 — Trigger-based L2 activation (the per-skill cost cut)**
- `modules/context/sections/skills.py` rewritten: renders **L1 metadata only** (name + description, ~50-100 tok/skill) + a `load_skill` trigger instruction for every non-core skill; full **L2 body only** for the `core` always-on set (`config.SKILL_CORE_ALWAYS_ON`, default `platform-management` — Q4). The always-inject `_get_skill_content` render **and** the 5,000-token aux budget are **deleted**. PRD-191 dedup preserved.
- New `load_skill` platform tool (3-file registration) injects a skill's `prompt_template` body on trigger. Per-turn activation signal logged (§7 measurement).

**S3 — L3 script execution via the workspace worker**
- New `run_skill_script` platform tool: materializes the skill's bundle into the per-workspace worker filesystem (`WorkspaceClient.write_file`) and invokes `WorkspaceClient.exec_command` — the sandboxed, token-gated, wall-clock-capped exec path (**not** the in-process `ActionExecutor`). Only stdout/stderr (capped) return to context; the script source never does. `collect_skill_bundle` resolves the bundle from `filesystem_path`.

**S4 — Tenanted, governed, scanned distribution**
- The spec-folder import path runs the same 2-stage scanner as git/plugin imports — static `quick_scan` always, `llm_security_scan` **ON for third-party/external** (git/plugin), skipped for trusted sources; auto-blocks on a critical static finding (no row persisted).
- `core/services/skill_l3_execution.py` — per-workspace L3 execution enablement stored on `workspace.settings` (no new table), audited via `SkillAuditLog`. New admin tool `platform_set_skill_script_execution` gates enablement on a scanner-pass at enable-time. **import ≠ executable.**

### Gerard's decisions implemented
- **Q1 (L3 sandbox posture):** L3 runs **only** through the workspace worker (separate process, per-workspace jail, `WORKER_INTERNAL_TOKEN`-gated, wall-clock + output-size capped); no platform secrets in the exec env; execution opt-in per skill per workspace behind a scanner-pass. Never the in-process `ActionExecutor`.
- **Q4 (core always-on):** small `core` set (`platform-management`) stays always-L2; everything else trigger-gates.

### Deviations / decisions to confirm (§12 — surfaced, not deferred)
1. **S1 provenance backfill scope (Q3).** The canonical scheme is delivered as a **resolver** that reads every legacy value canonically; the migration backfills `skill_metadata.description` (L1) but does **not** physically reshape `skill_source` strings. Reason: git's legacy `str(source_id)` is also the `SkillSource` join key and an `api/skills.py` filter key — reshaping it is the "stale/duplicate-provenance repair" the PRD's **Q3** flags as a separate data-pass. New import/export writes canonical form; legacy rows resolve via `parse_skill_source`. **Confirm** whether the git reshape lands in a follow-up data pass.
2. **S4 skill scanner entry.** Skills use `scan_skill_content` (the skill-native 2-stage entry — same `quick_scan` + `llm_security_scan` stages) rather than `scan_plugin`, so skills aren't mislabelled as plugins in the `security_scans` table; verdict recorded in `skill_metadata`.
3. **Third governance tool.** S4 enablement is a 3rd new tool (`platform_set_skill_script_execution`, `admin_only`) — the natural admin surface without a UI-less API route (avoids route-manifest churn). The two runtime tools remain `load_skill` + `run_skill_script`.

### Held / untouched
PRD-191's `agent_skills` UNIQUE + priority (schema, model order_by, migration, seeder) — untouched. Only the SkillsSection **render** tests that asserted the now-deleted always-inject path were updated (delete-what-you-replace).

### Test plan (CI is the gate — no local runs)
- `test_prd202_s1_skill_portability.py` — scheme resolution, import persists description as L1, export emits standard folder, import(export) round-trips.
- `test_prd202_s2_trigger_activation.py` — L1-only render, `load_skill` injects L2, untriggered-costs-L1, **source-grep guard** (no unconditional L2 render / no aux budget).
- `test_prd202_s3_l3_worker_exec.py` — worker exec invoked with materialized path, output-only, output cap, enablement gate, unknown-script refusal (worker mocked at WorkspaceClient boundary).
- `test_prd202_s4_governed_distribution.py` — 2-stage scan on import, LLM stage forced for external / skipped for trusted, critical-block, enablement audited, enable refused on critical / succeeds when clean.
- Updated: `test_skills_section.py` (rewritten for L1/core), `test_p2w1_agent_skills_repair.py` (arrival-order → L1; DB tests untouched), `test_context/test_service.py` (skills assertion → L1).

No new API routes → no `route-manifest.json` change. Migration self-applies on boot (`alembic upgrade heads`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added import and export support for standard skill folders, including bundled resources and metadata.
  * Added trigger-based skill loading: core skills remain available, while other skills load full content on demand.
  * Added sandboxed execution for bundled skill scripts with output limits and workspace-level controls.
  * Added security scanning and audit tracking for imported skills and script execution.
  * Improved skill source handling and compatibility with legacy provenance formats.

* **Bug Fixes**
  * Improved detection and refreshing of built-in skills.
  * Preserved skill descriptions during data migration and portability operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->