### PR TITLE
docs(prd): PRD-186 S3-Vectors hardening + PRD-197 reslim (post S3-correction)

### DIFF
--- a/docs/PRDS/PRD-186-S3-VECTORS-HARDENING.md
+++ b/docs/PRDS/PRD-186-S3-VECTORS-HARDENING.md
@@ -1,0 +1,104 @@
+# PRD-186 (Revised 2026-07-14) — S3 Vectors **Hardening**: guard the live shared-bucket plane (tenant-isolation completeness + dimension fail-loud + parity eval + config-integrity CI gate) — P2-16-adjacent
+
+> **Status:** DRAFT for review — spec only, **no build yet**. **This REVISES + supersedes the original `PRD-186-PHASE2-S3-VECTORS-RELIGHT.md`** (the per-workspace-bucket relight), which is now obsolete: main relit S3 a *different* way (a shared bucket + query-time isolation, `prd-172` commit `e2c86f6bd`), so the original's S1/S2 would **break the live prod config**. The RELIGHT file is retired on approval (delete-what-you-replace, §5).
+> **Grounded @ `main` b4748414a** (refs re-confirmed against live code, NOT the 121-behind `ralph/prd-186` branch). Feeds/aligns with the reslimmed PRD-197.
+
+---
+
+## 0. What changed since the original 186 (the reconciliation)
+
+The original 186 assumed the S8-probe world: *S3 dark because the bucket lacked `{workspace_id}`; fix = per-workspace templated buckets, fail-loud if absent.* **Main solved it differently and shipped it:** a **shared** bucket is now explicitly allowed (`config.py:1176-1177`), and tenant isolation moved from *physical* (separate buckets) to *logical* (a query-time metadata filter in `search()`). So:
+
+| Original 186 story | Verdict vs live main | Disposition |
+|---|---|---|
+| S1 per-workspace templated bucket | **obsolete** — main deliberately allows the shared bucket | **drop** |
+| S2 fail-loud on placeholder-less bucket | **inverted** — reviving it hard-aborts the live prod config | **drop** (main already fails on an *unset* bucket) |
+| S3 dimension-mismatch fail-loud | **still valid** — `_verify_or_recreate_index:117` is *still log-only* on main | **revive → S2 here** |
+| S4 re-embed / S5 probe-LIVE | **done** — S3 is populated and serving | **closed** (S5-here re-verifies coverage) |
+
+This revision keeps the one surviving guard and adds the **broader hardening** the plane now needs — grounded in what actually shipped.
+
+---
+
+## 1. What this is
+
+A **hardening** PRD for a plane that is **live, not dark**. Documents retrieve from S3 Vectors today (`_get_candidates → S3VectorsBackend`); `document_chunks` is now the content-hydration table, not the vector plane. The relight worked — but it shipped with the guards *off*: a dimension mismatch only logs, the tenant-isolation filter has a `None`-shaped hole, one of two write paths may not stamp `workspace_id`, there is no number proving S3 retrieval matches the pre-revert quality, and no CI gate stops the config drifting dark again. This PRD closes those — it is the "make the live S3 plane un-silently-breakable" work.
+
+**Framing (CLAUDE.md §3):** **Refactor / hardening**, not net-new — guards + one eval variant + one verification probe. The net-new is a `None`-fail-closed branch, a raise-on-mismatch, one `assert_vector_config_integrity()`, and an S3 eval variant. **Build size:** S–M · **Risk:** Medium — S1 changes the **live retrieval path** (a stricter isolation filter), so it is measured against the frozen baseline (§7) and the `None`-drop is surfaced as a decision (§8-Q1), not taken silently.
+
+**Why now / why measured:** S3 is the grounding plane for every agent answer over client documents, and it is running unguarded. The security half (tenant isolation) and the quality half (parity vs the pre-revert baseline) are both **numbers** — isolation-leak count and recall@k delta — so this is measurement-forward: prove isolation is complete and recall is flat-or-better, then the plane is trustworthy.
+
+---
+
+## 2. Current reality (grounded @ `main` b4748414a)
+
+- **S3 is the live vector plane, on a shared bucket.** `config.py:1176-1177` allows a bucket with no `{workspace_id}` placeholder; `S3VectorsBackend.__init__:55` templates the (optional) placeholder; `_get_candidates` (`modules/rag/service.py:1017`) constructs the backend per workspace. `document_chunks` is content hydration only (`service.py:1176 FROM document_chunks`).
+- **Isolation is a query-time filter — with a `None` hole.** `search()` (`s3_vectors_backend.py:132-207`) is bound to one `workspace_id`: it returns `[]` if an explicit `filters['workspace_id']` disagrees (`:158-168`), and drops any hit whose `metadata.workspace_id != required_ws` (`:193-195`). **But the drop is `if hit_ws is not None and hit_ws != required_ws`** — a hit with **no** `workspace_id` in metadata (`None`) is **passed through**. On a shared bucket that is a latent cross-tenant path for any unstamped chunk.
+- **Two write paths; only one is proven to stamp `workspace_id`.** `S3VectorsBackend.add_documents` **does** set `metadata["workspace_id"] = self.workspace_id` (`:245-250`). But `modules/rag/ingestion/processor.py:308-309` writes via `add_vectors(vectors, metadata_list)` with a **caller-supplied** metadata list whose `workspace_id` stamping is not guaranteed at that seam — the exact source of a `None`-workspace chunk.
+- **Dimension mismatch only logs.** `_verify_or_recreate_index` (`s3_vectors_backend.py:117-130`) logs `reported vs config` dimension and proceeds; it never raises. A stale comment at `:266` still says "4096-dim" while the live corpus + `config.S3_VECTORS_DIMENSION` are **2048**; the method docstring (`:82-84`) still claims delete-and-recreate although the code correctly never deletes — a misnomer + drift.
+- **No config-integrity function or CI gate.** Only `validate_security()` exists (`config.py:1164`); the extracted `assert_vector_config_integrity()` the original 186-S2 built was never merged, and there is no CI test pinning the (now shared-bucket) config rules.
+- **Re-embed + liveness are done.** S3 is populated and serving (the `prd-172` restore); `scripts/probe_document_vectors.py` (PRD-185 S8) remains the read-only liveness/coverage oracle. This PRD does **not** re-embed; it *verifies* coverage (S5).
+
+---
+
+## 3. Findings → fix → story
+
+| # | Finding (grounded) | Fix | Story |
+|---|---|---|---|
+| **isolation `None`-hole** | `search():194` passes hits with `workspace_id=None` on the shared bucket; `processor.py:308` may write unstamped chunks. | Make `search()` **fail-closed on `None`** (drop unlabeled hits on a shared bucket), and stamp `workspace_id` at **both** write paths so no unlabeled chunk is ever written. | **S1** |
+| **dimension log-only** | `_verify_or_recreate_index:117-130` logs a mismatch and proceeds; stale 4096 comment + delete-and-recreate docstring drift. | **Raise** (typed) on a confirmed index-vs-config dimension mismatch (never delete/mutate a populated index); rename the misnomer; fix the `:266`/`:82` drift. (Revives original 186-S3.) | **S2** |
+| **no config-integrity gate** | No `assert_vector_config_integrity()`, no CI test; the config can drift dark again silently (as it did for weeks pre-relight). | A pure `assert_vector_config_integrity()` for the **shared-bucket rules** (enabled ⇒ bucket set; dimension coherent), wired to hard-abort boot **outside** the swallowing `run_stage`, + a CI test. | **S3** |
+| **no parity number** | Nothing proves S3 retrieval matches the pre-revert (pgvector-fallback era) quality. | An **S3 recall/latency parity** variant in `evals/retrieval_recall.py`, asserted **flat-or-better** vs the frozen baseline (§7). | **S4** |
+| **coverage unverified** | No confirmation every live chunk is in S3 with `workspace_id` + dim 2048 (the S1 `None`-drop assumes coverage). | Extend `scripts/probe_document_vectors.py` to report per-workspace **`workspace_id`-stamped %** + dimension; **OPS**, Gerard runs; remediate gaps via the existing migrator. | **S5** |
+
+---
+
+## 4. Stories (test-first; CI is the only gate — no local runs)
+
+### S1 · Close the tenant-isolation gap — fail-closed on `None` + stamp both write paths — S · _security_
+Make the shared-bucket isolation total. (a) In `search()` (`s3_vectors_backend.py:193-195`) drop a hit whose `metadata.workspace_id` is **missing or `None`**, not only one that mismatches — on a shared bucket an unlabeled chunk must never reach another tenant's context (§8-Q1 confirms this behavior change). (b) Guarantee the write side: `add_documents` already stamps `workspace_id` (`:250`); audit `modules/rag/ingestion/processor.py:308` `add_vectors` and ensure its `metadata_list` carries `workspace_id` for every vector, at the seam, so no `None`-workspace chunk is ever written. 
+**Test:** `test_search_drops_unlabeled_hit_on_shared_bucket` (a hit with no `workspace_id` is excluded); `test_search_drops_mismatched_hit` (unchanged behavior held); `test_add_vectors_stamps_workspace_id` (the processor path writes `workspace_id` on every vector). Pure — mock the `s3vectors` client at the boundary; no AWS.
+**Notes:** This is the one story that changes the live retrieval path — measured flat-or-better on recall (§7) so the stricter filter doesn't silently drop *legitimate* results (it shouldn't: legitimate chunks are stamped). No `os.getenv`. 
+
+### S2 · Dimension-mismatch fails loud + kill the `_verify_or_recreate` misnomer — S · _revives original 186-S3_
+`_verify_or_recreate_index` (`s3_vectors_backend.py:117-130`) **raises** a typed error on a confirmed `get_index` dimension ≠ `config.S3_VECTORS_DIMENSION`, instead of logging and proceeding — so 2048-dim vectors can never be silently written to/queried against a wrong-dim index. **Never delete/recreate** a populated index (the `:118` invariant holds). Rename the method to its real behavior (e.g. `_assert_index_dimension`); fix the stale `4096` comment (`:266`) and the delete-and-recreate docstring (`:82-84`) to match live dim 2048.
+**Test:** `test_index_dimension_mismatch_raises` (mocked `get_index` returns 4096 under config 2048 ⇒ typed raise); `test_index_dimension_match_passes` (2048 ⇒ no raise). Pure — mock the client; no AWS.
+
+### S3 · Config-integrity CI gate for the shared-bucket rules — S · _durable fix_
+Add a pure `config.assert_vector_config_integrity()` that raises when `S3_VECTORS_ENABLED=true` **and** the bucket is unset **or** the configured dimension is incoherent — the **shared-bucket** rule set (a placeholder-less bucket is **valid**; do NOT reinstate the original 186-S2 placeholder requirement). Wire it to hard-abort boot **outside** the swallowing `run_stage` (the original 186 lesson: `bootstrap.py` swallowed the F005 `RuntimeError` for weeks), and add a CI test so the config can't ship dark again.
+**Test:** `test_vector_config_integrity_rejects_unset_bucket_when_enabled`; `test_vector_config_integrity_accepts_shared_bucket` (`"automatos-vectors"`, no placeholder ⇒ passes — the live prod shape); `test_vector_config_integrity_noop_when_disabled` (open-core local); `test_boot_aborts_on_bad_vector_config` (fatal, not a swallowed `failed` stage). Pure — patch `config` at the boundary; no DB/AWS.
+**Notes:** Extract the shared assertion so `validate_security` calls it (no duplicate string, §5). 
+
+### S4 · S3 recall/latency parity eval — S · _quality guard_
+Add an `s3` variant to `evals/retrieval_recall.py` that drives the real S3-backed `RAGService.retrieve` and records recall@k + latency, asserted **flat-or-better** vs the frozen pre-revert baseline (§7) using the existing honest-gate shape (published, exit-0, non-required lane). This is the number that proves the S3 relight held retrieval quality — and it is the same baseline PRD-197/198/199/201 consume.
+**Test:** `test_s3_retrieval_variant_registered` (the variant is A/B-able and defaults to the bundled snapshot); `test_parity_gate_flat_or_better` (the honest-gate arithmetic; a drop is a reported regression, not a red build). Pure — bundled jsonl + stdlib; no live S3/LLM.
+
+### S5 · Backfill/coverage verification — OPS (Gerard runs), reuse the probe — XS
+Extend `scripts/probe_document_vectors.py` (read-only) to report, per workspace, the **fraction of vectors carrying a `workspace_id` in metadata** and the index **dimension**, confirming S1's `None`-drop is safe (i.e. coverage is ~100% so the stricter filter removes nothing legitimate) and the corpus is uniformly dim 2048. If any workspace shows unstamped vectors, remediate by re-embedding those docs via the existing `scripts/migrate_to_s3_vectors.py` (no new migrator).
+**Deliverable (OPS, not CI):** the probe's per-workspace `workspace_id`-coverage + dimension finding, attached to close the PRD. **Gerard runs against prod** (needs AWS + DB); explicitly not a CI test.
+
+---
+
+## 5. Sequencing
+- **S5 (coverage probe) ideally first** — it tells us whether the `None`-drop (S1) is a no-op (100% stamped) or a live fix (gaps exist), and whether a remediation re-embed is needed before S1's stricter filter goes live.
+- **S2 + S3 are independent pure code** (different files) — parallel-safe, land any time.
+- **S1** lands after S5 confirms coverage (so the stricter filter can't strand legitimate chunks) and is measured by **S4's parity eval** on the same PR.
+- **S4** needs the frozen baseline (§7); its harness can land first and sit green until the baseline exists.
+- No document-data migration here (S3 is populated); the only prod motion is S5's optional remediation re-embed, Gerard's to run.
+
+## 6. Verification (CI is the only gate — no local runs)
+Per `feedback-no-local-servers`: **no servers, builds, `pytest`, `tsc`, or installs on the dev machine.** All code tests are pure — mock the `s3vectors` client and `config` at the boundary; no AWS/DB/network. The parity eval (S4) stays a **non-required, exit-0** lane (the number is the deliverable). S5 is an **OPS** probe Gerard runs against prod, not CI. No new routes (backend-internal) ⇒ no `route-manifest.json` change. Any config-integrity boot change is covered by S3's `test_boot_aborts_on_bad_vector_config`.
+
+## 7. Baseline capture / measurement
+Consumes the **same frozen retrieval baseline** PRD-197/198/199/201 use — freeze once, serve the wave. **Capture (Gerard):** `evals/retrieval_recall.py --live --workspace <id>` against the real S3-backed retrieve → `baseline/s3_retrieval_2026-07.json`. **Success = the delta:** tenant isolation **complete** (S1 — 0 unlabeled hits reachable, coverage ~100% per S5); recall@k **flat-or-better** vs baseline (S4 — the stricter filter costs no legitimate results); dimension mismatch **fails loud** (S2, was silent); config drift **caught at boot + CI** (S3, was swallowed for weeks); `workspace_id`-coverage **measured** (S5, was unknown).
+
+## 8. Open questions — Gerard's call (decide, don't let me defer — CLAUDE.md §12)
+1. **`None`-workspace fail-closed (the security behavior change).** S1 makes `search()` drop hits with missing/`None` `workspace_id` on the shared bucket. **Recommendation: yes, fail-closed** — isolation must not depend on every writer remembering to stamp; a stray unlabeled hit reaching a tenant is worse than dropping it (S5 confirms coverage so nothing legitimate is lost). Confirm.
+2. **Keep the shared bucket, or restore physical per-workspace buckets later?** **Recommendation: keep shared + the query-time filter** (simpler ops, isolation enforced fail-closed at query; per-workspace buckets were belt-and-suspenders that broke a working deploy). If you ever want physical separation it's a *new* PRD, not a revival of the dropped 186-S1.
+3. **Parity margin (S4).** **Recommendation: flat-or-better** (S3 recall@5 ≥ frozen baseline − a tiny epsilon); a real drop is a regression to investigate, not a ship. Confirm the epsilon.
+4. **Backfill remediation (S5).** If the probe finds unstamped/wrong-dim vectors, re-embed those docs via the existing migrator (Gerard-run) **before** S1's filter goes live. Confirm this is the remediation path (vs a metadata-only patch).
+5. **Baseline metric set (§7).** Confirm recall@k on the live gold set + `workspace_id`-coverage + dimension are the right before-numbers.
+
+---
+
+*Supersedes `PRD-186-PHASE2-S3-VECTORS-RELIGHT.md` (retire on approval, §5). Revives that PRD's still-valid S3 (dimension fail-loud) and its config-integrity/fail-loud lesson (`run_stage` swallowing), drops its obsolete per-workspace-bucket premise, and adds the tenant-isolation completeness + parity-eval + coverage-verification hardening the shipped shared-bucket design needs. All `file:line` refs grep-confirmed against `main @ b4748414a` (S3 live via shared bucket per `prd-172` `e2c86f6bd`; `search()` `None`-hole at `:194`; dimension log-only at `:117`; two write paths `add_documents:250` / `processor.py:308`). Aligns with the reslimmed PRD-197 (which drops dimension-authority → owned here, and drops retire-S3 → wrong). Reuses `scripts/probe_document_vectors.py` (S5) + `scripts/migrate_to_s3_vectors.py` (remediation) — no new probe/migrator. PILOT lens (the plane is live, cold-start ≠ defect); measurement-forward; security framed as isolation-completeness, not moat.*

--- a/docs/PRDS/PRD-197-PHASE2-WAVE-3-VECTOR-SUBSTRATE-CONSOLIDATION.md
+++ b/docs/PRDS/PRD-197-PHASE2-WAVE-3-VECTOR-SUBSTRATE-CONSOLIDATION.md
@@ -1,114 +1,96 @@
-# PRD-197 — Phase-2 Wave-3: Vector-substrate consolidation (retire S3 Vectors, one dimension authority, kill the zombies, snapshots + SLO) — P2-16
+# PRD-197 (Revised 2026-07-14) — Vector-substrate consolidation **reslimmed**: kill the F079 zombie store · settings-truth · Qdrant-memory snapshots · substrate telemetry · open-core local-RAG — P2-16
 
-> **Status:** DRAFT for review — spec only, **no build yet** (Gerard is baselining Auto first; this PRD is written to be measured against that baseline).
-> **Review id:** P2-16 · **Dossier:** `reports/dossiers/vector-substrate.md` J3–J7 + C.1/C.3/C.5/C.7, thesis-T2 · **Grounded @ `main` 119cc0dc3** (post Wave-2; refs re-confirm at build).
+> **Status:** DRAFT (revised) — spec only, no build yet. **The original 197 was written on an INVERTED premise** ("retire dead S3, keep pgvector"). In fact **S3 Vectors is the LIVE document plane** — the #514 pgvector fallback was reverted (`fa2987ad3`) and the shared bucket fixed (`e2c86f6bd`); pgvector `document_chunks` is now content-hydration only. This revision **drops the two wrong stories** (dimension-authority → now owned by the revised **PRD-186**; retire-S3 → *deleted*, it would kill the live backend) and **adds** the open-core local-RAG gap the revert exposed. **Pairs with PRD-186 (S3 hardening).** Grounded @ `main b4748414a`.
+
+---
+
+## 0. What changed (correction + reslim)
+
+| Original 197 story | Verdict | Disposition |
+|---|---|---|
+| S1 one dimension authority + config-integrity gate | **moved** — S3 dimension + config-integrity are the live-plane's concern | → **PRD-186** (S2/S3 there) |
+| S2 retire the "dark" S3 Vectors plane | **inverted** — S3 is the LIVE plane; deleting the backend breaks prod retrieval | **dropped** |
+| S3 kill the F079 zombie store | valid, S3-agnostic | **kept → S1** |
+| S4 settings-plane truth | valid | **kept → S2** |
+| S5 Qdrant **memory** snapshots | valid (memory planes only) | **kept → S3** |
+| S6 substrate telemetry | valid | **kept → S4** |
+| — | the #514 revert left the local edition with **no** document backend | **new → S5** |
 
 ---
 
 ## 1. What this is
 
-A **subtraction-and-truth** PRD, not a new engine. The vector substrate's *ideas* are right (one embedding seam, one cheap good model, payload-partitioned Qdrant); its *operation* is not — a document plane that was dark, dimension knobs that disagree, a settings card that does nothing, a destructive migration footgun, and a zombie store with wrong math that still has callers. This PRD makes the substrate **honest and single**: retire the dead S3 Vectors plane, make one dimension authority impossible to violate (CI-gated), migrate the last callers off the zombie store and delete it, back up the Qdrant planes, and put a number on the substrate so the next dark-plane incident is caught in hours, not weeks.
+The substrate consolidation **minus the S3-directional errors**. With PRD-186 now owning the S3 plane (dimension fail-loud, config-integrity, isolation), PRD-197 is the **S3-agnostic subtraction**: delete the genuinely-dead F079 zombie store, make the settings plane honest, back up the Qdrant *memory* planes, put a number on the substrate, and make **open-core RAG actually work** (the local edition has no document backend now that the pgvector fallback was reverted out).
 
-**Framing (CLAUDE.md §3):** this is **Refactor / Consolidation** — pick the canonical path (pgvector for documents, already live post-PRD-188; Qdrant for memory/field), migrate the losers, **delete them** (§5). Almost nothing here is net-new code; the net-new is one CI gate, one snapshot job, and one telemetry seam.
-
-**Build size:** M (mostly deletion + caller migration + one CI gate + one cron) · **Risk:** Medium (deleting a store with live callers — the caller migration is the real work and must be grep-proven complete before deletion; the document plane itself does **not** move, so retrieval quality is held constant by design).
-
-**Why now / why measured:** the whole point of Wave 0 was to make quality a number. This PRD changes the retrieval **substrate** without intending to change retrieval **quality** — so it is the cleanest possible thing to build against a live baseline: recall@k and latency should be **flat or better** across every story. If a story moves recall, that is a regression signal, not a feature. Baseline-capture is a first-class section below.
+**Framing (CLAUDE.md §3):** **Refactor / subtraction** — pick the canonical path, migrate the losers, delete them. **Build size:** S–M (mostly deletion + caller migration + one cron + one telemetry seam + one local-edition backend). **Risk:** Low — **nothing here touches the live S3 retrieval path**; recall is held constant by design (the document plane does not move).
 
 ---
 
-## 2. Current reality (grounded, not the review's July snapshot)
+## 2. Current reality (grounded @ `main` b4748414a — corrected)
 
-- **Documents run on pgvector, live.** `document_chunks` (~19k chunks, dim 2048 per the PRD-185 S8 probe) is the live document plane; PRD-188 built the hybrid (BM25 leg + Cohere rerank) **on it** (`modules/rag/` — `service.py`, `bm25_leg.py`, `fusion.py`, `retrieval_filters.py`). This plane is **not** dark and **does not move** in this PRD.
-- **S3 Vectors is dead.** `modules/search/vector_store/backends/s3_vectors_backend.py` (+ `_mock`), selectable via `get_vector_store(backend="s3_vectors")` (`modules/search/vector_store/__init__.py`); the PRD-185 S8 probe found it **dark** (bucket missing the `{workspace_id}` templating); `scripts/migrate_to_s3_vectors.py` is **destructive** (wipes pgvector before copying — a footgun); `scripts/recreate_s3_index.py` exists; PRD-186 (relight S3) was **retired** in favour of staying on pgvector. Nothing in production reads this plane.
-- **The zombie store still has callers.** `EnhancedVectorStore` / `SearchService` / `ContextRetrievalEngine` (`modules/search/vector_store/store.py`, `modules/search/service.py`, `modules/search/retrieval/context_retrieval_engine.py`) — the F079 trio the review flagged (its namesake table was dropped in PRD-135; its "cosine" uses the L2 operator). Live importers outside `modules/search/`: `api/documents.py`, `api/cloud_documents.py`, `modules/rag/ingestion/manager.py`, `modules/codegraph/codegraph_service.py`, `modules/nl2sql/service.py`, `modules/tools/discovery/handlers_documents.py`, `api/context_policy.py`. **Deletion requires migrating these first.**
-- **Dimension knobs disagree.** `config.py:911 S3_VECTORS_DIMENSION=2048`, `config.py:958 FIELD_EMBEDDING_DIM=2048`, and `modules/rag/config.py:93` reads the embedding dimension **from system settings** — three independent sources that happen to agree at 2048 today and will silently diverge the day someone changes one.
-- **No Qdrant backups.** Field memory (`field_memory`, PRD-166/108) and durable memory (`durable_memory`, PRD-187) live only on the Railway Qdrant with no snapshot — unrecoverable on loss.
-- **The eval instrument exists.** `evals/retrieval_recall.py` + `scripts/eval/retrieval_recall/` + the CI `Retrieval-recall eval` lane + the PRD-188 live gold set — this is the measurement instrument this PRD is verified against.
+- **Documents run on S3 Vectors, live.** `_get_candidates` (`modules/rag/service.py:1017`) constructs `S3VectorsBackend` (`:1010-1012`); `document_chunks` (pgvector) is the **content-hydration** table (`:1176 FROM document_chunks`), not the vector plane. This plane **does not move** in this PRD.
+- **The F079 zombie store is still present and still separate from the live path.** `modules/search/service.py`, `modules/search/retrieval/context_retrieval_engine.py`, `modules/search/vector_store/store.py` (the wrong-math `EnhancedVectorStore`/`SearchService`/`ContextRetrievalEngine` trio) — the live RAG path imports `S3VectorsBackend` **directly**, not these. **The importer surface has drifted** from the original 197's list (grep now shows `modules/__init__.py`, `modules/codegraph/codegraph_service.py`, plus *comment-only* "do not resurrect" refs in `modules/rag/bm25_leg.py`/`service.py`) — the real import set must be **re-traced at build**, not taken from the stale list.
+- **Settings-plane drift.** The embeddings admin card and `modules/memory/__init__` column names don't agree with the canonical `(embeddings, *)` keys — a settings placebo + stale columns.
+- **Qdrant memory planes have no snapshot.** `modules/memory/durable_store.py` (PRD-187 durable memory) + `field_memory` (PRD-166) live on the Railway Qdrant with no backup — unrecoverable on loss. (Document backups are S3's concern, PRD-186 — **not** here.)
+- **No substrate telemetry.** No per-seam candidates/latency/errors metric watches retrieval health.
+- **Open-core is broken.** With `S3_VECTORS_ENABLED=false` (the local/OSS default — S3 Vectors is AWS-only), the reverted pgvector fallback means the local edition has **no document backend at all** → local RAG constructs nothing and returns empty. This is the "make open-core RAG actually work" the review's P2-16 named — now a real, grounded gap.
 
 ---
 
 ## 3. Findings → fix → story
 
-| # (dossier) | Finding (grounded) | Fix | Story |
+| # | Finding (grounded) | Fix | Story |
 |---|---|---|---|
-| **C.3 / J4 (dimension authority)** | Three independent dimension knobs (`S3_VECTORS_DIMENSION`, `FIELD_EMBEDDING_DIM`, `modules/rag/config.py` system-setting) can silently diverge → a mismatch is discovered at query time as garbage, not at boot. | **One authority** — everything derives from the canonical `(embeddings, dimensions)` system setting; delete the independent knobs; add a **config-integrity CI gate** that fails the build if any plane's declared dimension disagrees with the authority (the same fail-loud posture PRD-192 gave the policy plane). | **S1** |
-| **C.1 / J1-fold (retire S3)** | The S3 Vectors plane is dark and was chosen to be *folded*, not relit (PRD-186 retired). The backend, the mock, the **destructive** migrate script, and the boot-abort-on-bad-S3 all still ship — dead weight and a footgun. | **Retire it** (§5 deletion-led): remove the `s3_vectors` / `s3_vectors_mock` backends from the factory and delete their modules; delete `scripts/migrate_to_s3_vectors.py` (destructive) and `scripts/recreate_s3_index.py`; remove the S3-bucket boot-abort (the plane it guarded is gone). `pgvector` becomes the only document backend the factory offers. | **S2** |
-| **C.5 / E.4 / J9 (kill the zombies)** | The F079 trio (`EnhancedVectorStore`/`SearchService`/`ContextRetrievalEngine`) is wrong-math dead code that still has 7 live importers — a store future code could resurrect. | **Migrate then delete:** repoint every importer onto the canonical `modules/rag/` pgvector path (documents) or the appropriate Qdrant adapter (memory/field), **grep-prove zero importers**, then delete the three modules + the dead `modules/search/vector_store/store.py`. | **S3** |
-| **C.2 / J3 (settings truth)** | The embeddings admin card and the manager reads don't agree on canonical `(embeddings, *)` keys; `modules/memory/__init__` has stale column names; the UI card is a settings-placebo. | Managers read the canonical `(embeddings, *)` keys through the config module; fix the `modules/memory/__init__` column names; **truthify or delete** the UI card (honest OFF over silent placebo — the PRD-196 lesson). | **S4** |
-| **C.7 / J7 (backups)** | Qdrant `field_memory` + `durable_memory` have no snapshot → unrecoverable on loss. | **Qdrant snapshot cron** on the existing memory-jobs scheduler pattern + a one-line runbook entry; retention per Gerard's call. | **S5** |
-| **G.1 / I.2 / J6 (a number on the substrate)** | No telemetry watches candidates/latency/errors per query seam → the next dark-plane goes unnoticed for weeks (as C.1 did). | A substrate-telemetry seam (candidates returned, latency, errors per retrieval) + a Command Center tile, reusing the PRD-185 observability plane. **This is the watchdog that makes every future substrate change measurable** (and feeds §7 baseline capture). | **S6** |
+| **F079 zombies** | The wrong-math trio still ships; importer surface drifted. | **Re-trace** real importers on main, migrate each to the canonical path (documents → `modules/rag`/S3; memory/field → Qdrant adapters), grep-prove zero, **delete** the trio + orphans. | **S1** |
+| **settings placebo** | Admin card + `memory/__init__` columns disagree with canonical `(embeddings,*)` keys. | Managers read canonical keys through config; fix the stale columns; **truthify-or-delete** the placebo card (honest-OFF over silent placebo). | **S2** |
+| **no memory backups** | Qdrant `durable_memory` + `field_memory` unrecoverable on loss. | **Snapshot cron** on the memory-jobs scheduler + a runbook line; cadence/retention/destination per Gerard (Q3). **Memory planes only** — documents are S3/PRD-186. | **S3** |
+| **no substrate number** | No telemetry watches retrieval health per seam. | A telemetry seam (candidates/latency/errors per retrieval seam) through the PRD-185 observability plane + a Command Center SLO tile. | **S4** |
+| **open-core broken** | Local edition (S3 off) has no document backend since the pgvector fallback was reverted. | Wire a **local-edition document backend** (pgvector-local or Qdrant-local, Q1) gated by config so a fresh clone's RAG **constructs and returns**; S3 stays the SaaS path. | **S5** |
 
 ---
 
 ## 4. Stories (test-first; CI is the only gate — no local runs)
 
-### S1 · One dimension authority + config-integrity CI gate — S · _vector-substrate C.3/J4_
-Everything that needs an embedding dimension derives it from the canonical `(embeddings, dimensions)` system setting (the `modules/rag/config.py:93` source, lifted to a single accessor in the config module). Delete `S3_VECTORS_DIMENSION` (`config.py:911`) and `FIELD_EMBEDDING_DIM` (`config.py:958`) as independent knobs; the field adapter and any remaining consumer read the one authority. Add a **pure config-integrity test** (CI-gated) that constructs each live plane's dimension and asserts they all equal the authority — a divergence **fails the build**, not a query.
-**Test:** `test_dimension_authority_single_source` (all planes resolve to the authority); `test_config_integrity_gate_fails_on_divergence` (a seeded mismatch raises, greppably). Pure — no DB/network.
-**Notes:** No `os.getenv` outside `config.py`. When a knob is deleted, repoint every reader in the same commit (grep first — recurring F070 lesson).
-
-### S2 · Retire the dark S3 Vectors plane — S · _vector-substrate C.1/J1-fold_
-Remove `s3_vectors` and `s3_vectors_mock` from the `get_vector_store` factory (`modules/search/vector_store/__init__.py`) and delete `backends/s3_vectors_backend.py` + `backends/s3_vectors_mock.py`. Delete `scripts/migrate_to_s3_vectors.py` (destructive) and `scripts/recreate_s3_index.py`. Remove the S3-bucket boot-abort added by #512 (the plane it guards no longer exists). `probe_document_vectors.py` is retained **only** if it still reports pgvector health after S3 is gone (else deleted with it).
-**Test:** `test_factory_offers_only_pgvector` (requesting a retired backend raises a clear error, not a silent fallback); `test_no_s3_vectors_imports_remain` (source-grep guard). Pure.
-**Notes:** Deletion-led, no `_legacy` shim (§5). If Gerard wants a future AWS-native option it is a *new* PRD against a *working* design, not this dead code kept on life support (Open questions Q2).
-
-### S3 · Migrate callers off the zombie store, then delete it — M · _vector-substrate C.5/E.4/J9_
-Repoint the 7 live importers (`api/documents.py`, `api/cloud_documents.py`, `modules/rag/ingestion/manager.py`, `modules/codegraph/codegraph_service.py`, `modules/nl2sql/service.py`, `modules/tools/discovery/handlers_documents.py`, `api/context_policy.py`) onto the canonical path: document reads/writes → `modules/rag/` pgvector; any memory/field use → the Qdrant adapters. **Grep-prove zero importers** of `EnhancedVectorStore`/`SearchService`/`ContextRetrievalEngine`, then delete `modules/search/vector_store/store.py`, `modules/search/service.py`, `modules/search/retrieval/context_retrieval_engine.py` (and any now-orphaned `modules/search/` siblings).
+### S1 · Kill the F079 zombie store — M · _vector-substrate C.5/E.4/J9_
+**Re-trace** the real importers of `EnhancedVectorStore`/`SearchService`/`ContextRetrievalEngine` on `main` (distinguish live imports from the comment-only "do not resurrect" references — the grep matches both). Repoint each real importer to the canonical path (documents → `modules/rag`/S3VectorsBackend; any memory/field use → the Qdrant adapters), **grep-prove zero importers**, then delete `modules/search/service.py`, `modules/search/retrieval/context_retrieval_engine.py`, `modules/search/vector_store/store.py`, and any now-orphaned siblings.
 **Test:** per-caller behavioural test that the migrated path returns equivalent results (fixture-fed, mocked at the boundary); `test_no_zombie_store_importers` (source-grep guard). Pure.
-**Notes:** This is the story that can move a number if done wrong — each caller migration is verified equivalent against the retrieval eval (§7). If a caller's semantics genuinely differ from the canonical path, that is surfaced as a finding, not silently flattened (§12).
+**Notes:** If a caller's semantics genuinely differ from the canonical path, surface it (§8-Q2), don't silently flatten. **Does not touch the live S3 retrieval** — held constant.
 
-### S4 · Settings-plane truth — S · _vector-substrate C.2/J3_
-Managers read canonical `(embeddings, *)` keys through the config module; fix the stale `modules/memory/__init__` column names; the embeddings admin card either reflects real state or is deleted (no placebo — the PRD-196 honest-UI lesson). Update the route-manifest only if a route changes.
-**Test:** `test_embeddings_settings_roundtrip` (a written setting is the one the manager reads); `test_no_stale_memory_init_columns`. Pure.
+### S2 · Settings-plane truth — S · _vector-substrate C.2/J3_
+Managers read the canonical `(embeddings, *)` keys through the config module; fix the stale `modules/memory/__init__` column names; the embeddings admin card reflects real state or is deleted (no placebo — the PRD-196 honest-UI lesson). Route-manifest updated only if a route changes.
+**Test:** `test_embeddings_settings_roundtrip`; `test_no_stale_memory_init_columns`. Pure.
 
-### S5 · Qdrant snapshots — XS · _vector-substrate C.7/J7_
-A snapshot job for `field_memory` + `durable_memory` on the existing memory-jobs scheduler pattern (`services/memory_jobs.py`, wired at `main.py`); cadence + retention + destination per Gerard's call (Q4). One runbook line documents restore.
+### S3 · Qdrant **memory** snapshots — XS · _vector-substrate C.7/J7_
+A snapshot job for `durable_memory` + `field_memory` on the existing memory-jobs scheduler pattern (`services/memory_jobs.py`, wired at `main.py`); cadence + retention + destination per Gerard (Q3). One runbook line documents restore. **Memory planes only** — document backups are PRD-186's (S3 Vectors).
 **Test:** `test_snapshot_job_registered`; `compute_next_snapshot` pure helper tested. No live Qdrant in tests.
 
-### S6 · Substrate telemetry → SLO tile — S · _vector-substrate G.1/I.2/J6_
-A telemetry seam recording candidates-returned / latency / errors per retrieval seam (documents + memory + field), through the PRD-185 observability plane; a Command Center tile surfaces it. **This is the instrument that makes §7's baseline continuous** — after this story, "is retrieval healthy?" is a live number, and the next dark-plane trips a tile, not a user complaint.
-**Test:** `test_substrate_telemetry_records_candidates_latency`; tile renders the healthy + degraded states. Pure/mocked.
+### S4 · Substrate telemetry → SLO tile — S · _vector-substrate G.1/I.2/J6_
+A telemetry seam recording candidates-returned / latency / errors per retrieval seam (documents/S3 + memory + field), through the PRD-185 observability plane; a Command Center tile surfaces healthy/degraded. Makes "is retrieval healthy?" a live number so the next dark-plane trips a tile, not a user complaint.
+**Test:** `test_substrate_telemetry_records_candidates_latency`; tile renders healthy + degraded. Pure/mocked. (Tracer singleton is `config` NOT `settings` — PRD-185 gotcha.)
+
+### S5 · Open-core local-RAG — S · _vector-substrate C.1 open-core / review P2-16_
+The local/OSS edition (`S3_VECTORS_ENABLED=false`) must have a working document backend — today it has none (the pgvector fallback was reverted). Wire a **local-edition document backend** (pgvector-local or Qdrant-local, Q1), selected by config, so a fresh clone's `RAGService.retrieve` constructs and returns real results; S3 Vectors stays the SaaS path. The P2-23 fresh-clone lane confirms.
+**Test:** `test_local_edition_rag_constructs_and_returns` (S3 off ⇒ the local backend serves candidates, not empty); `test_saas_edition_uses_s3` (S3 on ⇒ S3VectorsBackend path, unchanged). Pure/mocked.
+**Notes:** No `os.getenv` outside config.py; the edition switch is config. This is the one net-new backend seam — kept minimal (reuse the existing pgvector `document_chunks` content table as the local vector store, or a local Qdrant collection — Q1).
 
 ---
 
 ## 5. Sequencing
-- **S1 first** (dimension authority) — everything else assumes one dimension. **S2** (retire S3) is independent and parallel-safe. **S3** (kill zombies) is the long pole — it can land per-caller but the deletion is one commit after the last caller moves. **S4** parallel. **S5/S6** independent, land any time.
-- **S6 ideally lands early** if Gerard wants the live substrate tile feeding the baseline while he runs Auto (see §7) — it is the one story whose *output is the measurement instrument*, so pulling it forward makes the rest of the wave measurable in-flight.
-- No migration except S1's (if the dimension authority needs a settings backfill) and none that moves document data — the document plane is held constant on purpose.
+- **S1** (zombie kill) is the long pole — lands per-caller, deletion is one commit after the last importer moves. **S2/S3/S4** are independent and parallel-safe. **S5** (open-core) is independent; **S4 telemetry ideally lands early** if Gerard wants the tile feeding the §7 baseline while he runs Auto.
+- **No migration that moves document data** — the S3 plane is held constant on purpose. S3's snapshot job and S5's local backend add no document-data motion.
 
 ## 6. Verification (CI is the only gate — no local runs)
-Per `feedback-no-local-servers`: **no servers, builds, `pytest`, `tsc`, or installs on the dev machine.** Pure tests (mock Qdrant/pgvector/session at the boundary); the config-integrity gate + the two source-grep guards (no-S3, no-zombie-importers) follow the PRD-185 S5 import-regression shape — **repoint a guard in the same commit its symbol moves.** The **Retrieval-recall eval CI lane is the quality guard**: recall@k must be **flat-or-better** vs the frozen baseline (§7) at every story. Any new route → update the committed `orchestrator/reports/route-manifest.json`. Any migration authored in-PR; Gerard applies (note: the deploy entrypoint runs `alembic upgrade heads` on boot — a merged migration self-applies).
+Per `feedback-no-local-servers`: pure/mocked tests (mock Qdrant/S3/session at the boundary); the source-grep guard (no-zombie-importers) follows the PRD-185 S5 shape — repoint in the same commit the symbol moves. **The live S3 retrieval path is untouched → the Retrieval-recall eval must stay flat** (any move is a regression, not a feature). New route → update the committed `orchestrator/reports/route-manifest.json`. Migrations self-apply on boot.
 
-## 7. Baseline capture — run Auto, then measure (the point of building this now)
+## 7. Baseline capture / success
+Consumes the same frozen retrieval baseline as the wave (recall held **flat** — the plane doesn't move). **Success = the delta:** engines **one fewer** (zombie gone, importers 0 grep-proven); settings **honest** (no placebo); Qdrant memory **recoverable** (was not); substrate **observable** (0 numbers → live SLO tile); **open-core RAG constructs + returns** on a fresh clone (was empty).
 
-This PRD is designed to be built **against a live baseline**, because it changes the substrate while holding quality constant — so the measurement is the proof it worked.
-
-**Capture NOW, while Auto runs (before any S-story):**
-1. **Retrieval recall@k** on the PRD-188 live gold set — freeze the current numbers as `baseline/retrieval_recall_2026-07.json`. This is the single most important before-number: every story must hold it flat-or-better.
-2. **Retrieval latency + candidate counts** per seam (documents / memory / field) — from real traffic. **Turn on the Wave-0 telemetry to get this:** set `TRACING_ENABLED` (PRD-185 S9 Langfuse seam, default OFF) so real Auto usage is traced, and let S6's substrate tile (if pulled forward) accumulate the live distribution.
-3. **Dark-plane confirmation** — re-run `probe_document_vectors.py` once to record "pgvector live, S3 dark" as the documented pre-state (so the S2 retirement is provably removing a dead plane, not a used one).
-4. **Zombie-store call volume** — before S3, log how often each of the 7 importers actually hits the zombie path in real usage (confirms the migration surface is exercised, not theoretical).
-
-**Success = the delta (measured, not asserted):**
-- Recall@k: **flat-or-better** at every story (a drop is a regression, not a feature). ← the core guard.
-- Engines: **one fewer** (S3 gone); zombie importers **0** (grep-proven); dimension knobs **1** (was 3).
-- Substrate observability: from **0 numbers** to a live tile (S6) — the next dark-plane caught in hours.
-- Backups: field + durable memory **recoverable** (was unrecoverable).
-- Local edition: open-core RAG **constructs and returns** on a fresh clone (was shipping a broken S3 default) — the P2-23 fresh-clone lane will confirm.
-
-*(The eval-gated Wave-3 bets — Graphiti P2-17, NL2SQL P2-18 — consume this same baseline discipline. Freezing the retrieval baseline now serves the whole wave, not just this PRD.)*
+## 8. Open questions — Gerard's call (§12)
+1. **Open-core local document backend (replaces the old moot pgvector-vs-Qdrant-for-*docs* question).** For the OSS/local edition (S3 off), use **pgvector-local** (reuse the `document_chunks` table as the local vector store — one fewer service for self-hosters) or **Qdrant-local** (unify with the memory planes the local edition already runs)? **Recommendation: pgvector-local** — simplest fresh-clone story. Confirm.
+2. **Zombie importer scope.** Re-traced at build; if any caller's semantics genuinely differ from the canonical path, surfaced as a decision, not silently flattened. Migrate all in this PR (recommended) or slice?
+3. **Qdrant memory snapshot cadence / retention / destination.** Proposal: daily, 7-day retention, to the object store the platform already uses. Adjust + confirm destination.
+4. **Pull S4 telemetry forward** so the substrate tile is live while you run Auto (recommended — makes the wave measurable in-flight)?
 
 ---
 
-## 8. Open questions — Gerard's call (decide, don't let me defer — CLAUDE.md §12)
-
-1. **The consolidation fork (the big one).** The review's E.2 proposed moving document vectors **onto Qdrant** (one engine for all vectors, Qdrant Query-API RRF hybrid, snapshots for docs too). But PRD-188 already built the document hybrid (BM25 + rerank) **on the live pgvector plane**, and it works. **Recommendation: keep pgvector for documents** — retire S3, delete zombies, snapshot the Qdrant *memory* planes, and do **not** migrate document data (least risk, holds recall constant, pgvector hybrid is already shipped). **Alternative:** move docs to Qdrant anyway for true single-engine + Query-API RRF — more work, a re-embed/backfill risk, and it would re-open the recall number this PRD is trying to hold flat. Which posture ships? *(My strong lean: pgvector-for-docs; the "one engine" purity isn't worth re-litigating a working retrieval plane.)*
-2. **S3 artifacts: delete outright, or keep behind a flag for a future AWS-native option?** Recommendation: **delete** (the plane never worked; the migrate script is destructive; §5 no-shims). A future AWS-native vector option, if ever wanted, is a new PRD against a working design.
-3. **Zombie kill-list scope.** Migrate all 7 callers + delete the trio **in this PRD** (recommended — the point is the subtraction), or split the caller migration across follow-on slices? If any caller's semantics genuinely differ from the canonical path, I surface it as a decision, not a silent flatten.
-4. **Qdrant snapshot cadence / retention / destination.** Proposal: **daily snapshot, 7-day retention, to the same object store the platform already uses.** Adjust cadence/retention, and confirm the destination (Railway volume vs S3 bucket vs Qdrant Cloud snapshot).
-5. **Baseline metric set (§7).** Confirm the four capture items (recall@k on the live gold set, latency+candidates per seam, dark-plane probe, zombie call volume) are the right before-numbers, and **whether to pull S6 forward** so the substrate tile is live while you run Auto (recommended — it makes the rest of the wave measurable in-flight).
-
----
-
-*Traceability: every story cites `reports/dossiers/vector-substrate.md` (C.1 dark plane / C.2 settings / C.3 dimensions / C.5 zombies / C.7 backups; J3–J7 + J9 upgrade rows; E.2 consolidate / E.4 kill-list; G.1 metric) and thesis-T2 (stay modular-monolith, one engine less), under review id **P2-16** in `reports/PLATFORM_MODULE_DEEP_REVIEW_2026-07-04.md` §6 (Wave 3). All `file:line` refs re-confirmed by grep against `main @ 119cc0dc3` (post Wave-2: documents live on pgvector via PRD-188; S3 dark per the PRD-185 S8 probe; PRD-186 relight retired) and are current as written. Reuses PRD-185 (observability/telemetry seam), PRD-187 (durable Qdrant), PRD-188 (pgvector hybrid — held constant), PRD-166/108 (field Qdrant). Feeds P2-17/P2-18 (they consume the frozen retrieval baseline). North-Star framed; PILOT lens applied; measurement-forward per Gerard's build-and-measure intent; no moat framing.*
+*Supersedes the inverted original 197 (retire-S3/keep-pgvector). Traceability: `reports/dossiers/vector-substrate.md` (C.2 settings / C.5 zombies / C.7 backups; J6/J7/J9) and thesis-T2 (one engine less), under review id **P2-16**. S3 dimension/config-integrity/isolation now owned by the revised **PRD-186**; this PRD is S3-retrieval-agnostic and holds recall constant. All `file:line` re-confirmed @ `main b4748414a` (docs on S3 per `prd-172` revert; zombie trio + Qdrant memory planes present; open-core doc-backend gap real). Reuses PRD-185 (telemetry seam), PRD-187/166 (Qdrant memory — snapshotted here). PILOT lens; measurement-forward; no moat framing.*


### PR DESCRIPTION
## What

The two Wave-3 spec corrections drafted after the 2026-07-14 S3 discovery (documents run on **S3 Vectors**, not pgvector), preserved from the wave3 worktree before its cleanup (commit 8bca46a1f):

- **PRD-186-S3-VECTORS-HARDENING.md** — revives + extends the unmerged PRD-186 relight as the S3-plane hardening spec (config-integrity fail-loud boot, dimension-mismatch guards, recall/latency parity eval, backfill verification). The plane is live but unguarded; the ops half of the old 186 is already done, the code guards never landed.
- **PRD-197 (reslimmed)** — drops the inverted premise (retire-S3 would have deleted the live backend) and dimension-authority (→186); keeps F079 zombie-kill, settings-truth, Qdrant memory snapshots, telemetry, open-core local-RAG.

## Why now

Wave-3 is 4/7 built+merged (#540–543). These two docs define the remaining non-eval-gated work; the eval-gated pair (198/199) unblocks on the baseline freeze, in progress separately.

Docs only — no build in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated vector hardening specifications with tenant-isolation safeguards, dimension validation, configuration checks, and recall/latency evaluation requirements.
  * Clarified S3 Vectors as the live document retrieval backend and removed obsolete or conflicting roadmap items.
  * Added plans for local-edition document retrieval, retrieval-health telemetry, memory snapshots, and improved operational coverage verification.
  * Documented updated sequencing, validation criteria, baselines, and open decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->