### PR TITLE
feat(prd-204): Auto Watcher — persistent supervision of launched work

### DIFF
--- a/docs/PRDS/PRD-204-AUTO-WATCHER.md
+++ b/docs/PRDS/PRD-204-AUTO-WATCHER.md
@@ -1,0 +1,155 @@
+# PRD-204 — Auto Watcher: persistent supervision of launched work (own the outcome, not the launch)
+
+> Status: APPROVED FOR BUILD 2026-07-16 (Gerard) — §8 recommendations applied as build defaults; override at PR review.
+> Grounded @ `8e0543211` (origin/main, 2026-07-16). Relationship: PRD-200 is the same mechanics one altitude down (per-task verify-gate inside the mission tick); PRD-128 is the delivery plane; PRD-193/196 are the approval plane; PRD-185 built the breaker/telemetry substrate this consumes.
+> **Build size: L (one PR, 12 stories) · Risk: Medium** — one new background loop (rides the existing fcntl-locked UnifiedScheduler), all corrective actions policy-gated, every producer hook fail-soft.
+
+---
+
+## 1. What this is
+
+A **Watch** is a first-class, workspace-scoped row that supervises one launched unit of work — a mission, a playbook execution, or a scheduled playbook — from launch to a **verdict**. The loop: watch → check (event-driven at terminal choke points, heartbeat sweep as fallback) → score the output against the original intent → take a bounded corrective action if weak (tweak+rerun, replan, reassign, spawn agent from blueprint — each through the existing approval policy) → notify the user with the verdict.
+
+The product contract: when the user says "can you do X," Auto owns X to a verdict. Not "I started it, good luck" — started, watched, judged, corrected within guardrails, reported. Blueprints and the policy plane stay the boundary: the watcher never grants itself powers; every action rides `evaluate_approval` + the workspace autonomy setting + the §12.3 gate, exactly like a human-triggered action would.
+
+**Framing (CLAUDE.md §3): Extension.** The registry and decision loop are net-new; everything else wires production seams that already exist (dispatch spine, notification dispatcher, cross-model judge, approval grants, retry lineage). **Why now:** the deep review's verdict was "good bones, open loops" — this is the PRD that closes the loop the whole autonomy story hangs on, and four of its stories are straight fixes to silent-failure holes that exist today regardless of the watcher.
+
+**What this is NOT** (terminology guard): not the OS-review "generic watcher primitive" missing-channel (that is an *inbound-trigger* watcher — watch external conditions to *start* work); not infra monitoring (`core/monitoring/` Prometheus/psutil); not a unified event bus (§9).
+
+## 2. Current reality (grounded)
+
+- **No watch concept exists.** Broad grep (`watch|monitor|supervis|follow_up|check_back`) across `services/`, `core/`, `api/`, `modules/` finds only the autonomy vocabulary, scheduling follow-ups, Composio "monitoring" app-actions, and wizard SSE. Nothing supervises a launched unit to terminal state.
+- **Missions fail silently.** `_dispatch_mission_event` is called only for `mission_step_complete`, `mission_plan_ready`, `mission_complete` (`services/coordinator_service.py:2113/2432/2601/3998`). There is no `mission_failed` user notification; a failed run emits an internal `RUN_FAILED` audit event and stops.
+- **Budget-exceeded pause is silent.** The dispatcher blocks and transitions the run to `PAUSED` (`modules/coordination/dispatcher.py:645-666`) but `escalation_service.notify_budget_exceeded` is dead code — zero non-test callers.
+- **A failed mission's board card renders "done".** `_RUN_STATE_TO_BOARD_STATUS` maps `failed` and `cancelled` → `"done"` (`services/orchestration_board_bridge.py:303-315`).
+- **Breaker trips are silent.** `PlaybookSchedulerService._fire_playbook` skips the tick with only `logger.warning` when `breaker_is_open` (`services/playbook_scheduler.py:180-188`); the breaker also only gates cron — manual/webhook launches bypass it.
+- **Missed cron ticks are lost undetected.** Playbook schedules live in APScheduler `MemoryJobStore`, recreated from DB at boot, no `misfire_grace_time`/`coalesce` (`services/playbook_scheduler.py:127-134`).
+- **Playbooks are NOT silent anymore** (problem statement honesty): every terminal run fires `playbook_complete`/`playbook_failed` + an auto-report (`api/recipe_executor.py:1714/1993-2008`, PRD-185 S4). Board tasks notify both outcomes. The silent set is the five bullets above.
+- **The judge exists, per-task, advisory-becoming-gated.** `VerificationService` — wired cross-model LLM judge, 4 dims 0–1 (`modules/coordination/verification.py:41`), thresholds `COORDINATOR_VERIFICATION_*` 0.7/0.4, output-hash cached; PRD-200 S1 wired `_apply_verdict_fail` to requeue once (`modules/coordination/reconciler.py:553-625`). There is **no run-level output judging** and no business rubric anywhere.
+- **`PlaybookQualityService`** scores execution *mechanics* (5 heuristic dims), manual-only via `POST /assess-quality` — never auto-invoked. `workflow_recipes.success_rate` is declared, dashboard-read, **never written**.
+- **Delivery is already session-independent.** PRD-128 `NotificationDispatcher` + `notifications` inbox + telegram/slack/webhook fan-out + `auto_reporting` quiet-hours (`core/services/notification_dispatcher.py:45-62` — 14 event types). In-app is a 30s poll; no email/mobile push; deep links TODO.
+- **Approval machinery is ready, one seam unwired.** `evaluate_approval` (always_ask / auto_below_budget / full_auto, fails safe) + durable `ApprovalGrant` + ApprovalsInbox + resume-after-grant. `SUBJECT_PLAYBOOK_RUN` is defined (`core/models/approval_grants.py:53-55`) with **zero references** — `_requeue_subject` handles only `board_task` and `tool_call` (`api/approval_grants.py:182-290`).
+- **No rerun primitive.** Re-running means re-POST `/{recipe_id}/execute`; nothing copies a prior execution's inputs. `retry_of`/`attempt_count` columns exist but are written only by the stall auto-retry (`services/task_reconciler.py:218-247`).
+- **Step prompts are unversioned shared state.** `workflow_recipes.steps` JSONB, whole-playbook `version` string only; **no per-execution prompt override** — `execute_recipe` accepts `input_data` only (`api/workflow_recipes.py:832-833`). A watcher "tweak" today would mutate every future scheduled run.
+- **Chat cannot carry the report-back.** Chat turns are synchronous streaming HTTP (`api/chat.py:461-497`); no background path writes an assistant message. `ScheduledTaskService`'s docstring promises chat injection; `_trigger_agent_chat` executes the agent and **discards the output** (`services/scheduled_task_service.py:386-422`).
+- **Event substrate is partial.** LISTEN/NOTIFY push exists for board tasks only (`board_events` / `board_task_available`); missions emit 45 typed events into `orchestration_events` — an audit table with **no subscribers** (read-only REST poll, `api/missions.py:924-1000`). Four parallel event mechanisms, no bus.
+- **Cost is readable.** `llm_usage` rows per `execution_id` (tokens + dollars) + `compute_execution_metrics` (`services/report_service.py:39-146`); `orchestration_runs.budget_spent/tokens_used`; live ceilings enforced mid-run.
+- **Loop precedents to copy, not reinvent:** board dispatch spine (5s + `pg_notify` wakeup, lease/sweep/SLA-notify, `services/board_dispatcher.py:484-538`), coordinator 5s tick, TaskReconciler 60s stall→fail→backoff-retry, boot reaper, fcntl single-owner scheduler lock (`main.py:353-467`).
+- **Integration health has no substrate** (why Watch-type E is out of scope §9): nothing marks `ComposioConnection` `error`/`disconnected` at runtime; no connection event type in the dispatcher; `expires_at` unwatched.
+
+## 3. Findings → fix → story
+
+| # | Finding (grounded §2) | Fix | Story |
+|---|---|---|---|
+| 1 | No watch entity/loop anywhere | `watches` + `watch_events` registry + WatchService | S1, S2 |
+| 2 | Mission failure + budget-pause silent to user | `mission_failed` / `mission_budget_paused` notification events at the coordinator/dispatcher terminal+pause boundaries | S4 |
+| 3 | Failed mission board card shows "done" | map `failed→"failed"` (keep `cancelled→"done"`) | S4 |
+| 4 | Breaker trip silent; manual runs bypass unnoticed | `playbook_benched` notification when the scheduler skips on open breaker (once per open period) | S4 |
+| 5 | Missed cron ticks lost undetected | watcher tick compares croniter expected-fire vs latest `recipe_executions` row for scheduled watches | S5 |
+| 6 | Terminal states reach no subscriber (audit-table events only) | fail-soft `watch_ingest` hooks at the three terminal choke points; heartbeat sweep as fallback | S3, S5 |
+| 7 | No run-level output judging / business rubric | `RunVerdictService` extending the PRD-200 judge to run level, 6-dim rubric, 0–1 internal / 0–10 display | S6 |
+| 8 | No rerun primitive; tweak would mutate shared definition | rerun endpoint copying inputs + `step_overrides` honored per-execution without touching `workflow_recipes.steps` | S7 |
+| 9 | `SUBJECT_PLAYBOOK_RUN` defined, unwired | wire the `_requeue_subject` playbook_run resume branch → grant-gated rerun | S7 |
+| 10 | "Change direction / find a way" has no owner | watch decision step choosing from allowed actions (rerun / tweak+rerun / replan / reassign / spawn-agent / escalate), all via `evaluate_approval`, bounded by `action_budget` | S8, S10 |
+| 11 | Auto has no watch tools; no poll/wait tool exists | `platform_create_watch/list/get/cancel` + auto-create on Auto-launched missions | S9 |
+| 12 | No user-visible watchlist | minimal Watchlist surface + API; board/bell stay the action surfaces | S11 |
+
+## 4. Stories (test-first; CI is the only gate — no local runs)
+
+### S1 · Watch registry schema — M · _core/models_
+`watches`: `id` UUID PK, `workspace_id` FK NOT NULL, `created_by`, `owner_agent_id` NULL, `watch_type` (`mission|playbook_execution|scheduled_playbook`), `target_type`, `target_id`, `title`, `description`, `status` String(32) (`watching|acting|awaiting_approval|needs_attention|passed|failed|escalated|expired|cancelled`), `success_criteria` Text (intent snapshot), `failure_criteria` Text NULL, `quality_threshold` Float default 0.8, `check_interval_seconds` Int default 300, `last_checked_at`, `next_check_at`, `deadline_at` NULL, `policy` String(32) default `run_and_report` (`run_and_report|score_and_improve|watch_change|persistent`), `allowed_actions` JSONB, `action_budget` Int default 2, `actions_taken` Int default 0, `final_score` Float NULL, `final_verdict` Text NULL, `lineage` JSONB (ordered target chain — reruns/replans append), `version_id` (optimistic, house pattern), timestamps + `closed_at`.
+`watch_events`: `id`, `watch_id` FK, `event_type`, `summary`, `snapshot` JSONB, `score` NULL, `action_taken` NULL, `requires_attention` bool, `event_key` String — **UNIQUE(watch_id, event_key)** for idempotent ingest, `created_at`.
+Partial unique index: one non-terminal watch per (workspace_id, target_type, target_id). Alembic migration **chained on the current single head** (derive head by reading `alembic/versions` down_revision graph — do not run alembic locally).
+**Test:** model round-trip + dedup index + FK integrity (seed `workspaces` first — PRD-158 lesson).
+
+### S2 · WatchService — M · _services/watch_service.py_
+Create/get/list/cancel + guarded `transition()` (allowed-transition map, house style of `orchestration_enums`), `ingest(event_key, ...)` idempotent via the unique key, single-writer via `FOR UPDATE SKIP LOCKED` when the tick claims due watches. `record_action()` increments `actions_taken`, hard-stops at `action_budget` → `needs_attention` + escalation. Lineage helper: `follow(new_target)` appends to `lineage` and repoints the live target (a rerun/replanned run stays the SAME watch).
+**Test:** transition guard, idempotent double-ingest, budget hard-stop, lineage repoint.
+
+### S3 · Terminal choke-point hooks — S · _fail-soft, knowledge_flywheel pattern_
+Call `watch_ingest_terminal(...)` (try/except-log, never breaks the producer) from: mission terminal boundary (`_complete_verified_run` + fail/cancel paths in `coordinator_service`), playbook terminal (`recipe_executor` success block + `_fail_execution`), board-task complete/fail bridge. Payload: target ids, terminal state, output pointer, cost snapshot.
+**Test:** hook fires on each terminal path; a raising watch service does NOT fail the producer (assert mission/playbook completes normally).
+
+### S4 · Close the silent-failure holes — M · _independent of the registry; ships value even alone_
+1. Add to `NotificationDispatcher.VALID_EVENT_TYPES`: `mission_failed`, `mission_budget_paused`, `playbook_benched`, `watch_verdict`, `watch_action`, `watch_escalation`.
+2. Dispatch `mission_failed` (to `run.created_by`, reuse `_dispatch_mission_event`) at the run-failure boundary; `mission_budget_paused` at the budget-pause transition (retire the dead `notify_budget_exceeded` or wire it — one owner).
+3. Board mapping: `failed→"failed"` in `_RUN_STATE_TO_BOARD_STATUS`; update any tests asserting the old lie.
+4. `playbook_benched` once per breaker-open period from the scheduler skip path (dedupe via latest `watch_events`/notification lookback, not new state).
+**Test:** each event lands one `notifications` row with correct `event_type`/`link_id`; mapping test flipped.
+
+### S5 · Watcher tick — M · _services/watch_ticker.py on the UnifiedScheduler_
+Config: `WATCHER_ENABLED` default true, `WATCHER_TICK_SECONDS` default 300. Registered in `main.py` lifespan inside the fcntl-locked scheduler block (single owner across workers). Each tick: claim due watches (`next_check_at <= now`, SKIP LOCKED batch), per watch: refresh target state (cheap status read), deadline/`expired` handling, scheduled-playbook checks (croniter expected-fire vs latest execution → missed-run event; `breaker_is_open` → benched event), write `watch_event` only on **meaningful change** (state delta, not "still running"), reschedule `next_check_at`. Event hooks (S3) do the fast path; the tick is the fallback and the trend/missed-run brain. Notify only per §7.9 rules (terminal, threshold breach, action taken, approval needed, expiry).
+**Test:** tick idempotence (two ticks, one event), missed-cron detection with frozen clock fixtures, no-noise (running→running writes nothing).
+
+### S6 · Run-level verdict — M · _modules/coordination/run_verdict.py_
+`RunVerdictService` reusing `VerificationService`'s cross-model judge selection + output-hash cache, scoring the **run-level output** (mission `output_summary`+task outputs / playbook `output_data.final_output`+auto-report) against the watch's `success_criteria` on 6 dims: `business_usefulness, completeness, evidence_quality, clarity, actionability, reliability` — each 0–1, weighted mean, **internal 0–1, displayed ×10**. `reliability` folds in mechanics (tool failures/retries from `step_results` — reuse `PlaybookQualityService` heuristics rather than re-deriving). Verdict written to the watch (`final_score`, `final_verdict` with reasoning + caveats), `watch_verdict` notification with score + one-paragraph explanation. LLM cost attributed: `request_type='watch'`, execution-id threading like the recipe path so `llm_usage` shows supervision cost.
+**Test:** judge-stubbed scoring math, threshold verdict boundaries (0.79 fail / 0.80 pass), cache hit on identical output hash, cost row written.
+
+### S7 · Corrective actions v1: rerun + tweak — L · _the "acting" half_
+1. `POST /api/v1/playbooks/{recipe_id}/executions/{execution_id}/rerun` — new `RecipeExecution` copying `input_data`, `retry_of=<original>`, `attempt_count+1`, `triggered_by='watch_rerun'` (or `'rerun'` when human), optional `step_overrides`.
+2. `step_overrides` (`{step_id: {prompt_template: ...}}`) stored in `execution_metadata`, merged at execution start in the executor's step resolution — **`workflow_recipes.steps` is never mutated**. Overrides recorded in the watch event for before/after comparison.
+3. Gate: estimate rerun cost from the original run's `llm_usage` sum → `evaluate_approval`; auto path launches immediately; ask path creates `ApprovalGrant(subject_kind=SUBJECT_PLAYBOOK_RUN)` + `approval_pending` notification, watch → `awaiting_approval`.
+4. Wire `_requeue_subject` `playbook_run` branch: grant → launch the stored rerun spec; deny → watch `needs_attention`.
+**Test:** rerun copies inputs + lineage; override applied to prompt assembly without touching the template row (assert template unchanged); grant→resume launches; deny→no launch; budget-exceeded rerun estimate → ask path.
+
+### S8 · Direction-change actions: replan / reassign / spawn-agent — M
+Actions on mission watches, same `evaluate_approval` gate + `action_budget`:
+- **replan** — drive the existing coordinator replan path (`failed→replanning` is an allowed run transition; reuse the `platform_replan_mission` service method) with the watch's diagnosis as replan context.
+- **reassign** — requeue a failed/stalled task to a different capable agent (reuse dispatcher capability matching; skip if none — `no_capable_agent` → escalate).
+- **spawn_agent** — instantiate from an existing **blueprint** (never free-form; blueprint validation path stays authoritative), then reassign/replan onto it. **Always grant-gated in v1** regardless of policy (§8 Q5) — `full_auto` workspaces auto-approve under the dollar ceiling via the policy engine, consistent with PRD-193 semantics.
+- **escalate** — escalation-service board card (reuse `escalate_stalled_task` shape) + `watch_escalation` notification; terminal for the watch unless renewed.
+**Test:** each action once under `full_auto` (auto) and `always_ask` (grant card), budget exhaustion → escalate, spawn honors blueprint `rules` defaulting (onboarding-wall regression guard).
+
+### S9 · Auto tool surface — S · _modules/tools/discovery/actions_watches.py + handlers_
+`platform_create_watch` (target, criteria, threshold, policy, deadline), `platform_list_watches`, `platform_get_watch`, `platform_cancel_watch` — registered like `actions_missions`. Auto-create (Q1): `platform_create_mission` and the playbook-execute tool create a `run_and_report` watch by default (workspace setting `watch_auto_create`, default ON), success_criteria seeded from the user's request text (intent snapshot).
+**Test:** tool schema `required[]` matches handler defaults (blueprint-rules-wall lesson), auto-create writes the watch, handlers workspace-scoped.
+
+### S10 · Decision step — M · _policy first, LLM only where it earns it_
+Deterministic policy table drives the flow per watch `policy` (e.g. `run_and_report`: terminal→score→notify, no actions; `score_and_improve`: below-threshold→diagnose→one tweak+rerun→rescore→final). LLM is used for exactly two bounded jobs: (a) failure/low-score **diagnosis** (inputs: error, step_results compact, verdict reasoning → one-paragraph cause + proposed action + optional `step_overrides` draft), (b) tweak drafting. Both heartbeat-style single calls, cost-attributed to the watch, never unbounded loops — `action_budget` is the hard rail.
+**Test:** policy table transitions golden-file tested; diagnosis stubbed; runaway guard (action_budget=0 → straight to escalate).
+
+### S11 · Watchlist surface — M · _frontend + API_
+`GET /api/v1/watches` (+`/{id}` detail incl. recent events), `POST /api/v1/watches/{id}/cancel`, ws-scoped perms mirroring the board router. Minimal UI: Watchlist panel in the Command Center (table: title, type, status, last check, score/verdict; cancel action), polling hook (30–60s, house pattern), entries link to the board card / execution. **Update the committed `orchestrator/reports/route-manifest.json` by hand** (sorted `{method,path}` + count bump) — the frontend route-contract lane reads the committed file, it does not regenerate.
+**Test:** route-contract lane green; API list filtered by workspace; UI renders empty + populated states.
+
+### S12 · CI hardening — S
+Full test sweep for the above; ensure single alembic head; don't trip source-grep guard lanes (repoint any guard that referenced moved lines); no new routes missing from the manifest; migration boots via docker-entrypoint `alembic upgrade heads` semantics (idempotent, additive only).
+
+## 5. Sequencing
+
+S1→S2 (registry) → S3+S4 in parallel (hooks + silent-hole fixes; S4 has standalone value) → S5 (tick) → S6 (verdict) → S7 (rerun/tweak) → S8 (direction-change) → S9+S10 (tools + decision) → S11 (surface) → S12 rolling. Single PR, story-per-commit (`feat(prd-204): S<N> …`).
+
+## 6. Verification (CI is the only gate — no local runs)
+
+orchestrator-tests lane green (new units + integration); migrations lane single-head; frontend route-contract lane green against the updated manifest; CodeQL/security lanes clean (no new path/injection surface — watch APIs are read/cancel + gated actions); malware-scan lane (post-incident) green. Behavioural assertions in tests, not local servers.
+
+## 7. Baseline capture — freeze, then measure the delta
+
+Pre-merge truths to freeze in the PR body (queryable, tenant-safe):
+- `mission_failed` notifications possible: **0** (event type absent) → post: present + tested.
+- Terminal-notification coverage metric (notifications dossier headline): failure-path mission coverage **0%** → post: 100% of mission terminal states dispatch.
+- Missed-cron detectability: **0** (no mechanism) → post: detected within one tick.
+- Run-level output verdicts: **0** anywhere → post: every watched terminal run scored.
+- Rerun primitive: **absent** → post: endpoint + grant-gated path.
+Post-merge product metrics (PRD §14 of the source draft): % Auto-launched work with a watch, time-to-verdict, failures caught unprompted, tweak delta (score before/after), watch cost per verdict (`llm_usage where request_type='watch'`).
+
+## 8. Open questions — Gerard's call (decide, don't let me defer — CLAUDE.md §12)
+*Recommendations below are applied as build defaults; flag at PR review to flip.*
+
+1. **Auto-create watches for Auto-launched work?** → **REC: yes**, `run_and_report` policy, workspace-settable (`watch_auto_create` ON). Cheap (one row + existing events).
+2. **Default quality threshold?** → **REC: 0.8 internal (displayed 8/10)**, per-watch configurable. Note it is stricter than the task-judge's 0.7 pass — intentional at run level.
+3. **Rerun without approval?** → **REC: no blanket yes — route through `evaluate_approval` with the rerun's estimated cost.** `auto_below_budget`/`full_auto` auto-rerun under ceiling; `always_ask` gets the grant card. Consistent with PRD-193 + §12.3.
+4. **Report-back in chat?** → **REC: out of this PRD.** Delivery = bell + channels (works session-independently today). "Background→chat message" is a real primitive with threading/UX questions — candidate PRD-205; the `ScheduledTaskService` discard bug gets fixed there, not here.
+5. **spawn_agent autonomy?** → **REC: always grant-gated in v1** (blueprints only); `full_auto` + under-ceiling auto-approves via the policy engine. Revisit after live data.
+6. **Board mapping change (`failed→failed`) is user-visible** — cards that used to show done now show failed. → **REC: ship it; it was lying.**
+7. **Integration/Data watch (source-draft type E)?** → **REC: own PRD** — zero substrate today (no runtime connection-error writer, no event type, `expires_at` unwatched). Needs a connection-health story first.
+8. **Scale presentation?** → **REC: 0–1 internal everywhere (matches judge/thresholds), ×10 only at display/notification edge.**
+9. **Watch lineage across corrective actions?** → **REC: the watch follows the work** — reruns/replanned runs append to `lineage`, one watch one verdict; a new watch per attempt would fragment the story.
+
+## 9. Explicitly out of scope (each → its own future decision, not silently dropped)
+
+Unified event bus (hooks + sweep suffice at this scale; a fifth event mechanism would be the real risk); chat-message injection (§8 Q4 → PRD-205 candidate); integration/data watch (§8 Q7); multi-week business-outcome watch (source-draft type F); email/mobile-push delivery (notification plane extension, P2-26 digest territory); user-custom rubric UI; anomaly detection/predictive intervention. Source-draft §13 concurs.
+
+---
+
+*Traceability: source draft = Gerard's "Auto Watcher" side-PRD (2026-07-16); grounding = 5-agent repo survey @ `8e0543211` (missions/board, playbook/scheduling, events/notifications, scoring/heartbeats/integrations, PRD-landscape); closes deep-review open loops on missions (advisory-only verification → owned outcomes), playbooks (silent bench/missed-run), notifications (failure-path silence); addresses OS-review F090 (human can't watch Auto act) / F023 (green-over-failed) / F085 (babysit-or-trust-blindly); reuses PRD-128 dispatcher, PRD-193/196 grants+inbox, PRD-200 judge+gate patterns, PRD-185 breaker/telemetry, PRD-161 dispatch-spine idioms. Canonical terms: Mission, Playbook (=Recipe), Auto, Watch. PILOT lens applied — cold-start emptiness is not a defect signal.*

--- a/frontend/components/command-center/__tests__/governance-policy-pane.test.tsx
+++ b/frontend/components/command-center/__tests__/governance-policy-pane.test.tsx
@@ -9,17 +9,24 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 
-const { updatePolicy, updateBudget, statusMock } = vi.hoisted(() => ({
+// The mocked hook data MUST be reference-stable across renders (the sibling
+// tests' mockReturnValue idiom). An inline `() => ({ data: {...} })` mints a
+// NEW object every render, so PolicyPane's `useEffect(..., [policy])` re-runs
+// each pass and its `setOverrides(policy.route_overrides ?? {})` never bails
+// out (fresh object identity) -> an act()-flushed infinite render loop that
+// starves the event loop, hangs the whole vitest worker, and timed the
+// Frontend CI job out at 20m from PRD-196's merge onward.
+const { updatePolicy, updateBudget, statusMock, policyData, budgetData } = vi.hoisted(() => ({
   updatePolicy: vi.fn().mockResolvedValue({}),
   updateBudget: vi.fn().mockResolvedValue({}),
   statusMock: vi.fn(),
+  policyData: { posture: 'balanced', agents_inherit_admin: false, route_overrides: {} },
+  budgetData: {},
 }))
 
 vi.mock('@/hooks/use-governance', () => ({
-  usePolicy: () => ({
-    data: { posture: 'balanced', agents_inherit_admin: false, route_overrides: {} },
-  }),
-  useBudget: () => ({ data: {} }),
+  usePolicy: () => ({ data: policyData }),
+  useBudget: () => ({ data: budgetData }),
   useGovernanceStatus: () => statusMock(),
   useUpdatePolicy: () => ({ isLoading: false, mutateAsync: updatePolicy }),
   useUpdateBudget: () => ({ isLoading: false, mutateAsync: updateBudget }),

--- a/frontend/components/command-center/__tests__/watchlist-tab.test.tsx
+++ b/frontend/components/command-center/__tests__/watchlist-tab.test.tsx
@@ -1,0 +1,145 @@
+/**
+ * PRD-204 S11 -- the Watchlist panel.
+ *
+ * Empty state is honest ("Nothing being watched"); a populated list renders
+ * title/type/status/last-check/score columns off the watch registry shape
+ * (score is the backend's x10 display string); rows link to the watched
+ * mission / playbook execution; cancel goes through the house confirm
+ * primitive (PRD-169 -- no window.confirm) and calls the cancel mutation;
+ * closed watches offer no cancel.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import type { WatchRow } from '@/lib/api-client'
+
+const { cancelMutate } = vi.hoisted(() => ({
+  cancelMutate: vi.fn().mockResolvedValue({}),
+}))
+
+vi.mock('@/hooks/use-watches-api', () => ({
+  useWatches: vi.fn(),
+  useWatchDetail: vi.fn(() => ({ data: undefined, isLoading: false })),
+  useCancelWatch: () => ({ isLoading: false, mutateAsync: cancelMutate }),
+}))
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...rest }: any) => (
+    <a href={typeof href === 'string' ? href : String(href)} {...rest}>
+      {children}
+    </a>
+  ),
+}))
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+}))
+
+import { WatchlistTab } from '../watchlist-tab'
+import { useWatches } from '@/hooks/use-watches-api'
+
+const mockUseWatches = vi.mocked(useWatches)
+
+function watch(overrides?: Partial<WatchRow>): WatchRow {
+  return {
+    id: 'w-1',
+    title: 'Watch: Draft the Q4 memo',
+    watch_type: 'mission',
+    target_type: 'mission',
+    target_id: 'run-42',
+    status: 'watching',
+    policy: 'run_and_report',
+    success_criteria: 'The memo ships.',
+    quality_threshold: 0.8,
+    final_score: null,
+    final_score_display: 'unscored',
+    final_verdict: null,
+    actions_taken: 0,
+    action_budget: 2,
+    last_checked_at: new Date(Date.now() - 5 * 60_000).toISOString(),
+    next_check_at: null,
+    deadline_at: null,
+    created_at: new Date().toISOString(),
+    closed_at: null,
+    ...overrides,
+  }
+}
+
+function setWatches(watches: WatchRow[]) {
+  mockUseWatches.mockReturnValue({
+    data: { watches, total: watches.length },
+    isLoading: false,
+    isError: false,
+  } as any)
+}
+
+describe('WatchlistTab -- PRD-204 S11', () => {
+  beforeEach(() => {
+    cancelMutate.mockClear()
+  })
+
+  it('shows the simple empty state when nothing is being watched', () => {
+    setWatches([])
+    render(<WatchlistTab />)
+    expect(screen.getByText(/Nothing being watched/)).toBeInTheDocument()
+  })
+
+  it('renders a live watch row with type chip, status chip, relative check, and score', () => {
+    setWatches([watch()])
+    render(<WatchlistTab />)
+    expect(screen.getByText('Watch: Draft the Q4 memo')).toBeInTheDocument()
+    expect(screen.getByText('mission')).toBeInTheDocument()
+    expect(screen.getByText('watching')).toBeInTheDocument()
+    expect(screen.getByText(/minutes ago/)).toBeInTheDocument()
+    expect(screen.getByText('unscored')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Cancel/ })).toBeInTheDocument()
+  })
+
+  it('shows the x10 score display for a scored watch and no cancel when closed', () => {
+    setWatches([
+      watch({
+        id: 'w-2',
+        status: 'passed',
+        final_score: 0.83,
+        final_score_display: '8.3/10',
+        final_verdict: 'Delivered what was asked.',
+        closed_at: new Date().toISOString(),
+      }),
+    ])
+    render(<WatchlistTab />)
+    expect(screen.getByText('8.3/10')).toBeInTheDocument()
+    expect(screen.getByText('Delivered what was asked.')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Cancel/ })).not.toBeInTheDocument()
+  })
+
+  it('links the row to the watched mission / playbook execution', () => {
+    setWatches([
+      watch(),
+      watch({
+        id: 'w-3',
+        title: 'Watch: Weekly digest',
+        target_type: 'playbook_execution',
+        target_id: 'exec-9',
+      }),
+    ])
+    render(<WatchlistTab />)
+    expect(
+      screen.getByRole('link', { name: 'Watch: Draft the Q4 memo' }),
+    ).toHaveAttribute('href', '/assignments?tab=missions&mission=run-42')
+    expect(
+      screen.getByRole('link', { name: 'Watch: Weekly digest' }),
+    ).toHaveAttribute('href', '/assignments?tab=playbooks&execution=exec-9')
+  })
+
+  it('cancel rides the house confirm primitive and calls the mutation', async () => {
+    setWatches([watch({ id: 'w-7' })])
+    render(<WatchlistTab />)
+
+    // No mutation before the confirm dialog approves it.
+    fireEvent.click(screen.getByRole('button', { name: /Cancel/ }))
+    expect(cancelMutate).not.toHaveBeenCalled()
+    expect(screen.getByText(/Stop watching this work/)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /^Stop watching$/ }))
+    await waitFor(() => expect(cancelMutate).toHaveBeenCalledWith('w-7'))
+  })
+})

--- a/frontend/components/command-center/command-center-shell.tsx
+++ b/frontend/components/command-center/command-center-shell.tsx
@@ -23,6 +23,7 @@ import { useBoardTasks } from '@/hooks/use-board-tasks'
 import { useBoardEventStream } from '@/hooks/use-board-event-stream'
 import { useActivitySchedule } from '@/hooks/use-activity-api'
 import { useDecisionsNeeded } from '@/hooks/use-kpi-api'
+import { useWatches } from '@/hooks/use-watches-api'
 
 import { StatsStrip } from './stats-strip'
 import { IsItWorkingStrip } from './is-it-working-strip'
@@ -30,15 +31,24 @@ import { SummaryTab } from './summary-tab'
 import { BoardTab } from './board-tab'
 import { CalendarTab } from './calendar-tab'
 import { ActivityTab } from './activity-tab'
+import { WatchlistTab } from './watchlist-tab'
 import { GovernanceTab } from './governance-tab'
 
-type TabKey = 'summary' | 'board' | 'calendar' | 'activity' | 'governance'
+type TabKey =
+  | 'summary'
+  | 'board'
+  | 'calendar'
+  | 'activity'
+  | 'watchlist'
+  | 'governance'
 
 const TABS: { key: TabKey; label: string }[] = [
   { key: 'summary', label: 'Summary' },
   { key: 'board', label: 'Board' },
   { key: 'calendar', label: 'Calendar' },
   { key: 'activity', label: 'Activity' },
+  // PRD-204 S11: the watchlist -- work Auto is supervising to a verdict.
+  { key: 'watchlist', label: 'Watchlist' },
   // PRD-196 (P2-15): the governance pillar (Approvals · Audit · Policy ·
   // Compliance), ws-admin-only. The human surface for the policy plane.
   { key: 'governance', label: 'Governance' },
@@ -72,6 +82,9 @@ export function CommandCenterShell() {
   const { data: schedule } = useActivitySchedule('7d')
   const { data: feed } = useActivityFeed({ limit: 200 })
   const { data: decisions } = useDecisionsNeeded(10)
+  // PRD-204 S11: live watches only (the default list) -- the tab badge is
+  // "how many things is Auto supervising right now".
+  const { data: watchlist } = useWatches()
 
   // PRD-180 S1 (F090): real-time board push. Subscribes to the LISTEN/NOTIFY
   // SSE and invalidates the board cache on each pushed event — this is what
@@ -89,11 +102,12 @@ export function CommandCenterShell() {
       ),
       calendar: schedule?.scheduled?.length ?? 0,
       activity: feed?.total ?? feed?.items?.length ?? 0,
+      watchlist: watchlist?.total ?? 0,
       // No live badge on Governance — the pending-approvals count lives inside
       // the ws-admin-gated pane, not fetched for every member on the shell.
       governance: 0,
     }),
-    [decisions, columns, schedule, feed],
+    [decisions, columns, schedule, feed, watchlist],
   )
 
   const working = stats?.working_now ?? 0
@@ -178,6 +192,7 @@ export function CommandCenterShell() {
         {activeTab === 'board' && <BoardTab />}
         {activeTab === 'calendar' && <CalendarTab />}
         {activeTab === 'activity' && <ActivityTab />}
+        {activeTab === 'watchlist' && <WatchlistTab />}
         {activeTab === 'governance' && <GovernanceTab />}
       </div>
     </div>

--- a/frontend/components/command-center/watchlist-tab.tsx
+++ b/frontend/components/command-center/watchlist-tab.tsx
@@ -1,0 +1,287 @@
+'use client'
+
+/**
+ * WatchlistTab -- PRD-204 S11 (Auto Watcher).
+ *
+ * The minimal watchlist surface: every launched unit of work Auto is
+ * supervising to a verdict, one row each. Title links to the watched
+ * mission / playbook execution; status and score come straight off the
+ * watch registry (scores are 0-1 internally, displayed x10 by the
+ * backend's `final_score_display`); a live watch can be cancelled via the
+ * house confirm primitive (PRD-169 -- no window.confirm). A row expands to
+ * its recent watch_events timeline (created / terminal / scored /
+ * diagnosed / action ...), newest first.
+ *
+ * The board and the notification bell stay the ACTION surfaces -- this
+ * panel is read-and-cancel only, by design (PRD-204 S11).
+ */
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { formatDistanceToNow } from 'date-fns'
+import { ChevronDown, ChevronRight, Eye } from 'lucide-react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import { DeleteConfirmation } from '@/components/shared/delete-confirmation'
+import {
+  useCancelWatch,
+  useWatchDetail,
+  useWatches,
+} from '@/hooks/use-watches-api'
+import type { WatchRow } from '@/lib/api-client'
+
+const LIVE_STATUSES = new Set([
+  'watching',
+  'acting',
+  'awaiting_approval',
+  'needs_attention',
+])
+
+export function isLiveWatch(status: string): boolean {
+  return LIVE_STATUSES.has(status)
+}
+
+/** Design-token tone per watch status (raw palette classes are banned). */
+export function statusToneClass(status: string): string {
+  switch (status) {
+    case 'passed':
+      return 'text-success border-success'
+    case 'failed':
+    case 'expired':
+      return 'text-destructive border-destructive'
+    case 'awaiting_approval':
+    case 'needs_attention':
+    case 'escalated':
+      return 'text-warning border-warning'
+    case 'cancelled':
+      return 'text-muted-foreground border-border'
+    default:
+      // watching / acting -- healthy, in flight
+      return 'text-primary border-primary'
+  }
+}
+
+/** Where a watch row links: the board card / execution it supervises. */
+export function targetHref(watch: WatchRow): string | null {
+  switch (watch.target_type) {
+    case 'mission':
+      return `/assignments?tab=missions&mission=${watch.target_id}`
+    case 'playbook_execution':
+      return `/assignments?tab=playbooks&execution=${watch.target_id}`
+    case 'scheduled_playbook':
+      return '/assignments?tab=playbooks'
+    case 'board_task':
+      return '/command-center?tab=board'
+    default:
+      return null
+  }
+}
+
+function relativeLabel(iso: string | null): string {
+  if (!iso) return 'never'
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return 'never'
+  return formatDistanceToNow(d, { addSuffix: true })
+}
+
+function Chip({ tone, children }: { tone: string; children: React.ReactNode }) {
+  return (
+    <span
+      className={`inline-block whitespace-nowrap rounded border px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide ${tone}`}
+    >
+      {children}
+    </span>
+  )
+}
+
+/** Recent watch_events timeline, newest first (loaded on expand). */
+function WatchTimeline({ watchId }: { watchId: string }) {
+  const { data, isLoading } = useWatchDetail(watchId)
+
+  if (isLoading) {
+    return <p className="px-2 py-1.5 text-xs text-muted-foreground">Loading events...</p>
+  }
+  const events = data?.recent_events ?? []
+  if (events.length === 0) {
+    return <p className="px-2 py-1.5 text-xs text-muted-foreground">No events yet.</p>
+  }
+  return (
+    <ol className="flex flex-col gap-1 px-2 py-1.5" aria-label="Watch events">
+      {events.map((e, i) => (
+        <li key={`${e.event_type}-${e.created_at ?? i}`} className="flex items-baseline gap-2 text-xs">
+          <span
+            className={`shrink-0 font-medium uppercase tracking-wide ${
+              e.requires_attention ? 'text-warning' : 'text-muted-foreground'
+            }`}
+          >
+            {e.event_type.replace(/_/g, ' ')}
+          </span>
+          <span className="min-w-0 flex-1 truncate text-muted-foreground">
+            {e.summary ?? ''}
+          </span>
+          <span className="shrink-0 text-muted-foreground/70">
+            {relativeLabel(e.created_at)}
+          </span>
+        </li>
+      ))}
+    </ol>
+  )
+}
+
+function WatchRowItem({ watch }: { watch: WatchRow }) {
+  const cancelMut = useCancelWatch()
+  const [confirming, setConfirming] = useState(false)
+  const [expanded, setExpanded] = useState(false)
+
+  const live = isLiveWatch(watch.status)
+  const href = targetHref(watch)
+  const scoreLabel =
+    watch.final_score != null ? watch.final_score_display : 'unscored'
+
+  const handleCancel = async () => {
+    try {
+      await cancelMut.mutateAsync(watch.id)
+      toast.success('Watch cancelled')
+    } catch {
+      toast.error('Failed to cancel the watch')
+      throw new Error('cancel failed') // keep the confirm dialog open
+    }
+  }
+
+  return (
+    <>
+      <tr className="border-b border-border/30">
+        <td className="py-2 pr-2 align-top">
+          <button
+            type="button"
+            className="mt-0.5 text-muted-foreground hover:text-foreground"
+            aria-label={expanded ? 'Hide events' : 'Show events'}
+            aria-expanded={expanded}
+            onClick={() => setExpanded((v) => !v)}
+          >
+            {expanded ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
+          </button>
+        </td>
+        <td className="max-w-0 w-full py-2 pr-3 align-top">
+          {href ? (
+            <Link href={href as any} className="block truncate text-sm font-medium hover:underline">
+              {watch.title}
+            </Link>
+          ) : (
+            <span className="block truncate text-sm font-medium">{watch.title}</span>
+          )}
+          {watch.final_verdict && (
+            <p className="mt-0.5 truncate text-xs text-muted-foreground">{watch.final_verdict}</p>
+          )}
+        </td>
+        <td className="py-2 pr-3 align-top">
+          <Chip tone="text-muted-foreground border-border">
+            {watch.watch_type.replace(/_/g, ' ')}
+          </Chip>
+        </td>
+        <td className="py-2 pr-3 align-top">
+          <Chip tone={statusToneClass(watch.status)}>
+            {watch.status.replace(/_/g, ' ')}
+          </Chip>
+        </td>
+        <td className="whitespace-nowrap py-2 pr-3 align-top text-xs text-muted-foreground">
+          {relativeLabel(watch.last_checked_at)}
+        </td>
+        <td className="whitespace-nowrap py-2 pr-3 align-top text-xs">
+          <span className={watch.final_score != null ? 'font-medium' : 'text-muted-foreground'}>
+            {scoreLabel}
+          </span>
+        </td>
+        <td className="py-2 align-top">
+          {live && (
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={cancelMut.isLoading}
+              onClick={() => setConfirming(true)}
+            >
+              Cancel
+            </Button>
+          )}
+        </td>
+      </tr>
+      {expanded && (
+        <tr className="border-b border-border/30 bg-background/50">
+          <td />
+          <td colSpan={6}>
+            <WatchTimeline watchId={watch.id} />
+          </td>
+        </tr>
+      )}
+      <DeleteConfirmation
+        open={confirming}
+        onOpenChange={setConfirming}
+        title="Stop watching this work?"
+        description={`Auto will stop supervising "${watch.title}". The underlying work keeps running.`}
+        confirmLabel="Stop watching"
+        cancelLabel="Keep watching"
+        onConfirm={handleCancel}
+        loading={cancelMut.isLoading}
+      />
+    </>
+  )
+}
+
+export function WatchlistTab() {
+  const [includeClosed, setIncludeClosed] = useState(false)
+  const { data, isLoading, isError } = useWatches(includeClosed)
+
+  const watches = data?.watches ?? []
+
+  if (isLoading) {
+    return <p className="p-3 text-sm text-muted-foreground">Loading watchlist...</p>
+  }
+  if (isError) {
+    return <p className="p-3 text-sm text-muted-foreground">Could not load the watchlist.</p>
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center justify-between">
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          Watchlist {watches.length > 0 && <span className="text-foreground">({watches.length})</span>}
+        </h3>
+        <label className="flex cursor-pointer items-center gap-1.5 text-xs text-muted-foreground">
+          <input
+            type="checkbox"
+            checked={includeClosed}
+            onChange={(e) => setIncludeClosed(e.target.checked)}
+          />
+          Show closed
+        </label>
+      </div>
+
+      {watches.length === 0 ? (
+        <p className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Eye className="h-4 w-4" /> Nothing being watched.
+        </p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-left">
+            <thead>
+              <tr className="border-b border-border text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                <th className="w-6 py-1.5 pr-2" aria-label="Expand" />
+                <th className="py-1.5 pr-3">Watch</th>
+                <th className="py-1.5 pr-3">Type</th>
+                <th className="py-1.5 pr-3">Status</th>
+                <th className="py-1.5 pr-3">Last check</th>
+                <th className="py-1.5 pr-3">Score</th>
+                <th className="w-20 py-1.5" aria-label="Actions" />
+              </tr>
+            </thead>
+            <tbody>
+              {watches.map((w) => (
+                <WatchRowItem key={w.id} watch={w} />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/hooks/use-watches-api.ts
+++ b/frontend/hooks/use-watches-api.ts
@@ -1,0 +1,48 @@
+/**
+ * Watchlist React Query hooks -- PRD-204 S11 (Auto Watcher).
+ *
+ * Reads `GET /api/v1/watches` (live watches; `includeClosed` widens to the
+ * full history) and drives the cancel verb. Same shape as
+ * use-approval-grants.ts; polling mirrors use-activity-api.ts (60s interval,
+ * 30s staleTime) -- the watcher tick runs on minutes, so a minute-fresh list
+ * is honest without hammering.
+ */
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { apiClient } from '@/lib/api-client'
+import type { WatchDetailResponse, WatchesResponse } from '@/lib/api-client'
+
+export const watchesQueryKeys = {
+  all: ['watches'] as const,
+  list: (includeClosed?: boolean) =>
+    ['watches', 'list', includeClosed ? 'all' : 'live'] as const,
+  detail: (watchId: string) => ['watches', 'detail', watchId] as const,
+}
+
+export function useWatches(includeClosed: boolean = false) {
+  return useQuery<WatchesResponse>({
+    queryKey: watchesQueryKeys.list(includeClosed),
+    queryFn: () => apiClient.listWatches(includeClosed),
+    refetchInterval: 60_000,
+    staleTime: 30_000,
+  })
+}
+
+export function useWatchDetail(watchId: string | null) {
+  return useQuery<WatchDetailResponse>({
+    queryKey: watchesQueryKeys.detail(watchId ?? 'none'),
+    queryFn: () => apiClient.getWatch(watchId as string),
+    enabled: !!watchId,
+    refetchInterval: 60_000,
+    staleTime: 30_000,
+  })
+}
+
+export function useCancelWatch() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (watchId: string) => apiClient.cancelWatch(watchId),
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: watchesQueryKeys.all }),
+  })
+}

--- a/frontend/lib/api-client.ts
+++ b/frontend/lib/api-client.ts
@@ -240,6 +240,50 @@ export interface GdprWorkspaceErasureResult {
   [key: string]: any
 }
 
+// ===== PRD-204 Auto Watcher: watchlist types =====
+export interface WatchRow {
+  id: string
+  title: string
+  watch_type: string
+  target_type: string
+  target_id: string
+  status: string
+  policy: string
+  success_criteria: string | null
+  quality_threshold: number
+  final_score: number | null
+  /** x10 display convention from the backend, e.g. "8.3/10" or "unscored". */
+  final_score_display: string
+  final_verdict: string | null
+  actions_taken: number
+  action_budget: number
+  last_checked_at: string | null
+  next_check_at: string | null
+  deadline_at: string | null
+  created_at: string | null
+  closed_at: string | null
+  lineage?: Array<Record<string, string>>
+}
+
+export interface WatchEventRow {
+  event_type: string
+  summary: string | null
+  score: number | null
+  action_taken: string | null
+  requires_attention: boolean
+  created_at: string | null
+}
+
+export interface WatchesResponse {
+  watches: WatchRow[]
+  total: number
+}
+
+export interface WatchDetailResponse {
+  watch: WatchRow
+  recent_events: WatchEventRow[]
+}
+
 class ApiClient {
   private baseUrl: string
   private defaultHeaders: Record<string, string>
@@ -2187,6 +2231,20 @@ class ApiClient {
       method: 'POST',
       body: JSON.stringify({ confirm_workspace_id: confirmWorkspaceId }),
     })
+  }
+
+  // ===== PRD-204 S11 Auto Watcher: watchlist =====
+  async listWatches(includeClosed: boolean = false): Promise<WatchesResponse> {
+    const qs = includeClosed ? '?include_closed=true' : ''
+    return this.request<WatchesResponse>(`/api/v1/watches${qs}`)
+  }
+
+  async getWatch(watchId: string): Promise<WatchDetailResponse> {
+    return this.request<WatchDetailResponse>(`/api/v1/watches/${watchId}`)
+  }
+
+  async cancelWatch(watchId: string): Promise<{ watch: WatchRow }> {
+    return this.request(`/api/v1/watches/${watchId}/cancel`, { method: 'POST' })
   }
 }
 

--- a/orchestrator/alembic/versions/prd204_merge_heads.py
+++ b/orchestrator/alembic/versions/prd204_merge_heads.py
@@ -1,0 +1,40 @@
+"""PRD-204: collapse the two-headed revision forest back to one head.
+
+At PRD-204 branch time ``alembic heads`` returns two divergent heads:
+
+    - prd201_s1_msg_context_trace  (PRD-201, merged to main as its own child
+      of prd196_audit_logs_ws_created_idx)
+    - prd203_merge_heads           (the PRD-203 merge revision, which joined
+      prd200 / prd202 / prd203_voice_turns but predated PRD-201's merge and
+      so never included it)
+
+Two heads make ``alembic upgrade head`` (singular) ambiguous and fail the
+CI "exactly one head" gate. This is a **merge revision only** — no schema
+operations — joining the two lineages so ``alembic heads`` returns exactly
+one revision. The PRD-204 watch-registry migration chains onto this merge.
+
+Do NOT add ``CREATE``/``ALTER`` here — a merge revision that mutates schema
+is exactly what makes a later from-zero squash lossy (mirrors
+prd176_merge_heads / prd203_merge_heads).
+
+Revision ID: prd204_merge_heads
+Revises: prd201_s1_msg_context_trace, prd203_merge_heads
+Create Date: 2026-07-16
+"""
+
+# A pure merge point — no operations.
+revision = "prd204_merge_heads"
+down_revision = (
+    "prd201_s1_msg_context_trace",
+    "prd203_merge_heads",
+)
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """No-op: this revision only merges lineages."""
+
+
+def downgrade() -> None:
+    """No-op: splitting back into two heads needs no schema change."""

--- a/orchestrator/alembic/versions/prd204_merge_heads.py
+++ b/orchestrator/alembic/versions/prd204_merge_heads.py
@@ -9,11 +9,11 @@ At PRD-204 branch time ``alembic heads`` returns two divergent heads:
       so never included it)
 
 Two heads make ``alembic upgrade head`` (singular) ambiguous and fail the
-CI "exactly one head" gate. This is a **merge revision only** — no schema
-operations — joining the two lineages so ``alembic heads`` returns exactly
+CI "exactly one head" gate. This is a **merge revision only** -- no schema
+operations -- joining the two lineages so ``alembic heads`` returns exactly
 one revision. The PRD-204 watch-registry migration chains onto this merge.
 
-Do NOT add ``CREATE``/``ALTER`` here — a merge revision that mutates schema
+Do NOT add ``CREATE``/``ALTER`` here -- a merge revision that mutates schema
 is exactly what makes a later from-zero squash lossy (mirrors
 prd176_merge_heads / prd203_merge_heads).
 
@@ -22,7 +22,7 @@ Revises: prd201_s1_msg_context_trace, prd203_merge_heads
 Create Date: 2026-07-16
 """
 
-# A pure merge point — no operations.
+# A pure merge point -- no operations.
 revision = "prd204_merge_heads"
 down_revision = (
     "prd201_s1_msg_context_trace",

--- a/orchestrator/alembic/versions/prd204_watch_registry.py
+++ b/orchestrator/alembic/versions/prd204_watch_registry.py
@@ -1,4 +1,4 @@
-"""PRD-204 S1: watch registry — watches + watch_events
+"""PRD-204 S1: watch registry -- watches + watch_events
 
 A Watch is a first-class, workspace-scoped row supervising one launched unit
 of work (mission / playbook execution / scheduled playbook) from launch to a

--- a/orchestrator/alembic/versions/prd204_watch_registry.py
+++ b/orchestrator/alembic/versions/prd204_watch_registry.py
@@ -1,0 +1,188 @@
+"""PRD-204 S1: watch registry — watches + watch_events
+
+A Watch is a first-class, workspace-scoped row supervising one launched unit
+of work (mission / playbook execution / scheduled playbook) from launch to a
+verdict. watch_events is the append-only observation log with an idempotency
+key per observation.
+
+Invariants installed here:
+- CHECK constraint on watches.status (9-value lifecycle)
+- partial UNIQUE index: one NON-TERMINAL watch per
+  (workspace_id, target_type, target_id)
+- UNIQUE(watch_id, event_key) on watch_events for idempotent ingest
+- partial index on next_check_at for the watcher tick's SKIP LOCKED claim
+
+Additive only. Chains on prd204_merge_heads (the single head after merging
+the prd201/prd203 lineages).
+
+Revision ID: prd204_watch_registry
+Revises: prd204_merge_heads
+Create Date: 2026-07-16
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB, UUID as PGUUID
+
+revision = "prd204_watch_registry"
+down_revision = "prd204_merge_heads"
+branch_labels = None
+depends_on = None
+
+# Frozen snapshots of core/models/watch_enums.py at this revision.
+_WATCH_STATUSES = (
+    "watching",
+    "acting",
+    "awaiting_approval",
+    "needs_attention",
+    "passed",
+    "failed",
+    "escalated",
+    "expired",
+    "cancelled",
+)
+_TERMINAL_STATUSES_SQL = "'cancelled', 'escalated', 'expired', 'failed', 'passed'"
+
+
+def upgrade() -> None:
+    op.create_table(
+        "watches",
+        sa.Column(
+            "id",
+            PGUUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "workspace_id",
+            PGUUID(as_uuid=True),
+            sa.ForeignKey("workspaces.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("created_by", sa.String(255), nullable=True),
+        sa.Column(
+            "owner_agent_id",
+            sa.Integer,
+            sa.ForeignKey("agents.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("watch_type", sa.String(32), nullable=False),
+        sa.Column("target_type", sa.String(32), nullable=False),
+        sa.Column("target_id", sa.String(255), nullable=False),
+        sa.Column("title", sa.String(500), nullable=False),
+        sa.Column("description", sa.Text, nullable=True),
+        sa.Column(
+            "status", sa.String(32), nullable=False, server_default="watching"
+        ),
+        sa.Column("success_criteria", sa.Text, nullable=True),
+        sa.Column("failure_criteria", sa.Text, nullable=True),
+        sa.Column(
+            "quality_threshold", sa.Float, nullable=False, server_default="0.8"
+        ),
+        sa.Column(
+            "check_interval_seconds",
+            sa.Integer,
+            nullable=False,
+            server_default="300",
+        ),
+        sa.Column("last_checked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("next_check_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("deadline_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "policy", sa.String(32), nullable=False, server_default="run_and_report"
+        ),
+        sa.Column("allowed_actions", JSONB, nullable=True),
+        sa.Column("action_budget", sa.Integer, nullable=False, server_default="2"),
+        sa.Column("actions_taken", sa.Integer, nullable=False, server_default="0"),
+        sa.Column("final_score", sa.Float, nullable=True),
+        sa.Column("final_verdict", sa.Text, nullable=True),
+        sa.Column("lineage", JSONB, nullable=False, server_default=sa.text("'[]'")),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("closed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("version_id", sa.Integer, nullable=False, server_default="1"),
+        sa.CheckConstraint(
+            "status IN ({})".format(", ".join(repr(s) for s in _WATCH_STATUSES)),
+            name="ck_watches_status",
+        ),
+    )
+    op.create_index("ix_watches_workspace_id", "watches", ["workspace_id"])
+    # One non-terminal watch per (workspace_id, target_type, target_id).
+    op.create_index(
+        "uq_watches_live_target",
+        "watches",
+        ["workspace_id", "target_type", "target_id"],
+        unique=True,
+        postgresql_where=sa.text(
+            f"status NOT IN ({_TERMINAL_STATUSES_SQL})"
+        ),
+    )
+    # Tick claim path: due, claimable watches only.
+    op.create_index(
+        "ix_watches_due",
+        "watches",
+        ["next_check_at"],
+        postgresql_where=sa.text("status IN ('watching', 'acting')"),
+    )
+
+    op.create_table(
+        "watch_events",
+        sa.Column(
+            "id",
+            PGUUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "watch_id",
+            PGUUID(as_uuid=True),
+            sa.ForeignKey("watches.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("event_type", sa.String(50), nullable=False),
+        sa.Column("summary", sa.Text, nullable=True),
+        sa.Column("snapshot", JSONB, nullable=True),
+        sa.Column("score", sa.Float, nullable=True),
+        sa.Column("action_taken", sa.String(100), nullable=True),
+        sa.Column(
+            "requires_attention",
+            sa.Boolean,
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column("event_key", sa.String(255), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.UniqueConstraint("watch_id", "event_key", name="uq_watch_events_key"),
+    )
+    op.create_index("ix_watch_events_watch_id", "watch_events", ["watch_id"])
+    op.create_index(
+        "ix_watch_events_watch_created",
+        "watch_events",
+        ["watch_id", "created_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_watch_events_watch_created", table_name="watch_events")
+    op.drop_index("ix_watch_events_watch_id", table_name="watch_events")
+    op.drop_table("watch_events")
+    op.drop_index("ix_watches_due", table_name="watches")
+    op.drop_index("uq_watches_live_target", table_name="watches")
+    op.drop_index("ix_watches_workspace_id", table_name="watches")
+    op.drop_table("watches")

--- a/orchestrator/api/approval_grants.py
+++ b/orchestrator/api/approval_grants.py
@@ -168,11 +168,20 @@ async def _requeue_subject(db: Session, grant: ApprovalGrant) -> None:
     - ``tool_call`` (PRD-193 S4, P2-12): re-dispatch the stored call through
       the spine — or, for board-originated asks, ride the existing board
       re-queue so the re-run completes into the now-active grant (S2).
+    - ``playbook_run`` (PRD-204 S7/S8): the watcher's corrective-action
+      grants -- ``details.watch_action`` discriminates (rerun / replan /
+      reassign / spawn_agent); the stored spec launches and the supervising
+      watch follows the work. First real wiring of SUBJECT_PLAYBOOK_RUN.
     """
-    from core.models.approval_grants import SUBJECT_TOOL_CALL
+    from core.models.approval_grants import SUBJECT_PLAYBOOK_RUN, SUBJECT_TOOL_CALL
 
     if grant.subject_type == SUBJECT_TOOL_CALL:
         await _resume_tool_call(db, grant)
+        return
+    if grant.subject_type == SUBJECT_PLAYBOOK_RUN:
+        from services.watch_rerun import resume_playbook_run_grant
+
+        await resume_playbook_run_grant(db, grant)
         return
     if grant.subject_type != SUBJECT_BOARD_TASK:
         return
@@ -292,8 +301,14 @@ async def _resume_tool_call(db: Session, grant: ApprovalGrant) -> None:
 
 def _fail_subject(db: Session, grant: ApprovalGrant) -> None:
     """On deny, fail the blocked subject (the human refused the action)."""
-    from core.models.approval_grants import SUBJECT_TOOL_CALL
+    from core.models.approval_grants import SUBJECT_PLAYBOOK_RUN, SUBJECT_TOOL_CALL
 
+    if grant.subject_type == SUBJECT_PLAYBOOK_RUN:
+        # PRD-204 S7: no launch; the supervising watch parks for a human.
+        from services.watch_rerun import fail_playbook_run_grant
+
+        fail_playbook_run_grant(db, grant)
+        return
     if grant.subject_type == SUBJECT_TOOL_CALL:
         # PRD-193 S4: a denied tool call is a no-op execution — the grant's
         # DENIED status is the record; the S3 card renders the refusal; the

--- a/orchestrator/api/board_tasks.py
+++ b/orchestrator/api/board_tasks.py
@@ -216,6 +216,19 @@ async def _dispatch_task_complete(db: Session, workspace_id, task: BoardTask) ->
             exc_info=True,
         )
 
+    # PRD-204 S3: board-task terminal choke point (success) — every
+    # completion path funnels through this helper. Fail-soft.
+    from services.watch_hooks import watch_ingest_terminal
+
+    watch_ingest_terminal(
+        db,
+        workspace_id=workspace_id,
+        target_type="board_task",
+        target_id=str(task.id),
+        terminal_state="completed",
+        summary=(str(task.result)[:500] if task.result else None),
+    )
+
 
 async def _dispatch_task_failed(db: Session, workspace_id, task: BoardTask) -> None:
     """Fire a ``task_failed`` event (PRD-161 S3).
@@ -249,6 +262,18 @@ async def _dispatch_task_failed(db: Session, workspace_id, task: BoardTask) -> N
             getattr(task, "id", "?"),
             exc_info=True,
         )
+
+    # PRD-204 S3: board-task terminal choke point (failure). Fail-soft.
+    from services.watch_hooks import watch_ingest_terminal
+
+    watch_ingest_terminal(
+        db,
+        workspace_id=workspace_id,
+        target_type="board_task",
+        target_id=str(task.id),
+        terminal_state="failed",
+        summary=(task.error_message or "Execution failed")[:500],
+    )
 
 
 # ── Helpers ──────────────────────────────────────────────────────────

--- a/orchestrator/api/board_tasks.py
+++ b/orchestrator/api/board_tasks.py
@@ -216,7 +216,7 @@ async def _dispatch_task_complete(db: Session, workspace_id, task: BoardTask) ->
             exc_info=True,
         )
 
-    # PRD-204 S3: board-task terminal choke point (success) — every
+    # PRD-204 S3: board-task terminal choke point (success) -- every
     # completion path funnels through this helper. Fail-soft.
     from services.watch_hooks import watch_ingest_terminal
 

--- a/orchestrator/api/recipe_executor.py
+++ b/orchestrator/api/recipe_executor.py
@@ -83,6 +83,46 @@ async def _dispatch_playbook_event(
 
 
 # ---------------------------------------------------------------------------
+# PRD-204 S3: playbook terminal -> watch registry (fail-soft)
+# ---------------------------------------------------------------------------
+
+def _ingest_playbook_terminal_watch(
+    db: Session,
+    execution,
+    terminal_state: str,
+    summary: Optional[str] = None,
+) -> None:
+    """Report a playbook execution's terminal state to its live watch.
+
+    ONE seam for both the success block and ``_fail_execution`` so each
+    terminal path flows through the same tested call. Fail-soft end to end:
+    ``watch_ingest_terminal`` never raises into the executor.
+    """
+    from services.watch_hooks import watch_ingest_terminal
+
+    output_data = getattr(execution, "output_data", None) or {}
+    cost_snapshot = {
+        "total_tokens": output_data.get("total_tokens", 0),
+        "total_duration_ms": output_data.get("total_duration_ms", 0),
+    }
+    output_pointer = None
+    if output_data.get("final_output"):
+        output_pointer = (
+            f"recipe_execution:{execution.execution_id}:output_data.final_output"
+        )
+    watch_ingest_terminal(
+        db,
+        workspace_id=execution.workspace_id,
+        target_type="playbook_execution",
+        target_id=execution.execution_id,
+        terminal_state=terminal_state,
+        summary=summary,
+        cost_snapshot=cost_snapshot,
+        output_pointer=output_pointer,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Auto-report on playbook completion (mirrors heartbeat & task auto-reports)
 # ---------------------------------------------------------------------------
 async def _auto_create_playbook_report(
@@ -1723,6 +1763,15 @@ async def _execute_recipe_inner(
             status="ok",
         )
 
+        # PRD-204 S3: playbook terminal choke point (success) — joins the
+        # same transaction as the status update; fail-soft.
+        _ingest_playbook_terminal_watch(
+            db,
+            execution,
+            terminal_state="completed",
+            summary=f"{len(step_results)} steps completed in {total_duration // 1000}s",
+        )
+
         db.commit()
 
         # Complete the board task
@@ -1970,6 +2019,16 @@ async def _fail_execution(
             execution.completed_at = datetime.now(timezone.utc)
             if step_results is not None:
                 execution.step_results = step_results
+
+            # PRD-204 S3: playbook terminal choke point (failure) — joins the
+            # failure-status transaction below; fail-soft.
+            _ingest_playbook_terminal_watch(
+                db,
+                execution,
+                terminal_state="failed",
+                summary=(error_message or "Playbook execution failed")[:500],
+            )
+
             db.commit()
 
             # PRD-142 W3-S12: playbooks primitive heartbeat at the FAILED

--- a/orchestrator/api/recipe_executor.py
+++ b/orchestrator/api/recipe_executor.py
@@ -123,6 +123,41 @@ def _ingest_playbook_terminal_watch(
 
 
 # ---------------------------------------------------------------------------
+# PRD-204 S7: per-execution step overrides (rerun tweak)
+# ---------------------------------------------------------------------------
+
+def _apply_step_overrides(
+    steps: List[Dict[str, Any]],
+    overrides: Optional[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Merge ``execution_metadata.step_overrides`` into the step list.
+
+    Shape: ``{step_id: {"prompt_template": "..."}}``. Returns NEW dicts --
+    ``workflow_recipes.steps`` (the shared definition) is never mutated; a
+    tweak affects exactly this execution. Only ``prompt_template`` is
+    honoured; anything else in an override entry is ignored.
+    """
+    if not overrides or not isinstance(overrides, dict):
+        return [dict(step) for step in steps]
+
+    merged: List[Dict[str, Any]] = []
+    for step in steps:
+        step_id = str(step.get("step_id") or "")
+        override = overrides.get(step_id)
+        prompt = override.get("prompt_template") if isinstance(override, dict) else None
+        if isinstance(prompt, str) and prompt.strip():
+            merged.append({**step, "prompt_template": prompt})
+            logger.info(
+                "[recipe_direct] step %s prompt overridden for this execution "
+                "(PRD-204 S7 tweak)",
+                step_id,
+            )
+        else:
+            merged.append(dict(step))
+    return merged
+
+
+# ---------------------------------------------------------------------------
 # Auto-report on playbook completion (mirrors heartbeat & task auto-reports)
 # ---------------------------------------------------------------------------
 async def _auto_create_playbook_report(
@@ -1156,6 +1191,12 @@ async def _execute_recipe_inner(
         if not steps:
             await _fail_execution(db, recipe_execution_id, "Recipe has no steps")
             return
+
+        # PRD-204 S7: merge per-execution prompt overrides (rerun tweak) at
+        # execution start. The recipe row is never written back to.
+        step_overrides = (execution.execution_metadata or {}).get("step_overrides")
+        if step_overrides:
+            steps = _apply_step_overrides(steps, step_overrides)
 
         total_steps = len(steps)
         logger.info(f"[recipe_direct] Recipe '{recipe.name}' has {total_steps} steps")

--- a/orchestrator/api/recipe_executor.py
+++ b/orchestrator/api/recipe_executor.py
@@ -1763,7 +1763,7 @@ async def _execute_recipe_inner(
             status="ok",
         )
 
-        # PRD-204 S3: playbook terminal choke point (success) — joins the
+        # PRD-204 S3: playbook terminal choke point (success) -- joins the
         # same transaction as the status update; fail-soft.
         _ingest_playbook_terminal_watch(
             db,
@@ -2020,7 +2020,7 @@ async def _fail_execution(
             if step_results is not None:
                 execution.step_results = step_results
 
-            # PRD-204 S3: playbook terminal choke point (failure) — joins the
+            # PRD-204 S3: playbook terminal choke point (failure) -- joins the
             # failure-status transaction below; fail-soft.
             _ingest_playbook_terminal_watch(
                 db,

--- a/orchestrator/api/watches.py
+++ b/orchestrator/api/watches.py
@@ -1,0 +1,152 @@
+"""PRD-204 S11 -- the watchlist API.
+
+The minimal read/cancel surface over the watch registry (PRD-204 S1/S2):
+list this workspace's watches, drill into one (with its recent watch_events,
+newest first), and cancel a live one. Everything else about a watch -- follow,
+scoring, corrective actions -- belongs to the watcher tick and the S9 Auto
+tools; this router deliberately stays thin over ``WatchService`` and reuses
+the S9 serializer (``watch_to_dict``) so the HTTP and tool surfaces speak one
+shape.
+
+Auth mirrors the board router's plane (PRD-195 P2-14): the shared hybrid
+dependency resolves the workspace, and ``require_workspace_permission`` gates
+each route with the mission-plane strings -- ``missions:read`` for the reads
+(every workspace role holds it) and ``missions:update`` for cancel (editor and
+up), the same family the board's task mutations ride. Cross-workspace or
+missing ids are a plain 404.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+
+from core.auth.dependencies import RequestContext
+from core.auth.hybrid import get_request_context_hybrid
+from core.auth.workspace_permission import require_workspace_permission
+from core.database.database import get_db
+from core.models.watches import WatchEvent
+from modules.tools.discovery.handlers_watches import watch_to_dict
+from services.orchestration_state import InvalidTransitionError
+from services.watch_service import WatchService
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/api/v1/watches", tags=["watches"])
+
+# Recent-events cap for the detail view (a watch timeline is short-lived;
+# 50 covers created -> terminal -> scored -> actions with headroom).
+RECENT_EVENT_LIMIT = 50
+
+
+def _valid_watch_id(watch_id: str) -> str:
+    """Boundary validation: a malformed id reads as 'no such watch' (404),
+    never as a DB-level cast error surfacing a 500."""
+    try:
+        return str(UUID(str(watch_id)))
+    except (TypeError, ValueError):
+        raise HTTPException(status_code=404, detail="Watch not found")
+
+
+def _event_to_dict(event: WatchEvent) -> Dict[str, Any]:
+    """The S9 recent-event shape (handlers_watches.get_watch), unchanged."""
+    return {
+        "event_type": event.event_type,
+        "summary": event.summary,
+        "score": event.score,
+        "action_taken": event.action_taken,
+        "requires_attention": event.requires_attention,
+        "created_at": str(event.created_at) if event.created_at else None,
+    }
+
+
+@router.get(
+    "",
+    dependencies=[Depends(require_workspace_permission("missions:read"))],
+)
+async def list_watches(
+    status: Optional[str] = Query(
+        None, description="Filter by exact watch status (e.g. 'watching')"
+    ),
+    watch_type: Optional[str] = Query(
+        None, description="Filter by watch type (mission / playbook_execution / scheduled_playbook)"
+    ),
+    include_closed: bool = Query(
+        False, description="Without a status filter, include closed watches too"
+    ),
+    limit: int = Query(100, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    ctx: RequestContext = Depends(get_request_context_hybrid),
+    db: Session = Depends(get_db),
+) -> Dict[str, Any]:
+    """This workspace's watches, newest first. Live-only unless asked."""
+    watches = WatchService.list_watches(
+        db,
+        ctx.workspace_id,
+        status=status,
+        watch_type=watch_type,
+        include_closed=include_closed,
+        limit=limit,
+        offset=offset,
+    )
+    return {
+        "watches": [watch_to_dict(w) for w in watches],
+        "total": len(watches),
+    }
+
+
+@router.get(
+    "/{watch_id}",
+    dependencies=[Depends(require_workspace_permission("missions:read"))],
+)
+async def get_watch(
+    watch_id: str,
+    ctx: RequestContext = Depends(get_request_context_hybrid),
+    db: Session = Depends(get_db),
+) -> Dict[str, Any]:
+    """One watch (with lineage) plus its recent events, newest first."""
+    watch_id = _valid_watch_id(watch_id)
+    watch = WatchService.get_watch(db, ctx.workspace_id, watch_id)
+    if watch is None:
+        raise HTTPException(status_code=404, detail="Watch not found")
+
+    events = (
+        db.query(WatchEvent)
+        .filter(WatchEvent.watch_id == watch.id)
+        .order_by(WatchEvent.created_at.desc())
+        .limit(RECENT_EVENT_LIMIT)
+        .all()
+    )
+    return {
+        "watch": watch_to_dict(watch, include_lineage=True),
+        "recent_events": [_event_to_dict(e) for e in events],
+    }
+
+
+@router.post(
+    "/{watch_id}/cancel",
+    dependencies=[Depends(require_workspace_permission("missions:update"))],
+)
+async def cancel_watch(
+    watch_id: str,
+    ctx: RequestContext = Depends(get_request_context_hybrid),
+    db: Session = Depends(get_db),
+) -> Dict[str, Any]:
+    """Cancel a live watch. Closed watches refuse (422); unknown ids 404."""
+    watch_id = _valid_watch_id(watch_id)
+    try:
+        watch = WatchService.cancel_watch(db, ctx.workspace_id, watch_id)
+    except ValueError:
+        raise HTTPException(status_code=404, detail="Watch not found")
+    except InvalidTransitionError:
+        raise HTTPException(
+            status_code=422,
+            detail="That watch is already closed and cannot be cancelled.",
+        )
+    db.commit()
+    logger.info(
+        "[Watches] %s cancelled via API in workspace %s", watch_id, ctx.workspace_id
+    )
+    return {"watch": watch_to_dict(watch)}

--- a/orchestrator/api/workflow_recipes.py
+++ b/orchestrator/api/workflow_recipes.py
@@ -931,6 +931,123 @@ async def execute_recipe(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
+@router.post(
+    "/{recipe_id}/executions/{execution_id}/rerun",
+    dependencies=[Depends(require_workspace_permission("playbooks:execute"))],
+)
+async def rerun_recipe_execution(
+    recipe_id: str,
+    execution_id: str,
+    ctx: RequestContext = Depends(get_request_context_hybrid),
+    body: Dict[str, Any] = Body(default={}),
+    db: Session = Depends(get_db),
+):
+    """PRD-204 S7: rerun a prior execution -- the platform's rerun primitive.
+
+    Creates a NEW RecipeExecution copying the original's input_data
+    (retry_of lineage, attempt_count+1) with optional per-execution
+    step_overrides; the shared playbook definition is never mutated.
+
+    Routed through the workspace approval policy with the ORIGINAL run's
+    llm_usage dollar sum as the estimate: auto path launches immediately;
+    ask path parks a durable ApprovalGrant (approvals inbox) and returns
+    202-shaped JSON. A live watch on the original execution follows the
+    rerun (same watch, one verdict).
+
+    Body (optional):
+    - step_overrides: {step_id: {"prompt_template": "..."}}
+    """
+    try:
+        from services.watch_rerun import (
+            TRIGGERED_BY_HUMAN,
+            request_rerun,
+            validate_step_overrides,
+        )
+
+        recipe = db.query(WorkflowRecipe).filter(
+            WorkflowRecipe.owner_type == 'workspace',
+            WorkflowRecipe.workspace_id == ctx.workspace_id,
+            WorkflowRecipe.template_id == recipe_id
+        ).first()
+        if not recipe:
+            raise HTTPException(status_code=404, detail=f"Recipe '{recipe_id}' not found")
+
+        original = db.query(RecipeExecution).filter(
+            RecipeExecution.execution_id == execution_id,
+            RecipeExecution.workspace_id == ctx.workspace_id,
+            RecipeExecution.recipe_id == recipe.id,
+        ).first()
+        if not original:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Execution '{execution_id}' not found for this playbook",
+            )
+
+        step_overrides, err = validate_step_overrides(recipe, body.get("step_overrides"))
+        if err:
+            raise HTTPException(status_code=422, detail=err)
+
+        # Same admission guard as a fresh execute.
+        from services.concurrency_guard import check_concurrency
+        concurrency = await check_concurrency(ctx.workspace_id, db)
+        if not concurrency.allowed:
+            raise HTTPException(
+                status_code=429,
+                detail={
+                    "error": "concurrency_limit",
+                    "detail": concurrency.reason,
+                    "limits": concurrency.limits,
+                },
+            )
+
+        # A live watch on the original execution follows the rerun.
+        from services.watch_service import WatchService
+        watch = WatchService.find_live_watch(
+            db,
+            workspace_id=ctx.workspace_id,
+            target_type="playbook_execution",
+            target_id=execution_id,
+        )
+
+        outcome = await request_rerun(
+            db,
+            workspace_id=ctx.workspace_id,
+            recipe=recipe,
+            original=original,
+            step_overrides=step_overrides,
+            triggered_by=TRIGGERED_BY_HUMAN,
+            watch=watch,
+        )
+        db.commit()  # ask-path rows (grant / watch park) are flush-only
+
+        if outcome.launched:
+            return {
+                "recipe_execution_id": outcome.execution_id,
+                "rerun_of": execution_id,
+                "recipe_id": recipe_id,
+                "status": "started",
+                "step_overrides_applied": bool(step_overrides),
+                "approval": outcome.decision.audit_snapshot(),
+                "message": outcome.message,
+            }
+        return {
+            "recipe_execution_id": None,
+            "rerun_of": execution_id,
+            "recipe_id": recipe_id,
+            "status": "awaiting_approval",
+            "grant_id": outcome.grant_id,
+            "approval": outcome.decision.audit_snapshot(),
+            "message": outcome.message,
+        }
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"[rerun_recipe_execution] Unhandled error: {e}", exc_info=True)
+        db.rollback()
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
 @router.get("/{recipe_id}/executions/{execution_id}")
 async def get_recipe_execution_detail(
     recipe_id: str,

--- a/orchestrator/config.py
+++ b/orchestrator/config.py
@@ -550,6 +550,19 @@ class Config:
     # connection-liveness heartbeat cadence (a ':hb' comment), not a refresh tick.
     BOARD_SSE_HEARTBEAT_SECONDS: float = float(os.getenv("BOARD_SSE_HEARTBEAT_SECONDS", "20"))
 
+    # =============================================================================
+    # AUTO WATCHER (PRD-204: persistent supervision of launched work)
+    # =============================================================================
+    # The watcher tick rides the fcntl-locked UnifiedScheduler (single owner
+    # across workers). Each tick claims due watches with FOR UPDATE SKIP
+    # LOCKED, sweeps terminal states the S3 event hooks missed, detects
+    # missed cron fires / benched schedules on scheduled-playbook watches,
+    # and expires past-deadline watches.
+    WATCHER_ENABLED: bool = os.getenv("WATCHER_ENABLED", "true").lower() == "true"
+    # Sweep cadence. The S3 hooks are the fast path; the tick is the
+    # fallback and the missed-run/trend brain, so 5 minutes is plenty.
+    WATCHER_TICK_SECONDS: int = int(os.getenv("WATCHER_TICK_SECONDS", "300"))
+
     WORKER_INTERNAL_URL: str = os.getenv("WORKER_INTERNAL_URL", "http://localhost:8081")
     WORKER_INTERNAL_TOKEN: str = os.getenv("WORKER_INTERNAL_TOKEN", "")
 

--- a/orchestrator/core/models/__init__.py
+++ b/orchestrator/core/models/__init__.py
@@ -50,6 +50,21 @@ from .orchestration_enums import (  # noqa: F401
     BOARD_STATUS_MAP,
 )
 
+# PRD-204: Auto Watcher — watch registry
+from .watches import Watch, WatchEvent  # noqa: F401
+from .watch_enums import (  # noqa: F401
+    WatchStatus,
+    WatchType,
+    WatchTargetType,
+    WatchPolicy,
+    WatchEventType,
+    ALLOWED_WATCH_TRANSITIONS,
+    TERMINAL_WATCH_STATUSES,
+    LIVE_WATCH_STATUSES,
+    CLAIMABLE_WATCH_STATUSES,
+    WATCH_STATUS_FOR_TERMINAL_TARGET,
+)
+
 # PRD-72: Board Tasks — explicit import so `from core.models import BoardTask` works
 from .core import BoardTask  # noqa: F811
 from .core import BlogPost  # noqa: F811

--- a/orchestrator/core/models/__init__.py
+++ b/orchestrator/core/models/__init__.py
@@ -50,7 +50,7 @@ from .orchestration_enums import (  # noqa: F401
     BOARD_STATUS_MAP,
 )
 
-# PRD-204: Auto Watcher — watch registry
+# PRD-204: Auto Watcher -- watch registry
 from .watches import Watch, WatchEvent  # noqa: F401
 from .watch_enums import (  # noqa: F401
     WatchStatus,

--- a/orchestrator/core/models/watch_enums.py
+++ b/orchestrator/core/models/watch_enums.py
@@ -1,0 +1,196 @@
+"""
+Watch Enums — PRD-204 Auto Watcher
+===================================
+
+Canonical StrEnums, transition map, and terminal frozensets for the watch
+registry. Mirrors the house pattern of ``orchestration_enums`` (PRD-82A):
+enums + ALLOWED_*_TRANSITIONS dict + TERMINAL_* frozensets, consumed by the
+model's CHECK constraint and by ``WatchService.transition``.
+
+Source: PRD-204 Section 4 (S1/S2).
+"""
+
+from enum import Enum
+
+
+# ---------------------------------------------------------------------------
+# WatchStatus — watch lifecycle states (PRD-204 S1)
+# ---------------------------------------------------------------------------
+
+class WatchStatus(str, Enum):
+    WATCHING = "watching"                    # supervising the live target
+    ACTING = "acting"                        # a corrective action is in flight (S7/S8)
+    AWAITING_APPROVAL = "awaiting_approval"  # action parked on an ApprovalGrant
+    NEEDS_ATTENTION = "needs_attention"      # hard-stopped (action budget, lost target)
+    PASSED = "passed"                        # verdict: target reached a good terminal
+    FAILED = "failed"                        # verdict: target failed
+    ESCALATED = "escalated"                  # handed to a human; terminal unless renewed
+    EXPIRED = "expired"                      # deadline passed without a verdict
+    CANCELLED = "cancelled"                  # cancelled by user, or target cancelled
+
+
+# ---------------------------------------------------------------------------
+# WatchType — what kind of launched unit this watch supervises
+# ---------------------------------------------------------------------------
+
+class WatchType(str, Enum):
+    MISSION = "mission"
+    PLAYBOOK_EXECUTION = "playbook_execution"
+    SCHEDULED_PLAYBOOK = "scheduled_playbook"
+
+
+# ---------------------------------------------------------------------------
+# WatchTargetType — the concrete row the watch currently points at.
+# Distinct from WatchType because lineage can repoint a watch (``follow``)
+# and terminal hooks also ingest for board tasks.
+# ---------------------------------------------------------------------------
+
+class WatchTargetType(str, Enum):
+    MISSION = "mission"                      # orchestration_runs.id (UUID string)
+    PLAYBOOK_EXECUTION = "playbook_execution"  # recipe_executions.execution_id
+    SCHEDULED_PLAYBOOK = "scheduled_playbook"  # workflow_recipes.id (int as string)
+    BOARD_TASK = "board_task"                # board_tasks.id (int as string)
+
+
+# ---------------------------------------------------------------------------
+# WatchPolicy — decision-flow profile (S10 drives the full table; S1-S5 only
+# store the value)
+# ---------------------------------------------------------------------------
+
+class WatchPolicy(str, Enum):
+    RUN_AND_REPORT = "run_and_report"
+    SCORE_AND_IMPROVE = "score_and_improve"
+    WATCH_CHANGE = "watch_change"
+    PERSISTENT = "persistent"
+
+
+# ---------------------------------------------------------------------------
+# WatchEventType — vocabulary for watch_events.event_type
+# ---------------------------------------------------------------------------
+
+class WatchEventType(str, Enum):
+    CREATED = "created"                # watch row created
+    TERMINAL = "terminal"              # target reached a terminal state
+    MISSED_RUN = "missed_run"          # scheduled playbook missed an expected fire
+    BENCHED = "benched"                # scheduled playbook skipped on open breaker
+    EXPIRED = "expired"                # watch deadline passed
+    ACTION = "action"                  # corrective action recorded (S7/S8)
+    BUDGET_EXHAUSTED = "budget_exhausted"  # action budget hard-stop
+    FOLLOW = "follow"                  # lineage repoint (rerun/replan follows the work)
+    STATUS_CHANGE = "status_change"    # explicit watch transition worth recording
+    TARGET_MISSING = "target_missing"  # target row no longer exists
+    CANCELLED = "cancelled"            # watch cancelled
+
+
+# ===========================================================================
+# Terminal frozensets
+# ===========================================================================
+
+# ESCALATED is terminal-unless-renewed: it sits in the terminal set (so a new
+# watch on the same target is allowed by the partial unique index) but keeps
+# a single renewal transition back to WATCHING — the same shape as
+# RunState.FAILED -> REPLANNING in orchestration_enums.
+TERMINAL_WATCH_STATUSES: frozenset[WatchStatus] = frozenset(
+    {
+        WatchStatus.PASSED,
+        WatchStatus.FAILED,
+        WatchStatus.ESCALATED,
+        WatchStatus.EXPIRED,
+        WatchStatus.CANCELLED,
+    }
+)
+
+LIVE_WATCH_STATUSES: frozenset[WatchStatus] = frozenset(
+    s for s in WatchStatus if s not in TERMINAL_WATCH_STATUSES
+)
+
+# Only these statuses are claimed by the watcher tick (awaiting_approval and
+# needs_attention are parked on a human/grant, not on the clock).
+CLAIMABLE_WATCH_STATUSES: frozenset[WatchStatus] = frozenset(
+    {WatchStatus.WATCHING, WatchStatus.ACTING}
+)
+
+
+# ===========================================================================
+# Allowed transitions (house style of ALLOWED_RUN_TRANSITIONS)
+# ===========================================================================
+
+ALLOWED_WATCH_TRANSITIONS: dict[WatchStatus, frozenset[WatchStatus]] = {
+    WatchStatus.WATCHING: frozenset(
+        {
+            WatchStatus.ACTING,
+            WatchStatus.AWAITING_APPROVAL,
+            WatchStatus.NEEDS_ATTENTION,
+            WatchStatus.PASSED,
+            WatchStatus.FAILED,
+            WatchStatus.ESCALATED,
+            WatchStatus.EXPIRED,
+            WatchStatus.CANCELLED,
+        }
+    ),
+    WatchStatus.ACTING: frozenset(
+        {
+            WatchStatus.WATCHING,
+            WatchStatus.AWAITING_APPROVAL,
+            WatchStatus.NEEDS_ATTENTION,
+            WatchStatus.PASSED,
+            WatchStatus.FAILED,
+            WatchStatus.ESCALATED,
+            WatchStatus.EXPIRED,
+            WatchStatus.CANCELLED,
+        }
+    ),
+    WatchStatus.AWAITING_APPROVAL: frozenset(
+        {
+            WatchStatus.WATCHING,
+            WatchStatus.ACTING,
+            WatchStatus.NEEDS_ATTENTION,
+            WatchStatus.PASSED,
+            WatchStatus.FAILED,
+            WatchStatus.ESCALATED,
+            WatchStatus.EXPIRED,
+            WatchStatus.CANCELLED,
+        }
+    ),
+    WatchStatus.NEEDS_ATTENTION: frozenset(
+        {
+            WatchStatus.WATCHING,
+            WatchStatus.ACTING,
+            WatchStatus.PASSED,
+            WatchStatus.FAILED,
+            WatchStatus.ESCALATED,
+            WatchStatus.EXPIRED,
+            WatchStatus.CANCELLED,
+        }
+    ),
+    WatchStatus.PASSED: frozenset(),      # terminal
+    WatchStatus.FAILED: frozenset(),      # terminal
+    WatchStatus.ESCALATED: frozenset({WatchStatus.WATCHING}),  # renew only
+    WatchStatus.EXPIRED: frozenset(),     # terminal
+    WatchStatus.CANCELLED: frozenset(),   # terminal
+}
+
+
+# ===========================================================================
+# Terminal target state -> watch status (v1, pre-S6 scoring)
+# ===========================================================================
+
+# Until the S6 run-level verdict lands, a terminal target closes the watch by
+# outcome. S6 inserts scoring between "terminal observed" and "watch closed"
+# without changing this vocabulary.
+WATCH_STATUS_FOR_TERMINAL_TARGET: dict[str, WatchStatus] = {
+    "completed": WatchStatus.PASSED,
+    "verified": WatchStatus.PASSED,
+    "done": WatchStatus.PASSED,
+    "failed": WatchStatus.FAILED,
+    "cancelled": WatchStatus.CANCELLED,
+}
+
+
+def terminal_watch_statuses_sql() -> str:
+    """The terminal-status set as a SQL IN-list body (stable, sorted).
+
+    Single source for the model's partial unique index; the alembic migration
+    carries the same literal snapshot (migrations are frozen by design).
+    """
+    return ", ".join(repr(s.value) for s in sorted(TERMINAL_WATCH_STATUSES))

--- a/orchestrator/core/models/watch_enums.py
+++ b/orchestrator/core/models/watch_enums.py
@@ -1,5 +1,5 @@
 """
-Watch Enums — PRD-204 Auto Watcher
+Watch Enums -- PRD-204 Auto Watcher
 ===================================
 
 Canonical StrEnums, transition map, and terminal frozensets for the watch
@@ -14,7 +14,7 @@ from enum import Enum
 
 
 # ---------------------------------------------------------------------------
-# WatchStatus — watch lifecycle states (PRD-204 S1)
+# WatchStatus -- watch lifecycle states (PRD-204 S1)
 # ---------------------------------------------------------------------------
 
 class WatchStatus(str, Enum):
@@ -30,7 +30,7 @@ class WatchStatus(str, Enum):
 
 
 # ---------------------------------------------------------------------------
-# WatchType — what kind of launched unit this watch supervises
+# WatchType -- what kind of launched unit this watch supervises
 # ---------------------------------------------------------------------------
 
 class WatchType(str, Enum):
@@ -40,7 +40,7 @@ class WatchType(str, Enum):
 
 
 # ---------------------------------------------------------------------------
-# WatchTargetType — the concrete row the watch currently points at.
+# WatchTargetType -- the concrete row the watch currently points at.
 # Distinct from WatchType because lineage can repoint a watch (``follow``)
 # and terminal hooks also ingest for board tasks.
 # ---------------------------------------------------------------------------
@@ -53,7 +53,7 @@ class WatchTargetType(str, Enum):
 
 
 # ---------------------------------------------------------------------------
-# WatchPolicy — decision-flow profile (S10 drives the full table; S1-S5 only
+# WatchPolicy -- decision-flow profile (S10 drives the full table; S1-S5 only
 # store the value)
 # ---------------------------------------------------------------------------
 
@@ -65,7 +65,7 @@ class WatchPolicy(str, Enum):
 
 
 # ---------------------------------------------------------------------------
-# WatchEventType — vocabulary for watch_events.event_type
+# WatchEventType -- vocabulary for watch_events.event_type
 # ---------------------------------------------------------------------------
 
 class WatchEventType(str, Enum):
@@ -88,7 +88,7 @@ class WatchEventType(str, Enum):
 
 # ESCALATED is terminal-unless-renewed: it sits in the terminal set (so a new
 # watch on the same target is allowed by the partial unique index) but keeps
-# a single renewal transition back to WATCHING — the same shape as
+# a single renewal transition back to WATCHING -- the same shape as
 # RunState.FAILED -> REPLANNING in orchestration_enums.
 TERMINAL_WATCH_STATUSES: frozenset[WatchStatus] = frozenset(
     {

--- a/orchestrator/core/models/watch_enums.py
+++ b/orchestrator/core/models/watch_enums.py
@@ -80,6 +80,9 @@ class WatchEventType(str, Enum):
     STATUS_CHANGE = "status_change"    # explicit watch transition worth recording
     TARGET_MISSING = "target_missing"  # target row no longer exists
     CANCELLED = "cancelled"            # watch cancelled
+    SCORED = "scored"                  # run-level verdict written (S6)
+    DIAGNOSED = "diagnosed"            # failure/low-score diagnosis recorded (S10)
+    CHANGE_REPORT = "change_report"    # before/after comparison (watch_change / persistent)
 
 
 # ===========================================================================

--- a/orchestrator/core/models/watches.py
+++ b/orchestrator/core/models/watches.py
@@ -1,0 +1,247 @@
+"""
+Watch Models — PRD-204 Auto Watcher
+====================================
+
+SQLAlchemy models for the watch registry:
+- Watch: one row supervising one launched unit of work to a verdict
+- WatchEvent: append-only observations per watch (idempotent via event_key)
+
+Style mirrors ``core/models/orchestration.py`` (PRD-82A): UUID PKs with
+DB-generated defaults, workspace FK CASCADE, ``version_id`` optimistic
+locking on the mutable row, CHECK constraint built from the enum, append-only
+event table without version_id.
+
+Source: PRD-204 Section 4 S1.
+"""
+
+from sqlalchemy import (
+    Boolean,
+    CheckConstraint,
+    Column,
+    DateTime,
+    Float,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+    text,
+)
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.sql import func
+
+from core.database.base import Base
+from core.models.watch_enums import (
+    WatchPolicy,
+    WatchStatus,
+    terminal_watch_statuses_sql,
+)
+
+# PRD-204 defaults (Section 8 Q2/Q1 build defaults)
+DEFAULT_QUALITY_THRESHOLD = 0.8
+DEFAULT_CHECK_INTERVAL_SECONDS = 300
+DEFAULT_ACTION_BUDGET = 2
+
+
+class Watch(Base):
+    """A workspace-scoped supervisor for one launched unit of work.
+
+    The watch follows the work (Section 8 Q9): corrective reruns/replans
+    append to ``lineage`` and repoint ``target_type``/``target_id`` — one
+    watch, one verdict. At most ONE non-terminal watch may exist per
+    (workspace_id, target_type, target_id), enforced by a partial unique
+    index.
+    """
+
+    __tablename__ = "watches"
+
+    # Primary key — UUID with DB-generated default (house pattern)
+    id = Column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=func.gen_random_uuid(),
+    )
+
+    # Tenant isolation
+    workspace_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("workspaces.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+
+    # Ownership: Clerk user id string (same convention as
+    # orchestration_runs.created_by); owner_agent_id for Auto-created watches.
+    created_by = Column(String(255), nullable=True)
+    owner_agent_id = Column(
+        Integer,
+        ForeignKey("agents.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+
+    # What is being watched
+    watch_type = Column(String(32), nullable=False)   # WatchType
+    target_type = Column(String(32), nullable=False)  # WatchTargetType (current target)
+    target_id = Column(String(255), nullable=False)   # current target row id, as string
+    title = Column(String(500), nullable=False)
+    description = Column(Text, nullable=True)
+
+    # Lifecycle
+    status = Column(
+        String(32),
+        nullable=False,
+        default=WatchStatus.WATCHING.value,
+        server_default=WatchStatus.WATCHING.value,
+    )
+
+    # Intent snapshot — what "good" means for this launch
+    success_criteria = Column(Text, nullable=True)
+    failure_criteria = Column(Text, nullable=True)
+    quality_threshold = Column(
+        Float,
+        nullable=False,
+        default=DEFAULT_QUALITY_THRESHOLD,
+        server_default=text(str(DEFAULT_QUALITY_THRESHOLD)),
+    )
+
+    # Heartbeat sweep scheduling
+    check_interval_seconds = Column(
+        Integer,
+        nullable=False,
+        default=DEFAULT_CHECK_INTERVAL_SECONDS,
+        server_default=text(str(DEFAULT_CHECK_INTERVAL_SECONDS)),
+    )
+    last_checked_at = Column(DateTime(timezone=True), nullable=True)
+    next_check_at = Column(DateTime(timezone=True), nullable=True)
+    deadline_at = Column(DateTime(timezone=True), nullable=True)
+
+    # Decision profile + bounded corrective actions
+    policy = Column(
+        String(32),
+        nullable=False,
+        default=WatchPolicy.RUN_AND_REPORT.value,
+        server_default=WatchPolicy.RUN_AND_REPORT.value,
+    )
+    allowed_actions = Column(JSONB, nullable=True)  # e.g. ["rerun", "tweak", "replan"]
+    action_budget = Column(
+        Integer,
+        nullable=False,
+        default=DEFAULT_ACTION_BUDGET,
+        server_default=text(str(DEFAULT_ACTION_BUDGET)),
+    )
+    actions_taken = Column(Integer, nullable=False, default=0, server_default="0")
+
+    # Verdict (S6 writes score; v1 writes outcome text)
+    final_score = Column(Float, nullable=True)
+    final_verdict = Column(Text, nullable=True)
+
+    # Ordered target chain — reruns/replans append {target_type, target_id,
+    # followed_at, reason}; the columns above always hold the LIVE target.
+    lineage = Column(JSONB, nullable=False, server_default=text("'[]'"))
+
+    # Timestamps
+    created_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+    updated_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+    closed_at = Column(DateTime(timezone=True), nullable=True)
+
+    # Optimistic locking (house pattern — PRD-82A Section 5 principle 7)
+    version_id = Column(Integer, nullable=False, server_default="1")
+
+    __mapper_args__ = {"version_id_col": version_id}
+
+    __table_args__ = (
+        CheckConstraint(
+            f"status IN ({', '.join(repr(s.value) for s in WatchStatus)})",
+            name="ck_watches_status",
+        ),
+        # One non-terminal watch per target (PRD-204 S1)
+        Index(
+            "uq_watches_live_target",
+            "workspace_id",
+            "target_type",
+            "target_id",
+            unique=True,
+            postgresql_where=text(
+                f"status NOT IN ({terminal_watch_statuses_sql()})"
+            ),
+        ),
+        # Tick claim: due watches by next_check_at, live statuses only
+        Index(
+            "ix_watches_due",
+            "next_check_at",
+            postgresql_where=text("status IN ('watching', 'acting')"),
+        ),
+        {"extend_existing": True},
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<Watch id={self.id} status={self.status} "
+            f"target={self.target_type}:{self.target_id} "
+            f"title={(self.title[:40] if self.title else None)!r}>"
+        )
+
+
+class WatchEvent(Base):
+    """Append-only observation log for a watch.
+
+    ``UNIQUE(watch_id, event_key)`` makes ingest idempotent: producers and
+    the sweep tick can both report the same observation and exactly one row
+    lands. This table is never updated — no version_id column (same shape as
+    OrchestrationEvent).
+    """
+
+    __tablename__ = "watch_events"
+
+    id = Column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=func.gen_random_uuid(),
+    )
+
+    watch_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("watches.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+
+    event_type = Column(String(50), nullable=False)  # WatchEventType
+    summary = Column(Text, nullable=True)
+    snapshot = Column(JSONB, nullable=True)  # cost snapshot / output pointer / context
+    score = Column(Float, nullable=True)
+    action_taken = Column(String(100), nullable=True)
+    requires_attention = Column(
+        Boolean, nullable=False, default=False, server_default=text("false")
+    )
+
+    # Idempotency key — semantic identity of the observation
+    event_key = Column(String(255), nullable=False)
+
+    created_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+
+    __table_args__ = (
+        UniqueConstraint("watch_id", "event_key", name="uq_watch_events_key"),
+        Index("ix_watch_events_watch_created", "watch_id", "created_at"),
+        {"extend_existing": True},
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<WatchEvent id={self.id} watch={self.watch_id} "
+            f"type={self.event_type} key={self.event_key!r}>"
+        )

--- a/orchestrator/core/models/watches.py
+++ b/orchestrator/core/models/watches.py
@@ -1,5 +1,5 @@
 """
-Watch Models — PRD-204 Auto Watcher
+Watch Models -- PRD-204 Auto Watcher
 ====================================
 
 SQLAlchemy models for the watch registry:
@@ -48,7 +48,7 @@ class Watch(Base):
     """A workspace-scoped supervisor for one launched unit of work.
 
     The watch follows the work (Section 8 Q9): corrective reruns/replans
-    append to ``lineage`` and repoint ``target_type``/``target_id`` — one
+    append to ``lineage`` and repoint ``target_type``/``target_id`` -- one
     watch, one verdict. At most ONE non-terminal watch may exist per
     (workspace_id, target_type, target_id), enforced by a partial unique
     index.
@@ -56,7 +56,7 @@ class Watch(Base):
 
     __tablename__ = "watches"
 
-    # Primary key — UUID with DB-generated default (house pattern)
+    # Primary key -- UUID with DB-generated default (house pattern)
     id = Column(
         UUID(as_uuid=True),
         primary_key=True,
@@ -95,7 +95,7 @@ class Watch(Base):
         server_default=WatchStatus.WATCHING.value,
     )
 
-    # Intent snapshot — what "good" means for this launch
+    # Intent snapshot -- what "good" means for this launch
     success_criteria = Column(Text, nullable=True)
     failure_criteria = Column(Text, nullable=True)
     quality_threshold = Column(
@@ -136,7 +136,7 @@ class Watch(Base):
     final_score = Column(Float, nullable=True)
     final_verdict = Column(Text, nullable=True)
 
-    # Ordered target chain — reruns/replans append {target_type, target_id,
+    # Ordered target chain -- reruns/replans append {target_type, target_id,
     # followed_at, reason}; the columns above always hold the LIVE target.
     lineage = Column(JSONB, nullable=False, server_default=text("'[]'"))
 
@@ -154,7 +154,7 @@ class Watch(Base):
     )
     closed_at = Column(DateTime(timezone=True), nullable=True)
 
-    # Optimistic locking (house pattern — PRD-82A Section 5 principle 7)
+    # Optimistic locking (house pattern -- PRD-82A Section 5 principle 7)
     version_id = Column(Integer, nullable=False, server_default="1")
 
     __mapper_args__ = {"version_id_col": version_id}
@@ -197,7 +197,7 @@ class WatchEvent(Base):
 
     ``UNIQUE(watch_id, event_key)`` makes ingest idempotent: producers and
     the sweep tick can both report the same observation and exactly one row
-    lands. This table is never updated — no version_id column (same shape as
+    lands. This table is never updated -- no version_id column (same shape as
     OrchestrationEvent).
     """
 
@@ -225,7 +225,7 @@ class WatchEvent(Base):
         Boolean, nullable=False, default=False, server_default=text("false")
     )
 
-    # Idempotency key — semantic identity of the observation
+    # Idempotency key -- semantic identity of the observation
     event_key = Column(String(255), nullable=False)
 
     created_at = Column(

--- a/orchestrator/core/services/notification_dispatcher.py
+++ b/orchestrator/core/services/notification_dispatcher.py
@@ -52,9 +52,21 @@ VALID_EVENT_TYPES: frozenset[str] = frozenset(
         "mission_plan_ready",
         "mission_step_complete",
         "mission_complete",
+        # PRD-204 S4: the silent failure holes — a failed mission and a
+        # budget-paused mission previously reached no subscriber at all.
+        "mission_failed",
+        "mission_budget_paused",
         "playbook_step_complete",
         "playbook_complete",
         "playbook_failed",
+        # PRD-204 S4: scheduler skipped a cron fire on an open breaker with
+        # only a log line — now user-visible, once per breaker-open period.
+        "playbook_benched",
+        # PRD-204 S4: watcher-plane events (verdicts S5/S6, corrective
+        # actions S7/S8, escalations).
+        "watch_verdict",
+        "watch_action",
+        "watch_escalation",
         "trigger_fired",
         "report_submitted",
         "agent_error",

--- a/orchestrator/core/services/notification_dispatcher.py
+++ b/orchestrator/core/services/notification_dispatcher.py
@@ -52,7 +52,7 @@ VALID_EVENT_TYPES: frozenset[str] = frozenset(
         "mission_plan_ready",
         "mission_step_complete",
         "mission_complete",
-        # PRD-204 S4: the silent failure holes — a failed mission and a
+        # PRD-204 S4: the silent failure holes -- a failed mission and a
         # budget-paused mission previously reached no subscriber at all.
         "mission_failed",
         "mission_budget_paused",
@@ -60,7 +60,7 @@ VALID_EVENT_TYPES: frozenset[str] = frozenset(
         "playbook_complete",
         "playbook_failed",
         # PRD-204 S4: scheduler skipped a cron fire on an open breaker with
-        # only a log line — now user-visible, once per breaker-open period.
+        # only a log line -- now user-visible, once per breaker-open period.
         "playbook_benched",
         # PRD-204 S4: watcher-plane events (verdicts S5/S6, corrective
         # actions S7/S8, escalations).

--- a/orchestrator/main.py
+++ b/orchestrator/main.py
@@ -384,7 +384,7 @@ async def _boot_phase_2_extensions(app_instance: "FastAPI") -> "DeferredInitResu
                 except Exception as _tr_err:
                     logger.warning("Could not start TaskReconciler: %s", _tr_err)
 
-                # PRD-204 S5: Auto Watcher tick — heartbeat sweep for watches
+                # PRD-204 S5: Auto Watcher tick -- heartbeat sweep for watches
                 # (terminal fallback, missed-run/benched detection, expiry).
                 # Rides the same fcntl-locked scheduler: single owner across
                 # workers, so watch claims never race between processes.

--- a/orchestrator/main.py
+++ b/orchestrator/main.py
@@ -384,6 +384,18 @@ async def _boot_phase_2_extensions(app_instance: "FastAPI") -> "DeferredInitResu
                 except Exception as _tr_err:
                     logger.warning("Could not start TaskReconciler: %s", _tr_err)
 
+                # PRD-204 S5: Auto Watcher tick — heartbeat sweep for watches
+                # (terminal fallback, missed-run/benched detection, expiry).
+                # Rides the same fcntl-locked scheduler: single owner across
+                # workers, so watch claims never race between processes.
+                if config.WATCHER_ENABLED:
+                    try:
+                        from services.watch_ticker import get_watch_ticker
+                        await get_watch_ticker().start(scheduler=shared_sched)
+                        logger.info("WatchTicker started on unified scheduler")
+                    except Exception as _wt_err:
+                        logger.warning("Could not start WatchTicker: %s", _wt_err)
+
                 # PRD-79: Memory background jobs (consolidation, decay, promotion)
                 if config.MEMORY_JOBS_ENABLED:
                     try:

--- a/orchestrator/modules/coordination/reconciler.py
+++ b/orchestrator/modules/coordination/reconciler.py
@@ -207,7 +207,7 @@ class MissionReconciler:
 
             # --- Advance run state if appropriate ---
             if all_terminal:
-                return MissionReconciler._advance_run_on_completion(
+                advance_result = MissionReconciler._advance_run_on_completion(
                     db=db,
                     run=run,
                     all_tasks=all_tasks,
@@ -218,6 +218,14 @@ class MissionReconciler:
                     tasks_verified=tasks_verified,
                     tasks_verification_failed=tasks_verification_failed,
                 )
+                # PRD-204 S4: run failed on task outcomes — tell the user.
+                # (_advance_run_on_completion is sync; this is its async seam.)
+                if (
+                    advance_result.run_advanced
+                    and advance_result.run_new_state == RunState.FAILED.value
+                ):
+                    await MissionReconciler._notify_run_failed(db, run)
+                return advance_result
 
             # --- Check for fatal failure (task failed, retries exhausted) ---
             if failed_tasks:
@@ -227,6 +235,9 @@ class MissionReconciler:
                     failed_tasks=failed_tasks,
                 )
                 if fatal:
+                    # PRD-204 S4: fatal task failure failed the run — tell
+                    # the user.
+                    await MissionReconciler._notify_run_failed(db, run)
                     return ReconcileResult(
                         run_id=run_id,
                         stalls_detected=stalls_detected,
@@ -990,6 +1001,25 @@ class MissionReconciler:
                     return False
 
         return False
+
+    @staticmethod
+    async def _notify_run_failed(db: Session, run: OrchestrationRun) -> None:
+        """PRD-204 S4: mission_failed notification for reconciler-driven
+        failures (task cascades). Delegates to the single owner of the
+        failure message in coordinator_service; lazy import avoids the
+        module cycle (coordinator_service imports this module). Never
+        raises into reconciliation.
+        """
+        try:
+            from services.coordinator_service import notify_mission_failed
+
+            await notify_mission_failed(db, run)
+        except Exception:
+            logger.error(
+                "mission_failed dispatch failed for run %s (non-fatal)",
+                getattr(run, "id", "?"),
+                exc_info=True,
+            )
 
     @staticmethod
     def _skip_remaining_tasks(

--- a/orchestrator/modules/coordination/reconciler.py
+++ b/orchestrator/modules/coordination/reconciler.py
@@ -218,7 +218,7 @@ class MissionReconciler:
                     tasks_verified=tasks_verified,
                     tasks_verification_failed=tasks_verification_failed,
                 )
-                # PRD-204 S4: run failed on task outcomes — tell the user.
+                # PRD-204 S4: run failed on task outcomes -- tell the user.
                 # (_advance_run_on_completion is sync; this is its async seam.)
                 if (
                     advance_result.run_advanced
@@ -235,7 +235,7 @@ class MissionReconciler:
                     failed_tasks=failed_tasks,
                 )
                 if fatal:
-                    # PRD-204 S4: fatal task failure failed the run — tell
+                    # PRD-204 S4: fatal task failure failed the run -- tell
                     # the user.
                     await MissionReconciler._notify_run_failed(db, run)
                     return ReconcileResult(

--- a/orchestrator/modules/coordination/run_verdict.py
+++ b/orchestrator/modules/coordination/run_verdict.py
@@ -1,0 +1,618 @@
+"""
+Run-level Verdict Service -- PRD-204 S6
+=======================================
+
+Extends the PRD-200 per-task judge (``modules/coordination/verification.py``)
+to the RUN level: score the whole launched unit's output against the watch's
+``success_criteria`` on a 6-dimension business rubric.
+
+Dimensions (each 0-1, weighted mean -> ``watch.final_score``):
+- ``business_usefulness``, ``completeness``, ``evidence_quality``,
+  ``clarity``, ``actionability`` -- judged by the cross-model LLM;
+- ``reliability`` -- rule-based mechanics folded in from
+  ``PlaybookQualityService`` heuristics (tool failures / retries / step
+  status over ``step_results``) for playbooks, and a task-state analogue for
+  missions. Deliberately NOT an LLM opinion: the mechanics are already in
+  the rows.
+
+Scale (PRD-204 Section 8 Q8): 0-1 internal EVERYWHERE; only the notification
+display edge (``watch_notifications.format_score_display``) formats x10.
+
+Reuse (not re-derivation):
+- cross-model selection: ``verification._select_verifier_model``;
+- judge JSON extraction: ``verification._extract_judge_json``;
+- output-hash caching: same class-level cache pattern as
+  ``VerificationService`` -- keyed ``(watch_id, sha256(output))`` so a
+  rescore of identical output (e.g. rerun that produced the same thing)
+  costs zero LLM calls.
+
+LLM cost attribution: the manager is created with ``request_type='watch'``
+and ``_tracking_ctx['execution_id'] = 'watch-<id>'`` -- the recipe-executor
+idiom -- so ``llm_usage`` shows supervision cost per watch, WITHOUT
+polluting the watched execution's own rollup (which the S7 rerun estimate
+sums).
+
+Judge failure is fail-soft: after retries the verdict comes back
+``judge_failed=True`` with ``score=None`` -- the S10 decision step then
+closes by outcome (v1 semantics) instead of blocking the watch forever.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+from sqlalchemy.orm import Session
+
+from config import Config
+from modules.coordination.verification import (
+    _extract_judge_json,
+    _select_verifier_model,
+)
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Rubric
+# ---------------------------------------------------------------------------
+
+# The five judged dimensions + the mechanics-derived one. Weighted mean with
+# equal weights (one knob, one place -- adjust here if the rubric evolves).
+LLM_DIMENSIONS: Tuple[str, ...] = (
+    "business_usefulness",
+    "completeness",
+    "evidence_quality",
+    "clarity",
+    "actionability",
+)
+MECHANICS_DIMENSION = "reliability"
+ALL_DIMENSIONS: Tuple[str, ...] = LLM_DIMENSIONS + (MECHANICS_DIMENSION,)
+DIMENSION_WEIGHTS: Dict[str, float] = {dim: 1.0 / len(ALL_DIMENSIONS) for dim in ALL_DIMENSIONS}
+
+# Output text cap for the judge prompt (same guard as the task judge).
+MAX_OUTPUT_CHARS = 12000
+# Per-task / per-step excerpt cap when composing the run output bundle.
+EXCERPT_CHARS = 600
+
+
+# ---------------------------------------------------------------------------
+# Result dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RunOutputBundle:
+    """What the judge sees for one run-shaped target."""
+
+    text: str                       # composed run output
+    kind: str                       # 'mission' | 'playbook_execution'
+    terminal_state: str
+    mechanics_reliability: float    # 0-1 rule-based
+    executor_model: Optional[str] = None
+    empty: bool = False
+
+
+@dataclass(frozen=True)
+class RunVerdict:
+    """Immutable run-level verdict. ``score`` is None only on judge failure."""
+
+    score: Optional[float]
+    dimension_scores: Dict[str, float] = field(default_factory=dict)
+    reasoning: str = ""
+    caveats: List[str] = field(default_factory=list)
+    confidence: float = 1.0
+    tokens_used: int = 0
+    cached: bool = False
+    judge_failed: bool = False
+    output_hash: str = ""
+
+    def passes(self, threshold: float) -> bool:
+        """At-or-above passes (0.79 fails a 0.80 bar; 0.80 passes it)."""
+        return self.score is not None and self.score >= threshold
+
+    def as_text(self) -> str:
+        """The ``final_verdict`` text: score + reasoning + caveats."""
+        parts: List[str] = []
+        if self.judge_failed:
+            parts.append(
+                "Run-level scoring unavailable (judge failed after retries); "
+                "verdict recorded by outcome."
+            )
+        elif self.score is not None:
+            dims = ", ".join(
+                f"{d}={self.dimension_scores.get(d, 0.0):.2f}" for d in ALL_DIMENSIONS
+            )
+            parts.append(f"Run score {self.score:.2f} ({dims}).")
+        if self.reasoning:
+            parts.append(self.reasoning.strip())
+        if self.caveats:
+            parts.append("Caveats: " + "; ".join(str(c) for c in self.caveats) + ".")
+        return " ".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Pure scoring math (unit-testable without a DB or LLM)
+# ---------------------------------------------------------------------------
+
+
+def weighted_mean(dimension_scores: Dict[str, float]) -> float:
+    """Weighted mean over ALL_DIMENSIONS, missing dims scored 0."""
+    total = 0.0
+    for dim in ALL_DIMENSIONS:
+        raw = dimension_scores.get(dim, 0.0)
+        clamped = max(0.0, min(1.0, float(raw)))
+        total += clamped * DIMENSION_WEIGHTS[dim]
+    return round(total, 4)
+
+
+def mission_mechanics(task_states: List[Dict[str, Any]], run_state: str) -> float:
+    """Mission analogue of PlaybookQualityService reliability: task success
+    ratio + retry drag + outcome. Pure over ``[{state, attempts}]`` rows."""
+    status_score = 1.0 if run_state == "completed" else 0.0
+    if not task_states:
+        return round(0.4 * status_score + 0.6 * 0.5, 4)
+
+    done = sum(1 for t in task_states if t.get("state") in ("verified", "completed"))
+    failed = sum(1 for t in task_states if t.get("state") == "failed")
+    counted = max(1, done + failed)
+    success_ratio = done / counted
+
+    total = len(task_states)
+    retries = sum(max(0, int(t.get("attempts") or 1) - 1) for t in task_states)
+    retry_score = max(0.0, 1.0 - (retries / total) * 0.25)
+
+    return round(0.4 * status_score + 0.3 * success_ratio + 0.3 * retry_score, 4)
+
+
+def _hash_output(text: str) -> str:
+    return hashlib.sha256((text or "").encode()).hexdigest()
+
+
+def _compact(value: Any, limit: int = EXCERPT_CHARS) -> str:
+    text = value if isinstance(value, str) else json.dumps(value, default=str)
+    if len(text) > limit:
+        return text[:limit] + f"... (truncated, {len(text)} chars)"
+    return text
+
+
+# ---------------------------------------------------------------------------
+# Judge prompt
+# ---------------------------------------------------------------------------
+
+_RUN_JUDGE_SYSTEM_PROMPT = """\
+You are a business-quality reviewer for an AI agent platform. You review the
+FINAL OUTPUT of a completed unit of work (a mission or a playbook run)
+against the intent it was launched with, from the perspective of the person
+who asked for it.
+
+Rules:
+- Score each dimension 0.0 to 1.0, absolute (not relative to other runs).
+- business_usefulness: would the requester act on this as delivered?
+- completeness: does it cover everything the intent asked for?
+- evidence_quality: are claims grounded/attributed rather than asserted?
+- clarity: is it immediately understandable without cleanup?
+- actionability: are next steps / conclusions concrete and usable?
+- Shorter is not worse; longer is not better.
+- List concrete caveats the requester should know before trusting the output.
+- Return ONLY a single JSON object (no markdown, no prose outside JSON).
+"""
+
+
+def build_run_judge_prompt(
+    *,
+    success_criteria: str,
+    bundle: RunOutputBundle,
+) -> str:
+    """User prompt for the run-level judge. Pure -- golden-testable."""
+    output_display = bundle.text[:MAX_OUTPUT_CHARS]
+    if len(bundle.text) > MAX_OUTPUT_CHARS:
+        output_display += f"\n... (truncated, {len(bundle.text)} total characters)"
+
+    return f"""\
+## What was asked (success criteria / intent)
+{success_criteria}
+
+## What ran
+A {bundle.kind} that reached terminal state '{bundle.terminal_state}'.
+Mechanical reliability (computed from step/task records, for context only --
+do NOT return a reliability score): {bundle.mechanics_reliability:.2f}
+
+## Run output
+<run_output>
+{output_display}
+</run_output>
+
+## Required JSON output
+Return ONLY a JSON object with this exact structure:
+{{
+  "business_usefulness": 0.0-1.0,
+  "completeness": 0.0-1.0,
+  "evidence_quality": 0.0-1.0,
+  "clarity": 0.0-1.0,
+  "actionability": 0.0-1.0,
+  "confidence": 0.0-1.0,
+  "reasoning": "One-paragraph assessment against the intent",
+  "caveats": ["Concrete caveat 1", "Caveat 2"]
+}}
+"""
+
+
+# ---------------------------------------------------------------------------
+# RunVerdictService
+# ---------------------------------------------------------------------------
+
+
+def _default_llm_factory(watch, verifier_model: str):
+    """Build the judge LLM with watch cost attribution (recipe-executor
+    idiom: set ``_tracking_ctx`` execution_id + request_type)."""
+    from core.llm import create_llm_manager
+
+    llm = create_llm_manager(
+        service_name="watch_verdict",
+        model=verifier_model,
+        workspace_id=getattr(watch, "workspace_id", None),
+        request_type="watch",
+    )
+    if hasattr(llm, "_tracking_ctx"):
+        llm._tracking_ctx["request_type"] = "watch"
+        llm._tracking_ctx["execution_id"] = f"watch-{getattr(watch, 'id', 'unknown')}"
+    return llm
+
+
+class RunVerdictService:
+    """Scores a watch's run-level output. Stateless besides the class cache."""
+
+    # {(watch_id_str, output_hash): RunVerdict} -- VerificationService pattern.
+    _cache: Dict[Tuple[str, str], RunVerdict] = {}
+
+    # ------------------------------------------------------------------
+    # Cache
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def clear_cache(cls, watch_id) -> int:
+        keys = [k for k in cls._cache if k[0] == str(watch_id)]
+        for k in keys:
+            del cls._cache[k]
+        return len(keys)
+
+    # ------------------------------------------------------------------
+    # Output collection (cheap DB reads, no LLM)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def collect_run_output(db: Session, watch) -> Optional[RunOutputBundle]:
+        """Compose the judgeable output for the watch's CURRENT target.
+
+        Returns None when the target row is gone (caller parks the watch).
+        """
+        target_type = getattr(watch, "target_type", None)
+        if target_type == "mission":
+            return RunVerdictService._collect_mission(db, watch)
+        if target_type == "playbook_execution":
+            return RunVerdictService._collect_playbook(db, watch)
+        return None
+
+    @staticmethod
+    def _collect_mission(db: Session, watch) -> Optional[RunOutputBundle]:
+        from core.models.orchestration import OrchestrationRun, OrchestrationTask
+
+        run = (
+            db.query(OrchestrationRun)
+            .filter(OrchestrationRun.id == watch.target_id)
+            .first()
+        )
+        if run is None:
+            return None
+
+        tasks = (
+            db.query(OrchestrationTask)
+            .filter(OrchestrationTask.run_id == run.id)
+            .order_by(OrchestrationTask.sequence_number)
+            .all()
+        )
+
+        sections: List[str] = []
+        summary = getattr(run, "output_summary", None)
+        if summary:
+            sections.append("### Mission output summary\n" + _compact(summary, 4000))
+        for t in tasks:
+            output = getattr(t, "output", None)
+            if output:
+                sections.append(
+                    f"### Task: {getattr(t, 'title', '')} "
+                    f"[{getattr(t, 'state', '')}]\n{_compact(output)}"
+                )
+
+        task_states = [
+            {"state": getattr(t, "state", None), "attempts": getattr(t, "attempt_number", 1) or 1}
+            for t in tasks
+        ]
+        mechanics = mission_mechanics(task_states, getattr(run, "state", ""))
+        text = "\n\n".join(sections)
+        return RunOutputBundle(
+            text=text,
+            kind="mission",
+            terminal_state=getattr(run, "state", "unknown"),
+            mechanics_reliability=mechanics,
+            executor_model=None,  # multi-agent run: no single executor family
+            empty=not text.strip(),
+        )
+
+    @staticmethod
+    def _collect_playbook(db: Session, watch) -> Optional[RunOutputBundle]:
+        from core.models.core import RecipeExecution
+
+        execution = (
+            db.query(RecipeExecution)
+            .filter(RecipeExecution.execution_id == watch.target_id)
+            .first()
+        )
+        if execution is None:
+            return None
+
+        output_data = execution.output_data or {}
+        step_results = execution.step_results or []
+
+        sections: List[str] = []
+        final_output = output_data.get("final_output")
+        if final_output:
+            sections.append("### Final output\n" + _compact(final_output, 8000))
+        if step_results:
+            compact_steps = [
+                {
+                    "order": sr.get("order"),
+                    "name": sr.get("agent_name") or sr.get("name"),
+                    "status": sr.get("status"),
+                    "error": (str(sr.get("error"))[:200] if sr.get("error") else None),
+                    "retries": sr.get("retries", 0),
+                }
+                for sr in step_results
+                if isinstance(sr, dict)
+            ]
+            sections.append("### Step record\n" + _compact(compact_steps, 2000))
+        if execution.error_message:
+            sections.append("### Error\n" + _compact(execution.error_message, 1000))
+
+        # Reliability: reuse PlaybookQualityService's rule-based heuristics
+        # over step_results (PRD-204 S6 -- reuse, don't re-derive). The
+        # private call is deliberate and guarded; 0.5 = neutral on failure.
+        try:
+            from core.services.playbook_quality_service import PlaybookQualityService
+
+            mechanics = float(
+                PlaybookQualityService(db)._assess_reliability(execution, None)
+            )
+        except Exception:
+            logger.warning(
+                "[RunVerdict] reliability heuristic failed for %s -- neutral 0.5",
+                watch.target_id,
+                exc_info=True,
+            )
+            mechanics = 0.5
+
+        # Cross-model guarantee where cheaply knowable: the run's primary
+        # model from the llm_usage rollup.
+        executor_model: Optional[str] = None
+        try:
+            from services.report_service import compute_execution_metrics
+
+            executor_model = compute_execution_metrics(
+                db,
+                execution.workspace_id,
+                execution_id=execution.execution_id,
+            ).get("model")
+        except Exception:
+            logger.debug("[RunVerdict] executor model lookup failed", exc_info=True)
+
+        text = "\n\n".join(sections)
+        return RunOutputBundle(
+            text=text,
+            kind="playbook_execution",
+            terminal_state=execution.status or "unknown",
+            mechanics_reliability=max(0.0, min(1.0, mechanics)),
+            executor_model=executor_model,
+            empty=not text.strip(),
+        )
+
+    # ------------------------------------------------------------------
+    # Scoring
+    # ------------------------------------------------------------------
+
+    async def score_run(
+        self,
+        db: Session,
+        watch,
+        *,
+        bundle: Optional[RunOutputBundle] = None,
+        llm_factory: Optional[Callable[[Any, str], Any]] = None,
+    ) -> Optional[RunVerdict]:
+        """Score the watch's current target output. None = target missing.
+
+        ``bundle`` and ``llm_factory`` are injection seams for tests (judge
+        always stubbed; CI never calls a live model from this suite).
+        """
+        if bundle is None:
+            bundle = self.collect_run_output(db, watch)
+        if bundle is None:
+            return None
+
+        output_hash = _hash_output(bundle.text)
+        cache_key = (str(getattr(watch, "id", "")), output_hash)
+        cached = self._cache.get(cache_key)
+        if cached is not None:
+            logger.info("[RunVerdict] cache hit for watch %s", watch.id)
+            return RunVerdict(
+                score=cached.score,
+                dimension_scores=dict(cached.dimension_scores),
+                reasoning=cached.reasoning,
+                caveats=list(cached.caveats),
+                confidence=cached.confidence,
+                tokens_used=0,
+                cached=True,
+                judge_failed=cached.judge_failed,
+                output_hash=output_hash,
+            )
+
+        if bundle.empty:
+            # Deterministic floor -- no LLM call for nothing to judge.
+            dims = {dim: 0.0 for dim in LLM_DIMENSIONS}
+            dims[MECHANICS_DIMENSION] = bundle.mechanics_reliability
+            verdict = RunVerdict(
+                score=weighted_mean(dims),
+                dimension_scores=dims,
+                reasoning=(
+                    f"The {bundle.kind} reached '{bundle.terminal_state}' but "
+                    "produced no judgeable output."
+                ),
+                caveats=["No run output was found to score."],
+                output_hash=output_hash,
+            )
+            self._cache[cache_key] = verdict
+            return verdict
+
+        verdict = await self._run_judge(
+            watch, bundle, output_hash, llm_factory or _default_llm_factory
+        )
+        self._cache[cache_key] = verdict
+        return verdict
+
+    async def _run_judge(
+        self,
+        watch,
+        bundle: RunOutputBundle,
+        output_hash: str,
+        llm_factory: Callable[[Any, str], Any],
+    ) -> RunVerdict:
+        verifier_model = _select_verifier_model(bundle.executor_model)
+        criteria = (
+            getattr(watch, "success_criteria", None)
+            or getattr(watch, "title", None)
+            or "Deliver the launched work successfully."
+        )
+        prompt = build_run_judge_prompt(success_criteria=criteria, bundle=bundle)
+        messages = [
+            {"role": "system", "content": _RUN_JUDGE_SYSTEM_PROMPT},
+            {"role": "user", "content": prompt},
+        ]
+
+        max_retries = Config.COORDINATOR_MAX_VERIFICATION_RETRIES
+        last_error: Optional[str] = None
+
+        for attempt in range(1, max_retries + 1):
+            try:
+                llm = llm_factory(watch, verifier_model)
+                response = await llm.generate_response(messages)
+                raw = _extract_judge_json(getattr(response, "content", None))
+                if raw is None:
+                    last_error = f"non-JSON judge response (attempt {attempt})"
+                    logger.warning(
+                        "[RunVerdict] non-JSON judge response for watch %s "
+                        "(attempt %d/%d)",
+                        watch.id,
+                        attempt,
+                        max_retries,
+                    )
+                    continue
+
+                dims: Dict[str, float] = {}
+                for dim in LLM_DIMENSIONS:
+                    val = raw.get(dim)
+                    dims[dim] = (
+                        max(0.0, min(1.0, float(val)))
+                        if isinstance(val, (int, float))
+                        else 0.5
+                    )
+                dims[MECHANICS_DIMENSION] = bundle.mechanics_reliability
+
+                confidence = raw.get("confidence", 1.0)
+                confidence = (
+                    max(0.0, min(1.0, float(confidence)))
+                    if isinstance(confidence, (int, float))
+                    else 1.0
+                )
+                caveats = raw.get("caveats", [])
+                if not isinstance(caveats, list):
+                    caveats = []
+
+                tokens_used = 0
+                usage = getattr(response, "usage", None)
+                if usage:
+                    if hasattr(usage, "total_tokens"):
+                        tokens_used = usage.total_tokens
+                    elif isinstance(usage, dict):
+                        tokens_used = usage.get("total_tokens", 0)
+
+                score = weighted_mean(dims)
+                logger.info(
+                    "[RunVerdict] watch %s scored %.4f (model=%s, dims=%s)",
+                    watch.id,
+                    score,
+                    verifier_model,
+                    dims,
+                )
+                return RunVerdict(
+                    score=score,
+                    dimension_scores=dims,
+                    reasoning=str(raw.get("reasoning", "")),
+                    caveats=[str(c) for c in caveats],
+                    confidence=confidence,
+                    tokens_used=tokens_used,
+                    output_hash=output_hash,
+                )
+            except Exception as exc:  # noqa: BLE001 -- judged fail-soft below
+                last_error = f"judge call failed on attempt {attempt}: {exc}"
+                logger.error(
+                    "[RunVerdict] judge error for watch %s (attempt %d/%d)",
+                    watch.id,
+                    attempt,
+                    max_retries,
+                    exc_info=True,
+                )
+
+        logger.warning(
+            "[RunVerdict] judge exhausted %d retries for watch %s: %s",
+            max_retries,
+            watch.id,
+            last_error,
+        )
+        return RunVerdict(
+            score=None,
+            reasoning=f"Judge failed after {max_retries} attempts: {last_error}",
+            judge_failed=True,
+            output_hash=output_hash,
+        )
+
+    # ------------------------------------------------------------------
+    # Persistence
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def apply_verdict(db: Session, watch, verdict: RunVerdict):
+        """Write ``final_score``/``final_verdict`` + the idempotent SCORED
+        event. Joins the caller's transaction (flush via ingest)."""
+        from core.models.watch_enums import WatchEventType
+        from services.watch_service import WatchService
+
+        if verdict.score is not None:
+            watch.final_score = verdict.score
+        watch.final_verdict = verdict.as_text()
+
+        return WatchService.ingest(
+            db,
+            watch,
+            event_type=WatchEventType.SCORED.value,
+            event_key=f"scored:{watch.target_type}:{watch.target_id}:{verdict.output_hash[:12]}",
+            summary=verdict.reasoning[:500] if verdict.reasoning else "Run scored",
+            snapshot={
+                "dimension_scores": verdict.dimension_scores,
+                "confidence": verdict.confidence,
+                "caveats": verdict.caveats,
+                "judge_failed": verdict.judge_failed,
+                "cached": verdict.cached,
+            },
+            score=verdict.score,
+        )

--- a/orchestrator/modules/tools/discovery/actions_watches.py
+++ b/orchestrator/modules/tools/discovery/actions_watches.py
@@ -1,0 +1,208 @@
+"""Watch ActionDefinitions -- PRD-204 S9 (create, list, get, cancel).
+
+CONTRACT GUARD (onboarding-wall lesson, PRD memory): ``required[]`` lists
+ONLY fields the handler cannot default. Every optional field here has a
+handler-side default -- a required field that the handler defaults
+dead-ends the LLM. test_prd204_watch_tools locks this.
+"""
+
+from .action_registry import ActionDefinition, ActionRegistry
+
+
+def register_watch_actions(registry: ActionRegistry) -> None:
+    """Register watch actions (PRD-204 S9)."""
+
+    registry.register(ActionDefinition(
+        name="platform_create_watch",
+        description=(
+            "Put a launched unit of work under supervision. A watch follows a "
+            "mission or playbook execution to a verdict: it detects the terminal "
+            "state, scores the output against the success criteria (0-1, "
+            "displayed x10), takes bounded corrective action when the policy "
+            "allows, and notifies the user. Use after launching work the user "
+            "cares about, or when the user says 'keep an eye on it', 'make sure "
+            "it gets done', 'check the result'."
+        ),
+        category="watches",
+        parameters={
+            "type": "object",
+            "properties": {
+                "target_type": {
+                    "type": "string",
+                    "enum": ["mission", "playbook_execution", "scheduled_playbook"],
+                    "description": (
+                        "What kind of thing to watch: a mission (run UUID), a "
+                        "playbook execution (execution_id like 'exec-...'), or a "
+                        "scheduled playbook (playbook id -- watches the schedule "
+                        "for missed/benched runs)."
+                    ),
+                },
+                "target_id": {
+                    "type": "string",
+                    "description": (
+                        "The id of the target: mission UUID, execution_id, or "
+                        "playbook id."
+                    ),
+                },
+                "title": {
+                    "type": "string",
+                    "description": "Short human label (default: derived from the target).",
+                },
+                "success_criteria": {
+                    "type": "string",
+                    "description": (
+                        "What 'good' means for this work, in the user's words -- "
+                        "the run output is scored against this (default: derived "
+                        "from the target's goal/name)."
+                    ),
+                },
+                "quality_threshold": {
+                    "type": "number",
+                    "description": (
+                        "Pass bar on the 0-1 internal scale (default 0.8, "
+                        "displayed as 8/10)."
+                    ),
+                },
+                "policy": {
+                    "type": "string",
+                    "enum": [
+                        "run_and_report",
+                        "score_and_improve",
+                        "watch_change",
+                        "persistent",
+                    ],
+                    "description": (
+                        "Decision profile (default run_and_report). "
+                        "run_and_report: score + notify + close, no actions. "
+                        "score_and_improve: below-threshold triggers one "
+                        "diagnose+tweak+rerun cycle. watch_change: compare a "
+                        "rerun against the prior run and report the delta. "
+                        "persistent: recurring supervision of a scheduled "
+                        "playbook until the deadline."
+                    ),
+                },
+                "deadline_hours": {
+                    "type": "number",
+                    "description": (
+                        "Give up after this many hours without a verdict "
+                        "(default: no deadline)."
+                    ),
+                },
+                "action_budget": {
+                    "type": "integer",
+                    "description": (
+                        "Max corrective actions before escalating to a human "
+                        "(default 2)."
+                    ),
+                },
+            },
+            "required": ["target_type", "target_id"],
+        },
+        permission_level="write",
+        requires_confirmation=False,
+        tags=["watches", "write", "supervision", "quality", "follow-up"],
+        examples=[
+            "keep an eye on that mission and tell me how it went",
+            "watch this playbook run and make sure the output is good",
+            "make sure the nightly report actually runs",
+            "supervise the launch and improve it if the result is weak",
+        ],
+    ))
+
+    registry.register(ActionDefinition(
+        name="platform_list_watches",
+        description=(
+            "List watches in this workspace -- id, title, status "
+            "(watching/acting/awaiting_approval/needs_attention/passed/failed/"
+            "escalated/expired/cancelled), score, target. Live watches by "
+            "default. For one watch's full timeline use platform_get_watch."
+        ),
+        category="watches",
+        parameters={
+            "type": "object",
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "description": "Filter by exact status (omit for all live).",
+                },
+                "watch_type": {
+                    "type": "string",
+                    "enum": ["mission", "playbook_execution", "scheduled_playbook"],
+                    "description": "Filter by watch type.",
+                },
+                "include_closed": {
+                    "type": "boolean",
+                    "description": "Include closed watches (default false).",
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Max results (default 20, max 50).",
+                },
+            },
+            "required": [],
+        },
+        permission_level="read",
+        tags=["watches", "read", "list", "status"],
+        examples=[
+            "what are you watching right now?",
+            "list my watches",
+            "any watches that need attention?",
+        ],
+    ))
+
+    registry.register(ActionDefinition(
+        name="platform_get_watch",
+        description=(
+            "Full detail of ONE watch: status, score/verdict, action budget, "
+            "target lineage (reruns/replans it followed), and the recent event "
+            "timeline."
+        ),
+        category="watches",
+        parameters={
+            "type": "object",
+            "properties": {
+                "watch_id": {
+                    "type": "string",
+                    "description": "The watch UUID.",
+                },
+            },
+            "required": ["watch_id"],
+        },
+        permission_level="read",
+        tags=["watches", "read", "details", "verdict"],
+        examples=[
+            "how is that watch doing?",
+            "show me the watch verdict",
+            "what happened on the report watch?",
+        ],
+    ))
+
+    registry.register(ActionDefinition(
+        name="platform_cancel_watch",
+        description=(
+            "Cancel a live watch (stop supervising -- the watched work itself "
+            "keeps running). Closed watches cannot be cancelled."
+        ),
+        category="watches",
+        parameters={
+            "type": "object",
+            "properties": {
+                "watch_id": {
+                    "type": "string",
+                    "description": "The watch UUID to cancel.",
+                },
+                "reason": {
+                    "type": "string",
+                    "description": "Why (recorded on the watch timeline).",
+                },
+            },
+            "required": ["watch_id"],
+        },
+        permission_level="write",
+        requires_confirmation=False,
+        tags=["watches", "write", "cancel"],
+        examples=[
+            "stop watching that mission",
+            "cancel the watch on the nightly report",
+        ],
+    ))

--- a/orchestrator/modules/tools/discovery/handlers_missions.py
+++ b/orchestrator/modules/tools/discovery/handlers_missions.py
@@ -125,6 +125,27 @@ async def create_mission(db: Session, workspace_id: UUID, params: Dict[str, Any]
             config=config,
         )
 
+        # PRD-204 S9 (Q1): Auto-launched missions get a run_and_report watch
+        # by default (workspace setting watch_auto_create, default ON);
+        # success_criteria is the user's request text. Fail-soft -- a broken
+        # watcher never breaks a launch.
+        from modules.tools.discovery.handlers_watches import auto_create_watch
+
+        auto_create_watch(
+            db,
+            workspace_id,
+            target_type="mission",
+            target_id=str(run.id),
+            title=f"Watch: {goal[:80]}",
+            success_criteria=goal,
+            created_by=params.get("_created_by"),
+            owner_agent_id=(
+                int(params["_agent_id"])
+                if str(params.get("_agent_id") or "").isdigit()
+                else None
+            ),
+        )
+
         # Summarize the plan for the caller (PRD-164 S2: includes the agent
         # match preview so the approval card can show reasons).
         plan = run.plan or {}

--- a/orchestrator/modules/tools/discovery/handlers_playbooks.py
+++ b/orchestrator/modules/tools/discovery/handlers_playbooks.py
@@ -479,6 +479,35 @@ async def execute_playbook(db: Session, workspace_id: UUID, params: Dict[str, An
         triggered_by="platform_action",
     )
     db.add(execution)
+
+    # PRD-204 S9 (Q1): Auto-launched playbook runs get a run_and_report
+    # watch by default (workspace setting watch_auto_create, default ON);
+    # criteria seeded from the request context. Fail-soft by contract.
+    from modules.tools.discovery.handlers_watches import auto_create_watch
+
+    criteria = f"Playbook '{playbook.name}' completes and delivers its expected output."
+    if input_data:
+        import json as _json
+
+        try:
+            criteria += f" Inputs: {_json.dumps(input_data, default=str)[:400]}"
+        except Exception:
+            pass
+    auto_create_watch(
+        db,
+        workspace_id,
+        target_type="playbook_execution",
+        target_id=execution_id,
+        title=f"Watch: {playbook.name[:80]}",
+        success_criteria=criteria,
+        created_by=(str(params.get("_created_by")) if params.get("_created_by") else None),
+        owner_agent_id=(
+            int(params["_agent_id"])
+            if str(params.get("_agent_id") or "").isdigit()
+            else None
+        ),
+    )
+
     db.commit()  # Must commit before async task (it opens its own session)
 
     # Launch async execution via the consolidated PlaybookEngine seam.

--- a/orchestrator/modules/tools/discovery/handlers_playbooks.py
+++ b/orchestrator/modules/tools/discovery/handlers_playbooks.py
@@ -479,36 +479,46 @@ async def execute_playbook(db: Session, workspace_id: UUID, params: Dict[str, An
         triggered_by="platform_action",
     )
     db.add(execution)
+    db.commit()  # Must commit before async task (it opens its own session)
 
     # PRD-204 S9 (Q1): Auto-launched playbook runs get a run_and_report
     # watch by default (workspace setting watch_auto_create, default ON);
-    # criteria seeded from the request context. Fail-soft by contract.
-    from modules.tools.discovery.handlers_watches import auto_create_watch
+    # criteria seeded from the request context. Fail-soft by contract --
+    # committed separately AFTER the execution row so a watch problem can
+    # never poison the launch transaction.
+    try:
+        from modules.tools.discovery.handlers_watches import auto_create_watch
 
-    criteria = f"Playbook '{playbook.name}' completes and delivers its expected output."
-    if input_data:
-        import json as _json
+        criteria = f"Playbook '{playbook.name}' completes and delivers its expected output."
+        if input_data:
+            import json as _json
 
-        try:
-            criteria += f" Inputs: {_json.dumps(input_data, default=str)[:400]}"
-        except Exception:
-            pass
-    auto_create_watch(
-        db,
-        workspace_id,
-        target_type="playbook_execution",
-        target_id=execution_id,
-        title=f"Watch: {playbook.name[:80]}",
-        success_criteria=criteria,
-        created_by=(str(params.get("_created_by")) if params.get("_created_by") else None),
-        owner_agent_id=(
-            int(params["_agent_id"])
-            if str(params.get("_agent_id") or "").isdigit()
-            else None
-        ),
-    )
-
-    db.commit()  # Must commit before async task (it opens its own session)
+            try:
+                criteria += f" Inputs: {_json.dumps(input_data, default=str)[:400]}"
+            except Exception:
+                pass
+        watch = auto_create_watch(
+            db,
+            workspace_id,
+            target_type="playbook_execution",
+            target_id=execution_id,
+            title=f"Watch: {playbook.name[:80]}",
+            success_criteria=criteria,
+            created_by=(str(params.get("_created_by")) if params.get("_created_by") else None),
+            owner_agent_id=(
+                int(params["_agent_id"])
+                if str(params.get("_agent_id") or "").isdigit()
+                else None
+            ),
+        )
+        if watch is not None:
+            db.commit()
+    except Exception:
+        db.rollback()
+        logger.warning(
+            "[PlatformExecutor] watch auto-create commit failed for %s -- "
+            "launch unaffected", execution_id, exc_info=True,
+        )
 
     # Launch async execution via the consolidated PlaybookEngine seam.
     # PRD-142 W3-S12: every backend launch site goes through the engine —

--- a/orchestrator/modules/tools/discovery/handlers_watches.py
+++ b/orchestrator/modules/tools/discovery/handlers_watches.py
@@ -1,0 +1,424 @@
+"""Watch handlers for PlatformActionExecutor -- PRD-204 S9.
+
+Workspace-scoped CRUD over the watch registry + the fail-soft auto-create
+helper the mission/playbook launch handlers call (Section 8 Q1:
+``watch_auto_create`` default ON, ``run_and_report`` policy,
+success_criteria seeded from the user's request text).
+
+CONTRACT: every field the ActionDefinition marks optional is defaulted
+here; only ``target_type``/``target_id`` (create) and ``watch_id``
+(get/cancel) are required -- see actions_watches.py.
+"""
+
+import logging
+from datetime import timedelta
+from typing import Any, Dict, Optional
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+_VALID_TARGET_TYPES = ("mission", "playbook_execution", "scheduled_playbook")
+_MAX_LIST_LIMIT = 50
+_RECENT_EVENT_LIMIT = 10
+
+
+def _actor(params: Dict[str, Any]) -> Optional[str]:
+    """The human behind this action (executor-injected), else None."""
+    created_by = params.get("_created_by")
+    return str(created_by) if created_by else None
+
+
+def _owner_agent_id(params: Dict[str, Any]) -> Optional[int]:
+    raw = params.get("_agent_id")
+    try:
+        return int(raw) if raw is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _watch_to_dict(watch, *, include_lineage: bool = False) -> Dict[str, Any]:
+    from services.watch_notifications import format_score_display
+
+    data = {
+        "id": str(watch.id),
+        "title": watch.title,
+        "watch_type": watch.watch_type,
+        "target_type": watch.target_type,
+        "target_id": watch.target_id,
+        "status": watch.status,
+        "policy": watch.policy,
+        "success_criteria": watch.success_criteria,
+        "quality_threshold": watch.quality_threshold,
+        "final_score": watch.final_score,
+        "final_score_display": format_score_display(watch.final_score),
+        "final_verdict": watch.final_verdict,
+        "actions_taken": watch.actions_taken,
+        "action_budget": watch.action_budget,
+        "last_checked_at": str(watch.last_checked_at) if watch.last_checked_at else None,
+        "next_check_at": str(watch.next_check_at) if watch.next_check_at else None,
+        "deadline_at": str(watch.deadline_at) if watch.deadline_at else None,
+        "created_at": str(watch.created_at) if watch.created_at else None,
+        "closed_at": str(watch.closed_at) if watch.closed_at else None,
+    }
+    if include_lineage:
+        data["lineage"] = watch.lineage or []
+    return data
+
+
+def _resolve_target(
+    db: Session, workspace_id: UUID, target_type: str, target_id: str
+) -> Optional[Dict[str, str]]:
+    """Workspace-scoped target lookup -> {title, criteria} or None.
+
+    Boundary validation: a watch on a target that does not exist (or lives
+    in another workspace) is refused at creation, not parked later.
+    """
+    try:
+        if target_type == "mission":
+            from core.models.orchestration import OrchestrationRun
+
+            run = (
+                db.query(OrchestrationRun)
+                .filter(
+                    OrchestrationRun.id == str(target_id),
+                    OrchestrationRun.workspace_id == workspace_id,
+                )
+                .first()
+            )
+            if run is None:
+                return None
+            goal = (run.goal or "").strip()
+            return {
+                "title": f"Watch: {goal[:80]}" if goal else f"Watch: mission {target_id}",
+                "criteria": goal or "The mission completes successfully.",
+            }
+
+        if target_type == "playbook_execution":
+            from core.models.core import RecipeExecution, WorkflowTemplate
+
+            execution = (
+                db.query(RecipeExecution)
+                .filter(
+                    RecipeExecution.execution_id == str(target_id),
+                    RecipeExecution.workspace_id == workspace_id,
+                )
+                .first()
+            )
+            if execution is None:
+                return None
+            recipe = (
+                db.query(WorkflowTemplate)
+                .filter(WorkflowTemplate.id == execution.recipe_id)
+                .first()
+            )
+            name = getattr(recipe, "name", None) or f"playbook {execution.recipe_id}"
+            return {
+                "title": f"Watch: {name[:80]}",
+                "criteria": f"Playbook '{name}' completes and delivers its expected output.",
+            }
+
+        if target_type == "scheduled_playbook":
+            from core.models.core import WorkflowTemplate
+
+            try:
+                recipe_id = int(target_id)
+            except (TypeError, ValueError):
+                return None
+            recipe = (
+                db.query(WorkflowTemplate)
+                .filter(
+                    WorkflowTemplate.id == recipe_id,
+                    WorkflowTemplate.workspace_id == workspace_id,
+                )
+                .first()
+            )
+            if recipe is None:
+                return None
+            return {
+                "title": f"Watch: {recipe.name[:70]} (schedule)",
+                "criteria": f"Scheduled playbook '{recipe.name}' keeps running on time.",
+            }
+    except Exception:
+        logger.warning(
+            "[Watches] target resolve failed for %s:%s", target_type, target_id,
+            exc_info=True,
+        )
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Tool handlers
+# ---------------------------------------------------------------------------
+
+
+async def create_watch(db: Session, workspace_id: UUID, params: Dict[str, Any]) -> Dict[str, Any]:
+    """platform_create_watch."""
+    from core.models.watch_enums import WatchPolicy
+    from core.models.watches import (
+        DEFAULT_ACTION_BUDGET,
+        DEFAULT_QUALITY_THRESHOLD,
+    )
+    from services.watch_service import WatchAlreadyExistsError, WatchService
+
+    target_type = params.get("target_type")
+    target_id = params.get("target_id")
+    if target_type not in _VALID_TARGET_TYPES:
+        return {
+            "success": False,
+            "error": f"target_type must be one of {list(_VALID_TARGET_TYPES)}",
+        }
+    if not target_id:
+        return {"success": False, "error": "target_id is required"}
+    target_id = str(target_id)
+
+    resolved = _resolve_target(db, workspace_id, target_type, target_id)
+    if resolved is None:
+        return {
+            "success": False,
+            "error": f"No {target_type} '{target_id}' found in this workspace",
+        }
+
+    policy = params.get("policy") or WatchPolicy.RUN_AND_REPORT.value
+    if policy not in {p.value for p in WatchPolicy}:
+        return {
+            "success": False,
+            "error": f"policy must be one of {sorted(p.value for p in WatchPolicy)}",
+        }
+
+    threshold = params.get("quality_threshold")
+    if threshold is None:
+        threshold = DEFAULT_QUALITY_THRESHOLD
+    try:
+        threshold = max(0.0, min(1.0, float(threshold)))
+    except (TypeError, ValueError):
+        return {"success": False, "error": "quality_threshold must be a number in [0, 1]"}
+
+    deadline_at = None
+    deadline_hours = params.get("deadline_hours")
+    if deadline_hours is not None:
+        try:
+            hours = float(deadline_hours)
+        except (TypeError, ValueError):
+            return {"success": False, "error": "deadline_hours must be a number"}
+        if hours <= 0:
+            return {"success": False, "error": "deadline_hours must be positive"}
+        from datetime import datetime, timezone
+
+        deadline_at = datetime.now(timezone.utc) + timedelta(hours=hours)
+
+    action_budget = params.get("action_budget")
+    if action_budget is None:
+        action_budget = DEFAULT_ACTION_BUDGET
+    try:
+        action_budget = max(0, int(action_budget))
+    except (TypeError, ValueError):
+        return {"success": False, "error": "action_budget must be an integer"}
+
+    try:
+        watch = WatchService.create_watch(
+            db,
+            workspace_id=workspace_id,
+            watch_type=target_type,
+            target_type=target_type,
+            target_id=target_id,
+            title=(params.get("title") or resolved["title"])[:500],
+            created_by=_actor(params),
+            owner_agent_id=_owner_agent_id(params),
+            success_criteria=params.get("success_criteria") or resolved["criteria"],
+            quality_threshold=threshold,
+            deadline_at=deadline_at,
+            policy=policy,
+            action_budget=action_budget,
+        )
+    except WatchAlreadyExistsError:
+        existing = WatchService.find_live_watch(
+            db, workspace_id=workspace_id, target_type=target_type, target_id=target_id
+        )
+        return {
+            "success": True,
+            "existing": True,
+            "watch": _watch_to_dict(existing) if existing else None,
+            "message": f"That {target_type} is already being watched.",
+        }
+    except Exception as e:
+        logger.error("[Watches] create_watch failed: %s", e, exc_info=True)
+        return {"success": False, "error": f"Failed to create watch: {str(e)[:300]}"}
+
+    return {
+        "success": True,
+        "existing": False,
+        "watch": _watch_to_dict(watch),
+        "message": (
+            f"Watching {target_type} {target_id} to a verdict "
+            f"(policy {policy}, bar {threshold:.2f})."
+        ),
+    }
+
+
+async def list_watches(db: Session, workspace_id: UUID, params: Dict[str, Any]) -> Dict[str, Any]:
+    """platform_list_watches."""
+    from services.watch_service import WatchService
+
+    try:
+        limit = min(int(params.get("limit", 20)), _MAX_LIST_LIMIT)
+    except (TypeError, ValueError):
+        limit = 20
+
+    try:
+        watches = WatchService.list_watches(
+            db,
+            workspace_id,
+            status=params.get("status"),
+            watch_type=params.get("watch_type"),
+            include_closed=bool(params.get("include_closed", False)),
+            limit=limit,
+        )
+    except Exception as e:
+        logger.error("[Watches] list_watches failed: %s", e, exc_info=True)
+        return {"success": False, "error": f"Failed to list watches: {str(e)[:300]}"}
+
+    return {
+        "success": True,
+        "watches": [_watch_to_dict(w) for w in watches],
+        "total": len(watches),
+    }
+
+
+async def get_watch(db: Session, workspace_id: UUID, params: Dict[str, Any]) -> Dict[str, Any]:
+    """platform_get_watch."""
+    from core.models.watches import WatchEvent
+    from services.watch_service import WatchService
+
+    watch_id = params.get("watch_id")
+    if not watch_id:
+        return {"success": False, "error": "watch_id is required"}
+
+    try:
+        watch = WatchService.get_watch(db, workspace_id, str(watch_id))
+    except Exception:
+        watch = None
+    if watch is None:
+        return {"success": False, "error": f"Watch {watch_id} not found"}
+
+    events = (
+        db.query(WatchEvent)
+        .filter(WatchEvent.watch_id == watch.id)
+        .order_by(WatchEvent.created_at.desc())
+        .limit(_RECENT_EVENT_LIMIT)
+        .all()
+    )
+    return {
+        "success": True,
+        "watch": _watch_to_dict(watch, include_lineage=True),
+        "recent_events": [
+            {
+                "event_type": e.event_type,
+                "summary": e.summary,
+                "score": e.score,
+                "action_taken": e.action_taken,
+                "requires_attention": e.requires_attention,
+                "created_at": str(e.created_at) if e.created_at else None,
+            }
+            for e in events
+        ],
+    }
+
+
+async def cancel_watch(db: Session, workspace_id: UUID, params: Dict[str, Any]) -> Dict[str, Any]:
+    """platform_cancel_watch."""
+    from services.orchestration_state import InvalidTransitionError
+    from services.watch_service import WatchService
+
+    watch_id = params.get("watch_id")
+    if not watch_id:
+        return {"success": False, "error": "watch_id is required"}
+
+    try:
+        watch = WatchService.cancel_watch(
+            db, workspace_id, str(watch_id), reason=params.get("reason")
+        )
+    except ValueError as e:
+        return {"success": False, "error": str(e)[:300]}
+    except InvalidTransitionError:
+        return {
+            "success": False,
+            "error": "That watch is already closed and cannot be cancelled.",
+        }
+    except Exception as e:
+        logger.error("[Watches] cancel_watch failed: %s", e, exc_info=True)
+        return {"success": False, "error": f"Failed to cancel watch: {str(e)[:300]}"}
+
+    return {
+        "success": True,
+        "watch": _watch_to_dict(watch),
+        "message": f"Watch {watch.id} cancelled.",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Auto-create (Section 8 Q1) -- called by the launch handlers, fail-soft
+# ---------------------------------------------------------------------------
+
+
+def auto_create_watch(
+    db: Session,
+    workspace_id: UUID,
+    *,
+    target_type: str,
+    target_id: str,
+    title: str,
+    success_criteria: str,
+    created_by: Optional[str] = None,
+    owner_agent_id: Optional[int] = None,
+):
+    """Create the default run_and_report watch on Auto-launched work.
+
+    Gated on the ``watch_auto_create`` workspace setting (default ON).
+    Idempotent (one live watch per target) and fail-soft: NEVER raises into
+    the launching handler -- a broken watcher must not break a launch.
+    Returns the Watch or None.
+    """
+    try:
+        from services.watch_service import (
+            WatchService,
+            watch_auto_create_enabled,
+        )
+
+        if not watch_auto_create_enabled(db, workspace_id):
+            return None
+        if WatchService.find_live_watch(
+            db,
+            workspace_id=workspace_id,
+            target_type=target_type,
+            target_id=str(target_id),
+        ) is not None:
+            return None
+
+        watch = WatchService.create_watch(
+            db,
+            workspace_id=workspace_id,
+            watch_type=target_type,
+            target_type=target_type,
+            target_id=str(target_id),
+            title=title[:500],
+            created_by=created_by,
+            owner_agent_id=owner_agent_id,
+            success_criteria=success_criteria,
+        )
+        logger.info(
+            "[Watches] auto-created watch %s on %s:%s",
+            watch.id,
+            target_type,
+            target_id,
+        )
+        return watch
+    except Exception:
+        logger.warning(
+            "[Watches] auto-create failed for %s:%s -- launch unaffected",
+            target_type,
+            target_id,
+            exc_info=True,
+        )
+        return None

--- a/orchestrator/modules/tools/discovery/handlers_watches.py
+++ b/orchestrator/modules/tools/discovery/handlers_watches.py
@@ -38,7 +38,9 @@ def _owner_agent_id(params: Dict[str, Any]) -> Optional[int]:
         return None
 
 
-def _watch_to_dict(watch, *, include_lineage: bool = False) -> Dict[str, Any]:
+def watch_to_dict(watch, *, include_lineage: bool = False) -> Dict[str, Any]:
+    """Canonical watch serialization -- shared by the S9 tool handlers and
+    the S11 watchlist API (api/watches.py) so both surfaces speak one shape."""
     from services.watch_notifications import format_score_display
 
     data = {
@@ -239,7 +241,7 @@ async def create_watch(db: Session, workspace_id: UUID, params: Dict[str, Any]) 
         return {
             "success": True,
             "existing": True,
-            "watch": _watch_to_dict(existing) if existing else None,
+            "watch": watch_to_dict(existing) if existing else None,
             "message": f"That {target_type} is already being watched.",
         }
     except Exception as e:
@@ -249,7 +251,7 @@ async def create_watch(db: Session, workspace_id: UUID, params: Dict[str, Any]) 
     return {
         "success": True,
         "existing": False,
-        "watch": _watch_to_dict(watch),
+        "watch": watch_to_dict(watch),
         "message": (
             f"Watching {target_type} {target_id} to a verdict "
             f"(policy {policy}, bar {threshold:.2f})."
@@ -281,7 +283,7 @@ async def list_watches(db: Session, workspace_id: UUID, params: Dict[str, Any]) 
 
     return {
         "success": True,
-        "watches": [_watch_to_dict(w) for w in watches],
+        "watches": [watch_to_dict(w) for w in watches],
         "total": len(watches),
     }
 
@@ -311,7 +313,7 @@ async def get_watch(db: Session, workspace_id: UUID, params: Dict[str, Any]) -> 
     )
     return {
         "success": True,
-        "watch": _watch_to_dict(watch, include_lineage=True),
+        "watch": watch_to_dict(watch, include_lineage=True),
         "recent_events": [
             {
                 "event_type": e.event_type,
@@ -352,7 +354,7 @@ async def cancel_watch(db: Session, workspace_id: UUID, params: Dict[str, Any]) 
 
     return {
         "success": True,
-        "watch": _watch_to_dict(watch),
+        "watch": watch_to_dict(watch),
         "message": f"Watch {watch.id} cancelled.",
     }
 

--- a/orchestrator/modules/tools/discovery/platform_actions.py
+++ b/orchestrator/modules/tools/discovery/platform_actions.py
@@ -44,6 +44,7 @@ from .actions_api_keys import register_api_keys_actions  # PRD-143 S11
 from .actions_power import register_power_actions  # PRD-142 Wave 4 (W4-S5)
 from .actions_autonomy import register_autonomy_actions
 from .actions_deliverables import register_deliverables_actions  # PRD-164 S3
+from .actions_watches import register_watch_actions  # PRD-204 S9
 
 
 def register_all_actions(registry: ActionRegistry) -> None:
@@ -81,6 +82,7 @@ def register_all_actions(registry: ActionRegistry) -> None:
     register_power_actions(registry)  # PRD-142 Wave 4 (W4-S5): power-mode tool
     register_autonomy_actions(registry)
     register_deliverables_actions(registry)  # PRD-164 S3: deliverable list/get tools
+    register_watch_actions(registry)  # PRD-204 S9: watch create/list/get/cancel
 
     # Workspace tools (file I/O, grep, exec, git)
     from .workspace_actions import register_workspace_actions

--- a/orchestrator/modules/tools/discovery/platform_executor.py
+++ b/orchestrator/modules/tools/discovery/platform_executor.py
@@ -192,6 +192,12 @@ from modules.tools.discovery.handlers_blog import (
     create_blog_post_from_topic,
     generate_cover_image,
 )
+from modules.tools.discovery.handlers_watches import (  # PRD-204 S9
+    create_watch,
+    list_watches,
+    get_watch,
+    cancel_watch,
+)
 from modules.tools.discovery.handlers_missions import (
     create_mission,
     list_missions,
@@ -451,6 +457,11 @@ class PlatformActionExecutor:
             "platform_create_mission": create_mission,
             "platform_list_missions": list_missions,
             "platform_get_mission": get_mission,
+            # PRD-204 S9: Watches (supervision to a verdict)
+            "platform_create_watch": create_watch,
+            "platform_list_watches": list_watches,
+            "platform_get_watch": get_watch,
+            "platform_cancel_watch": cancel_watch,
             # PRD-163 S1: mission lifecycle control
             "platform_approve_mission": approve_mission,
             "platform_reject_mission": reject_mission,

--- a/orchestrator/reports/route-manifest.json
+++ b/orchestrator/reports/route-manifest.json
@@ -1,5 +1,5 @@
 {
-  "route_count": 763,
+  "route_count": 767,
   "routes": [
     {
       "method": "GET",
@@ -2394,6 +2394,18 @@
       "path": "/api/v1/tasks/{task_id}/status"
     },
     {
+      "method": "GET",
+      "path": "/api/v1/watches"
+    },
+    {
+      "method": "GET",
+      "path": "/api/v1/watches/{watch_id}"
+    },
+    {
+      "method": "POST",
+      "path": "/api/v1/watches/{watch_id}/cancel"
+    },
+    {
       "method": "POST",
       "path": "/api/verticals/{vertical}/gdpr/erase"
     },
@@ -2684,6 +2696,10 @@
     {
       "method": "POST",
       "path": "/api/workflow-recipes/{recipe_id}/executions/{execution_id}/cancel"
+    },
+    {
+      "method": "POST",
+      "path": "/api/workflow-recipes/{recipe_id}/executions/{execution_id}/rerun"
     },
     {
       "method": "GET",

--- a/orchestrator/router_manifest.py
+++ b/orchestrator/router_manifest.py
@@ -81,6 +81,8 @@ MANIFEST_ROUTERS: tuple[RouterSpec, ...] = (
     # PRD-196 (P2-15) — governance operator surface: audit-log + status (S3),
     # policy posture + budget editors (S4). Ws-admin gated at the router.
     RouterSpec("api.governance"),
+    # PRD-204 S11 -- watchlist read/cancel surface over the watch registry.
+    RouterSpec("api.watches"),
 )
 
 

--- a/orchestrator/services/coordinator_service.py
+++ b/orchestrator/services/coordinator_service.py
@@ -332,6 +332,59 @@ async def _dispatch_mission_event(
         )
 
 
+async def notify_mission_failed(db: Session, run: OrchestrationRun) -> None:
+    """PRD-204 S4: dispatch ``mission_failed`` at the run-failure boundary.
+
+    ONE owner of the failure message shape, called from every async
+    failure site (reconciler task-failure cascades, joiner halt, plan
+    validation). Reuses the ``_dispatch_mission_event`` seam (resolves
+    ``run.created_by`` to a user_id; never raises). Previously a failed
+    run emitted only an internal RUN_FAILED audit event — the user was
+    never told.
+    """
+    detail = run.stop_detail or run.stop_reason or "Mission failed"
+    await _dispatch_mission_event(
+        db=db,
+        run=run,
+        event_type="mission_failed",
+        title=f"Mission failed: {(run.goal or 'Mission')[:110]}",
+        message=str(detail)[:500],
+        status="error",
+    )
+
+
+async def notify_mission_budget_paused(db: Session, run: OrchestrationRun) -> None:
+    """PRD-204 S4: dispatch ``mission_budget_paused`` at the budget-pause
+    transition (the dispatcher blocked and moved the run to PAUSED —
+    previously silent). Single owner of this event; the dead
+    ``escalation_service.notify_budget_exceeded`` board-card path was
+    removed in the same story.
+    """
+    spent = run.budget_spent or {}
+    budget_cfg = run.budget_config or {}
+    parts = []
+    if spent.get("cost") is not None:
+        parts.append(f"spent ${float(spent.get('cost') or 0):.2f}")
+    if budget_cfg.get("max_cost") is not None:
+        parts.append(f"ceiling ${float(budget_cfg['max_cost']):.2f}")
+    if run.token_budget_estimate:
+        parts.append(
+            f"tokens {run.tokens_used or 0}/{run.token_budget_estimate}"
+        )
+    detail = "; ".join(parts) or "budget exceeded"
+    await _dispatch_mission_event(
+        db=db,
+        run=run,
+        event_type="mission_budget_paused",
+        title=f"Mission paused on budget: {(run.goal or 'Mission')[:100]}",
+        message=(
+            f"Budget exceeded ({detail}). Increase the budget and resume "
+            f"to continue."
+        ),
+        status="warning",
+    )
+
+
 # ---------------------------------------------------------------------------
 # Mission cost audit
 # ---------------------------------------------------------------------------
@@ -1417,6 +1470,20 @@ class CoordinatorService:
         # --- Dispatch phase (parallel via dispatch_ready) ---
         dispatch_results = MissionDispatcher.dispatch_ready(db, run, agents)
 
+        # PRD-204 S4: the dispatcher's budget gate pauses silently (sync
+        # code cannot await the dispatcher). This is that transition's
+        # async seam: the run entered dispatch RUNNING and came out PAUSED
+        # with a budget skip reason — tell the user, once (the tick will
+        # not re-process a PAUSED run, so this cannot repeat).
+        if (
+            RunState(run.state) == RunState.PAUSED
+            and any(
+                r.skipped_reason in ("budget_exceeded", "budget_critical_deferred")
+                for r in dispatch_results
+            )
+        ):
+            await notify_mission_budget_paused(db, run)
+
         # Collect successfully dispatched tasks for concurrent execution
         dispatched = [r for r in dispatch_results if r.dispatched]
 
@@ -1666,6 +1733,8 @@ class CoordinatorService:
                 run.id, run.state, exc_info=True,
             )
             return
+        # PRD-204 S4: the user is told the mission failed (joiner halt path).
+        await notify_mission_failed(db, run)
         await _store_mission_memory_safe(
             db, run.id, outcome="failed", failure_reason=reason,
         )
@@ -2302,6 +2371,8 @@ class CoordinatorService:
                 stop_reason="coordinator_error",
                 stop_detail="Plan validation failed after all retries",
             )
+            # PRD-204 S4: the user is told the mission failed (planning path).
+            await notify_mission_failed(db, run)
             await _store_mission_memory_safe(
                 db, run.id, outcome="failed",
                 failure_reason="Plan validation failed after all retries",

--- a/orchestrator/services/coordinator_service.py
+++ b/orchestrator/services/coordinator_service.py
@@ -342,15 +342,28 @@ async def notify_mission_failed(db: Session, run: OrchestrationRun) -> None:
     run emitted only an internal RUN_FAILED audit event -- the user was
     never told.
     """
-    detail = run.stop_detail or run.stop_reason or "Mission failed"
-    await _dispatch_mission_event(
-        db=db,
-        run=run,
-        event_type="mission_failed",
-        title=f"Mission failed: {(run.goal or 'Mission')[:110]}",
-        message=str(detail)[:500],
-        status="error",
-    )
+    try:
+        detail = (
+            getattr(run, "stop_detail", None)
+            or getattr(run, "stop_reason", None)
+            or "Mission failed"
+        )
+        goal = getattr(run, "goal", None) or "Mission"
+        await _dispatch_mission_event(
+            db=db,
+            run=run,
+            event_type="mission_failed",
+            title=f"Mission failed: {goal[:110]}",
+            message=str(detail)[:500],
+            status="error",
+        )
+    except Exception:
+        # A notification must never break the failure path it reports on.
+        logger.error(
+            "[Coordinator] mission_failed notify failed for run %s",
+            getattr(run, "id", "?"),
+            exc_info=True,
+        )
 
 
 async def notify_mission_budget_paused(db: Session, run: OrchestrationRun) -> None:
@@ -360,29 +373,39 @@ async def notify_mission_budget_paused(db: Session, run: OrchestrationRun) -> No
     ``escalation_service.notify_budget_exceeded`` board-card path was
     removed in the same story.
     """
-    spent = run.budget_spent or {}
-    budget_cfg = run.budget_config or {}
-    parts = []
-    if spent.get("cost") is not None:
-        parts.append(f"spent ${float(spent.get('cost') or 0):.2f}")
-    if budget_cfg.get("max_cost") is not None:
-        parts.append(f"ceiling ${float(budget_cfg['max_cost']):.2f}")
-    if run.token_budget_estimate:
-        parts.append(
-            f"tokens {run.tokens_used or 0}/{run.token_budget_estimate}"
+    try:
+        spent = getattr(run, "budget_spent", None) or {}
+        budget_cfg = getattr(run, "budget_config", None) or {}
+        token_budget = getattr(run, "token_budget_estimate", None)
+        parts = []
+        if spent.get("cost") is not None:
+            parts.append(f"spent ${float(spent.get('cost') or 0):.2f}")
+        if budget_cfg.get("max_cost") is not None:
+            parts.append(f"ceiling ${float(budget_cfg['max_cost']):.2f}")
+        if token_budget:
+            parts.append(
+                f"tokens {getattr(run, 'tokens_used', 0) or 0}/{token_budget}"
+            )
+        detail = "; ".join(parts) or "budget exceeded"
+        goal = getattr(run, "goal", None) or "Mission"
+        await _dispatch_mission_event(
+            db=db,
+            run=run,
+            event_type="mission_budget_paused",
+            title=f"Mission paused on budget: {goal[:100]}",
+            message=(
+                f"Budget exceeded ({detail}). Increase the budget and resume "
+                f"to continue."
+            ),
+            status="warning",
         )
-    detail = "; ".join(parts) or "budget exceeded"
-    await _dispatch_mission_event(
-        db=db,
-        run=run,
-        event_type="mission_budget_paused",
-        title=f"Mission paused on budget: {(run.goal or 'Mission')[:100]}",
-        message=(
-            f"Budget exceeded ({detail}). Increase the budget and resume "
-            f"to continue."
-        ),
-        status="warning",
-    )
+    except Exception:
+        # A notification must never break the pause path it reports on.
+        logger.error(
+            "[Coordinator] mission_budget_paused notify failed for run %s",
+            getattr(run, "id", "?"),
+            exc_info=True,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/orchestrator/services/coordinator_service.py
+++ b/orchestrator/services/coordinator_service.py
@@ -339,7 +339,7 @@ async def notify_mission_failed(db: Session, run: OrchestrationRun) -> None:
     failure site (reconciler task-failure cascades, joiner halt, plan
     validation). Reuses the ``_dispatch_mission_event`` seam (resolves
     ``run.created_by`` to a user_id; never raises). Previously a failed
-    run emitted only an internal RUN_FAILED audit event — the user was
+    run emitted only an internal RUN_FAILED audit event -- the user was
     never told.
     """
     detail = run.stop_detail or run.stop_reason or "Mission failed"
@@ -355,7 +355,7 @@ async def notify_mission_failed(db: Session, run: OrchestrationRun) -> None:
 
 async def notify_mission_budget_paused(db: Session, run: OrchestrationRun) -> None:
     """PRD-204 S4: dispatch ``mission_budget_paused`` at the budget-pause
-    transition (the dispatcher blocked and moved the run to PAUSED —
+    transition (the dispatcher blocked and moved the run to PAUSED --
     previously silent). Single owner of this event; the dead
     ``escalation_service.notify_budget_exceeded`` board-card path was
     removed in the same story.
@@ -1473,7 +1473,7 @@ class CoordinatorService:
         # PRD-204 S4: the dispatcher's budget gate pauses silently (sync
         # code cannot await the dispatcher). This is that transition's
         # async seam: the run entered dispatch RUNNING and came out PAUSED
-        # with a budget skip reason — tell the user, once (the tick will
+        # with a budget skip reason -- tell the user, once (the tick will
         # not re-process a PAUSED run, so this cannot repeat).
         if (
             RunState(run.state) == RunState.PAUSED

--- a/orchestrator/services/escalation_service.py
+++ b/orchestrator/services/escalation_service.py
@@ -101,6 +101,70 @@ def check_blocked_escalations(db: Session, workspace_id) -> int:
 # orchestration_board_bridge, so a second escalation card added nothing.
 
 
+def escalate_watch(
+    db: Session,
+    workspace_id,
+    watch,
+    reason: str,
+) -> Optional[BoardTask]:
+    """PRD-204 S8: hand a watch to a human via a board card.
+
+    A watch-flavoured SIBLING of ``escalate_stalled_task`` -- deliberately
+    NOT an overload of the stall semantics (different tags, different copy,
+    different dedupe key). One open escalation card per watch; the
+    ``watch_escalation`` notification is dispatched by the caller
+    (watch_actions), not here -- this module stays sync + DB-only.
+    """
+    watch_id = str(getattr(watch, "id", ""))
+    title = getattr(watch, "title", None) or "watched work"
+
+    existing = (
+        db.query(BoardTask.id)
+        .filter(
+            BoardTask.workspace_id == workspace_id,
+            BoardTask.tags.contains(["escalation", f"watch:{watch_id}"]),
+            BoardTask.status.notin_(["done"]),
+        )
+        .first()
+    )
+    if existing:
+        return None
+
+    target_type = getattr(watch, "target_type", "?")
+    target_id = getattr(watch, "target_id", "?")
+    actions_taken = getattr(watch, "actions_taken", 0) or 0
+    budget = getattr(watch, "action_budget", 0) or 0
+
+    escalation = BoardTask(
+        workspace_id=workspace_id,
+        title=f"Watch escalation: '{title[:90]}'",
+        description=(
+            f"The watcher is handing this to a human.\n\n"
+            f"**Reason:** {reason}\n\n"
+            f"**Watched target:** {target_type}:{target_id}\n"
+            f"**Corrective actions used:** {actions_taken}/{budget}\n\n"
+            f"Review the watch timeline and decide: rerun, replan, reassign, "
+            f"or accept the outcome."
+        ),
+        status="inbox",
+        priority="high",
+        review_mode="human",
+        created_by_type="system",
+        created_by_id="watch_decider",
+        tags=["escalation", f"watch:{watch_id}"],
+    )
+    db.add(escalation)
+    db.flush()
+
+    logger.warning(
+        "Created watch escalation card for watch %s in workspace %s: %s",
+        watch_id,
+        workspace_id,
+        reason,
+    )
+    return escalation
+
+
 def escalate_stalled_task(
     db: Session,
     workspace_id,

--- a/orchestrator/services/escalation_service.py
+++ b/orchestrator/services/escalation_service.py
@@ -1,12 +1,12 @@
 """
-Escalation Service — auto-escalate blocked and repeatedly-stalled tasks.
+Escalation Service -- auto-escalate blocked and repeatedly-stalled tasks.
 
 Creates board tasks for human attention when:
 - A board task has been blocked > 24 hours
 - A task has stalled repeatedly (2+ stalls)
 
 (Budget-paused missions are surfaced by the coordinator's
-``mission_budget_paused`` notification — PRD-204 S4 — not by a board card.)
+``mission_budget_paused`` notification -- PRD-204 S4 -- not by a board card.)
 """
 
 import logging

--- a/orchestrator/services/escalation_service.py
+++ b/orchestrator/services/escalation_service.py
@@ -1,10 +1,12 @@
 """
-Escalation Service — auto-escalate blocked tasks and budget-paused missions.
+Escalation Service — auto-escalate blocked and repeatedly-stalled tasks.
 
 Creates board tasks for human attention when:
 - A board task has been blocked > 24 hours
-- A mission is paused due to budget exceeded
 - A task has stalled repeatedly (2+ stalls)
+
+(Budget-paused missions are surfaced by the coordinator's
+``mission_budget_paused`` notification — PRD-204 S4 — not by a board card.)
 """
 
 import logging
@@ -90,60 +92,13 @@ def check_blocked_escalations(db: Session, workspace_id) -> int:
     return created
 
 
-def notify_budget_exceeded(
-    db: Session,
-    run,
-) -> Optional[BoardTask]:
-    """
-    Create a board task notifying humans that a mission was paused due to budget.
-    Idempotent: won't create duplicate notifications.
-    """
-    workspace_id = run.workspace_id
-
-    # Check for existing notification
-    existing = (
-        db.query(BoardTask.id)
-        .filter(
-            BoardTask.workspace_id == workspace_id,
-            BoardTask.tags.contains(["escalation", f"budget:{run.id}"]),
-            BoardTask.status.notin_(["done"]),
-        )
-        .first()
-    )
-    if existing:
-        return None
-
-    budget_spent = run.budget_spent or {}
-    budget_config = run.budget_config or {}
-    goal = (run.goal or "Mission")[:120]
-
-    escalation = BoardTask(
-        workspace_id=workspace_id,
-        title=f"Budget exceeded: '{goal}' — mission paused",
-        description=(
-            f"Mission `{run.id}` has been paused because its budget was exceeded.\n\n"
-            f"**Goal:** {run.goal}\n\n"
-            f"**Spent:** {budget_spent.get('tokens', 0):,} tokens, ${budget_spent.get('cost', 0):.4f}\n"
-            f"**Budget:** {budget_config.get('max_tokens', 'N/A')} tokens, ${budget_config.get('max_cost', 'N/A')}\n\n"
-            f"To resume, increase the budget and use the resume API."
-        ),
-        status="inbox",
-        priority="urgent",
-        review_mode="human",
-        created_by_type="system",
-        created_by_id="escalation_service",
-        orchestration_run_id=run.id,
-        tags=["escalation", f"budget:{run.id}"],
-    )
-    db.add(escalation)
-    db.flush()
-
-    logger.warning(
-        "Created budget escalation for paused mission %s in workspace %s",
-        run.id,
-        workspace_id,
-    )
-    return escalation
+# PRD-204 S4: notify_budget_exceeded was removed. It was dead code (zero
+# non-test callers since introduction) and duplicated the budget-pause
+# surface. The single owner of that boundary is now the coordinator's
+# ``notify_mission_budget_paused`` (a real ``mission_budget_paused``
+# notification dispatched when the dispatcher's budget gate pauses a run);
+# the paused mission's board card already flips to "blocked" via
+# orchestration_board_bridge, so a second escalation card added nothing.
 
 
 def escalate_stalled_task(

--- a/orchestrator/services/orchestration_board_bridge.py
+++ b/orchestrator/services/orchestration_board_bridge.py
@@ -311,7 +311,7 @@ _RUN_STATE_TO_BOARD_STATUS: dict[str, str] = {
     RunState.AWAITING_HUMAN.value: "review",
     RunState.COMPLETED.value: "done",
     # PRD-204 S4 (OS-review F023): a failed mission's card used to render
-    # "done" — the board was lying. "failed" is a valid board status
+    # "done" -- the board was lying. "failed" is a valid board status
     # (api/board_tasks.VALID_STATUSES). cancelled stays "done": the user
     # deliberately closed it.
     RunState.FAILED.value: "failed",
@@ -359,7 +359,7 @@ def sync_mission_board_status(
     if new_status == "in_progress" and board_task.started_at is None:
         board_task.started_at = run.started_at or datetime.now(timezone.utc)
 
-    # "failed" is terminal for the card too (PRD-204 S4) — stamp completion.
+    # "failed" is terminal for the card too (PRD-204 S4) -- stamp completion.
     if new_status in ("done", "failed") and board_task.completed_at is None:
         board_task.completed_at = run.completed_at or datetime.now(timezone.utc)
 

--- a/orchestrator/services/orchestration_board_bridge.py
+++ b/orchestrator/services/orchestration_board_bridge.py
@@ -310,7 +310,11 @@ _RUN_STATE_TO_BOARD_STATUS: dict[str, str] = {
     RunState.VERIFYING.value: "in_progress",
     RunState.AWAITING_HUMAN.value: "review",
     RunState.COMPLETED.value: "done",
-    RunState.FAILED.value: "done",
+    # PRD-204 S4 (OS-review F023): a failed mission's card used to render
+    # "done" — the board was lying. "failed" is a valid board status
+    # (api/board_tasks.VALID_STATUSES). cancelled stays "done": the user
+    # deliberately closed it.
+    RunState.FAILED.value: "failed",
     RunState.CANCELLED.value: "done",
 }
 
@@ -355,7 +359,8 @@ def sync_mission_board_status(
     if new_status == "in_progress" and board_task.started_at is None:
         board_task.started_at = run.started_at or datetime.now(timezone.utc)
 
-    if new_status == "done" and board_task.completed_at is None:
+    # "failed" is terminal for the card too (PRD-204 S4) — stamp completion.
+    if new_status in ("done", "failed") and board_task.completed_at is None:
         board_task.completed_at = run.completed_at or datetime.now(timezone.utc)
 
     # Store failure info when mission fails

--- a/orchestrator/services/orchestration_state.py
+++ b/orchestrator/services/orchestration_state.py
@@ -292,7 +292,7 @@ def transition_run(
             "Failed to sync mission board status for run %s", run.id, exc_info=True,
         )
 
-    # PRD-204 S3: mission terminal choke point — EVERY run transition to a
+    # PRD-204 S3: mission terminal choke point -- EVERY run transition to a
     # terminal state flows through here (coordinator, reconciler, joiner,
     # human cancel/reject), so one fail-soft hook covers all producers.
     # watch_ingest_terminal never raises (documented fail-soft seam); the

--- a/orchestrator/services/orchestration_state.py
+++ b/orchestrator/services/orchestration_state.py
@@ -292,6 +292,41 @@ def transition_run(
             "Failed to sync mission board status for run %s", run.id, exc_info=True,
         )
 
+    # PRD-204 S3: mission terminal choke point — EVERY run transition to a
+    # terminal state flows through here (coordinator, reconciler, joiner,
+    # human cancel/reject), so one fail-soft hook covers all producers.
+    # watch_ingest_terminal never raises (documented fail-soft seam); the
+    # extra guard mirrors the board-sync seam above so even a broken import
+    # cannot fail the transition.
+    if new_state in TERMINAL_RUN_STATES:
+        try:
+            from services.watch_hooks import watch_ingest_terminal
+
+            cost_snapshot = {
+                "tokens_used": run.tokens_used or 0,
+                "budget_spent": run.budget_spent or {},
+            }
+            watch_ingest_terminal(
+                db,
+                workspace_id=run.workspace_id,
+                target_type="mission",
+                target_id=str(run.id),
+                terminal_state=new_state.value,
+                summary=stop_detail or reason,
+                cost_snapshot=cost_snapshot,
+                output_pointer=(
+                    f"mission:{run.id}:output_summary"
+                    if run.output_summary is not None
+                    else None
+                ),
+            )
+        except Exception:
+            logger.warning(
+                "Watch terminal hook failed for run %s (non-fatal)",
+                run.id,
+                exc_info=True,
+            )
+
     # PRD-123 Pattern #1: Produce frozen transition record
     transition = RunTransition(
         run_id=run.id,

--- a/orchestrator/services/playbook_scheduler.py
+++ b/orchestrator/services/playbook_scheduler.py
@@ -26,6 +26,13 @@ class PlaybookSchedulerService:
     def __init__(self):
         self._scheduler: Optional[AsyncIOScheduler] = None
         self._owns_scheduler: bool = False  # True when we created our own scheduler (tests)
+        # PRD-204 S4: once-per-breaker-open-period latch for playbook_benched.
+        # In-memory is deliberate and sufficient: the scheduler is a
+        # single-owner process (fcntl lock in main.py lifespan), so exactly
+        # one instance observes every skip. Cleared when the breaker closes
+        # (the check passes again); a process restart re-notifies at most
+        # once per still-open breaker, which is acceptable for an alert.
+        self._benched_notified: set[int] = set()
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -185,7 +192,20 @@ class PlaybookSchedulerService:
                     "last %d runs all failed; skipping cron re-fire until a manual run succeeds",
                     playbook.id, playbook.name, _cfg.PLAYBOOK_BREAKER_THRESHOLD,
                 )
+                # PRD-204 S4: the bench used to be a log line only. Notify
+                # the workspace once per breaker-open period (in-memory
+                # latch — see __init__; cleared below when the breaker
+                # closes).
+                if playbook.id not in self._benched_notified:
+                    self._benched_notified.add(playbook.id)
+                    await self._notify_playbook_benched(
+                        db, playbook, _cfg.PLAYBOOK_BREAKER_THRESHOLD
+                    )
                 return
+
+            # Breaker closed — clear the bench latch so the NEXT open period
+            # notifies again.
+            self._benched_notified.discard(playbook.id)
 
             execution_id = f"cron-{uuid4().hex[:12]}"
             execution = RecipeExecution(
@@ -232,6 +252,45 @@ class PlaybookSchedulerService:
             logger.error("[PlaybookScheduler] Failed to fire playbook %d: %s", playbook_id, e, exc_info=True)
         finally:
             db.close()
+
+    # ------------------------------------------------------------------
+    # PRD-204 S4: benched notification
+    # ------------------------------------------------------------------
+
+    async def _notify_playbook_benched(self, db, playbook, threshold: int) -> None:
+        """Dispatch ``playbook_benched`` — the scheduler skipped a cron fire
+        because the repeated-failure breaker is open. Workspace-wide (a
+        scheduled playbook has no single requesting user). Never raises
+        into the fire path.
+
+        The dispatcher never commits (it joins the caller's transaction);
+        the commit below is THIS caller's: ``_fire_playbook`` owns a
+        scheduler-local session whose only pending write on the skip path
+        is the notification row, and the session closes right after.
+        """
+        try:
+            from core.services.notification_dispatcher import NotificationDispatcher
+
+            dispatcher = NotificationDispatcher(db, str(playbook.workspace_id))
+            await dispatcher.dispatch(
+                event_type="playbook_benched",
+                title=f"Playbook benched: {playbook.name}",
+                message=(
+                    f"The last {threshold} runs all failed, so scheduled runs "
+                    f"are paused. Fix the cause and run it manually once to "
+                    f"re-enable the schedule."
+                ),
+                link_type="playbook",
+                link_id=str(playbook.id),
+                status="warning",
+            )
+            db.commit()
+        except Exception:
+            logger.error(
+                "[PlaybookScheduler] playbook_benched dispatch failed for %s",
+                getattr(playbook, "id", "?"),
+                exc_info=True,
+            )
 
     # ------------------------------------------------------------------
     # Status

--- a/orchestrator/services/playbook_scheduler.py
+++ b/orchestrator/services/playbook_scheduler.py
@@ -194,7 +194,7 @@ class PlaybookSchedulerService:
                 )
                 # PRD-204 S4: the bench used to be a log line only. Notify
                 # the workspace once per breaker-open period (in-memory
-                # latch — see __init__; cleared below when the breaker
+                # latch -- see __init__; cleared below when the breaker
                 # closes).
                 if playbook.id not in self._benched_notified:
                     self._benched_notified.add(playbook.id)
@@ -203,7 +203,7 @@ class PlaybookSchedulerService:
                     )
                 return
 
-            # Breaker closed — clear the bench latch so the NEXT open period
+            # Breaker closed -- clear the bench latch so the NEXT open period
             # notifies again.
             self._benched_notified.discard(playbook.id)
 
@@ -258,7 +258,7 @@ class PlaybookSchedulerService:
     # ------------------------------------------------------------------
 
     async def _notify_playbook_benched(self, db, playbook, threshold: int) -> None:
-        """Dispatch ``playbook_benched`` — the scheduler skipped a cron fire
+        """Dispatch ``playbook_benched`` -- the scheduler skipped a cron fire
         because the repeated-failure breaker is open. Workspace-wide (a
         scheduled playbook has no single requesting user). Never raises
         into the fire path.

--- a/orchestrator/services/watch_actions.py
+++ b/orchestrator/services/watch_actions.py
@@ -1,0 +1,746 @@
+"""
+Watch direction-change actions -- PRD-204 S8
+============================================
+
+The mission-watch corrective actions: ``replan`` / ``reassign`` /
+``spawn_agent`` / ``escalate``. Every action rides the SAME rails as S7's
+rerun: ``WatchService.record_action`` is the budget hard-stop (exhausted ->
+escalate), ``evaluate_approval`` is the gate (auto executes now; ask parks
+a ``SUBJECT_PLAYBOOK_RUN`` grant whose ``details.watch_action``
+discriminates -- the S7 resume/deny branches already handle it via the
+``WATCH_GRANT_EXECUTORS`` registry this module populates on import).
+
+Action semantics (all reuse existing production paths -- nothing new grants
+itself powers):
+
+- ``replan``    -- ``CoordinatorService.replan_mission`` (the
+  platform_replan_mission path) with the watch diagnosis as replanner
+  notes; ``failed -> replanning -> running`` transitions stay authoritative.
+- ``reassign``  -- requeue THE failed task to a different capable agent:
+  ``AgentMatcher.rank`` excluding the agent that failed; if none,
+  ``no_capable_agent`` -> escalate. Transition-legal shape (the replan
+  idiom, narrowed): run ``failed -> replanning``, failed task ``->
+  skipped``, a clone task pinned to the chosen agent (``agent_role`` set to
+  the agent's NAME -- the PRD-163 S4 explicit-override the dispatcher
+  always honours), dependency edges re-wired, run ``-> running``, clone
+  ``-> queued``.
+- ``spawn_agent`` -- blueprints only: the workspace must have a blueprint
+  (specified or default); the agent is created through the SAME
+  ``handlers_agents.create_agent`` path Auto uses, then
+  ``blueprint_validator.validate_agent`` stays authoritative (strict-mode
+  failures roll the agent back). Empty/defaulted blueprint ``rules`` pass
+  -- the onboarding-wall regression stays closed. ALWAYS grant-gated in v1
+  (Section 8 Q5): only a ``full_auto`` decision auto-approves;
+  ``auto_below_budget``'s auto lane deliberately does NOT.
+- ``escalate``  -- ``escalation_service.escalate_watch`` board card (a
+  watch-flavoured sibling of the stall escalation, NOT an overload) +
+  ``watch_escalation`` notification + watch ``-> escalated``
+  (terminal-unless-renewed). Never gated, never budgeted: it is the escape
+  hatch.
+
+Budget ordering (documented decision): the action is recorded against the
+budget at INITIATION -- before the gate -- so a grant that a human later
+denies still consumed an attempt. That is deliberate: the budget bounds how
+many times the watcher may ASK the platform to do something, which also
+prevents infinite ask-loops.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+from uuid import uuid4
+
+from sqlalchemy.orm import Session
+
+from core.services.approval_policy import FULL_AUTO, evaluate_approval
+
+logger = logging.getLogger(__name__)
+
+ACTION_RERUN = "rerun"          # playbook watches (S7 owns execution)
+ACTION_REPLAN = "replan"
+ACTION_REASSIGN = "reassign"
+ACTION_SPAWN_AGENT = "spawn_agent"
+ACTION_ESCALATE = "escalate"
+
+MISSION_ACTIONS = frozenset({ACTION_REPLAN, ACTION_REASSIGN, ACTION_SPAWN_AGENT})
+
+
+@dataclass(frozen=True)
+class WatchActionOutcome:
+    """What happened to a requested corrective action."""
+
+    action: str
+    executed: bool = False        # ran to completion now
+    parked: bool = False          # awaiting an approval grant
+    escalated: bool = False       # handed to a human instead
+    grant_id: Optional[int] = None
+    detail: str = ""
+    error: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Cost estimate for the gate
+# ---------------------------------------------------------------------------
+
+
+def estimate_mission_action_cost_usd(run) -> float:
+    """The mission's spend so far -- the honest proxy for redoing the failed
+    subtree (replan/reassign re-run similar work; spawn adds an agent doing
+    similar work)."""
+    spent = (getattr(run, "budget_spent", None) or {}).get("cost")
+    if isinstance(spent, (int, float)) and spent > 0:
+        return float(spent)
+    return 0.0
+
+
+# ---------------------------------------------------------------------------
+# Entry point (used by the S10 decider and, indirectly, the grant resume)
+# ---------------------------------------------------------------------------
+
+
+async def run_mission_action(
+    db: Session,
+    watch,
+    action: str,
+    *,
+    diagnosis: Optional[str] = None,
+    notes: Optional[str] = None,
+    spawn_spec: Optional[Dict[str, Any]] = None,
+) -> WatchActionOutcome:
+    """Attempt a corrective action on a mission watch.
+
+    Flow: resolve run -> (escalate short-circuits) -> budget rail ->
+    approval gate -> execute now / park on grant. Never raises; failures
+    come back as outcomes the decider can escalate on.
+    """
+    from services.watch_service import WatchService
+
+    if action == ACTION_ESCALATE:
+        await escalate_watch_now(
+            db, watch, reason=diagnosis or notes or "Watcher requested escalation"
+        )
+        return WatchActionOutcome(action=action, escalated=True, detail="escalated")
+
+    if action not in MISSION_ACTIONS:
+        return WatchActionOutcome(
+            action=action, error=f"unknown mission action {action!r}"
+        )
+
+    run = _resolve_run(db, watch)
+    if run is None:
+        await escalate_watch_now(
+            db, watch, reason=f"target mission {watch.target_id} no longer exists"
+        )
+        return WatchActionOutcome(
+            action=action, escalated=True, error="target mission missing"
+        )
+
+    # --- budget hard rail (record at initiation; see module docstring) ---
+    _, allowed = WatchService.record_action(
+        db,
+        watch,
+        action=action,
+        summary=diagnosis or f"Watcher corrective action: {action}",
+        snapshot={"diagnosis": diagnosis, "notes": notes},
+    )
+    if not allowed:
+        await escalate_watch_now(
+            db,
+            watch,
+            reason=(
+                f"Action budget exhausted "
+                f"({watch.actions_taken}/{watch.action_budget}) -- "
+                f"refused '{action}'"
+            ),
+        )
+        return WatchActionOutcome(
+            action=action, escalated=True, detail="action budget exhausted"
+        )
+
+    # --- approval gate ---
+    estimated = estimate_mission_action_cost_usd(run)
+    decision = evaluate_approval(db, watch.workspace_id, estimated)
+    auto = decision.auto_approve
+    if action == ACTION_SPAWN_AGENT and decision.policy != FULL_AUTO:
+        # Section 8 Q5: spawn is ALWAYS grant-gated in v1 -- only full_auto
+        # (with the autonomy gate, enforced inside evaluate_approval)
+        # auto-approves; auto_below_budget's auto lane does not apply.
+        auto = False
+
+    if auto:
+        outcome = await _execute_action(
+            db, watch, run, action,
+            diagnosis=diagnosis, notes=notes, spawn_spec=spawn_spec,
+        )
+        if outcome.error and not outcome.escalated:
+            await escalate_watch_now(
+                db, watch, reason=f"'{action}' failed: {outcome.error}"
+            )
+            return WatchActionOutcome(
+                action=action, escalated=True, error=outcome.error
+            )
+        return outcome
+
+    grant = _park_action_grant(
+        db, watch, run, action,
+        decision=decision, diagnosis=diagnosis, notes=notes, spawn_spec=spawn_spec,
+    )
+    await _notify_action_approval_pending(db, watch, grant, action)
+    return WatchActionOutcome(
+        action=action,
+        parked=True,
+        grant_id=grant.id,
+        detail=f"awaiting approval grant {grant.id} ({decision.reason})",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Executors
+# ---------------------------------------------------------------------------
+
+
+async def _execute_action(
+    db: Session,
+    watch,
+    run,
+    action: str,
+    *,
+    diagnosis: Optional[str],
+    notes: Optional[str],
+    spawn_spec: Optional[Dict[str, Any]],
+) -> WatchActionOutcome:
+    if action == ACTION_REPLAN:
+        return await _execute_replan(db, watch, run, diagnosis=diagnosis, notes=notes)
+    if action == ACTION_REASSIGN:
+        return await _execute_reassign(db, watch, run, diagnosis=diagnosis)
+    if action == ACTION_SPAWN_AGENT:
+        return await _execute_spawn_agent(
+            db, watch, run, spawn_spec=spawn_spec, diagnosis=diagnosis
+        )
+    return WatchActionOutcome(action=action, error=f"no executor for {action!r}")
+
+
+async def _execute_replan(
+    db: Session, watch, run, *, diagnosis: Optional[str], notes: Optional[str]
+) -> WatchActionOutcome:
+    """Drive the EXISTING coordinator replan path with the watch diagnosis
+    as replanner context (the platform_replan_mission service method)."""
+    from core.models.orchestration_enums import ActorType
+    from services.coordinator_service import CoordinatorService
+
+    replan_notes = "\n\n".join(
+        p for p in (notes, f"Watcher diagnosis: {diagnosis}" if diagnosis else None) if p
+    ) or None
+
+    try:
+        await CoordinatorService().replan_mission(
+            db,
+            run.id,
+            actor_id="watcher",
+            notes=replan_notes,
+            actor_type=ActorType.COORDINATOR,
+            trigger="watch",
+        )
+    except Exception as exc:  # noqa: BLE001 -- outcome-shaped, caller escalates
+        logger.error(
+            "[WatchActions] replan failed for run %s", run.id, exc_info=True
+        )
+        return WatchActionOutcome(action=ACTION_REPLAN, error=str(exc)[:300])
+
+    _pull_check_forward(db, watch)
+    logger.info("[WatchActions] replanned mission %s for watch %s", run.id, watch.id)
+    return WatchActionOutcome(
+        action=ACTION_REPLAN, executed=True, detail=f"mission {run.id} replanning"
+    )
+
+
+async def _execute_reassign(
+    db: Session,
+    watch,
+    run,
+    *,
+    diagnosis: Optional[str],
+    preferred_agent_name: Optional[str] = None,
+) -> WatchActionOutcome:
+    """Requeue the failed task to a DIFFERENT capable agent."""
+    from core.models.core import Agent
+    from core.models.orchestration import (
+        OrchestrationTask,
+        OrchestrationTaskDependency,
+    )
+    from core.models.orchestration_enums import ActorType, RunState, TaskState
+    from modules.coordination.agent_matcher import AgentMatcher
+    from services.orchestration_board_bridge import (
+        create_task_board_task,
+        sync_board_status,
+    )
+    from services.orchestration_state import transition_run, transition_task
+
+    failed_task = (
+        db.query(OrchestrationTask)
+        .filter(
+            OrchestrationTask.run_id == run.id,
+            OrchestrationTask.state == TaskState.FAILED.value,
+        )
+        .order_by(OrchestrationTask.sequence_number)
+        .first()
+    )
+    if failed_task is None:
+        return WatchActionOutcome(
+            action=ACTION_REASSIGN, error="no failed task to reassign"
+        )
+
+    # --- choose the replacement agent (capability matching, prior excluded)
+    input_context = failed_task.input_context if isinstance(failed_task.input_context, dict) else {}
+    prior_agent_id = (input_context.get("agent_match") or {}).get("agent_id")
+
+    if preferred_agent_name:
+        chosen_name = preferred_agent_name  # spawn path pins its new agent
+    else:
+        agents = (
+            db.query(Agent)
+            .filter(Agent.workspace_id == run.workspace_id, Agent.status == "active")
+            .all()
+        )
+        ranked = AgentMatcher.rank(
+            db,
+            failed_task,
+            agents,
+            task_spec={
+                "agent_role": failed_task.agent_role,
+                "required_tools": input_context.get("required_tools", []),
+            },
+        )
+        candidates = [r for r in ranked if r.agent_id != prior_agent_id]
+        if not candidates:
+            return WatchActionOutcome(
+                action=ACTION_REASSIGN, error="no_capable_agent"
+            )
+        chosen_name = candidates[0].agent_name
+
+    # --- transition-legal requeue (narrow replan shape) ---
+    try:
+        transition_run(
+            db, run=run, new_state=RunState.REPLANNING,
+            actor_type=ActorType.COORDINATOR, actor_id="watcher",
+            reason=f"Watch reassign of task {failed_task.id} -> {chosen_name}",
+        )
+
+        failed_task.failure_reason_code = "reassigned_by_watch"
+        failed_task.failure_detail = (
+            f"Reassigned by the watcher to '{chosen_name}'"
+            + (f": {diagnosis}" if diagnosis else "")
+        )
+        transition_task(
+            db, task=failed_task, new_state=TaskState.SKIPPED,
+            actor_type=ActorType.COORDINATOR, actor_id="watcher",
+            reason="Replaced by watch reassign",
+        )
+        sync_board_status(db, failed_task)
+
+        clone = OrchestrationTask(
+            run_id=run.id,
+            title=failed_task.title,
+            description=failed_task.description,
+            task_type=failed_task.task_type,
+            sequence_number=failed_task.sequence_number,
+            agent_role=chosen_name,  # explicit-override pin (PRD-163 S4)
+            state=TaskState.PENDING.value,
+            state_type="initial",
+            verification_criteria=failed_task.verification_criteria,
+            input_context={
+                **{k: v for k, v in input_context.items() if k != "agent_match"},
+                "watch_reassign": {
+                    "replaces_task_id": str(failed_task.id),
+                    "excluded_agent_id": prior_agent_id,
+                    "diagnosis": diagnosis,
+                },
+            },
+            max_retries=failed_task.max_retries,
+            complexity=failed_task.complexity,
+            estimated_tokens=failed_task.estimated_tokens,
+        )
+        db.add(clone)
+        db.flush()
+
+        # Clone inherits the failed task's prerequisites; dependents repoint.
+        for dep in (
+            db.query(OrchestrationTaskDependency)
+            .filter(OrchestrationTaskDependency.task_id == failed_task.id)
+            .all()
+        ):
+            db.add(
+                OrchestrationTaskDependency(
+                    task_id=clone.id, depends_on_task_id=dep.depends_on_task_id
+                )
+            )
+        db.query(OrchestrationTaskDependency).filter(
+            OrchestrationTaskDependency.depends_on_task_id == failed_task.id
+        ).update(
+            {OrchestrationTaskDependency.depends_on_task_id: clone.id},
+            synchronize_session=False,
+        )
+
+        transition_run(
+            db, run=run, new_state=RunState.RUNNING,
+            actor_type=ActorType.COORDINATOR, actor_id="watcher",
+            reason="Watch reassign complete -- resuming",
+        )
+        transition_task(
+            db, task=clone, new_state=TaskState.QUEUED,
+            actor_type=ActorType.COORDINATOR, actor_id="watcher",
+            reason=f"Queued for '{chosen_name}' after watch reassign",
+        )
+        try:
+            create_task_board_task(db, run, clone)
+        except Exception:
+            logger.warning(
+                "[WatchActions] board card for reassigned task failed (non-fatal)",
+                exc_info=True,
+            )
+        sync_board_status(db, clone)
+    except Exception as exc:  # noqa: BLE001 -- outcome-shaped, caller escalates
+        logger.error(
+            "[WatchActions] reassign failed for run %s", run.id, exc_info=True
+        )
+        return WatchActionOutcome(action=ACTION_REASSIGN, error=str(exc)[:300])
+
+    _pull_check_forward(db, watch)
+    logger.info(
+        "[WatchActions] reassigned task %s -> %s (clone %s) for watch %s",
+        failed_task.id,
+        chosen_name,
+        clone.id,
+        watch.id,
+    )
+    return WatchActionOutcome(
+        action=ACTION_REASSIGN,
+        executed=True,
+        detail=f"task requeued to '{chosen_name}'",
+    )
+
+
+async def _execute_spawn_agent(
+    db: Session,
+    watch,
+    run,
+    *,
+    spawn_spec: Optional[Dict[str, Any]],
+    diagnosis: Optional[str],
+) -> WatchActionOutcome:
+    """Instantiate an agent from an existing blueprint ONLY, then put it to
+    work (reassign onto it; replan when there is no failed task)."""
+    from core.models.orchestration import OrchestrationTask
+    from core.models.orchestration_enums import TaskState
+    from modules.tools.discovery.handlers_agents import create_agent
+    from services.blueprint_validator import (
+        get_blueprint_by_id,
+        get_default_blueprint,
+        validate_agent,
+    )
+
+    spec = dict(spawn_spec or {})
+
+    # Blueprints only -- no free-form spawning (Section 8 Q5).
+    blueprint = None
+    blueprint_id = spec.get("blueprint_id")
+    if blueprint_id:
+        try:
+            from uuid import UUID as _UUID
+
+            blueprint = get_blueprint_by_id(db, run.workspace_id, _UUID(str(blueprint_id)))
+        except (ValueError, TypeError):
+            blueprint = None
+    else:
+        blueprint = get_default_blueprint(db, run.workspace_id)
+    if blueprint is None:
+        return WatchActionOutcome(
+            action=ACTION_SPAWN_AGENT,
+            error="no blueprint available (spawn is blueprints-only)",
+        )
+
+    failed_task = (
+        db.query(OrchestrationTask)
+        .filter(
+            OrchestrationTask.run_id == run.id,
+            OrchestrationTask.state == TaskState.FAILED.value,
+        )
+        .order_by(OrchestrationTask.sequence_number)
+        .first()
+    )
+    role = (failed_task.agent_role if failed_task is not None else None) or "specialist"
+    name = spec.get("name") or f"{role}-watch-{uuid4().hex[:6]}"
+
+    params: Dict[str, Any] = {
+        "name": name,
+        "agent_type": spec.get("agent_type", "chatbot"),
+        "description": spec.get("description")
+        or f"Spawned by the watcher from blueprint '{blueprint.name}' to recover mission {run.id}",
+        "tags": ["watch-spawned", f"blueprint:{blueprint.id}"],
+    }
+    if spec.get("system_prompt"):
+        params["system_prompt"] = spec["system_prompt"]
+    if spec.get("model_id"):
+        params["model_id"] = spec["model_id"]
+
+    result = await create_agent(db, run.workspace_id, params)
+    if not result.get("success"):
+        return WatchActionOutcome(
+            action=ACTION_SPAWN_AGENT,
+            error=f"agent creation failed: {result.get('error')}"[:300],
+        )
+    agent_id = result["agent"]["id"]
+
+    # Blueprint rules validation stays authoritative. Defaulted/empty rules
+    # pass cleanly (onboarding-wall guard); strict-mode failures roll the
+    # spawn back.
+    validation = validate_agent(db, run.workspace_id, agent_id, blueprint_id=blueprint.id)
+    if validation.get("enforce_mode") == "strict" and not validation.get("pass"):
+        from core.models.core import Agent
+
+        db.query(Agent).filter(Agent.id == agent_id).delete()
+        db.flush()
+        return WatchActionOutcome(
+            action=ACTION_SPAWN_AGENT,
+            error=(
+                "blueprint validation failed: "
+                + "; ".join(validation.get("failures", []))
+            )[:300],
+        )
+
+    # Put the new agent to work.
+    if failed_task is not None:
+        follow_up = await _execute_reassign(
+            db, watch, run, diagnosis=diagnosis, preferred_agent_name=name
+        )
+    else:
+        follow_up = await _execute_replan(
+            db, watch, run,
+            diagnosis=diagnosis,
+            notes=f"A new agent '{name}' (id {agent_id}) was spawned to help; assign it the failed work.",
+        )
+    if follow_up.error:
+        return WatchActionOutcome(
+            action=ACTION_SPAWN_AGENT,
+            error=f"agent {agent_id} spawned but follow-up {follow_up.action} failed: {follow_up.error}"[:300],
+        )
+
+    detail = f"spawned agent '{name}' (id {agent_id}) and {follow_up.detail}"
+    warnings = validation.get("warnings") or []
+    if warnings:
+        detail += f" (blueprint warnings: {'; '.join(warnings)[:200]})"
+    logger.info("[WatchActions] %s for watch %s", detail, watch.id)
+    return WatchActionOutcome(action=ACTION_SPAWN_AGENT, executed=True, detail=detail)
+
+
+# ---------------------------------------------------------------------------
+# Escalate (the ungated escape hatch)
+# ---------------------------------------------------------------------------
+
+
+async def escalate_watch_now(db: Session, watch, *, reason: str) -> None:
+    """Board card + watch_escalation notification + watch -> escalated."""
+    from core.models.watch_enums import WatchEventType, WatchStatus
+    from services.escalation_service import escalate_watch
+    from services.watch_notifications import dispatch_watch_notification
+    from services.watch_service import WatchService
+
+    try:
+        card = escalate_watch(db, watch.workspace_id, watch, reason)
+    except Exception:
+        logger.error(
+            "[WatchActions] escalation card failed for watch %s",
+            getattr(watch, "id", "?"),
+            exc_info=True,
+        )
+        card = None
+
+    WatchService.ingest(
+        db,
+        watch,
+        event_type=WatchEventType.STATUS_CHANGE.value,
+        event_key=f"escalated:{watch.target_type}:{watch.target_id}:{watch.actions_taken or 0}",
+        summary=f"Escalated to a human: {reason}",
+        snapshot={"board_task_id": getattr(card, "id", None)},
+        requires_attention=True,
+    )
+    if WatchStatus(watch.status) != WatchStatus.ESCALATED:
+        WatchService.transition(db, watch, WatchStatus.ESCALATED, reason=reason)
+
+    await dispatch_watch_notification(
+        db,
+        watch,
+        event_type="watch_escalation",
+        title=f"Watch escalated: {(watch.title or '')[:100]}",
+        message=reason,
+        status="warning",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Grant parking + resume executors (the S7 playbook_run flow, more actions)
+# ---------------------------------------------------------------------------
+
+
+def _park_action_grant(
+    db: Session,
+    watch,
+    run,
+    action: str,
+    *,
+    decision,
+    diagnosis: Optional[str],
+    notes: Optional[str],
+    spawn_spec: Optional[Dict[str, Any]],
+):
+    """PENDING SUBJECT_PLAYBOOK_RUN grant carrying the mission-action spec.
+
+    One pending corrective action per run at a time (idempotency via
+    find_pending_grant -- a second ask reuses the pending grant).
+    """
+    from core.models.approval_grants import SUBJECT_PLAYBOOK_RUN
+    from core.models.watch_enums import WatchEventType, WatchStatus
+    from core.services.approval_grants import create_grant, find_pending_grant
+    from services.watch_service import WatchService
+
+    existing = find_pending_grant(
+        db,
+        watch.workspace_id,
+        subject_type=SUBJECT_PLAYBOOK_RUN,
+        subject_id=str(run.id),
+    )
+    grant = existing
+    if grant is None:
+        grant = create_grant(
+            db,
+            watch.workspace_id,
+            subject_type=SUBJECT_PLAYBOOK_RUN,
+            subject_id=str(run.id),
+            tool_name=f"watch_{action}",
+            reason=decision.reason,
+            estimated_cost_usd=decision.estimated_cost,
+        )
+        grant.details = {
+            "watch_action": action,
+            "watch_id": str(watch.id),
+            "mission_id": str(run.id),
+            "spec": {
+                "diagnosis": diagnosis,
+                "notes": notes,
+                "spawn_spec": spawn_spec,
+            },
+        }
+        db.flush()
+
+    WatchService.ingest(
+        db,
+        watch,
+        event_type=WatchEventType.STATUS_CHANGE.value,
+        event_key=f"grant-pending:{grant.id}",
+        summary=f"Corrective action '{action}' parked on approval grant {grant.id}",
+        snapshot={"grant_id": grant.id, "watch_action": action},
+    )
+    if WatchStatus(watch.status) != WatchStatus.AWAITING_APPROVAL:
+        WatchService.transition(
+            db, watch, WatchStatus.AWAITING_APPROVAL,
+            reason=f"awaiting grant {grant.id}",
+        )
+    return grant
+
+
+async def _notify_action_approval_pending(db: Session, watch, grant, action: str) -> None:
+    from services.watch_notifications import dispatch_watch_notification
+
+    await dispatch_watch_notification(
+        db,
+        watch,
+        event_type="approval_pending",
+        title=f"Approval needed: {action} for '{(watch.title or '')[:80]}'",
+        message=(
+            f"The watcher wants to run '{action}' on the watched mission "
+            f"(grant {grant.id}, estimated ${float(grant.estimated_cost_usd or 0):.2f}). "
+            "Review it in the approvals inbox."
+        ),
+        status="warning",
+    )
+
+
+def _resolve_run(db: Session, watch):
+    from core.models.orchestration import OrchestrationRun
+
+    try:
+        return (
+            db.query(OrchestrationRun)
+            .filter(
+                OrchestrationRun.id == watch.target_id,
+                OrchestrationRun.workspace_id == watch.workspace_id,
+            )
+            .first()
+        )
+    except Exception:
+        logger.warning(
+            "[WatchActions] run resolve failed for %s", watch.target_id, exc_info=True
+        )
+        return None
+
+
+def _pull_check_forward(db: Session, watch) -> None:
+    """The corrective attempt is in flight -- recheck promptly."""
+    from datetime import datetime, timezone
+
+    try:
+        watch.next_check_at = datetime.now(timezone.utc)
+        db.flush()
+    except Exception:
+        logger.debug("[WatchActions] next_check pull failed", exc_info=True)
+
+
+# ---------------------------------------------------------------------------
+# Grant-resume executors (registered into the S7 registry on import)
+# ---------------------------------------------------------------------------
+
+
+async def _grant_execute_mission_action(db: Session, grant) -> Dict[str, Any]:
+    """Execute a granted mission action from its stored spec. The grant is
+    already the approval -- no second gate, no second budget charge."""
+    from services.watch_rerun import _load_watch, _resume_watch_to_watching
+
+    details = dict(grant.details) if isinstance(grant.details, dict) else {}
+    action = details.get("watch_action")
+    spec = details.get("spec") or {}
+    watch = _load_watch(db, grant)
+    if watch is None:
+        return {"success": False, "error": "watch no longer exists"}
+
+    run = _resolve_run(db, watch)
+    if run is None:
+        return {"success": False, "error": "target mission no longer exists"}
+
+    _resume_watch_to_watching(db, watch)
+    outcome = await _execute_action(
+        db,
+        watch,
+        run,
+        action,
+        diagnosis=spec.get("diagnosis"),
+        notes=spec.get("notes"),
+        spawn_spec=spec.get("spawn_spec"),
+    )
+    if outcome.error:
+        await escalate_watch_now(
+            db, watch, reason=f"granted '{action}' failed: {outcome.error}"
+        )
+        return {"success": False, "error": outcome.error}
+    return {"success": True, "detail": outcome.detail}
+
+
+def _register_grant_executors() -> None:
+    from services.watch_rerun import WATCH_GRANT_EXECUTORS
+
+    for action in (ACTION_REPLAN, ACTION_REASSIGN, ACTION_SPAWN_AGENT):
+        WATCH_GRANT_EXECUTORS.setdefault(action, _grant_execute_mission_action)
+
+
+_register_grant_executors()

--- a/orchestrator/services/watch_decider.py
+++ b/orchestrator/services/watch_decider.py
@@ -1,0 +1,896 @@
+"""
+Watch decision step -- PRD-204 S10
+==================================
+
+The deterministic brain between "terminal observed" and "watch closed".
+``WatchService.ingest_terminal`` records the terminal and pulls the next
+check forward; the ticker claims the watch and hands it here. Policy is a
+DATA TABLE (golden-file tested), not scattered ifs:
+
+    POLICY_TABLE[policy] = {
+        scores:             score the run output (S6 RunVerdictService)
+        acts_on_low_score:  below-threshold completed run -> diagnose + act
+        acts_on_failure:    failed run -> diagnose + act
+        compares:           build a before/after change report from lineage
+        recurring:          never closes on target terminal (persistent)
+    }
+
+Decision spine per terminal:
+    cancelled/unknown   -- handled at ingest (S2 semantics unchanged)
+    persistent          -- record meaningful change, notify on flip, stay
+    score (if scores)   -- S6 verdict -> final_score/final_verdict; a failed
+                           judge degrades to close-by-outcome (fail-soft)
+    pass                -- close PASSED + watch_verdict notification
+    low score / failure -- if the policy acts AND no improve cycle was spent
+                           (ONE tweak+rerun, then rescore -> final):
+                           diagnose (LLM job a) -> choose allowed action ->
+                           playbook: record_action + S7 request_rerun
+                           mission:  S8 run_mission_action (own budget+gate)
+                           else close FAILED + watch_verdict
+    action budget       -- record_action / run_mission_action hard-stop ->
+                           escalate (board card + watch_escalation)
+
+LLM is used for EXACTLY two bounded jobs (single calls, cost-attributed
+``request_type='watch'`` / ``execution_id='watch-<id>'`` like S6):
+(a) failure/low-score diagnosis -> one-paragraph cause + proposed action +
+optional step_overrides draft; (b) tweak drafting when a tweak was proposed
+without overrides. Never loops -- ``action_budget`` is the hard rail.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Optional
+
+from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# The policy table (S10) -- golden-file locked in tests/golden/
+# ---------------------------------------------------------------------------
+
+POLICY_TABLE: Dict[str, Dict[str, bool]] = {
+    "run_and_report": {
+        "scores": True,
+        "acts_on_low_score": False,
+        "acts_on_failure": False,
+        "compares": False,
+        "recurring": False,
+    },
+    "score_and_improve": {
+        "scores": True,
+        "acts_on_low_score": True,
+        "acts_on_failure": True,
+        "compares": False,
+        "recurring": False,
+    },
+    "watch_change": {
+        "scores": True,
+        "acts_on_low_score": False,
+        "acts_on_failure": False,
+        "compares": True,
+        "recurring": False,
+    },
+    "persistent": {
+        "scores": False,
+        "acts_on_low_score": False,
+        "acts_on_failure": False,
+        "compares": False,
+        "recurring": True,
+    },
+}
+
+# Default corrective vocabulary per watch shape (watch.allowed_actions
+# overrides). tweak_rerun collapses onto the S7 rerun with step_overrides.
+DEFAULT_ALLOWED_ACTIONS: Dict[str, List[str]] = {
+    "mission": ["replan", "reassign", "spawn_agent", "escalate"],
+    "playbook_execution": ["rerun", "tweak_rerun", "escalate"],
+    "board_task": ["escalate"],
+    "scheduled_playbook": ["escalate"],
+}
+
+_COMPLETED_STATES = frozenset({"completed", "verified", "done"})
+
+# Decision labels (returned for logging/tests)
+DECIDED_PASSED = "closed_passed"
+DECIDED_FAILED = "closed_failed"
+DECIDED_ACTED = "acted"
+DECIDED_PARKED = "parked_on_grant"
+DECIDED_ESCALATED = "escalated"
+DECIDED_RECORDED = "recorded_change"
+DECIDED_NOOP = "noop"
+
+
+# ---------------------------------------------------------------------------
+# Diagnosis (LLM job a) + tweak drafting (LLM job b)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Diagnosis:
+    """One bounded LLM read of why the run came up short."""
+
+    cause: str
+    proposed_action: str
+    step_overrides: Optional[Dict[str, Dict[str, str]]] = None
+    confidence: float = 0.5
+
+
+_DIAGNOSIS_SYSTEM_PROMPT = """\
+You are the diagnosis step of a work supervisor. A launched unit of work
+finished badly (failed, or scored below its quality bar). Read the evidence
+and answer with ONE root cause and ONE proposed next action.
+
+Rules:
+- cause: one paragraph, concrete, grounded in the evidence given.
+- proposed_action: exactly one of the allowed actions you are given.
+- step_overrides: ONLY when you propose tweak_rerun and can write a better
+  prompt for a specific step id; otherwise null.
+- Return ONLY a single JSON object.
+"""
+
+_TWEAK_SYSTEM_PROMPT = """\
+You are drafting a one-shot prompt tweak for a playbook step that produced
+weak output. Rewrite the step prompt to fix the diagnosed problem while
+keeping the step's original job. Return ONLY a JSON object:
+{"step_overrides": {"<step_id>": {"prompt_template": "..."}}}
+"""
+
+
+def _default_llm_factory(watch, model: Optional[str] = None):
+    """Same cost attribution as S6: request_type='watch', watch-scoped
+    execution_id."""
+    from core.llm import create_llm_manager
+
+    llm = create_llm_manager(
+        service_name="watch_decider",
+        model=model,
+        workspace_id=getattr(watch, "workspace_id", None),
+        request_type="watch",
+    )
+    if hasattr(llm, "_tracking_ctx"):
+        llm._tracking_ctx["request_type"] = "watch"
+        llm._tracking_ctx["execution_id"] = f"watch-{getattr(watch, 'id', 'unknown')}"
+    return llm
+
+
+class WatchDiagnoser:
+    """The two bounded LLM jobs. Injectable factory; always stubbed in CI."""
+
+    def __init__(self, llm_factory: Optional[Callable[..., Any]] = None):
+        self._llm_factory = llm_factory or _default_llm_factory
+
+    async def diagnose(
+        self,
+        db: Session,
+        watch,
+        *,
+        terminal_state: str,
+        verdict_reasoning: Optional[str],
+        allowed_actions: List[str],
+    ) -> Optional[Diagnosis]:
+        """Single diagnosis call. None on any failure (caller falls back to
+        the deterministic default action)."""
+        evidence = self._collect_evidence(db, watch, terminal_state)
+        prompt = f"""\
+## What was asked
+{getattr(watch, 'success_criteria', None) or getattr(watch, 'title', '')}
+
+## What happened
+Terminal state: {terminal_state}
+{f"Verdict reasoning: {verdict_reasoning}" if verdict_reasoning else ""}
+
+## Evidence
+{evidence}
+
+## Allowed actions
+{allowed_actions}
+
+## Required JSON output
+{{
+  "cause": "one-paragraph root cause",
+  "proposed_action": "one of {allowed_actions}",
+  "step_overrides": {{"<step_id>": {{"prompt_template": "..."}}}} or null,
+  "confidence": 0.0-1.0
+}}
+"""
+        raw = await self._call_json(
+            watch,
+            [
+                {"role": "system", "content": _DIAGNOSIS_SYSTEM_PROMPT},
+                {"role": "user", "content": prompt},
+            ],
+        )
+        if raw is None:
+            return None
+
+        proposed = str(raw.get("proposed_action") or "").strip()
+        if proposed not in allowed_actions:
+            proposed = ""
+        overrides = raw.get("step_overrides")
+        if not isinstance(overrides, dict) or not overrides:
+            overrides = None
+        confidence = raw.get("confidence", 0.5)
+        confidence = (
+            max(0.0, min(1.0, float(confidence)))
+            if isinstance(confidence, (int, float))
+            else 0.5
+        )
+        return Diagnosis(
+            cause=str(raw.get("cause") or "").strip()[:2000],
+            proposed_action=proposed,
+            step_overrides=overrides,
+            confidence=confidence,
+        )
+
+    async def draft_tweak(
+        self, db: Session, watch, *, diagnosis: Diagnosis
+    ) -> Optional[Dict[str, Dict[str, str]]]:
+        """LLM job b: draft step_overrides for a proposed tweak that came
+        without them. Single call; None on failure (plain rerun instead)."""
+        steps_text = self._collect_recipe_steps(db, watch)
+        if not steps_text:
+            return None
+        prompt = f"""\
+## Diagnosed problem
+{diagnosis.cause}
+
+## Playbook steps (id + current prompt)
+{steps_text}
+
+Return the JSON tweak now.
+"""
+        raw = await self._call_json(
+            watch,
+            [
+                {"role": "system", "content": _TWEAK_SYSTEM_PROMPT},
+                {"role": "user", "content": prompt},
+            ],
+        )
+        if raw is None:
+            return None
+        overrides = raw.get("step_overrides")
+        return overrides if isinstance(overrides, dict) and overrides else None
+
+    # -- internals -----------------------------------------------------
+
+    async def _call_json(self, watch, messages) -> Optional[Dict[str, Any]]:
+        from modules.coordination.verification import _extract_judge_json
+
+        try:
+            llm = self._llm_factory(watch)
+            response = await llm.generate_response(messages)
+            return _extract_judge_json(getattr(response, "content", None))
+        except Exception:
+            logger.error(
+                "[WatchDecider] LLM call failed for watch %s",
+                getattr(watch, "id", "?"),
+                exc_info=True,
+            )
+            return None
+
+    @staticmethod
+    def _collect_evidence(db: Session, watch, terminal_state: str) -> str:
+        """Compact, deterministic evidence block (no LLM)."""
+        try:
+            if watch.target_type == "playbook_execution":
+                from core.models.core import RecipeExecution
+
+                execution = (
+                    db.query(RecipeExecution)
+                    .filter(RecipeExecution.execution_id == watch.target_id)
+                    .first()
+                )
+                if execution is None:
+                    return "(target execution missing)"
+                steps = [
+                    {
+                        "step_id": sr.get("step_id"),
+                        "status": sr.get("status"),
+                        "error": (str(sr.get("error"))[:200] if sr.get("error") else None),
+                        "retries": sr.get("retries", 0),
+                    }
+                    for sr in (execution.step_results or [])
+                    if isinstance(sr, dict)
+                ]
+                return json.dumps(
+                    {
+                        "error_message": (execution.error_message or "")[:500],
+                        "step_results": steps,
+                    },
+                    default=str,
+                )[:4000]
+
+            if watch.target_type == "mission":
+                from core.models.orchestration import OrchestrationTask
+
+                failed = (
+                    db.query(OrchestrationTask)
+                    .filter(
+                        OrchestrationTask.run_id == watch.target_id,
+                        OrchestrationTask.state == "failed",
+                    )
+                    .order_by(OrchestrationTask.sequence_number)
+                    .all()
+                )
+                return json.dumps(
+                    {
+                        "failed_tasks": [
+                            {
+                                "title": t.title,
+                                "agent_role": t.agent_role,
+                                "failure": (t.failure_detail or t.failure_reason_code or "")[:300],
+                            }
+                            for t in failed
+                        ]
+                    },
+                    default=str,
+                )[:4000]
+        except Exception:
+            logger.warning("[WatchDecider] evidence collection failed", exc_info=True)
+        return "(no structured evidence available)"
+
+    @staticmethod
+    def _collect_recipe_steps(db: Session, watch) -> Optional[str]:
+        try:
+            from core.models.core import RecipeExecution, WorkflowTemplate
+
+            execution = (
+                db.query(RecipeExecution)
+                .filter(RecipeExecution.execution_id == watch.target_id)
+                .first()
+            )
+            if execution is None:
+                return None
+            recipe = (
+                db.query(WorkflowTemplate)
+                .filter(WorkflowTemplate.id == execution.recipe_id)
+                .first()
+            )
+            if recipe is None:
+                return None
+            lines = [
+                f"- {s.get('step_id')}: {str(s.get('prompt_template') or '')[:300]}"
+                for s in (recipe.steps or [])
+                if isinstance(s, dict)
+            ]
+            return "\n".join(lines)[:4000] or None
+        except Exception:
+            logger.warning("[WatchDecider] step collection failed", exc_info=True)
+            return None
+
+
+# ---------------------------------------------------------------------------
+# The decider
+# ---------------------------------------------------------------------------
+
+
+class WatchDecider:
+    """Deterministic policy spine. Stateless besides injected seams."""
+
+    def __init__(self, verdict_service=None, diagnoser: Optional[WatchDiagnoser] = None):
+        self._verdict_service = verdict_service
+        self._diagnoser = diagnoser or WatchDiagnoser()
+
+    # -- policy helpers -------------------------------------------------
+
+    @staticmethod
+    def policy_flags(policy: str) -> Dict[str, bool]:
+        return POLICY_TABLE.get(policy, POLICY_TABLE["run_and_report"])
+
+    @staticmethod
+    def allowed_actions(watch) -> List[str]:
+        configured = getattr(watch, "allowed_actions", None)
+        if isinstance(configured, list) and configured:
+            return [str(a) for a in configured]
+        return list(
+            DEFAULT_ALLOWED_ACTIONS.get(watch.target_type, ["escalate"])
+        )
+
+    def _verdicts(self):
+        if self._verdict_service is None:
+            from modules.coordination.run_verdict import RunVerdictService
+
+            self._verdict_service = RunVerdictService()
+        return self._verdict_service
+
+    # -- entry point (ticker calls this on a claimed, live watch) -------
+
+    async def decide_terminal(
+        self, db: Session, watch, terminal_state: str, now
+    ) -> str:
+        """Run the policy table against a terminal target. Returns a
+        decision label (logging/tests). Never raises into the tick."""
+        from core.models.watch_enums import CLAIMABLE_WATCH_STATUSES, WatchStatus
+
+        if WatchStatus(watch.status) not in CLAIMABLE_WATCH_STATUSES:
+            return DECIDED_NOOP
+
+        flags = self.policy_flags(watch.policy)
+
+        if flags["recurring"]:
+            return await self._observe_persistent(db, watch, terminal_state)
+
+        # --- score (S6) ---
+        verdict = None
+        if flags["scores"]:
+            verdict = await self._score(db, watch)
+
+        completed = terminal_state in _COMPLETED_STATES
+        scored = verdict is not None and verdict.score is not None
+        passed = bool(
+            completed
+            and (
+                not flags["scores"]
+                or not scored  # judge unavailable -> close by outcome
+                or verdict.passes(watch.quality_threshold or 0.8)
+            )
+        )
+
+        if flags["compares"]:
+            self._record_change_report(db, watch, verdict)
+
+        if passed:
+            return await self._close(
+                db,
+                watch,
+                passed=True,
+                terminal_state=terminal_state,
+                explanation=(verdict.reasoning if verdict else None)
+                or "The watched work completed.",
+            )
+
+        # --- below threshold or failed ---
+        acts = flags["acts_on_failure"] if not completed else flags["acts_on_low_score"]
+        improve_spent = (watch.actions_taken or 0) > 0
+        budget_left = (watch.actions_taken or 0) < (watch.action_budget or 0)
+        if acts and not improve_spent:
+            if not budget_left:
+                # Runaway guard: action_budget=0 -> straight to escalate,
+                # no diagnosis LLM spend when no action is possible.
+                from services.watch_actions import escalate_watch_now
+
+                await escalate_watch_now(
+                    db,
+                    watch,
+                    reason=(
+                        f"Run ended '{terminal_state}' below the bar and the "
+                        f"action budget is 0 -- handing to a human."
+                    ),
+                )
+                return DECIDED_ESCALATED
+            return await self._diagnose_and_act(
+                db, watch, terminal_state=terminal_state, verdict=verdict
+            )
+
+        explanation = self._failure_explanation(watch, terminal_state, verdict, improve_spent)
+        watch.final_verdict = explanation
+        return await self._close(
+            db,
+            watch,
+            passed=False,
+            terminal_state=terminal_state,
+            explanation=explanation,
+        )
+
+    # -- persistent -----------------------------------------------------
+
+    async def _observe_persistent(self, db: Session, watch, terminal_state: str) -> str:
+        """Recurring watch on a run-shaped target: record the observation,
+        notify on a meaningful CHANGE, never close on terminal (deadline
+        expiry is the ticker's job)."""
+        from core.models.watch_enums import WatchEventType
+        from services.watch_notifications import dispatch_watch_notification
+        from services.watch_service import WatchService
+
+        event = WatchService.ingest(
+            db,
+            watch,
+            event_type=WatchEventType.CHANGE_REPORT.value,
+            event_key=f"observed:{watch.target_type}:{watch.target_id}:{terminal_state}",
+            summary=f"Observed terminal state '{terminal_state}'",
+            snapshot={"terminal_state": terminal_state},
+        )
+        if event is None:
+            return DECIDED_NOOP  # same observation already recorded
+
+        previous = self._previous_observation(db, watch, before_event_id=event.id)
+        if previous is not None and previous != terminal_state:
+            degraded = terminal_state == "failed"
+            await dispatch_watch_notification(
+                db,
+                watch,
+                event_type="watch_escalation" if degraded else "watch_verdict",
+                title=(
+                    f"Watched work {'degraded' if degraded else 'recovered'}: "
+                    f"{(watch.title or '')[:90]}"
+                ),
+                message=(
+                    f"State changed '{previous}' -> '{terminal_state}' on "
+                    f"{watch.target_type} {watch.target_id}."
+                ),
+                status="error" if degraded else "ok",
+            )
+        return DECIDED_RECORDED
+
+    @staticmethod
+    def _previous_observation(db: Session, watch, *, before_event_id) -> Optional[str]:
+        from core.models.watch_enums import WatchEventType
+        from core.models.watches import WatchEvent
+
+        row = (
+            db.query(WatchEvent)
+            .filter(
+                WatchEvent.watch_id == watch.id,
+                WatchEvent.event_type == WatchEventType.CHANGE_REPORT.value,
+                WatchEvent.id != before_event_id,
+            )
+            .order_by(WatchEvent.created_at.desc())
+            .first()
+        )
+        if row is None or not isinstance(row.snapshot, dict):
+            return None
+        return row.snapshot.get("terminal_state")
+
+    async def observe_scheduled(self, db: Session, watch, playbook, now) -> str:
+        """Persistent flip detection for scheduled-playbook watches (called
+        from the ticker's scheduled branch): compare the two most recent
+        terminal executions; notify on a status flip."""
+        from core.models.core import RecipeExecution
+        from core.models.watch_enums import WatchEventType
+        from services.watch_notifications import dispatch_watch_notification
+        from services.watch_service import WatchService
+
+        latest_two = (
+            db.query(RecipeExecution)
+            .filter(
+                RecipeExecution.recipe_id == playbook.id,
+                RecipeExecution.status.in_(("completed", "failed")),
+            )
+            .order_by(RecipeExecution.started_at.desc())
+            .limit(2)
+            .all()
+        )
+        if len(latest_two) < 2:
+            return DECIDED_NOOP
+        latest, previous = latest_two[0], latest_two[1]
+        if latest.status == previous.status:
+            return DECIDED_NOOP
+
+        event = WatchService.ingest(
+            db,
+            watch,
+            event_type=WatchEventType.CHANGE_REPORT.value,
+            event_key=f"flip:{latest.execution_id}",
+            summary=(
+                f"Run outcome flipped '{previous.status}' -> '{latest.status}' "
+                f"on playbook '{playbook.name}'"
+            ),
+            snapshot={
+                "previous": {"execution_id": previous.execution_id, "status": previous.status},
+                "latest": {"execution_id": latest.execution_id, "status": latest.status},
+            },
+            requires_attention=(latest.status == "failed"),
+        )
+        if event is None:
+            return DECIDED_NOOP
+
+        degraded = latest.status == "failed"
+        await dispatch_watch_notification(
+            db,
+            watch,
+            event_type="watch_escalation" if degraded else "watch_verdict",
+            title=(
+                f"Scheduled playbook {'started failing' if degraded else 'recovered'}: "
+                f"{playbook.name[:80]}"
+            ),
+            message=(
+                f"Latest run {latest.execution_id} {latest.status} "
+                f"(previous run {previous.status})."
+            ),
+            status="error" if degraded else "ok",
+        )
+        return DECIDED_RECORDED
+
+    # -- scoring / closing ----------------------------------------------
+
+    async def _score(self, db: Session, watch):
+        try:
+            verdicts = self._verdicts()
+            verdict = await verdicts.score_run(db, watch)
+            if verdict is not None:
+                verdicts.apply_verdict(db, watch, verdict)
+            return verdict
+        except Exception:
+            logger.error(
+                "[WatchDecider] scoring failed for watch %s",
+                getattr(watch, "id", "?"),
+                exc_info=True,
+            )
+            return None
+
+    async def _close(
+        self, db: Session, watch, *, passed: bool, terminal_state: str,
+        explanation: Optional[str],
+    ) -> str:
+        from core.models.watch_enums import WatchStatus
+        from services.watch_notifications import notify_watch_verdict
+        from services.watch_service import WatchService
+
+        if not passed and not watch.final_verdict:
+            watch.final_verdict = explanation
+
+        WatchService.transition(
+            db,
+            watch,
+            WatchStatus.PASSED if passed else WatchStatus.FAILED,
+            reason=f"decision step: terminal '{terminal_state}'",
+        )
+        await notify_watch_verdict(
+            db,
+            watch,
+            score=watch.final_score,
+            explanation=explanation,
+            passed=passed,
+            terminal_state=terminal_state,
+        )
+        return DECIDED_PASSED if passed else DECIDED_FAILED
+
+    @staticmethod
+    def _failure_explanation(watch, terminal_state, verdict, improve_spent) -> str:
+        bits = []
+        if terminal_state in _COMPLETED_STATES:
+            score = getattr(verdict, "score", None) if verdict else None
+            bar = watch.quality_threshold or 0.8
+            if score is not None:
+                bits.append(
+                    f"The run completed but scored {score:.2f} against a bar of {bar:.2f}."
+                )
+            else:
+                bits.append("The run completed but could not be scored.")
+        else:
+            bits.append(f"The run reached terminal state '{terminal_state}'.")
+        if improve_spent:
+            bits.append(
+                "A corrective attempt was already made; closing with the final result."
+            )
+        if verdict is not None and verdict.reasoning:
+            bits.append(verdict.reasoning.strip())
+        return " ".join(bits)
+
+    # -- change report (watch_change) ------------------------------------
+
+    def _record_change_report(self, db: Session, watch, verdict) -> None:
+        """Before/after from lineage: prior target's SCORED event vs the
+        current verdict. Purely deterministic -- no LLM comparison."""
+        from core.models.watch_enums import WatchEventType
+        from core.models.watches import WatchEvent
+        from services.watch_service import WatchService
+
+        lineage = watch.lineage or []
+        if len(lineage) < 2:
+            return
+        prior_target_id = lineage[-2].get("target_id")
+
+        prior_scored = (
+            db.query(WatchEvent)
+            .filter(
+                WatchEvent.watch_id == watch.id,
+                WatchEvent.event_type == WatchEventType.SCORED.value,
+                WatchEvent.event_key.like(f"scored:%:{prior_target_id}:%"),
+            )
+            .order_by(WatchEvent.created_at.desc())
+            .first()
+        )
+        before = prior_scored.score if prior_scored is not None else None
+        after = getattr(verdict, "score", None) if verdict else None
+        delta = (
+            round(after - before, 4)
+            if isinstance(before, (int, float)) and isinstance(after, (int, float))
+            else None
+        )
+        WatchService.ingest(
+            db,
+            watch,
+            event_type=WatchEventType.CHANGE_REPORT.value,
+            event_key=f"change:{watch.target_type}:{watch.target_id}",
+            summary=(
+                f"Before/after: {before if before is not None else 'unscored'} -> "
+                f"{after if after is not None else 'unscored'}"
+                + (f" (delta {delta:+.4f})" if delta is not None else "")
+            ),
+            snapshot={
+                "before_target_id": prior_target_id,
+                "before_score": before,
+                "after_target_id": watch.target_id,
+                "after_score": after,
+                "delta": delta,
+            },
+            score=after,
+        )
+
+    # -- diagnose + act ---------------------------------------------------
+
+    async def _diagnose_and_act(
+        self, db: Session, watch, *, terminal_state: str, verdict
+    ) -> str:
+        from services.watch_actions import (
+            ACTION_ESCALATE,
+            MISSION_ACTIONS,
+            escalate_watch_now,
+            run_mission_action,
+        )
+        from core.models.watch_enums import WatchEventType
+        from services.watch_service import WatchService
+
+        allowed = self.allowed_actions(watch)
+        diagnosis = await self._diagnoser.diagnose(
+            db,
+            watch,
+            terminal_state=terminal_state,
+            verdict_reasoning=getattr(verdict, "reasoning", None) if verdict else None,
+            allowed_actions=allowed,
+        )
+        action = self._choose_action(watch, diagnosis, allowed)
+        cause = (
+            diagnosis.cause
+            if diagnosis is not None and diagnosis.cause
+            else f"Run ended '{terminal_state}' below the bar (diagnosis unavailable)."
+        )
+
+        WatchService.ingest(
+            db,
+            watch,
+            event_type=WatchEventType.DIAGNOSED.value,
+            event_key=f"diagnosed:{watch.target_id}:{watch.actions_taken or 0}",
+            summary=cause[:500],
+            snapshot={
+                "proposed_action": action,
+                "confidence": getattr(diagnosis, "confidence", None),
+                "has_step_overrides": bool(getattr(diagnosis, "step_overrides", None)),
+            },
+        )
+
+        if action == ACTION_ESCALATE:
+            await escalate_watch_now(db, watch, reason=cause)
+            return DECIDED_ESCALATED
+
+        if action in MISSION_ACTIONS:
+            outcome = await run_mission_action(db, watch, action, diagnosis=cause)
+            if outcome.escalated:
+                return DECIDED_ESCALATED
+            if outcome.parked:
+                return DECIDED_PARKED
+            if outcome.executed:
+                await self._notify_action(db, watch, action, cause)
+                return DECIDED_ACTED
+            await escalate_watch_now(
+                db, watch, reason=f"'{action}' failed: {outcome.error}"
+            )
+            return DECIDED_ESCALATED
+
+        # playbook rerun / tweak_rerun
+        return await self._act_rerun(db, watch, action, diagnosis, cause)
+
+    @staticmethod
+    def _choose_action(watch, diagnosis: Optional[Diagnosis], allowed: List[str]) -> str:
+        """Deterministic choice: the diagnosis proposal when allowed, else
+        the first sensible allowed default, else escalate."""
+        proposed = getattr(diagnosis, "proposed_action", "") if diagnosis else ""
+        if proposed in allowed:
+            return proposed
+        # No usable diagnosis: plain rerun before a tweak label (there is
+        # nothing to tweak FROM), then the mission defaults.
+        for fallback in ("rerun", "tweak_rerun", "replan", "reassign"):
+            if fallback in allowed:
+                return fallback
+        return "escalate"
+
+    async def _act_rerun(
+        self, db: Session, watch, action: str, diagnosis: Optional[Diagnosis], cause: str
+    ) -> str:
+        from core.models.core import RecipeExecution, WorkflowTemplate
+        from services.watch_actions import escalate_watch_now
+        from services.watch_rerun import (
+            TRIGGERED_BY_WATCH,
+            request_rerun,
+            validate_step_overrides,
+        )
+        from services.watch_service import WatchService
+
+        original = (
+            db.query(RecipeExecution)
+            .filter(
+                RecipeExecution.execution_id == watch.target_id,
+                RecipeExecution.workspace_id == watch.workspace_id,
+            )
+            .first()
+        )
+        recipe = (
+            db.query(WorkflowTemplate)
+            .filter(WorkflowTemplate.id == original.recipe_id)
+            .first()
+            if original is not None
+            else None
+        )
+        if original is None or recipe is None:
+            await escalate_watch_now(
+                db, watch, reason="rerun impossible: execution or playbook missing"
+            )
+            return DECIDED_ESCALATED
+
+        # Tweak drafting (LLM job b) only when a tweak was chosen without
+        # overrides from the diagnosis.
+        overrides = getattr(diagnosis, "step_overrides", None) if diagnosis else None
+        if action == "tweak_rerun" and not overrides and diagnosis is not None:
+            overrides = await self._diagnoser.draft_tweak(db, watch, diagnosis=diagnosis)
+        validated, err = validate_step_overrides(recipe, overrides)
+        if err:
+            logger.warning(
+                "[WatchDecider] dropping invalid drafted overrides for watch %s: %s",
+                watch.id,
+                err,
+            )
+            validated = None
+
+        _, allowed_budget = WatchService.record_action(
+            db,
+            watch,
+            action=action,
+            summary=cause,
+            snapshot={"step_overrides": validated},
+        )
+        if not allowed_budget:
+            await escalate_watch_now(
+                db,
+                watch,
+                reason=(
+                    f"Action budget exhausted "
+                    f"({watch.actions_taken}/{watch.action_budget}) -- refused '{action}'"
+                ),
+            )
+            return DECIDED_ESCALATED
+
+        outcome = await request_rerun(
+            db,
+            workspace_id=watch.workspace_id,
+            recipe=recipe,
+            original=original,
+            step_overrides=validated,
+            triggered_by=TRIGGERED_BY_WATCH,
+            watch=watch,
+        )
+        if outcome.launched:
+            await self._notify_action(db, watch, action, cause)
+            return DECIDED_ACTED
+        return DECIDED_PARKED
+
+    @staticmethod
+    async def _notify_action(db: Session, watch, action: str, cause: str) -> None:
+        from services.watch_notifications import dispatch_watch_notification
+
+        await dispatch_watch_notification(
+            db,
+            watch,
+            event_type="watch_action",
+            title=f"Watcher acting ({action}): {(watch.title or '')[:90]}",
+            message=cause,
+            status="warning",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Singleton (house pattern)
+# ---------------------------------------------------------------------------
+
+_watch_decider: Optional[WatchDecider] = None
+
+
+def get_watch_decider() -> WatchDecider:
+    global _watch_decider
+    if _watch_decider is None:
+        _watch_decider = WatchDecider()
+    return _watch_decider

--- a/orchestrator/services/watch_hooks.py
+++ b/orchestrator/services/watch_hooks.py
@@ -1,5 +1,5 @@
 """
-Watch terminal hooks — PRD-204 S3
+Watch terminal hooks -- PRD-204 S3
 ==================================
 
 THE documented fail-soft seam between producers and the watch registry.
@@ -10,7 +10,7 @@ producer, so this wrapper catches EVERYTHING and logs (the
 knowledge_flywheel / _dispatch_mission_event pattern).
 
 This is the one place a blanket ``except Exception`` around watch ingest is
-sanctioned — everywhere else watch errors propagate normally.
+sanctioned -- everywhere else watch errors propagate normally.
 
 Sync + DB-only by design: the mission choke point (``transition_run``) is
 synchronous, so the hook cannot await. The ingest joins the CALLER's
@@ -39,7 +39,7 @@ def watch_ingest_terminal(
     cost_snapshot: Optional[Dict[str, Any]] = None,
     output_pointer: Optional[str] = None,
 ) -> None:
-    """Report a target's terminal state to its live watch — fail-soft.
+    """Report a target's terminal state to its live watch -- fail-soft.
 
     No-op when the target has no live watch. Idempotent per
     (watch, target): duplicate deliveries are swallowed by the event_key
@@ -58,9 +58,9 @@ def watch_ingest_terminal(
             cost_snapshot=cost_snapshot,
             output_pointer=output_pointer,
         )
-    except Exception:  # noqa: BLE001 — the sanctioned fail-soft seam (PRD-204 S3)
+    except Exception:  # noqa: BLE001 -- the sanctioned fail-soft seam (PRD-204 S3)
         logger.warning(
-            "[WatchHooks] terminal ingest failed for %s:%s (state=%s) — "
+            "[WatchHooks] terminal ingest failed for %s:%s (state=%s) -- "
             "producer unaffected",
             target_type,
             target_id,

--- a/orchestrator/services/watch_hooks.py
+++ b/orchestrator/services/watch_hooks.py
@@ -1,0 +1,69 @@
+"""
+Watch terminal hooks — PRD-204 S3
+==================================
+
+THE documented fail-soft seam between producers and the watch registry.
+Producers (mission transition choke point, playbook executor terminal
+blocks, board-task terminal dispatch) call :func:`watch_ingest_terminal`
+at their terminal boundaries; a raising watch service must NEVER break the
+producer, so this wrapper catches EVERYTHING and logs (the
+knowledge_flywheel / _dispatch_mission_event pattern).
+
+This is the one place a blanket ``except Exception`` around watch ingest is
+sanctioned — everywhere else watch errors propagate normally.
+
+Sync + DB-only by design: the mission choke point (``transition_run``) is
+synchronous, so the hook cannot await. The ingest joins the CALLER's
+transaction (no commit here); notifications stay with the producers (S4)
+and the watcher tick (S5).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+
+def watch_ingest_terminal(
+    db: Session,
+    workspace_id: UUID | str,
+    target_type: str,
+    target_id: str,
+    terminal_state: str,
+    summary: Optional[str] = None,
+    cost_snapshot: Optional[Dict[str, Any]] = None,
+    output_pointer: Optional[str] = None,
+) -> None:
+    """Report a target's terminal state to its live watch — fail-soft.
+
+    No-op when the target has no live watch. Idempotent per
+    (watch, target): duplicate deliveries are swallowed by the event_key
+    unique constraint. Never raises into the producer.
+    """
+    try:
+        from services.watch_service import WatchService
+
+        WatchService.ingest_terminal(
+            db,
+            workspace_id=workspace_id,
+            target_type=target_type,
+            target_id=str(target_id),
+            terminal_state=terminal_state,
+            summary=summary,
+            cost_snapshot=cost_snapshot,
+            output_pointer=output_pointer,
+        )
+    except Exception:  # noqa: BLE001 — the sanctioned fail-soft seam (PRD-204 S3)
+        logger.warning(
+            "[WatchHooks] terminal ingest failed for %s:%s (state=%s) — "
+            "producer unaffected",
+            target_type,
+            target_id,
+            terminal_state,
+            exc_info=True,
+        )

--- a/orchestrator/services/watch_notifications.py
+++ b/orchestrator/services/watch_notifications.py
@@ -126,11 +126,17 @@ async def notify_watch_verdict(
     message = build_verdict_message(
         watch, score=score, explanation=explanation, terminal_state=terminal_state
     )
+    if passed:
+        status = "ok"
+    elif terminal_state == "failed":
+        status = "error"
+    else:
+        status = "warning"  # completed but below the bar
     return await dispatch_watch_notification(
         db,
         watch,
         event_type="watch_verdict",
         title=title,
         message=message,
-        status="ok" if passed else "warning",
+        status=status,
     )

--- a/orchestrator/services/watch_notifications.py
+++ b/orchestrator/services/watch_notifications.py
@@ -1,0 +1,136 @@
+"""
+Watch notification seam -- PRD-204 S6
+=====================================
+
+Single owner of watch-flavoured NotificationDispatcher calls. Extracted from
+``WatchTicker._dispatch_watch_event`` (stage 1) so the S6 verdict path, the
+S8 action/escalation paths, and the S10 decision step all dispatch through
+ONE tested seam instead of three re-implementations.
+
+Contract:
+- getattr-defensive on the watch (tests pass SimpleNamespace stand-ins);
+- resolves ``watch.created_by`` (Clerk id) to an internal user id so the
+  creator is targeted; falls back to workspace-wide when unresolvable;
+- NEVER raises into the caller (returns False on any failure) -- watcher
+  notifications are best-effort, the registry rows are the truth;
+- scores are 0-1 internal everywhere; ONLY this display edge formats x10
+  (PRD-204 Section 8 Q8).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+
+def format_score_display(score: Optional[float]) -> str:
+    """0-1 internal score -> the x10 display string ('0.83' -> '8.3/10')."""
+    if score is None:
+        return "unscored"
+    return f"{score * 10:.1f}/10"
+
+
+async def dispatch_watch_notification(
+    db: Session,
+    watch,
+    *,
+    event_type: str,
+    title: str,
+    message: Optional[str],
+    status: str = "ok",
+) -> bool:
+    """Fire a watch-related event through NotificationDispatcher.
+
+    Joins the caller's transaction. Returns True iff the dispatch call
+    completed; False (logged) on any failure -- never raises.
+    """
+    try:
+        from core.models.core import User
+        from core.services.notification_dispatcher import NotificationDispatcher
+
+        workspace_id = getattr(watch, "workspace_id", None)
+        if workspace_id is None:
+            return False
+
+        user_id: Optional[int] = None
+        created_by = getattr(watch, "created_by", None)
+        if created_by:
+            user_row = (
+                db.query(User.id)
+                .filter(User.clerk_user_id == created_by)
+                .first()
+            )
+            if user_row:
+                user_id = user_row[0]
+
+        dispatcher = NotificationDispatcher(db, str(workspace_id))
+        await dispatcher.dispatch(
+            event_type=event_type,
+            title=title,
+            message=message,
+            link_type="watch",
+            link_id=str(getattr(watch, "id", "")),
+            status=status,
+            user_id=user_id,
+        )
+        return True
+    except Exception:
+        logger.error(
+            "[WatchNotifications] %s dispatch failed for watch %s",
+            event_type,
+            getattr(watch, "id", "?"),
+            exc_info=True,
+        )
+        return False
+
+
+def build_verdict_message(
+    watch,
+    *,
+    score: Optional[float],
+    explanation: Optional[str],
+    terminal_state: Optional[str] = None,
+) -> str:
+    """One-paragraph verdict body: score (displayed x10) + explanation."""
+    threshold = getattr(watch, "quality_threshold", None)
+    parts = []
+    if score is not None:
+        line = f"Run scored {format_score_display(score)}"
+        if threshold is not None:
+            line += f" against a bar of {format_score_display(threshold)}"
+        parts.append(line + ".")
+    elif terminal_state:
+        parts.append(f"The watched work reached terminal state '{terminal_state}'.")
+    if explanation:
+        parts.append(explanation.strip())
+    return " ".join(p for p in parts if p)
+
+
+async def notify_watch_verdict(
+    db: Session,
+    watch,
+    *,
+    score: Optional[float],
+    explanation: Optional[str],
+    passed: bool,
+    terminal_state: Optional[str] = None,
+) -> bool:
+    """The S6 verdict notification: score + one-paragraph explanation."""
+    title_bits = getattr(watch, "title", "") or "watched work"
+    verdict_word = "passed" if passed else "needs a look"
+    title = f"Watch verdict ({verdict_word}): {title_bits[:100]}"
+    message = build_verdict_message(
+        watch, score=score, explanation=explanation, terminal_state=terminal_state
+    )
+    return await dispatch_watch_notification(
+        db,
+        watch,
+        event_type="watch_verdict",
+        title=title,
+        message=message,
+        status="ok" if passed else "warning",
+    )

--- a/orchestrator/services/watch_rerun.py
+++ b/orchestrator/services/watch_rerun.py
@@ -443,6 +443,17 @@ async def resume_playbook_run_grant(db: Session, grant) -> None:
     details = dict(grant.details) if isinstance(grant.details, dict) else {}
     action = details.get("watch_action")
 
+    # The S8 mission-action executors register on import (deferred to avoid
+    # a module cycle: watch_actions imports from this module).
+    try:
+        import services.watch_actions  # noqa: F401
+    except Exception:
+        logger.warning(
+            "[WatchRerun] watch_actions import failed -- mission actions "
+            "unavailable for grant resume",
+            exc_info=True,
+        )
+
     try:
         if action == "rerun":
             result = await _resume_rerun(db, grant, details)

--- a/orchestrator/services/watch_rerun.py
+++ b/orchestrator/services/watch_rerun.py
@@ -1,0 +1,587 @@
+"""
+Playbook rerun + tweak -- PRD-204 S7
+====================================
+
+The platform's first rerun primitive: copy a prior execution's inputs into a
+NEW ``RecipeExecution`` (``retry_of`` lineage, ``attempt_count+1`` -- the
+``task_reconciler`` stall-retry idiom) with optional per-execution
+``step_overrides`` that the executor merges at run start.
+``workflow_recipes.steps`` is NEVER mutated -- a tweak affects exactly one
+execution.
+
+Approval plane (PRD-204 Section 8 Q3): every rerun rides
+``evaluate_approval`` with the ORIGINAL run's ``llm_usage`` dollar sum as
+the estimate. Auto path launches immediately; ask path parks a durable
+``ApprovalGrant(subject_type=SUBJECT_PLAYBOOK_RUN)`` -- the first real use
+of that subject kind -- carrying the full rerun spec in ``details`` so the
+grant endpoint can launch it later with zero re-derivation.
+
+Grant details schema (stable contract for the approvals inbox + S8):
+
+    {
+      "watch_action": "rerun",            # discriminator (S8 adds more)
+      "watch_id": "<uuid>" | null,
+      "rerun_of": "exec-...",             # original execution_id
+      "recipe_id": 123,
+      "spec": {
+        "input_data": {...},              # copied from the original
+        "step_overrides": {"<step_id>": {"prompt_template": "..."}} | null,
+        "triggered_by": "rerun" | "watch_rerun",
+        "attempt_count": 2
+      },
+      "executed_result": {...}            # written by resume/deny
+    }
+
+``resume_playbook_run_grant`` / ``fail_playbook_run_grant`` are the
+``_requeue_subject`` / ``_fail_subject`` branches for ALL watch corrective
+actions -- ``details["watch_action"]`` discriminates; S8 registers the
+mission-action executors via ``WATCH_GRANT_EXECUTORS``.
+
+Transactions: ``request_rerun`` COMMITS on the auto path (the playbook
+engine's task opens its own session, so the row must be visible before
+launch -- the execute-route precedent); the ask path only flushes and the
+caller commits.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, Dict, Optional, Tuple
+from uuid import UUID, uuid4
+
+from sqlalchemy.orm import Session
+
+from core.models.core import RecipeExecution, WorkflowTemplate
+from core.services.approval_policy import ApprovalDecision, evaluate_approval
+
+logger = logging.getLogger(__name__)
+
+TRIGGERED_BY_HUMAN = "rerun"
+TRIGGERED_BY_WATCH = "watch_rerun"
+
+# S8 registers mission-action executors here: {watch_action: async fn(db, grant) -> dict}
+WATCH_GRANT_EXECUTORS: Dict[str, Callable[[Session, Any], Awaitable[Dict[str, Any]]]] = {}
+
+
+@dataclass(frozen=True)
+class RerunOutcome:
+    """Result of a gated rerun request."""
+
+    launched: bool
+    execution_id: Optional[str]
+    grant_id: Optional[int]
+    decision: ApprovalDecision
+    message: str
+
+
+def _utcnow_iso() -> str:
+    from datetime import datetime, timezone
+
+    return datetime.now(timezone.utc).isoformat()
+
+
+# ---------------------------------------------------------------------------
+# Boundary validation
+# ---------------------------------------------------------------------------
+
+
+def validate_step_overrides(
+    recipe: WorkflowTemplate, step_overrides: Any
+) -> Tuple[Optional[Dict[str, Dict[str, str]]], Optional[str]]:
+    """Validate + normalise ``{step_id: {prompt_template: str}}``.
+
+    Returns (normalised, None) or (None, error). Unknown step ids and
+    non-string prompts are rejected at the boundary (never trust input).
+    """
+    if step_overrides in (None, {}):
+        return None, None
+    if not isinstance(step_overrides, dict):
+        return None, "step_overrides must be an object of {step_id: {prompt_template}}"
+
+    known_ids = {
+        str(s.get("step_id"))
+        for s in (recipe.steps or [])
+        if isinstance(s, dict) and s.get("step_id")
+    }
+    normalised: Dict[str, Dict[str, str]] = {}
+    for step_id, override in step_overrides.items():
+        sid = str(step_id)
+        if sid not in known_ids:
+            return None, f"Unknown step_id in step_overrides: {sid}"
+        if not isinstance(override, dict):
+            return None, f"step_overrides[{sid}] must be an object"
+        prompt = override.get("prompt_template")
+        if not isinstance(prompt, str) or not prompt.strip():
+            return None, (
+                f"step_overrides[{sid}].prompt_template must be a non-empty string"
+            )
+        normalised[sid] = {"prompt_template": prompt}
+    return (normalised or None), None
+
+
+# ---------------------------------------------------------------------------
+# Cost estimate (the original run's llm_usage dollar sum)
+# ---------------------------------------------------------------------------
+
+
+def estimate_rerun_cost_usd(
+    db: Session, workspace_id: UUID | str, execution_id: str
+) -> float:
+    """What the original execution cost -- the honest rerun estimate."""
+    try:
+        from services.report_service import compute_execution_metrics
+
+        metrics = compute_execution_metrics(
+            db, workspace_id, execution_id=str(execution_id)
+        )
+        return float(metrics.get("cost_usd") or 0.0)
+    except Exception:
+        logger.warning(
+            "[WatchRerun] cost estimate failed for %s -- using 0.0",
+            execution_id,
+            exc_info=True,
+        )
+        return 0.0
+
+
+# ---------------------------------------------------------------------------
+# The copy idiom (task_reconciler precedent, ORM shape)
+# ---------------------------------------------------------------------------
+
+
+def create_rerun_execution(
+    db: Session,
+    recipe: WorkflowTemplate,
+    original: RecipeExecution,
+    *,
+    step_overrides: Optional[Dict[str, Dict[str, str]]] = None,
+    triggered_by: str = TRIGGERED_BY_HUMAN,
+) -> RecipeExecution:
+    """Stage the copied execution row (flush only -- caller owns commit).
+
+    Copies ``input_data``, chains ``retry_of``, bumps ``attempt_count``.
+    ``step_overrides`` live in ``execution_metadata`` for the executor's
+    run-start merge -- the recipe row is untouched.
+    """
+    metadata: Dict[str, Any] = {
+        "execution_type": "recipe_direct",
+        "total_steps": len(recipe.steps or []),
+        "rerun_of": original.execution_id,
+    }
+    if step_overrides:
+        metadata["step_overrides"] = step_overrides
+
+    execution = RecipeExecution(
+        execution_id=f"rerun-{uuid4().hex[:12]}",
+        recipe_id=recipe.id,
+        workspace_id=original.workspace_id,
+        status="pending",
+        input_data=dict(original.input_data or {}),
+        current_step=0,
+        triggered_by=triggered_by,
+        execution_metadata=metadata,
+        attempt_count=(original.attempt_count or 1) + 1,
+        retry_of=original.execution_id,
+    )
+    db.add(execution)
+    db.flush()
+    return execution
+
+
+def launch_execution(execution: RecipeExecution) -> None:
+    """Fire the execution through the consolidated PlaybookEngine seam
+    (PRD-142 W3-S12: every backend launch site goes through the engine).
+    The row MUST be committed before this call (the task opens its own
+    session)."""
+    from services.playbook_engine import get_playbook_engine
+
+    get_playbook_engine().launch(
+        recipe_execution_id=execution.execution_id,
+        recipe_id=execution.recipe_id,
+        workspace_id=UUID(str(execution.workspace_id)),
+        input_data=execution.input_data or {},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Notifications (best-effort, never raise)
+# ---------------------------------------------------------------------------
+
+
+async def _notify_approval_pending(
+    db: Session, workspace_id, grant, recipe: WorkflowTemplate
+) -> None:
+    try:
+        from core.services.notification_dispatcher import NotificationDispatcher
+
+        dispatcher = NotificationDispatcher(db, str(workspace_id))
+        await dispatcher.dispatch(
+            event_type="approval_pending",
+            title=f"Approval needed: rerun '{recipe.name}'",
+            message=(
+                f"A rerun of playbook '{recipe.name}' is waiting for approval "
+                f"(estimated ${float(grant.estimated_cost_usd or 0):.2f}). "
+                "Review it in the approvals inbox."
+            ),
+            link_type="approval_grant",
+            link_id=str(grant.id),
+            status="warning",
+        )
+    except Exception:
+        logger.error(
+            "[WatchRerun] approval_pending dispatch failed for grant %s",
+            getattr(grant, "id", "?"),
+            exc_info=True,
+        )
+
+
+# ---------------------------------------------------------------------------
+# The gated request
+# ---------------------------------------------------------------------------
+
+
+async def request_rerun(
+    db: Session,
+    *,
+    workspace_id: UUID | str,
+    recipe: WorkflowTemplate,
+    original: RecipeExecution,
+    step_overrides: Optional[Dict[str, Dict[str, str]]] = None,
+    triggered_by: str = TRIGGERED_BY_HUMAN,
+    watch=None,
+    override_auto_approve: bool = False,
+) -> RerunOutcome:
+    """Rerun an execution through the approval policy.
+
+    Auto path: creates + COMMITS + launches the copy; a supervising watch
+    follows the new execution (lineage repoint -- same watch, one verdict).
+    Ask path: stages a PENDING ``SUBJECT_PLAYBOOK_RUN`` grant with the rerun
+    spec in details, parks the watch in ``awaiting_approval``, fires the
+    ``approval_pending`` notification. Caller commits.
+    """
+    estimated = estimate_rerun_cost_usd(db, workspace_id, original.execution_id)
+    decision = evaluate_approval(
+        db, workspace_id, estimated, override_auto_approve=override_auto_approve
+    )
+
+    if decision.auto_approve:
+        execution = create_rerun_execution(
+            db,
+            recipe,
+            original,
+            step_overrides=step_overrides,
+            triggered_by=triggered_by,
+        )
+        if watch is not None:
+            _follow_watch(db, watch, execution, step_overrides, triggered_by)
+        db.commit()  # row must be visible to the engine's own session
+        launch_execution(execution)
+        logger.info(
+            "[WatchRerun] launched rerun %s of %s (auto: %s)",
+            execution.execution_id,
+            original.execution_id,
+            decision.reason,
+        )
+        return RerunOutcome(
+            launched=True,
+            execution_id=execution.execution_id,
+            grant_id=None,
+            decision=decision,
+            message=f"Rerun {execution.execution_id} launched.",
+        )
+
+    # --- ask path: durable grant carrying the spec ---
+    from core.models.approval_grants import SUBJECT_PLAYBOOK_RUN
+    from core.services.approval_grants import create_grant, find_pending_grant
+
+    existing = find_pending_grant(
+        db,
+        workspace_id,
+        subject_type=SUBJECT_PLAYBOOK_RUN,
+        subject_id=original.execution_id,
+    )
+    if existing is not None:
+        logger.info(
+            "[WatchRerun] pending rerun grant %s already exists for %s",
+            existing.id,
+            original.execution_id,
+        )
+        return RerunOutcome(
+            launched=False,
+            execution_id=None,
+            grant_id=existing.id,
+            decision=decision,
+            message="A rerun approval is already pending for this execution.",
+        )
+
+    grant = create_grant(
+        db,
+        workspace_id,
+        subject_type=SUBJECT_PLAYBOOK_RUN,
+        subject_id=original.execution_id,
+        tool_name="playbook_rerun",
+        reason=decision.reason,
+        estimated_cost_usd=decision.estimated_cost,
+    )
+    watch_id = str(watch.id) if watch is not None and getattr(watch, "id", None) else None
+    grant.details = {
+        "watch_action": "rerun",
+        "watch_id": watch_id,
+        "rerun_of": original.execution_id,
+        "recipe_id": recipe.id,
+        "spec": {
+            "input_data": dict(original.input_data or {}),
+            "step_overrides": step_overrides,
+            "triggered_by": triggered_by,
+            "attempt_count": (original.attempt_count or 1) + 1,
+        },
+    }
+    db.flush()
+
+    if watch is not None:
+        _park_watch_awaiting_approval(db, watch, grant)
+
+    await _notify_approval_pending(db, workspace_id, grant, recipe)
+
+    return RerunOutcome(
+        launched=False,
+        execution_id=None,
+        grant_id=grant.id,
+        decision=decision,
+        message=(
+            f"Rerun needs approval ({decision.reason}). "
+            f"Grant {grant.id} is pending in the approvals inbox."
+        ),
+    )
+
+
+def _follow_watch(db, watch, execution, step_overrides, triggered_by) -> None:
+    """The watch follows the rerun (Section 8 Q9); overrides land on the
+    FOLLOW event snapshot for before/after comparison. Fail-soft."""
+    try:
+        from services.watch_service import WatchService
+
+        WatchService.follow(
+            db,
+            watch,
+            new_target_type="playbook_execution",
+            new_target_id=execution.execution_id,
+            reason=f"rerun of {execution.retry_of} ({triggered_by})",
+            snapshot={
+                "rerun_of": execution.retry_of,
+                "step_overrides": step_overrides,
+                "triggered_by": triggered_by,
+            },
+        )
+    except Exception:
+        logger.warning(
+            "[WatchRerun] watch follow failed for %s (non-fatal)",
+            getattr(watch, "id", "?"),
+            exc_info=True,
+        )
+
+
+def _park_watch_awaiting_approval(db, watch, grant) -> None:
+    """awaiting_approval park + event. Fail-soft (the grant is the truth)."""
+    try:
+        from core.models.watch_enums import WatchEventType, WatchStatus
+        from services.watch_service import WatchService
+
+        WatchService.ingest(
+            db,
+            watch,
+            event_type=WatchEventType.STATUS_CHANGE.value,
+            event_key=f"grant-pending:{grant.id}",
+            summary=f"Corrective action parked on approval grant {grant.id}",
+            snapshot={"grant_id": grant.id, "watch_action": "rerun"},
+        )
+        if WatchStatus(watch.status) != WatchStatus.AWAITING_APPROVAL:
+            WatchService.transition(
+                db,
+                watch,
+                WatchStatus.AWAITING_APPROVAL,
+                reason=f"awaiting grant {grant.id}",
+            )
+    except Exception:
+        logger.warning(
+            "[WatchRerun] could not park watch %s on grant %s (non-fatal)",
+            getattr(watch, "id", "?"),
+            grant.id,
+            exc_info=True,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Grant resume/deny -- the _requeue_subject / _fail_subject branches
+# ---------------------------------------------------------------------------
+
+
+def _load_watch(db: Session, grant) -> Optional[Any]:
+    details = grant.details if isinstance(grant.details, dict) else {}
+    watch_id = details.get("watch_id")
+    if not watch_id:
+        return None
+    try:
+        from services.watch_service import WatchService
+
+        return WatchService.get_watch(db, grant.workspace_id, watch_id)
+    except Exception:
+        logger.warning("[WatchRerun] watch load failed for grant %s", grant.id, exc_info=True)
+        return None
+
+
+async def resume_playbook_run_grant(db: Session, grant) -> None:
+    """Granted: execute the stored watch action (PRD-204 S7/S8).
+
+    ``details["watch_action"]`` discriminates. ``rerun`` is handled here;
+    mission actions (replan/reassign/spawn_agent) execute via the S8
+    registry. The outcome lands on ``details.executed_result`` -- fail LOUD
+    but contained (an honest failure on the grant, never an exception out of
+    the grant endpoint).
+    """
+    details = dict(grant.details) if isinstance(grant.details, dict) else {}
+    action = details.get("watch_action")
+
+    try:
+        if action == "rerun":
+            result = await _resume_rerun(db, grant, details)
+        elif action in WATCH_GRANT_EXECUTORS:
+            result = await WATCH_GRANT_EXECUTORS[action](db, grant)
+        else:
+            result = {
+                "success": False,
+                "error": f"grant carries no executable watch_action ({action!r})",
+            }
+    except Exception as exc:  # noqa: BLE001 -- contained per grant contract
+        logger.error(
+            "[WatchRerun] playbook_run grant %s resume failed", grant.id, exc_info=True
+        )
+        result = {"success": False, "error": str(exc)[:500]}
+
+    grant.details = {
+        **details,
+        "executed_result": {**result, "executed_at": _utcnow_iso()},
+    }
+
+
+async def _resume_rerun(db: Session, grant, details: Dict[str, Any]) -> Dict[str, Any]:
+    spec = details.get("spec") or {}
+    recipe = (
+        db.query(WorkflowTemplate)
+        .filter(
+            WorkflowTemplate.id == details.get("recipe_id"),
+            WorkflowTemplate.workspace_id == grant.workspace_id,
+        )
+        .first()
+    )
+    original = (
+        db.query(RecipeExecution)
+        .filter(
+            RecipeExecution.execution_id == details.get("rerun_of"),
+            RecipeExecution.workspace_id == grant.workspace_id,
+        )
+        .first()
+    )
+    watch = _load_watch(db, grant)
+
+    if recipe is None or original is None:
+        _park_watch_needs_attention(
+            db, watch, reason=f"grant {grant.id}: rerun target no longer exists"
+        )
+        return {"success": False, "error": "recipe or original execution not found"}
+
+    execution = create_rerun_execution(
+        db,
+        recipe,
+        original,
+        step_overrides=spec.get("step_overrides"),
+        triggered_by=spec.get("triggered_by") or TRIGGERED_BY_WATCH,
+    )
+
+    if watch is not None:
+        _resume_watch_to_watching(db, watch)
+        _follow_watch(
+            db, watch, execution, spec.get("step_overrides"), spec.get("triggered_by")
+        )
+
+    # The engine's task opens its own session: persist the row (and the
+    # watch/grant state staged so far) before launching.
+    db.commit()
+    launch_execution(execution)
+    logger.info(
+        "[WatchRerun] grant %s resumed -> launched %s (rerun of %s)",
+        grant.id,
+        execution.execution_id,
+        original.execution_id,
+    )
+    return {"success": True, "execution_id": execution.execution_id}
+
+
+def fail_playbook_run_grant(db: Session, grant) -> None:
+    """Denied: no launch; a supervised watch parks in needs_attention."""
+    details = dict(grant.details) if isinstance(grant.details, dict) else {}
+    watch = _load_watch(db, grant)
+    _park_watch_needs_attention(
+        db,
+        watch,
+        reason=f"approval grant {grant.id} denied by a human reviewer",
+    )
+    grant.details = {
+        **details,
+        "executed_result": {
+            "success": False,
+            "error": "denied by a human reviewer",
+            "executed_at": _utcnow_iso(),
+        },
+    }
+
+
+def _resume_watch_to_watching(db, watch) -> None:
+    try:
+        from core.models.watch_enums import WatchStatus
+        from services.watch_service import WatchService
+
+        if WatchStatus(watch.status) == WatchStatus.AWAITING_APPROVAL:
+            WatchService.transition(
+                db, watch, WatchStatus.WATCHING, reason="grant approved"
+            )
+    except Exception:
+        logger.warning(
+            "[WatchRerun] watch %s resume-to-watching failed (non-fatal)",
+            getattr(watch, "id", "?"),
+            exc_info=True,
+        )
+
+
+def _park_watch_needs_attention(db, watch, *, reason: str) -> None:
+    if watch is None:
+        return
+    try:
+        from core.models.watch_enums import WatchEventType, WatchStatus
+        from services.watch_service import WatchService
+
+        WatchService.ingest(
+            db,
+            watch,
+            event_type=WatchEventType.STATUS_CHANGE.value,
+            event_key=f"grant-denied:{reason[:80]}",
+            summary=reason,
+            requires_attention=True,
+        )
+        if WatchStatus(watch.status) not in (
+            WatchStatus.NEEDS_ATTENTION,
+            WatchStatus.PASSED,
+            WatchStatus.FAILED,
+            WatchStatus.EXPIRED,
+            WatchStatus.CANCELLED,
+        ):
+            WatchService.transition(
+                db, watch, WatchStatus.NEEDS_ATTENTION, reason=reason
+            )
+    except Exception:
+        logger.warning(
+            "[WatchRerun] could not park watch %s (non-fatal)",
+            getattr(watch, "id", "?"),
+            exc_info=True,
+        )

--- a/orchestrator/services/watch_service.py
+++ b/orchestrator/services/watch_service.py
@@ -77,6 +77,32 @@ def _utcnow() -> datetime:
     return datetime.now(timezone.utc)
 
 
+def watch_auto_create_enabled(db: Session, workspace_id: UUID | str) -> bool:
+    """PRD-204 S9 (Section 8 Q1): the ``watch_auto_create`` workspace setting.
+
+    Default ON. Reads ``workspace.settings`` (the approval_policy pattern).
+    Only an explicit boolean False turns it off; a missing workspace returns
+    False (nothing to attach a watch to), any other read problem defaults ON.
+    """
+    try:
+        from core.models.workspaces import Workspace
+
+        ws = db.query(Workspace).filter(Workspace.id == workspace_id).first()
+        if ws is None:
+            return False
+        value = (ws.settings or {}).get("watch_auto_create")
+        if isinstance(value, bool):
+            return value
+        return True
+    except Exception:
+        logger.warning(
+            "[Watch] watch_auto_create read failed for %s -- defaulting ON",
+            workspace_id,
+            exc_info=True,
+        )
+        return True
+
+
 class WatchService:
     """Stateless service over the watch registry (caller manages sessions)."""
 

--- a/orchestrator/services/watch_service.py
+++ b/orchestrator/services/watch_service.py
@@ -1,5 +1,5 @@
 """
-WatchService — PRD-204 S2
+WatchService -- PRD-204 S2
 ==========================
 
 Single owner of watch-registry mutations: create/get/list/cancel, the guarded
@@ -12,7 +12,7 @@ the ``follow`` lineage helper, and the tick's ``claim_due_watches``
 
 Transaction contract:
 - Every method except ``claim_due_watches`` joins the CALLER's transaction
-  (flush only, never commit) — same principle as orchestration_state.
+  (flush only, never commit) -- same principle as orchestration_state.
 - ``claim_due_watches`` COMMITS: the claim is its own transaction so
   SKIP LOCKED serialises concurrent tickers (claim_tasks precedent).
 
@@ -113,7 +113,7 @@ class WatchService:
 
         Raises WatchAlreadyExistsError when a non-terminal watch already
         supervises the target (the partial unique index is the race-safe
-        backstop — a concurrent create surfaces as IntegrityError).
+        backstop -- a concurrent create surfaces as IntegrityError).
         """
         moment = now or _utcnow()
         target_id = str(target_id)
@@ -232,7 +232,7 @@ class WatchService:
         *,
         reason: Optional[str] = None,
     ) -> Watch:
-        """Cancel a live watch (guarded — cancelling a closed watch raises)."""
+        """Cancel a live watch (guarded -- cancelling a closed watch raises)."""
         watch = WatchService.get_watch(db, workspace_id, watch_id)
         if watch is None:
             raise ValueError(f"Watch {watch_id} not found in workspace {workspace_id}")
@@ -316,7 +316,7 @@ class WatchService:
         """Record an observation exactly once.
 
         A duplicate (watch_id, event_key) is swallowed via a SAVEPOINT so the
-        caller's outer transaction survives, and ``None`` is returned — the
+        caller's outer transaction survives, and ``None`` is returned -- the
         caller can use "was this the first writer?" to decide follow-up work
         (the S5 tick notifies only when the sweep beat the producer hook).
         """
@@ -344,7 +344,7 @@ class WatchService:
         return event
 
     # ------------------------------------------------------------------
-    # Terminal ingest — the seam the S3 hooks and the S5 sweep both call
+    # Terminal ingest -- the seam the S3 hooks and the S5 sweep both call
     # ------------------------------------------------------------------
 
     @staticmethod
@@ -363,7 +363,7 @@ class WatchService:
 
         Idempotent: exactly one terminal event per (watch, target). On first
         ingest the watch closes by outcome (WATCH_STATUS_FOR_TERMINAL_TARGET)
-        with an unscored v1 verdict — S6 inserts run-level scoring between
+        with an unscored v1 verdict -- S6 inserts run-level scoring between
         "terminal observed" and "watch closed" without changing this seam.
 
         Returns the NEW WatchEvent when this call was the first writer,
@@ -431,7 +431,7 @@ class WatchService:
         moved WATCHING -> ACTING). Returns ``(watch, False)`` on the hard
         stop: the budget is exhausted, a ``budget_exhausted`` event lands
         (requires_attention) and the watch parks in NEEDS_ATTENTION. The
-        caller (S8/S10 decision step) owns any escalation notification —
+        caller (S8/S10 decision step) owns any escalation notification --
         this module stays sync + DB-only.
         """
         taken = watch.actions_taken or 0
@@ -444,7 +444,7 @@ class WatchService:
                 event_type=WatchEventType.BUDGET_EXHAUSTED.value,
                 event_key=f"budget_exhausted:{taken}",
                 summary=(
-                    f"Action budget exhausted ({taken}/{budget}) — "
+                    f"Action budget exhausted ({taken}/{budget}) -- "
                     f"refused action '{action}'"
                 ),
                 requires_attention=True,
@@ -477,7 +477,7 @@ class WatchService:
         return watch, True
 
     # ------------------------------------------------------------------
-    # Lineage — the watch follows the work (PRD-204 Section 8 Q9)
+    # Lineage -- the watch follows the work (PRD-204 Section 8 Q9)
     # ------------------------------------------------------------------
 
     @staticmethod
@@ -510,7 +510,7 @@ class WatchService:
             "since": moment.isoformat(),
             "reason": reason or "follow",
         }
-        # Immutable append — never mutate the JSONB list in place.
+        # Immutable append -- never mutate the JSONB list in place.
         watch.lineage = [*(watch.lineage or []), entry]
         watch.target_type = new_target_type
         watch.target_id = new_target_id
@@ -527,7 +527,7 @@ class WatchService:
         return watch
 
     # ------------------------------------------------------------------
-    # Tick claim — FOR UPDATE SKIP LOCKED (board_dispatcher idiom)
+    # Tick claim -- FOR UPDATE SKIP LOCKED (board_dispatcher idiom)
     # ------------------------------------------------------------------
 
     @staticmethod
@@ -541,12 +541,12 @@ class WatchService:
 
         The locked SELECT grabs only rows no other transaction holds
         (SKIP LOCKED), and the surrounding UPDATE reschedules
-        ``next_check_at`` in the same statement — the reschedule IS the
+        ``next_check_at`` in the same statement -- the reschedule IS the
         lease, so a crashed ticker simply re-claims on a later tick.
         ``version_id`` is bumped so optimistic ORM writers see the claim.
 
         NOTE: COMMITS the claim (its own transaction), then returns freshly
-        loaded rows — same contract as board_dispatcher.claim_tasks.
+        loaded rows -- same contract as board_dispatcher.claim_tasks.
         """
         moment = now or _utcnow()
         claimable = ", ".join(

--- a/orchestrator/services/watch_service.py
+++ b/orchestrator/services/watch_service.py
@@ -492,10 +492,13 @@ class WatchService:
         new_target_id: str,
         reason: Optional[str] = None,
         now: Optional[datetime] = None,
+        snapshot: Optional[Dict[str, Any]] = None,
     ) -> Watch:
         """Repoint a live watch at a new target (rerun/replan stays the SAME
         watch). Appends to ``lineage`` immutably and pulls the next check
-        forward so the tick picks the new target up promptly.
+        forward so the tick picks the new target up promptly. ``snapshot``
+        (e.g. the S7 step_overrides) lands on the FOLLOW event for
+        before/after comparison.
         """
         if WatchStatus(watch.status) in TERMINAL_WATCH_STATUSES:
             raise InvalidTransitionError(
@@ -525,6 +528,7 @@ class WatchService:
             event_type=WatchEventType.FOLLOW.value,
             event_key=f"follow:{new_target_type}:{new_target_id}",
             summary=reason or f"Watch now follows {new_target_type}:{new_target_id}",
+            snapshot=snapshot,
         )
         db.flush()
         return watch

--- a/orchestrator/services/watch_service.py
+++ b/orchestrator/services/watch_service.py
@@ -1,0 +1,592 @@
+"""
+WatchService — PRD-204 S2
+==========================
+
+Single owner of watch-registry mutations: create/get/list/cancel, the guarded
+status ``transition`` (ALLOWED_WATCH_TRANSITIONS, house style of
+``orchestration_state``), idempotent ``ingest`` (duplicate event_key swallowed
+via the UNIQUE constraint under a savepoint), the terminal-ingest seam the
+S3 producer hooks call, ``record_action`` with the action-budget hard stop,
+the ``follow`` lineage helper, and the tick's ``claim_due_watches``
+(FOR UPDATE SKIP LOCKED, board_dispatcher idiom).
+
+Transaction contract:
+- Every method except ``claim_due_watches`` joins the CALLER's transaction
+  (flush only, never commit) — same principle as orchestration_state.
+- ``claim_due_watches`` COMMITS: the claim is its own transaction so
+  SKIP LOCKED serialises concurrent tickers (claim_tasks precedent).
+
+Notifications are deliberately NOT dispatched here: producers own their
+terminal notifications (mission_complete / mission_failed / playbook_*), and
+the watcher tick (S5) owns watcher-only notifications (sweep-caught terminal,
+missed run, expiry). Keeping this module sync + DB-only lets the fail-soft
+hooks call it from sync producers (transition_run) and async ones alike.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional, Tuple
+from uuid import UUID
+
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+from sqlalchemy.orm.exc import StaleDataError
+
+from core.models.watches import (
+    DEFAULT_ACTION_BUDGET,
+    DEFAULT_CHECK_INTERVAL_SECONDS,
+    DEFAULT_QUALITY_THRESHOLD,
+    Watch,
+    WatchEvent,
+)
+from core.models.watch_enums import (
+    ALLOWED_WATCH_TRANSITIONS,
+    CLAIMABLE_WATCH_STATUSES,
+    LIVE_WATCH_STATUSES,
+    TERMINAL_WATCH_STATUSES,
+    WATCH_STATUS_FOR_TERMINAL_TARGET,
+    WatchEventType,
+    WatchPolicy,
+    WatchStatus,
+)
+from services.orchestration_state import ConflictError, InvalidTransitionError
+
+logger = logging.getLogger(__name__)
+
+# Default batch size for the tick's claim.
+DEFAULT_CLAIM_LIMIT = 50
+
+
+class WatchAlreadyExistsError(Exception):
+    """A non-terminal watch already supervises this target."""
+
+    def __init__(self, workspace_id: Any, target_type: str, target_id: str):
+        self.workspace_id = workspace_id
+        self.target_type = target_type
+        self.target_id = target_id
+        super().__init__(
+            f"A live watch already exists for {target_type}:{target_id} "
+            f"in workspace {workspace_id}"
+        )
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class WatchService:
+    """Stateless service over the watch registry (caller manages sessions)."""
+
+    # ------------------------------------------------------------------
+    # Create / read / cancel
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def create_watch(
+        db: Session,
+        *,
+        workspace_id: UUID | str,
+        watch_type: str,
+        target_type: str,
+        target_id: str,
+        title: str,
+        created_by: Optional[str] = None,
+        owner_agent_id: Optional[int] = None,
+        description: Optional[str] = None,
+        success_criteria: Optional[str] = None,
+        failure_criteria: Optional[str] = None,
+        quality_threshold: float = DEFAULT_QUALITY_THRESHOLD,
+        check_interval_seconds: int = DEFAULT_CHECK_INTERVAL_SECONDS,
+        deadline_at: Optional[datetime] = None,
+        policy: str = WatchPolicy.RUN_AND_REPORT.value,
+        allowed_actions: Optional[List[str]] = None,
+        action_budget: int = DEFAULT_ACTION_BUDGET,
+        now: Optional[datetime] = None,
+    ) -> Watch:
+        """Create a watch on a target. One live watch per target.
+
+        ``lineage`` invariant: the ordered target chain INCLUDES the original
+        target, so ``lineage[-1]`` always mirrors the live target columns.
+
+        Raises WatchAlreadyExistsError when a non-terminal watch already
+        supervises the target (the partial unique index is the race-safe
+        backstop — a concurrent create surfaces as IntegrityError).
+        """
+        moment = now or _utcnow()
+        target_id = str(target_id)
+
+        existing = WatchService.find_live_watch(
+            db, workspace_id=workspace_id, target_type=target_type, target_id=target_id
+        )
+        if existing is not None:
+            raise WatchAlreadyExistsError(workspace_id, target_type, target_id)
+
+        watch = Watch(
+            workspace_id=str(workspace_id),
+            created_by=created_by,
+            owner_agent_id=owner_agent_id,
+            watch_type=watch_type,
+            target_type=target_type,
+            target_id=target_id,
+            title=title,
+            description=description,
+            status=WatchStatus.WATCHING.value,
+            success_criteria=success_criteria,
+            failure_criteria=failure_criteria,
+            quality_threshold=quality_threshold,
+            check_interval_seconds=check_interval_seconds,
+            next_check_at=moment + timedelta(seconds=check_interval_seconds),
+            deadline_at=deadline_at,
+            policy=policy,
+            allowed_actions=allowed_actions,
+            action_budget=action_budget,
+            actions_taken=0,
+            lineage=[
+                {
+                    "target_type": target_type,
+                    "target_id": target_id,
+                    "since": moment.isoformat(),
+                    "reason": "created",
+                }
+            ],
+        )
+        db.add(watch)
+        db.flush()
+
+        WatchService.ingest(
+            db,
+            watch,
+            event_type=WatchEventType.CREATED.value,
+            event_key="created",
+            summary=f"Watch created on {target_type}:{target_id}",
+        )
+        return watch
+
+    @staticmethod
+    def get_watch(
+        db: Session, workspace_id: UUID | str, watch_id: UUID | str
+    ) -> Optional[Watch]:
+        """Workspace-scoped point read."""
+        return (
+            db.query(Watch)
+            .filter(
+                Watch.id == str(watch_id),
+                Watch.workspace_id == str(workspace_id),
+            )
+            .first()
+        )
+
+    @staticmethod
+    def list_watches(
+        db: Session,
+        workspace_id: UUID | str,
+        *,
+        status: Optional[str] = None,
+        watch_type: Optional[str] = None,
+        include_closed: bool = False,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> List[Watch]:
+        """Workspace-scoped listing, newest first."""
+        q = db.query(Watch).filter(Watch.workspace_id == str(workspace_id))
+        if status is not None:
+            q = q.filter(Watch.status == status)
+        elif not include_closed:
+            q = q.filter(
+                Watch.status.in_([s.value for s in LIVE_WATCH_STATUSES])
+            )
+        if watch_type is not None:
+            q = q.filter(Watch.watch_type == watch_type)
+        return (
+            q.order_by(Watch.created_at.desc()).offset(offset).limit(limit).all()
+        )
+
+    @staticmethod
+    def find_live_watch(
+        db: Session,
+        *,
+        workspace_id: UUID | str,
+        target_type: str,
+        target_id: str,
+    ) -> Optional[Watch]:
+        """The (at most one) non-terminal watch supervising a target."""
+        return (
+            db.query(Watch)
+            .filter(
+                Watch.workspace_id == str(workspace_id),
+                Watch.target_type == target_type,
+                Watch.target_id == str(target_id),
+                Watch.status.in_([s.value for s in LIVE_WATCH_STATUSES]),
+            )
+            .first()
+        )
+
+    @staticmethod
+    def cancel_watch(
+        db: Session,
+        workspace_id: UUID | str,
+        watch_id: UUID | str,
+        *,
+        reason: Optional[str] = None,
+    ) -> Watch:
+        """Cancel a live watch (guarded — cancelling a closed watch raises)."""
+        watch = WatchService.get_watch(db, workspace_id, watch_id)
+        if watch is None:
+            raise ValueError(f"Watch {watch_id} not found in workspace {workspace_id}")
+        WatchService.transition(
+            db, watch, WatchStatus.CANCELLED, reason=reason or "Cancelled"
+        )
+        WatchService.ingest(
+            db,
+            watch,
+            event_type=WatchEventType.CANCELLED.value,
+            event_key="cancelled",
+            summary=reason or "Watch cancelled",
+        )
+        return watch
+
+    # ------------------------------------------------------------------
+    # Guarded transition (house style of transition_run)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def transition(
+        db: Session,
+        watch: Watch,
+        new_status: WatchStatus,
+        *,
+        reason: Optional[str] = None,
+    ) -> Watch:
+        """Transition a watch with the allowed-transition guard.
+
+        Sets ``closed_at`` on terminal statuses. Flushes so the optimistic
+        version check fires (StaleDataError -> ConflictError, house pattern).
+        """
+        current = WatchStatus(watch.status)
+        allowed = ALLOWED_WATCH_TRANSITIONS.get(current, frozenset())
+        if new_status not in allowed:
+            raise InvalidTransitionError(
+                entity_type="watch",
+                entity_id=watch.id,
+                current_state=current.value,
+                target_state=new_status.value,
+            )
+
+        watch.status = new_status.value
+        if new_status in TERMINAL_WATCH_STATUSES:
+            watch.closed_at = _utcnow()
+        elif current in TERMINAL_WATCH_STATUSES:
+            # escalated -> watching renewal re-opens the watch
+            watch.closed_at = None
+
+        try:
+            db.flush()
+        except StaleDataError:
+            raise ConflictError(entity_type="watch", entity_id=watch.id)
+
+        logger.info(
+            "[Watch] %s transitioned: %s -> %s%s",
+            watch.id,
+            current.value,
+            new_status.value,
+            f" ({reason})" if reason else "",
+        )
+        return watch
+
+    # ------------------------------------------------------------------
+    # Idempotent ingest
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def ingest(
+        db: Session,
+        watch: Watch,
+        *,
+        event_type: str,
+        event_key: str,
+        summary: Optional[str] = None,
+        snapshot: Optional[Dict[str, Any]] = None,
+        score: Optional[float] = None,
+        action_taken: Optional[str] = None,
+        requires_attention: bool = False,
+    ) -> Optional[WatchEvent]:
+        """Record an observation exactly once.
+
+        A duplicate (watch_id, event_key) is swallowed via a SAVEPOINT so the
+        caller's outer transaction survives, and ``None`` is returned — the
+        caller can use "was this the first writer?" to decide follow-up work
+        (the S5 tick notifies only when the sweep beat the producer hook).
+        """
+        event = WatchEvent(
+            watch_id=watch.id,
+            event_type=event_type,
+            summary=summary,
+            snapshot=snapshot,
+            score=score,
+            action_taken=action_taken,
+            requires_attention=requires_attention,
+            event_key=event_key,
+        )
+        try:
+            with db.begin_nested():
+                db.add(event)
+                db.flush()
+        except IntegrityError:
+            logger.debug(
+                "[Watch] duplicate event swallowed (watch=%s key=%r)",
+                watch.id,
+                event_key,
+            )
+            return None
+        return event
+
+    # ------------------------------------------------------------------
+    # Terminal ingest — the seam the S3 hooks and the S5 sweep both call
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def ingest_terminal(
+        db: Session,
+        *,
+        workspace_id: UUID | str,
+        target_type: str,
+        target_id: str,
+        terminal_state: str,
+        summary: Optional[str] = None,
+        cost_snapshot: Optional[Dict[str, Any]] = None,
+        output_pointer: Optional[str] = None,
+    ) -> Optional[WatchEvent]:
+        """Ingest a target's terminal state into its live watch, if any.
+
+        Idempotent: exactly one terminal event per (watch, target). On first
+        ingest the watch closes by outcome (WATCH_STATUS_FOR_TERMINAL_TARGET)
+        with an unscored v1 verdict — S6 inserts run-level scoring between
+        "terminal observed" and "watch closed" without changing this seam.
+
+        Returns the NEW WatchEvent when this call was the first writer,
+        else ``None`` (already ingested, or no live watch on the target).
+        """
+        watch = WatchService.find_live_watch(
+            db,
+            workspace_id=workspace_id,
+            target_type=target_type,
+            target_id=str(target_id),
+        )
+        if watch is None:
+            return None
+
+        snapshot: Dict[str, Any] = {"terminal_state": terminal_state}
+        if cost_snapshot:
+            snapshot["cost"] = cost_snapshot
+        if output_pointer:
+            snapshot["output_pointer"] = output_pointer
+
+        event = WatchService.ingest(
+            db,
+            watch,
+            event_type=WatchEventType.TERMINAL.value,
+            event_key=f"terminal:{target_type}:{target_id}",
+            summary=summary or f"Target reached terminal state '{terminal_state}'",
+            snapshot=snapshot,
+        )
+        if event is None:
+            return None
+
+        # Unknown terminal vocabularies park the watch for a human instead of
+        # guessing a verdict.
+        new_status = WATCH_STATUS_FOR_TERMINAL_TARGET.get(
+            terminal_state, WatchStatus.NEEDS_ATTENTION
+        )
+        verdict = (
+            f"Target {target_type}:{target_id} reached terminal state "
+            f"'{terminal_state}'."
+        )
+        if summary:
+            verdict = f"{verdict} {summary}"
+        watch.final_verdict = verdict
+        WatchService.transition(
+            db, watch, new_status, reason=f"target terminal: {terminal_state}"
+        )
+        return event
+
+    # ------------------------------------------------------------------
+    # Bounded corrective actions
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def record_action(
+        db: Session,
+        watch: Watch,
+        *,
+        action: str,
+        summary: Optional[str] = None,
+        snapshot: Optional[Dict[str, Any]] = None,
+    ) -> Tuple[Watch, bool]:
+        """Record a corrective action against the watch's action budget.
+
+        Returns ``(watch, True)`` when the action was recorded (and the watch
+        moved WATCHING -> ACTING). Returns ``(watch, False)`` on the hard
+        stop: the budget is exhausted, a ``budget_exhausted`` event lands
+        (requires_attention) and the watch parks in NEEDS_ATTENTION. The
+        caller (S8/S10 decision step) owns any escalation notification —
+        this module stays sync + DB-only.
+        """
+        taken = watch.actions_taken or 0
+        budget = watch.action_budget or 0
+
+        if taken >= budget:
+            WatchService.ingest(
+                db,
+                watch,
+                event_type=WatchEventType.BUDGET_EXHAUSTED.value,
+                event_key=f"budget_exhausted:{taken}",
+                summary=(
+                    f"Action budget exhausted ({taken}/{budget}) — "
+                    f"refused action '{action}'"
+                ),
+                requires_attention=True,
+            )
+            if WatchStatus(watch.status) != WatchStatus.NEEDS_ATTENTION:
+                WatchService.transition(
+                    db,
+                    watch,
+                    WatchStatus.NEEDS_ATTENTION,
+                    reason="action budget exhausted",
+                )
+            return watch, False
+
+        watch.actions_taken = taken + 1
+        WatchService.ingest(
+            db,
+            watch,
+            event_type=WatchEventType.ACTION.value,
+            event_key=f"action:{watch.actions_taken}:{action}",
+            summary=summary or f"Action taken: {action}",
+            snapshot=snapshot,
+            action_taken=action,
+        )
+        if WatchStatus(watch.status) == WatchStatus.WATCHING:
+            WatchService.transition(
+                db, watch, WatchStatus.ACTING, reason=f"action: {action}"
+            )
+        else:
+            db.flush()
+        return watch, True
+
+    # ------------------------------------------------------------------
+    # Lineage — the watch follows the work (PRD-204 Section 8 Q9)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def follow(
+        db: Session,
+        watch: Watch,
+        *,
+        new_target_type: str,
+        new_target_id: str,
+        reason: Optional[str] = None,
+        now: Optional[datetime] = None,
+    ) -> Watch:
+        """Repoint a live watch at a new target (rerun/replan stays the SAME
+        watch). Appends to ``lineage`` immutably and pulls the next check
+        forward so the tick picks the new target up promptly.
+        """
+        if WatchStatus(watch.status) in TERMINAL_WATCH_STATUSES:
+            raise InvalidTransitionError(
+                entity_type="watch",
+                entity_id=watch.id,
+                current_state=watch.status,
+                target_state="follow",
+            )
+
+        moment = now or _utcnow()
+        new_target_id = str(new_target_id)
+        entry = {
+            "target_type": new_target_type,
+            "target_id": new_target_id,
+            "since": moment.isoformat(),
+            "reason": reason or "follow",
+        }
+        # Immutable append — never mutate the JSONB list in place.
+        watch.lineage = [*(watch.lineage or []), entry]
+        watch.target_type = new_target_type
+        watch.target_id = new_target_id
+        watch.next_check_at = moment
+
+        WatchService.ingest(
+            db,
+            watch,
+            event_type=WatchEventType.FOLLOW.value,
+            event_key=f"follow:{new_target_type}:{new_target_id}",
+            summary=reason or f"Watch now follows {new_target_type}:{new_target_id}",
+        )
+        db.flush()
+        return watch
+
+    # ------------------------------------------------------------------
+    # Tick claim — FOR UPDATE SKIP LOCKED (board_dispatcher idiom)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def claim_due_watches(
+        db: Session,
+        *,
+        limit: int = DEFAULT_CLAIM_LIMIT,
+        now: Optional[datetime] = None,
+    ) -> List[Watch]:
+        """Atomically claim up to ``limit`` due watches for this ticker.
+
+        The locked SELECT grabs only rows no other transaction holds
+        (SKIP LOCKED), and the surrounding UPDATE reschedules
+        ``next_check_at`` in the same statement — the reschedule IS the
+        lease, so a crashed ticker simply re-claims on a later tick.
+        ``version_id`` is bumped so optimistic ORM writers see the claim.
+
+        NOTE: COMMITS the claim (its own transaction), then returns freshly
+        loaded rows — same contract as board_dispatcher.claim_tasks.
+        """
+        moment = now or _utcnow()
+        claimable = ", ".join(
+            repr(s.value) for s in sorted(CLAIMABLE_WATCH_STATUSES)
+        )
+        rows = db.execute(
+            text(
+                f"""
+                UPDATE watches AS w
+                   SET last_checked_at = :now,
+                       next_check_at   = :now
+                           + make_interval(secs => w.check_interval_seconds),
+                       updated_at      = :now,
+                       version_id      = w.version_id + 1
+                 WHERE w.id IN (
+                       SELECT id
+                         FROM watches
+                        WHERE status IN ({claimable})
+                          AND next_check_at IS NOT NULL
+                          AND next_check_at <= :now
+                        ORDER BY next_check_at
+                        FOR UPDATE SKIP LOCKED
+                        LIMIT :limit
+                 )
+             RETURNING w.id
+                """
+            ),
+            {"now": moment, "limit": limit},
+        ).fetchall()
+        db.commit()
+
+        ids = [r[0] for r in rows]
+        if not ids:
+            return []
+
+        claimed = (
+            db.query(Watch)
+            .filter(Watch.id.in_(ids))
+            .order_by(Watch.next_check_at.asc())
+            .all()
+        )
+        logger.info("[Watch] claimed %d due watch(es)", len(claimed))
+        return claimed

--- a/orchestrator/services/watch_service.py
+++ b/orchestrator/services/watch_service.py
@@ -384,13 +384,25 @@ class WatchService:
         summary: Optional[str] = None,
         cost_snapshot: Optional[Dict[str, Any]] = None,
         output_pointer: Optional[str] = None,
+        now: Optional[datetime] = None,
     ) -> Optional[WatchEvent]:
         """Ingest a target's terminal state into its live watch, if any.
 
-        Idempotent: exactly one terminal event per (watch, target). On first
-        ingest the watch closes by outcome (WATCH_STATUS_FOR_TERMINAL_TARGET)
-        with an unscored v1 verdict -- S6 inserts run-level scoring between
-        "terminal observed" and "watch closed" without changing this seam.
+        Idempotent: exactly one terminal event per (watch, target).
+
+        S10 semantics (replaces the v1 close-by-outcome):
+        - scorable terminals (completed/verified/done/failed) do NOT close
+          the watch here -- the terminal is recorded and ``next_check_at``
+          is pulled to now, so the watcher tick hands the watch to the
+          decision step (score -> act/close -> notify) within one tick.
+          Sync producers cannot await the judge; the tick is the one async
+          brain.
+        - ``cancelled`` closes immediately (nothing to score) -- v1 shape.
+        - unknown terminal vocabularies park the watch for a human
+          (needs_attention) instead of guessing a verdict -- v1 shape.
+
+        The pull-forward runs even on duplicate deliveries (self-healing:
+        a crashed decider gets re-poked until the watch closes).
 
         Returns the NEW WatchEvent when this call was the first writer,
         else ``None`` (already ingested, or no live watch on the target).
@@ -419,26 +431,47 @@ class WatchService:
             snapshot=snapshot,
         )
 
-        # Close the watch even when the event was a duplicate: a prior
-        # attempt may have committed the event but lost the close on a
-        # version conflict (e.g. the tick's claim bumped version_id under
-        # the producer hook). find_live_watch guarantees the watch is live
-        # here, so the close is the self-healing half of idempotency.
-        # Unknown terminal vocabularies park the watch for a human instead
-        # of guessing a verdict.
-        new_status = WATCH_STATUS_FOR_TERMINAL_TARGET.get(
-            terminal_state, WatchStatus.NEEDS_ATTENTION
-        )
-        verdict = (
-            f"Target {target_type}:{target_id} reached terminal state "
-            f"'{terminal_state}'."
-        )
-        if summary:
-            verdict = f"{verdict} {summary}"
-        watch.final_verdict = verdict
-        WatchService.transition(
-            db, watch, new_status, reason=f"target terminal: {terminal_state}"
-        )
+        mapped = WATCH_STATUS_FOR_TERMINAL_TARGET.get(terminal_state)
+
+        if mapped is None:
+            # Unknown vocabulary -> park for a human (unchanged from v1).
+            verdict = (
+                f"Target {target_type}:{target_id} reached unknown terminal "
+                f"state '{terminal_state}'."
+            )
+            if summary:
+                verdict = f"{verdict} {summary}"
+            watch.final_verdict = verdict
+            if WatchStatus(watch.status) != WatchStatus.NEEDS_ATTENTION:
+                WatchService.transition(
+                    db,
+                    watch,
+                    WatchStatus.NEEDS_ATTENTION,
+                    reason=f"unknown terminal state: {terminal_state}",
+                )
+            return event
+
+        if mapped == WatchStatus.CANCELLED:
+            # Cancelled work has nothing to score -- close now (v1 shape).
+            verdict = (
+                f"Target {target_type}:{target_id} was cancelled."
+            )
+            if summary:
+                verdict = f"{verdict} {summary}"
+            watch.final_verdict = verdict
+            WatchService.transition(
+                db, watch, WatchStatus.CANCELLED, reason="target cancelled"
+            )
+            return event
+
+        # Scorable terminal: hand to the decision step (S6/S10) by pulling
+        # the next check to NOW. Status is untouched -- the watch stays
+        # claimable for the tick. Recurring (persistent) watches keep their
+        # normal cadence: they observe terminals forever, and a pull-forward
+        # on every duplicate delivery would make them hot-loop every tick.
+        if watch.policy != WatchPolicy.PERSISTENT.value:
+            watch.next_check_at = now or _utcnow()
+            db.flush()
         return event
 
     # ------------------------------------------------------------------

--- a/orchestrator/services/watch_service.py
+++ b/orchestrator/services/watch_service.py
@@ -392,11 +392,14 @@ class WatchService:
             summary=summary or f"Target reached terminal state '{terminal_state}'",
             snapshot=snapshot,
         )
-        if event is None:
-            return None
 
-        # Unknown terminal vocabularies park the watch for a human instead of
-        # guessing a verdict.
+        # Close the watch even when the event was a duplicate: a prior
+        # attempt may have committed the event but lost the close on a
+        # version conflict (e.g. the tick's claim bumped version_id under
+        # the producer hook). find_live_watch guarantees the watch is live
+        # here, so the close is the self-healing half of idempotency.
+        # Unknown terminal vocabularies park the watch for a human instead
+        # of guessing a verdict.
         new_status = WATCH_STATUS_FOR_TERMINAL_TARGET.get(
             terminal_state, WatchStatus.NEEDS_ATTENTION
         )
@@ -582,10 +585,16 @@ class WatchService:
         if not ids:
             return []
 
+        # populate_existing is REQUIRED: the raw UPDATE above bumped
+        # version_id outside the ORM, so an identity-mapped instance from
+        # earlier in this session still carries the stale version. Without
+        # the refresh, the next optimistic-locked write on a claimed watch
+        # would StaleDataError against its own claim.
         claimed = (
             db.query(Watch)
             .filter(Watch.id.in_(ids))
             .order_by(Watch.next_check_at.asc())
+            .execution_options(populate_existing=True)
             .all()
         )
         logger.info("[Watch] claimed %d due watch(es)", len(claimed))

--- a/orchestrator/services/watch_ticker.py
+++ b/orchestrator/services/watch_ticker.py
@@ -417,44 +417,22 @@ class WatchTicker:
         message: Optional[str],
         status: str = "ok",
     ) -> None:
-        """Fire a watch-related event through NotificationDispatcher.
+        """Fire a watch-related event through the shared notification seam.
 
-        Joins the caller's transaction (tick commits per watch). Resolves
-        ``watch.created_by`` (Clerk id) to a user_id so the creator is
-        targeted; workspace-wide when unresolvable. Never raises into the
-        sweep.
+        Kept as a ticker method (test seam); the body is the S6 shared
+        helper so the verdict/action/decision paths and the sweep all
+        dispatch identically. Never raises into the sweep.
         """
-        try:
-            from core.models.core import User
-            from core.services.notification_dispatcher import NotificationDispatcher
+        from services.watch_notifications import dispatch_watch_notification
 
-            user_id: Optional[int] = None
-            if watch.created_by:
-                user_row = (
-                    db.query(User.id)
-                    .filter(User.clerk_user_id == watch.created_by)
-                    .first()
-                )
-                if user_row:
-                    user_id = user_row[0]
-
-            dispatcher = NotificationDispatcher(db, str(watch.workspace_id))
-            await dispatcher.dispatch(
-                event_type=event_type,
-                title=title,
-                message=message,
-                link_type="watch",
-                link_id=str(watch.id),
-                status=status,
-                user_id=user_id,
-            )
-        except Exception:
-            logger.error(
-                "[WatchTicker] %s dispatch failed for watch %s",
-                event_type,
-                getattr(watch, "id", "?"),
-                exc_info=True,
-            )
+        await dispatch_watch_notification(
+            db,
+            watch,
+            event_type=event_type,
+            title=title,
+            message=message,
+            status=status,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/orchestrator/services/watch_ticker.py
+++ b/orchestrator/services/watch_ticker.py
@@ -20,12 +20,15 @@ fallback and the trend brain:
   writes nothing),
 - reschedules ``next_check_at`` (done inside the claim).
 
-Notification rules (PRD-204 S5): the tick dispatches only for conditions no
-producer covers -- sweep-caught terminal (``watch_verdict``: the producer's
-hook AND its own notification evidently did not land), missed run and
-expiry (``watch_escalation``). Benched watch_events are recorded here, but
-the ``playbook_benched`` NOTIFICATION is owned by the scheduler skip path
-(S4, once per breaker-open period) -- dispatching it from the tick too would
+Notification rules (PRD-204 S5/S10): terminal-state verdicts are owned by
+the DECISION STEP (services/watch_decider.py) -- the tick records the
+terminal (idempotent) and hands the live watch to
+``WatchDecider.decide_terminal`` which scores (S6), acts (S7/S8) or closes,
+and dispatches ``watch_verdict``/``watch_action``. The tick itself
+dispatches only what no other owner covers: missed run and expiry
+(``watch_escalation``). Benched watch_events are recorded here, but the
+``playbook_benched`` NOTIFICATION is owned by the scheduler skip path (S4,
+once per breaker-open period) -- dispatching it from the tick too would
 double-notify every bench.
 """
 
@@ -42,6 +45,7 @@ from core.models.watches import Watch
 from core.models.watch_enums import (
     CLAIMABLE_WATCH_STATUSES,
     WatchEventType,
+    WatchPolicy,
     WatchStatus,
     WatchTargetType,
 )
@@ -206,29 +210,29 @@ class WatchTicker:
         if state not in _RUN_TERMINAL:
             return  # no-noise: running -> running writes nothing
 
-        # Sweep fallback: the hook missed this terminal (crash between the
-        # terminal write and the hook's transaction, hook disabled, etc.).
-        event = WatchService.ingest_terminal(
+        # Record the terminal (idempotent; the producer hook usually beat
+        # us here). PRD-204 S10: ingest no longer closes scorable terminals
+        # -- the DECISION STEP owns score -> act/close -> notify.
+        WatchService.ingest_terminal(
             db,
             workspace_id=watch.workspace_id,
             target_type=watch.target_type,
             target_id=watch.target_id,
             terminal_state=state,
             summary="Detected by watcher sweep",
+            now=now,
         )
-        if event is not None:
-            # The producer's notification path was evidently missed too --
-            # the watch verdict is the safety-net signal.
-            await self._dispatch_watch_event(
-                db,
-                watch,
-                event_type="watch_verdict",
-                title=f"Watch closed ({state}): {watch.title[:100]}",
-                message=(
-                    f"The watched {watch.watch_type} reached terminal state "
-                    f"'{state}'. Verdict: {watch.status}."
-                ),
-                status="ok" if state == "completed" else "error",
+        if WatchStatus(watch.status) in CLAIMABLE_WATCH_STATUSES:
+            from services.watch_decider import get_watch_decider
+
+            decision = await get_watch_decider().decide_terminal(
+                db, watch, state, now
+            )
+            logger.info(
+                "[WatchTicker] decision for watch %s (terminal=%s): %s",
+                watch.id,
+                state,
+                decision,
             )
 
     def _read_target_state(self, db: Session, watch: Watch) -> Optional[str]:
@@ -402,6 +406,14 @@ class WatchTicker:
                 ),
                 status="warning",
             )
+
+        # PRD-204 S10: persistent watches also report OUTCOME FLIPS between
+        # consecutive runs (completed <-> failed) -- notify on meaningful
+        # change, never close on a run terminal.
+        if watch.policy == WatchPolicy.PERSISTENT.value:
+            from services.watch_decider import get_watch_decider
+
+            await get_watch_decider().observe_scheduled(db, watch, playbook, now)
 
     # ------------------------------------------------------------------
     # Notification seam (mirrors coordinator_service._dispatch_mission_event)

--- a/orchestrator/services/watch_ticker.py
+++ b/orchestrator/services/watch_ticker.py
@@ -1,16 +1,16 @@
 """
-WatchTicker — PRD-204 S5
+WatchTicker -- PRD-204 S5
 =========================
 
 The watcher heartbeat sweep on the UnifiedScheduler (TaskReconciler
-pattern). The S3 event hooks are the FAST path — a terminal state normally
+pattern). The S3 event hooks are the FAST path -- a terminal state normally
 reaches the watch in the producer's own transaction. The tick is the
 fallback and the trend brain:
 
 - claims due watches (``next_check_at <= now``) via FOR UPDATE SKIP LOCKED
   (single-writer; the claim's reschedule doubles as the lease),
 - refreshes the target's state with a cheap status read; a terminal state
-  the hooks missed is ingested here (idempotent — the event_key dedupe
+  the hooks missed is ingested here (idempotent -- the event_key dedupe
   makes "hook then sweep" write exactly one event),
 - handles ``deadline_at`` -> expired,
 - for scheduled-playbook watches: croniter expected-fire vs the latest
@@ -21,11 +21,11 @@ fallback and the trend brain:
 - reschedules ``next_check_at`` (done inside the claim).
 
 Notification rules (PRD-204 S5): the tick dispatches only for conditions no
-producer covers — sweep-caught terminal (``watch_verdict``: the producer's
+producer covers -- sweep-caught terminal (``watch_verdict``: the producer's
 hook AND its own notification evidently did not land), missed run and
 expiry (``watch_escalation``). Benched watch_events are recorded here, but
 the ``playbook_benched`` NOTIFICATION is owned by the scheduler skip path
-(S4, once per breaker-open period) — dispatching it from the tick too would
+(S4, once per breaker-open period) -- dispatching it from the tick too would
 double-notify every bench.
 """
 
@@ -54,7 +54,7 @@ _RUN_TERMINAL = frozenset({"completed", "failed", "cancelled"})
 _EXECUTION_TERMINAL = frozenset({"completed", "failed", "cancelled"})
 _BOARD_TERMINAL = {"done": "completed", "failed": "failed"}
 
-# A cron fire only counts as missed once it is this many seconds overdue —
+# A cron fire only counts as missed once it is this many seconds overdue --
 # absorbs scheduler jitter and slow launches without false alarms.
 MISSED_RUN_GRACE_SECONDS = 120
 
@@ -92,7 +92,7 @@ class WatchTicker:
             replace_existing=True,
             max_instances=1,
         )
-        logger.info("[WatchTicker] Started — tick every %ds", interval)
+        logger.info("[WatchTicker] Started -- tick every %ds", interval)
 
     async def stop(self):
         """Remove the tick job from the scheduler."""
@@ -105,7 +105,7 @@ class WatchTicker:
     # ------------------------------------------------------------------
 
     async def _tick(self):
-        """Scheduled entry point — opens its own session."""
+        """Scheduled entry point -- opens its own session."""
         from core.database.database import SessionLocal
 
         db = SessionLocal()
@@ -119,7 +119,7 @@ class WatchTicker:
     async def tick_once(self, db: Session, now: datetime) -> int:
         """One sweep pass at a fixed ``now`` (injected for frozen-clock
         tests). Returns the number of watches processed. Per-watch errors
-        roll back that watch's work only — the sweep keeps going.
+        roll back that watch's work only -- the sweep keeps going.
         """
         claimed = WatchService.claim_due_watches(db, now=now)  # commits
         for watch in claimed:
@@ -217,7 +217,7 @@ class WatchTicker:
             summary="Detected by watcher sweep",
         )
         if event is not None:
-            # The producer's notification path was evidently missed too —
+            # The producer's notification path was evidently missed too --
             # the watch verdict is the safety-net signal.
             await self._dispatch_watch_event(
                 db,
@@ -317,7 +317,7 @@ class WatchTicker:
         # open the scheduler creates no new rows, so the key is stable for
         # the whole open period -> exactly one benched event per period.
         # The playbook_benched NOTIFICATION is owned by the scheduler skip
-        # path (S4) — see module docstring.
+        # path (S4) -- see module docstring.
         from services.playbook_breaker import breaker_is_open
 
         if breaker_is_open(db, playbook.id):

--- a/orchestrator/services/watch_ticker.py
+++ b/orchestrator/services/watch_ticker.py
@@ -1,0 +1,471 @@
+"""
+WatchTicker — PRD-204 S5
+=========================
+
+The watcher heartbeat sweep on the UnifiedScheduler (TaskReconciler
+pattern). The S3 event hooks are the FAST path — a terminal state normally
+reaches the watch in the producer's own transaction. The tick is the
+fallback and the trend brain:
+
+- claims due watches (``next_check_at <= now``) via FOR UPDATE SKIP LOCKED
+  (single-writer; the claim's reschedule doubles as the lease),
+- refreshes the target's state with a cheap status read; a terminal state
+  the hooks missed is ingested here (idempotent — the event_key dedupe
+  makes "hook then sweep" write exactly one event),
+- handles ``deadline_at`` -> expired,
+- for scheduled-playbook watches: croniter expected-fire vs the latest
+  ``recipe_executions`` row -> missed-run event; ``breaker_is_open`` ->
+  benched event,
+- writes a watch_event only on MEANINGFUL change (running -> running
+  writes nothing),
+- reschedules ``next_check_at`` (done inside the claim).
+
+Notification rules (PRD-204 S5): the tick dispatches only for conditions no
+producer covers — sweep-caught terminal (``watch_verdict``: the producer's
+hook AND its own notification evidently did not land), missed run and
+expiry (``watch_escalation``). Benched watch_events are recorded here, but
+the ``playbook_benched`` NOTIFICATION is owned by the scheduler skip path
+(S4, once per breaker-open period) — dispatching it from the tick too would
+double-notify every bench.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from sqlalchemy.orm import Session
+
+from core.models.watches import Watch
+from core.models.watch_enums import (
+    CLAIMABLE_WATCH_STATUSES,
+    WatchEventType,
+    WatchStatus,
+    WatchTargetType,
+)
+from services.watch_service import WatchService
+
+logger = logging.getLogger(__name__)
+
+# Terminal vocabularies per target table (cheap status reads).
+_RUN_TERMINAL = frozenset({"completed", "failed", "cancelled"})
+_EXECUTION_TERMINAL = frozenset({"completed", "failed", "cancelled"})
+_BOARD_TERMINAL = {"done": "completed", "failed": "failed"}
+
+# A cron fire only counts as missed once it is this many seconds overdue —
+# absorbs scheduler jitter and slow launches without false alarms.
+MISSED_RUN_GRACE_SECONDS = 120
+
+
+def _aware(dt: Optional[datetime]) -> Optional[datetime]:
+    """Normalise DB datetimes (some legacy columns are tz-naive UTC)."""
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+class WatchTicker:
+    """Background sweep loop over the watch registry."""
+
+    def __init__(self):
+        self._scheduler: Optional[AsyncIOScheduler] = None
+
+    # ------------------------------------------------------------------
+    # Lifecycle (TaskReconciler pattern)
+    # ------------------------------------------------------------------
+
+    async def start(self, scheduler: AsyncIOScheduler):
+        """Register the watcher tick on the shared scheduler."""
+        from config import config as app_config
+
+        self._scheduler = scheduler
+        interval = app_config.WATCHER_TICK_SECONDS
+        self._scheduler.add_job(
+            self._tick,
+            "interval",
+            seconds=interval,
+            id="watch_ticker_tick",
+            replace_existing=True,
+            max_instances=1,
+        )
+        logger.info("[WatchTicker] Started — tick every %ds", interval)
+
+    async def stop(self):
+        """Remove the tick job from the scheduler."""
+        if self._scheduler and self._scheduler.get_job("watch_ticker_tick"):
+            self._scheduler.remove_job("watch_ticker_tick")
+            logger.info("[WatchTicker] Stopped")
+
+    # ------------------------------------------------------------------
+    # Tick
+    # ------------------------------------------------------------------
+
+    async def _tick(self):
+        """Scheduled entry point — opens its own session."""
+        from core.database.database import SessionLocal
+
+        db = SessionLocal()
+        try:
+            await self.tick_once(db, now=datetime.now(timezone.utc))
+        except Exception:
+            logger.error("[WatchTicker] tick failed", exc_info=True)
+        finally:
+            db.close()
+
+    async def tick_once(self, db: Session, now: datetime) -> int:
+        """One sweep pass at a fixed ``now`` (injected for frozen-clock
+        tests). Returns the number of watches processed. Per-watch errors
+        roll back that watch's work only — the sweep keeps going.
+        """
+        claimed = WatchService.claim_due_watches(db, now=now)  # commits
+        for watch in claimed:
+            try:
+                await self._check_watch(db, watch, now)
+                db.commit()
+            except Exception:
+                db.rollback()
+                logger.error(
+                    "[WatchTicker] check failed for watch %s",
+                    getattr(watch, "id", "?"),
+                    exc_info=True,
+                )
+        return len(claimed)
+
+    # ------------------------------------------------------------------
+    # Per-watch checks
+    # ------------------------------------------------------------------
+
+    async def _check_watch(self, db: Session, watch: Watch, now: datetime) -> None:
+        if watch.target_type == WatchTargetType.SCHEDULED_PLAYBOOK.value:
+            await self._check_scheduled_playbook(db, watch, now)
+        else:
+            await self._check_run_target(db, watch, now)
+
+        # Deadline -> expired (only if the checks above left the watch live).
+        if (
+            WatchStatus(watch.status) in CLAIMABLE_WATCH_STATUSES
+            and watch.deadline_at is not None
+            and _aware(watch.deadline_at) <= now
+        ):
+            event = WatchService.ingest(
+                db,
+                watch,
+                event_type=WatchEventType.EXPIRED.value,
+                event_key="expired",
+                summary=(
+                    f"Deadline {_aware(watch.deadline_at).isoformat()} passed "
+                    f"without a verdict"
+                ),
+                requires_attention=True,
+            )
+            WatchService.transition(
+                db, watch, WatchStatus.EXPIRED, reason="deadline passed"
+            )
+            if event is not None:
+                await self._dispatch_watch_event(
+                    db,
+                    watch,
+                    event_type="watch_escalation",
+                    title=f"Watch expired: {watch.title[:110]}",
+                    message=(
+                        "The deadline passed before the watched work reached "
+                        "a verdict."
+                    ),
+                    status="warning",
+                )
+
+    # -------------------------------------------------- run-shaped targets
+
+    async def _check_run_target(self, db: Session, watch: Watch, now: datetime) -> None:
+        """Cheap status read for mission / playbook-execution / board-task
+        targets. Writes NOTHING while the target is still in flight."""
+        state = self._read_target_state(db, watch)
+
+        if state is None:
+            event = WatchService.ingest(
+                db,
+                watch,
+                event_type=WatchEventType.TARGET_MISSING.value,
+                event_key=f"missing:{watch.target_type}:{watch.target_id}",
+                summary=(
+                    f"Target {watch.target_type}:{watch.target_id} no longer "
+                    f"exists (deleted or archived)"
+                ),
+                requires_attention=True,
+            )
+            if event is not None and WatchStatus(watch.status) != WatchStatus.NEEDS_ATTENTION:
+                WatchService.transition(
+                    db, watch, WatchStatus.NEEDS_ATTENTION, reason="target missing"
+                )
+            return
+
+        if state not in _RUN_TERMINAL:
+            return  # no-noise: running -> running writes nothing
+
+        # Sweep fallback: the hook missed this terminal (crash between the
+        # terminal write and the hook's transaction, hook disabled, etc.).
+        event = WatchService.ingest_terminal(
+            db,
+            workspace_id=watch.workspace_id,
+            target_type=watch.target_type,
+            target_id=watch.target_id,
+            terminal_state=state,
+            summary="Detected by watcher sweep",
+        )
+        if event is not None:
+            # The producer's notification path was evidently missed too —
+            # the watch verdict is the safety-net signal.
+            await self._dispatch_watch_event(
+                db,
+                watch,
+                event_type="watch_verdict",
+                title=f"Watch closed ({state}): {watch.title[:100]}",
+                message=(
+                    f"The watched {watch.watch_type} reached terminal state "
+                    f"'{state}'. Verdict: {watch.status}."
+                ),
+                status="ok" if state == "completed" else "error",
+            )
+
+    def _read_target_state(self, db: Session, watch: Watch) -> Optional[str]:
+        """Return the target's current status string, or None if the target
+        row is gone / unreadable-by-type."""
+        target_type = watch.target_type
+        if target_type == WatchTargetType.MISSION.value:
+            from core.models.orchestration import OrchestrationRun
+
+            row = (
+                db.query(OrchestrationRun.state)
+                .filter(OrchestrationRun.id == watch.target_id)
+                .first()
+            )
+            return row[0] if row else None
+
+        if target_type == WatchTargetType.PLAYBOOK_EXECUTION.value:
+            from core.models.core import RecipeExecution
+
+            row = (
+                db.query(RecipeExecution.status)
+                .filter(RecipeExecution.execution_id == watch.target_id)
+                .first()
+            )
+            return row[0] if row else None
+
+        if target_type == WatchTargetType.BOARD_TASK.value:
+            from core.models.core import BoardTask
+
+            try:
+                task_id = int(watch.target_id)
+            except (TypeError, ValueError):
+                return None
+            row = db.query(BoardTask.status).filter(BoardTask.id == task_id).first()
+            if row is None:
+                return None
+            return _BOARD_TERMINAL.get(row[0], "running")
+
+        logger.warning(
+            "[WatchTicker] unknown target_type %r on watch %s",
+            target_type,
+            watch.id,
+        )
+        return None
+
+    # ------------------------------------------- scheduled-playbook targets
+
+    async def _check_scheduled_playbook(
+        self, db: Session, watch: Watch, now: datetime
+    ) -> None:
+        """Missed-run + benched checks for a cron-scheduled playbook."""
+        from core.models import WorkflowTemplate as WorkflowPlaybook
+        from core.models.core import RecipeExecution
+
+        try:
+            recipe_id = int(watch.target_id)
+        except (TypeError, ValueError):
+            recipe_id = None
+        playbook = (
+            db.query(WorkflowPlaybook).filter(WorkflowPlaybook.id == recipe_id).first()
+            if recipe_id is not None
+            else None
+        )
+        if playbook is None:
+            event = WatchService.ingest(
+                db,
+                watch,
+                event_type=WatchEventType.TARGET_MISSING.value,
+                event_key=f"missing:scheduled_playbook:{watch.target_id}",
+                summary=f"Scheduled playbook {watch.target_id} no longer exists",
+                requires_attention=True,
+            )
+            if event is not None and WatchStatus(watch.status) != WatchStatus.NEEDS_ATTENTION:
+                WatchService.transition(
+                    db, watch, WatchStatus.NEEDS_ATTENTION, reason="target missing"
+                )
+            return
+
+        sc = playbook.schedule_config or {}
+        cron_expression = sc.get("cron_expression")
+        if sc.get("type") != "cron" or not cron_expression:
+            return  # nothing schedule-shaped to supervise
+
+        # --- Benched: breaker open -> record on the watch timeline. The
+        # latest terminal execution id keys the event: while the breaker is
+        # open the scheduler creates no new rows, so the key is stable for
+        # the whole open period -> exactly one benched event per period.
+        # The playbook_benched NOTIFICATION is owned by the scheduler skip
+        # path (S4) — see module docstring.
+        from services.playbook_breaker import breaker_is_open
+
+        if breaker_is_open(db, playbook.id):
+            latest_terminal = (
+                db.query(RecipeExecution.id)
+                .filter(
+                    RecipeExecution.recipe_id == playbook.id,
+                    RecipeExecution.status.in_(("completed", "failed")),
+                )
+                .order_by(RecipeExecution.started_at.desc())
+                .first()
+            )
+            bench_key = (
+                f"benched:{latest_terminal[0]}" if latest_terminal else "benched:none"
+            )
+            WatchService.ingest(
+                db,
+                watch,
+                event_type=WatchEventType.BENCHED.value,
+                event_key=bench_key,
+                summary=(
+                    f"Playbook '{playbook.name}' is benched: the repeated-"
+                    f"failure breaker is open, scheduled runs are paused"
+                ),
+                requires_attention=True,
+            )
+
+        # --- Missed run: expected fire (croniter, via the single source of
+        # truth schedule_util.next_run) vs the latest execution row.
+        from services.schedule_util import next_run
+
+        latest = (
+            db.query(RecipeExecution.started_at)
+            .filter(RecipeExecution.recipe_id == playbook.id)
+            .order_by(RecipeExecution.started_at.desc())
+            .first()
+        )
+        baseline = _aware(latest[0]) if latest else _aware(watch.created_at)
+        if baseline is None:
+            return
+
+        expected = next_run(cron_expression, now=baseline)
+        if expected is None:
+            return
+        overdue_by = (now - expected).total_seconds()
+        if overdue_by < MISSED_RUN_GRACE_SECONDS:
+            return  # not due yet, or within launch-jitter grace
+
+        # Did anything actually run at/after the expected fire?
+        ran = (
+            db.query(RecipeExecution.id)
+            .filter(
+                RecipeExecution.recipe_id == playbook.id,
+                RecipeExecution.started_at >= expected.replace(tzinfo=None),
+            )
+            .first()
+        )
+        if ran is not None:
+            return
+
+        event = WatchService.ingest(
+            db,
+            watch,
+            event_type=WatchEventType.MISSED_RUN.value,
+            event_key=f"missed:{expected.isoformat()}",
+            summary=(
+                f"Playbook '{playbook.name}' missed its expected fire at "
+                f"{expected.isoformat()} (no execution row)"
+            ),
+            snapshot={"expected_fire": expected.isoformat()},
+            requires_attention=True,
+        )
+        if event is not None:
+            await self._dispatch_watch_event(
+                db,
+                watch,
+                event_type="watch_escalation",
+                title=f"Missed scheduled run: {playbook.name}",
+                message=(
+                    f"Expected a run at {expected.isoformat()} but none "
+                    f"started. The schedule may be stalled."
+                ),
+                status="warning",
+            )
+
+    # ------------------------------------------------------------------
+    # Notification seam (mirrors coordinator_service._dispatch_mission_event)
+    # ------------------------------------------------------------------
+
+    async def _dispatch_watch_event(
+        self,
+        db: Session,
+        watch: Watch,
+        *,
+        event_type: str,
+        title: str,
+        message: Optional[str],
+        status: str = "ok",
+    ) -> None:
+        """Fire a watch-related event through NotificationDispatcher.
+
+        Joins the caller's transaction (tick commits per watch). Resolves
+        ``watch.created_by`` (Clerk id) to a user_id so the creator is
+        targeted; workspace-wide when unresolvable. Never raises into the
+        sweep.
+        """
+        try:
+            from core.models.core import User
+            from core.services.notification_dispatcher import NotificationDispatcher
+
+            user_id: Optional[int] = None
+            if watch.created_by:
+                user_row = (
+                    db.query(User.id)
+                    .filter(User.clerk_user_id == watch.created_by)
+                    .first()
+                )
+                if user_row:
+                    user_id = user_row[0]
+
+            dispatcher = NotificationDispatcher(db, str(watch.workspace_id))
+            await dispatcher.dispatch(
+                event_type=event_type,
+                title=title,
+                message=message,
+                link_type="watch",
+                link_id=str(watch.id),
+                status=status,
+                user_id=user_id,
+            )
+        except Exception:
+            logger.error(
+                "[WatchTicker] %s dispatch failed for watch %s",
+                event_type,
+                getattr(watch, "id", "?"),
+                exc_info=True,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Singleton (house pattern)
+# ---------------------------------------------------------------------------
+
+_watch_ticker: Optional[WatchTicker] = None
+
+
+def get_watch_ticker() -> WatchTicker:
+    global _watch_ticker
+    if _watch_ticker is None:
+        _watch_ticker = WatchTicker()
+    return _watch_ticker

--- a/orchestrator/tests/golden/prd204_policy_table.json
+++ b/orchestrator/tests/golden/prd204_policy_table.json
@@ -1,0 +1,51 @@
+{
+  "default_allowed_actions": {
+    "board_task": [
+      "escalate"
+    ],
+    "mission": [
+      "replan",
+      "reassign",
+      "spawn_agent",
+      "escalate"
+    ],
+    "playbook_execution": [
+      "rerun",
+      "tweak_rerun",
+      "escalate"
+    ],
+    "scheduled_playbook": [
+      "escalate"
+    ]
+  },
+  "policy_table": {
+    "persistent": {
+      "acts_on_failure": false,
+      "acts_on_low_score": false,
+      "compares": false,
+      "recurring": true,
+      "scores": false
+    },
+    "run_and_report": {
+      "acts_on_failure": false,
+      "acts_on_low_score": false,
+      "compares": false,
+      "recurring": false,
+      "scores": true
+    },
+    "score_and_improve": {
+      "acts_on_failure": true,
+      "acts_on_low_score": true,
+      "compares": false,
+      "recurring": false,
+      "scores": true
+    },
+    "watch_change": {
+      "acts_on_failure": false,
+      "acts_on_low_score": false,
+      "compares": true,
+      "recurring": false,
+      "scores": true
+    }
+  }
+}

--- a/orchestrator/tests/test_prd204_rerun.py
+++ b/orchestrator/tests/test_prd204_rerun.py
@@ -1,0 +1,568 @@
+"""PRD-204 S7 -- rerun + tweak + grant wiring.
+
+Covers: the copy idiom (inputs + retry_of lineage + attempt_count), the
+per-execution step-override merge (shared playbook definition NEVER
+mutated), the approval gate (always_ask parks a SUBJECT_PLAYBOOK_RUN grant;
+full_auto under-ceiling launches; over-ceiling estimate parks), grant ->
+resume launches + the watch follows, deny -> no launch + needs_attention.
+
+The playbook engine launch is ALWAYS stubbed (no local runs -- CI is the
+gate); notification dispatch is captured at the dispatcher seam (the
+``notifications`` table is migration-only and absent from the test schema).
+"""
+from __future__ import annotations
+
+import asyncio
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+from core.database.database import get_database_url
+from core.models import WorkflowTemplate
+from core.models.core import LLMUsage, RecipeExecution
+from core.models.approval_grants import (
+    ApprovalGrant,
+    GrantStatus,
+    SUBJECT_PLAYBOOK_RUN,
+)
+from core.models.watches import WatchEvent
+from core.models.watch_enums import WatchEventType, WatchStatus
+from core.services.approval_grants import grant_grant
+from services.watch_service import WatchService
+
+FROZEN_NOW = datetime(2026, 7, 16, 12, 0, 0, tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# Pure: executor-side override merge
+# ---------------------------------------------------------------------------
+
+
+def test_apply_step_overrides_new_dicts_only_prompt_honoured():
+    from api.recipe_executor import _apply_step_overrides
+
+    steps = [
+        {"step_id": "s1", "order": 1, "prompt_template": "original one", "agent_id": 7},
+        {"step_id": "s2", "order": 2, "prompt_template": "original two", "agent_id": 8},
+    ]
+    overrides = {
+        "s1": {"prompt_template": "tweaked one", "agent_id": 99, "order": 42},
+        "missing": {"prompt_template": "never lands"},
+        "s2": "not-a-dict",
+    }
+    merged = _apply_step_overrides(steps, overrides)
+
+    assert merged[0]["prompt_template"] == "tweaked one"
+    # Only prompt_template is honoured -- agent/order untouched.
+    assert merged[0]["agent_id"] == 7
+    assert merged[0]["order"] == 1
+    assert merged[1]["prompt_template"] == "original two"
+    # The source list is never mutated (new dicts).
+    assert steps[0]["prompt_template"] == "original one"
+    assert merged[0] is not steps[0]
+
+    # No overrides -> plain copies.
+    plain = _apply_step_overrides(steps, None)
+    assert plain[0] == steps[0] and plain[0] is not steps[0]
+
+
+def test_validate_step_overrides_boundary():
+    from services.watch_rerun import validate_step_overrides
+
+    class _Recipe:
+        steps = [{"step_id": "s1", "order": 1}, {"step_id": "s2", "order": 2}]
+
+    ok, err = validate_step_overrides(_Recipe(), {"s1": {"prompt_template": "new"}})
+    assert err is None
+    assert ok == {"s1": {"prompt_template": "new"}}
+
+    assert validate_step_overrides(_Recipe(), None) == (None, None)
+    assert validate_step_overrides(_Recipe(), {}) == (None, None)
+
+    _, err = validate_step_overrides(_Recipe(), {"nope": {"prompt_template": "x"}})
+    assert "Unknown step_id" in err
+    _, err = validate_step_overrides(_Recipe(), {"s1": "just a string"})
+    assert "must be an object" in err
+    _, err = validate_step_overrides(_Recipe(), {"s1": {"prompt_template": "  "}})
+    assert "non-empty string" in err
+    _, err = validate_step_overrides(_Recipe(), ["not", "a", "dict"])
+    assert "must be an object" in err
+
+
+# ---------------------------------------------------------------------------
+# DB fixtures (stage-1 pattern; skip cleanly without Postgres)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def engine():
+    try:
+        eng = create_engine(get_database_url(), pool_pre_ping=True)
+        with eng.connect() as c:
+            c.execute(text("SELECT 1 FROM watches LIMIT 1"))
+            c.execute(text("SELECT 1 FROM recipe_executions LIMIT 1"))
+            c.execute(text("SELECT 1 FROM approval_grants LIMIT 1"))
+    except Exception as exc:  # noqa: BLE001
+        pytest.skip(f"rerun suite needs a reachable Postgres with schema: {exc}")
+    yield eng
+    eng.dispose()
+
+
+@pytest.fixture
+def new_session(engine):
+    return sessionmaker(bind=engine, expire_on_commit=False)
+
+
+@pytest.fixture
+def workspace(new_session):
+    ws_id = str(uuid.uuid4())
+    s = new_session()
+    s.execute(
+        text(
+            "INSERT INTO workspaces (id, name) "
+            "VALUES (CAST(:id AS uuid), :n) ON CONFLICT (id) DO NOTHING"
+        ),
+        {"id": ws_id, "n": "prd204-rerun"},
+    )
+    s.commit()
+    s.close()
+
+    yield ws_id
+
+    s = new_session()
+    for stmt in (
+        "DELETE FROM watch_events WHERE watch_id IN "
+        "(SELECT id FROM watches WHERE workspace_id = CAST(:w AS uuid))",
+        "DELETE FROM watches WHERE workspace_id = CAST(:w AS uuid)",
+        "DELETE FROM approval_grants WHERE workspace_id = CAST(:w AS uuid)",
+        "DELETE FROM llm_usage WHERE workspace_id = CAST(:w AS uuid)",
+        "DELETE FROM recipe_executions WHERE workspace_id = CAST(:w AS uuid)",
+        "DELETE FROM workflow_recipes WHERE workspace_id = CAST(:w AS uuid)",
+        "DELETE FROM workspaces WHERE id = CAST(:w AS uuid)",
+    ):
+        s.execute(text(stmt), {"w": ws_id})
+    s.commit()
+    s.close()
+
+
+@pytest.fixture
+def stub_launch(monkeypatch):
+    """No local playbook runs: capture engine launches instead."""
+    import services.watch_rerun as wr
+
+    launched = []
+    monkeypatch.setattr(wr, "launch_execution", lambda execution: launched.append(execution.execution_id))
+    return launched
+
+
+@pytest.fixture
+def capture_notifications(monkeypatch):
+    """Capture NotificationDispatcher.dispatch at the seam (never SELECT
+    notifications -- the table is migration-only)."""
+    from core.services.notification_dispatcher import NotificationDispatcher
+
+    sent = []
+
+    async def _capture(self, event_type, title, message=None, **kwargs):
+        sent.append({"event_type": event_type, "title": title,
+                     "message": message, **kwargs})
+        return {"dispatched_to": ["in_app"]}
+
+    monkeypatch.setattr(NotificationDispatcher, "dispatch", _capture)
+    return sent
+
+
+def _seed_recipe_and_execution(s, ws_id, *, cost_rows=()):
+    recipe = WorkflowTemplate(
+        template_id=f"prd204-rr-{uuid.uuid4().hex[:10]}",
+        name="rerun test playbook",
+        description="prd204 rerun",
+        workspace_id=ws_id,
+        template_definition={"steps": []},
+        steps=[
+            {"step_id": "s1", "order": 1, "prompt_template": "do the thing"},
+            {"step_id": "s2", "order": 2, "prompt_template": "summarise it"},
+        ],
+        created_by="user_test",
+    )
+    s.add(recipe)
+    s.commit()
+
+    original = RecipeExecution(
+        execution_id=f"exec-{uuid.uuid4().hex[:12]}",
+        recipe_id=recipe.id,
+        workspace_id=ws_id,
+        status="completed",
+        input_data={"topic": "quarterly numbers"},
+        attempt_count=1,
+        triggered_by="user@example.com",
+    )
+    s.add(original)
+    for cost in cost_rows:
+        s.add(
+            LLMUsage(
+                workspace_id=ws_id,
+                model_id="openai/gpt-4o-mini",
+                provider="openai",
+                tier="direct",
+                execution_id=original.execution_id,
+                request_type="recipe",
+                input_tokens=100,
+                output_tokens=100,
+                total_tokens=200,
+                input_cost=cost / 2,
+                output_cost=cost / 2,
+                total_cost=cost,
+                status="success",
+            )
+        )
+    s.commit()
+    return recipe, original
+
+
+def _set_policy(s, ws_id, settings):
+    s.execute(
+        text("UPDATE workspaces SET settings = CAST(:cfg AS jsonb) WHERE id = CAST(:w AS uuid)"),
+        {"cfg": __import__("json").dumps(settings), "w": ws_id},
+    )
+    s.commit()
+
+
+def _make_watch(s, ws_id, original):
+    watch = WatchService.create_watch(
+        s,
+        workspace_id=ws_id,
+        watch_type="playbook_execution",
+        target_type="playbook_execution",
+        target_id=original.execution_id,
+        title="Watch: rerun test",
+        success_criteria="deliver the summary",
+        policy="score_and_improve",
+        now=FROZEN_NOW,
+    )
+    s.commit()
+    return watch
+
+
+# ---------------------------------------------------------------------------
+# Copy idiom
+# ---------------------------------------------------------------------------
+
+
+def test_create_rerun_execution_copies_inputs_and_lineage(workspace, new_session):
+    from services.watch_rerun import create_rerun_execution
+
+    s = new_session()
+    recipe, original = _seed_recipe_and_execution(s, workspace)
+    overrides = {"s1": {"prompt_template": "do the thing, but cite sources"}}
+
+    rerun = create_rerun_execution(
+        s, recipe, original, step_overrides=overrides, triggered_by="watch_rerun"
+    )
+    s.commit()
+
+    assert rerun.execution_id.startswith("rerun-")
+    assert rerun.retry_of == original.execution_id
+    assert rerun.attempt_count == 2
+    assert rerun.triggered_by == "watch_rerun"
+    assert rerun.input_data == {"topic": "quarterly numbers"}
+    assert rerun.input_data is not original.input_data  # a copy, never shared
+    assert rerun.execution_metadata["rerun_of"] == original.execution_id
+    assert rerun.execution_metadata["step_overrides"] == overrides
+
+    # The shared definition is untouched -- the tweak lives ONLY on this
+    # execution's metadata.
+    s.refresh(recipe)
+    assert recipe.steps[0]["prompt_template"] == "do the thing"
+    s.close()
+
+
+def test_estimate_rerun_cost_sums_original_llm_usage(workspace, new_session):
+    from services.watch_rerun import estimate_rerun_cost_usd
+
+    s = new_session()
+    _, original = _seed_recipe_and_execution(s, workspace, cost_rows=(1.25, 0.75))
+    estimate = estimate_rerun_cost_usd(s, workspace, original.execution_id)
+    assert estimate == pytest.approx(2.0)
+    # No usage rows -> 0.0, never raises.
+    assert estimate_rerun_cost_usd(s, workspace, "exec-none") == 0.0
+    s.close()
+
+
+# ---------------------------------------------------------------------------
+# Approval gate
+# ---------------------------------------------------------------------------
+
+
+def test_always_ask_parks_grant_watch_and_notifies(
+    workspace, new_session, stub_launch, capture_notifications
+):
+    from services.watch_rerun import request_rerun
+
+    s = new_session()
+    recipe, original = _seed_recipe_and_execution(s, workspace)
+    watch = _make_watch(s, workspace, original)
+    # Default policy is always_ask (no settings needed).
+
+    outcome = asyncio.run(
+        request_rerun(
+            s,
+            workspace_id=workspace,
+            recipe=recipe,
+            original=original,
+            step_overrides={"s1": {"prompt_template": "tweak"}},
+            triggered_by="watch_rerun",
+            watch=watch,
+        )
+    )
+    s.commit()
+
+    assert outcome.launched is False
+    assert stub_launch == []  # nothing ran
+    assert outcome.grant_id is not None
+
+    grant = s.query(ApprovalGrant).get(outcome.grant_id)
+    assert grant.subject_type == SUBJECT_PLAYBOOK_RUN
+    assert grant.subject_id == original.execution_id
+    assert grant.status == GrantStatus.PENDING.value
+    assert grant.details["watch_action"] == "rerun"
+    assert grant.details["watch_id"] == str(watch.id)
+    assert grant.details["rerun_of"] == original.execution_id
+    assert grant.details["spec"]["input_data"] == {"topic": "quarterly numbers"}
+    assert grant.details["spec"]["step_overrides"] == {"s1": {"prompt_template": "tweak"}}
+
+    s.refresh(watch)
+    assert watch.status == WatchStatus.AWAITING_APPROVAL.value
+
+    pending = [n for n in capture_notifications if n["event_type"] == "approval_pending"]
+    assert len(pending) == 1
+    assert str(grant.id) in str(pending[0].get("link_id"))
+
+    # Idempotent: a second ask reuses the pending grant.
+    second = asyncio.run(
+        request_rerun(
+            s, workspace_id=workspace, recipe=recipe, original=original,
+            triggered_by="watch_rerun",
+        )
+    )
+    assert second.grant_id == grant.id
+    assert (
+        s.query(ApprovalGrant)
+        .filter(
+            ApprovalGrant.workspace_id == workspace,
+            ApprovalGrant.subject_id == original.execution_id,
+        )
+        .count()
+        == 1
+    )
+    s.close()
+
+
+def test_full_auto_under_ceiling_launches_and_watch_follows(
+    workspace, new_session, stub_launch, capture_notifications
+):
+    from services.watch_rerun import request_rerun
+
+    s = new_session()
+    recipe, original = _seed_recipe_and_execution(s, workspace)
+    watch = _make_watch(s, workspace, original)
+    _set_policy(
+        s,
+        workspace,
+        {
+            "approval_policy": {"policy": "full_auto"},
+            "autonomy": {"level": "full"},  # Section 12.3 gate ON
+        },
+    )
+
+    outcome = asyncio.run(
+        request_rerun(
+            s,
+            workspace_id=workspace,
+            recipe=recipe,
+            original=original,
+            step_overrides={"s2": {"prompt_template": "summarise with citations"}},
+            triggered_by="watch_rerun",
+            watch=watch,
+        )
+    )
+
+    assert outcome.launched is True
+    assert stub_launch == [outcome.execution_id]
+
+    rerun = (
+        s.query(RecipeExecution)
+        .filter(RecipeExecution.execution_id == outcome.execution_id)
+        .first()
+    )
+    assert rerun is not None
+    assert rerun.retry_of == original.execution_id
+
+    s.refresh(watch)
+    # One watch, one verdict: the watch now supervises the rerun.
+    assert watch.target_id == outcome.execution_id
+    assert watch.status == WatchStatus.WATCHING.value
+    follow_events = (
+        s.query(WatchEvent)
+        .filter_by(watch_id=watch.id, event_type=WatchEventType.FOLLOW.value)
+        .all()
+    )
+    assert len(follow_events) == 1
+    # Overrides recorded on the watch event for before/after comparison.
+    assert follow_events[0].snapshot["step_overrides"] == {
+        "s2": {"prompt_template": "summarise with citations"}
+    }
+    s.close()
+
+
+def test_over_ceiling_estimate_parks_under_auto_below_budget(
+    workspace, new_session, stub_launch, capture_notifications
+):
+    from services.watch_rerun import request_rerun
+
+    s = new_session()
+    recipe, original = _seed_recipe_and_execution(s, workspace, cost_rows=(5.0,))
+    _set_policy(
+        s,
+        workspace,
+        {"approval_policy": {"policy": "auto_below_budget", "approval_dollar_ceiling": 1.0}},
+    )
+
+    outcome = asyncio.run(
+        request_rerun(s, workspace_id=workspace, recipe=recipe, original=original)
+    )
+    s.commit()
+    assert outcome.launched is False  # $5 estimate > $1 ceiling -> ask
+    assert outcome.grant_id is not None
+    assert stub_launch == []
+
+    # Raise the ceiling above the estimate -> auto path.
+    s.query(ApprovalGrant).filter(ApprovalGrant.id == outcome.grant_id).delete()
+    _set_policy(
+        s,
+        workspace,
+        {"approval_policy": {"policy": "auto_below_budget", "approval_dollar_ceiling": 10.0}},
+    )
+    second = asyncio.run(
+        request_rerun(s, workspace_id=workspace, recipe=recipe, original=original)
+    )
+    assert second.launched is True
+    assert stub_launch == [second.execution_id]
+    s.close()
+
+
+# ---------------------------------------------------------------------------
+# Grant resume / deny
+# ---------------------------------------------------------------------------
+
+
+def _park_rerun_grant(s, workspace, recipe, original, watch):
+    from services.watch_rerun import request_rerun
+
+    outcome = asyncio.run(
+        request_rerun(
+            s,
+            workspace_id=workspace,
+            recipe=recipe,
+            original=original,
+            step_overrides={"s1": {"prompt_template": "tweaked"}},
+            triggered_by="watch_rerun",
+            watch=watch,
+        )
+    )
+    s.commit()
+    return s.query(ApprovalGrant).get(outcome.grant_id)
+
+
+def test_grant_resume_launches_stored_spec_and_watch_follows(
+    workspace, new_session, stub_launch, capture_notifications
+):
+    from services.watch_rerun import resume_playbook_run_grant
+
+    s = new_session()
+    recipe, original = _seed_recipe_and_execution(s, workspace)
+    watch = _make_watch(s, workspace, original)
+    grant = _park_rerun_grant(s, workspace, recipe, original, watch)
+
+    grant_grant(grant, granted_by="user:42")
+    asyncio.run(resume_playbook_run_grant(s, grant))
+    s.commit()
+
+    result = grant.details["executed_result"]
+    assert result["success"] is True
+    new_execution_id = result["execution_id"]
+    assert stub_launch == [new_execution_id]
+
+    rerun = (
+        s.query(RecipeExecution)
+        .filter(RecipeExecution.execution_id == new_execution_id)
+        .first()
+    )
+    assert rerun.retry_of == original.execution_id
+    assert rerun.execution_metadata["step_overrides"] == {"s1": {"prompt_template": "tweaked"}}
+    assert rerun.triggered_by == "watch_rerun"
+
+    s.refresh(watch)
+    assert watch.status == WatchStatus.WATCHING.value  # resumed from the park
+    assert watch.target_id == new_execution_id
+    s.close()
+
+
+def test_grant_deny_no_launch_watch_needs_attention(
+    workspace, new_session, stub_launch, capture_notifications
+):
+    from core.services.approval_grants import deny_grant
+    from services.watch_rerun import fail_playbook_run_grant
+
+    s = new_session()
+    recipe, original = _seed_recipe_and_execution(s, workspace)
+    watch = _make_watch(s, workspace, original)
+    grant = _park_rerun_grant(s, workspace, recipe, original, watch)
+
+    deny_grant(grant, revoked_by="user:42")
+    fail_playbook_run_grant(s, grant)
+    s.commit()
+
+    assert stub_launch == []
+    assert grant.details["executed_result"]["success"] is False
+    # No rerun row was ever created.
+    reruns = (
+        s.query(RecipeExecution)
+        .filter(RecipeExecution.retry_of == original.execution_id)
+        .count()
+    )
+    assert reruns == 0
+
+    s.refresh(watch)
+    assert watch.status == WatchStatus.NEEDS_ATTENTION.value
+    s.close()
+
+
+def test_resume_with_missing_target_parks_watch(workspace, new_session, stub_launch):
+    """Self-healing: a granted rerun whose recipe/execution vanished parks
+    the watch instead of crashing the grant endpoint."""
+    from services.watch_rerun import resume_playbook_run_grant
+
+    s = new_session()
+    recipe, original = _seed_recipe_and_execution(s, workspace)
+    watch = _make_watch(s, workspace, original)
+    grant = _park_rerun_grant(s, workspace, recipe, original, watch)
+
+    # Vaporise the original execution.
+    s.query(RecipeExecution).filter(
+        RecipeExecution.execution_id == original.execution_id
+    ).delete()
+    s.commit()
+
+    grant_grant(grant, granted_by="user:42")
+    asyncio.run(resume_playbook_run_grant(s, grant))
+    s.commit()
+
+    assert grant.details["executed_result"]["success"] is False
+    assert stub_launch == []
+    s.refresh(watch)
+    assert watch.status == WatchStatus.NEEDS_ATTENTION.value
+    s.close()

--- a/orchestrator/tests/test_prd204_run_verdict.py
+++ b/orchestrator/tests/test_prd204_run_verdict.py
@@ -1,0 +1,537 @@
+"""PRD-204 S6 -- run-level verdict: judge-stubbed scoring math, threshold
+boundaries (0.79 fail / 0.80 pass), output-hash cache hit, cost attribution
+(request_type='watch' + watch-scoped execution_id), and the DB-backed
+collect/apply round-trip.
+
+The judge is ALWAYS stubbed (no live model anywhere in this suite). Pure
+tests run without a DB; the collect/apply tests use the stage-1 DB fixture
+pattern and skip cleanly when Postgres is absent.
+"""
+from __future__ import annotations
+
+import asyncio
+import uuid
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from modules.coordination.run_verdict import (
+    ALL_DIMENSIONS,
+    LLM_DIMENSIONS,
+    MECHANICS_DIMENSION,
+    RunOutputBundle,
+    RunVerdict,
+    RunVerdictService,
+    _default_llm_factory,
+    build_run_judge_prompt,
+    mission_mechanics,
+    weighted_mean,
+)
+
+FROZEN_NOW = datetime(2026, 7, 16, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _bundle(text="The quarterly report: revenue up 12%.", state="completed", mech=1.0):
+    return RunOutputBundle(
+        text=text,
+        kind="playbook_execution",
+        terminal_state=state,
+        mechanics_reliability=mech,
+        executor_model="openai/gpt-4o-mini",
+        empty=not text.strip(),
+    )
+
+
+def _watch_stub(**overrides):
+    base = dict(
+        id=uuid.uuid4(),
+        workspace_id=uuid.uuid4(),
+        target_type="playbook_execution",
+        target_id="exec-abc123",
+        title="Watch: quarterly report",
+        success_criteria="Produce the quarterly revenue report",
+        quality_threshold=0.8,
+        created_by=None,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+class _StubResponse:
+    def __init__(self, content, total_tokens=321):
+        self.content = content
+        self.usage = {"total_tokens": total_tokens}
+
+
+class _StubLLM:
+    """Judge stub: returns queued payloads, counts calls."""
+
+    def __init__(self, payloads):
+        self.payloads = list(payloads)
+        self.calls = 0
+
+    async def generate_response(self, messages):
+        self.calls += 1
+        payload = self.payloads.pop(0)
+        if isinstance(payload, Exception):
+            raise payload
+        return _StubResponse(payload)
+
+
+def _judge_json(**dims):
+    import json
+
+    body = {
+        "business_usefulness": 0.9,
+        "completeness": 0.9,
+        "evidence_quality": 0.9,
+        "clarity": 0.9,
+        "actionability": 0.9,
+        "confidence": 0.95,
+        "reasoning": "Solid, grounded output.",
+        "caveats": ["Numbers not independently verified"],
+    }
+    body.update(dims)
+    return json.dumps(body)
+
+
+def _score(service, watch, bundle, llm):
+    return asyncio.run(
+        service.score_run(None, watch, bundle=bundle, llm_factory=lambda w, m: llm)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pure scoring math
+# ---------------------------------------------------------------------------
+
+
+def test_weighted_mean_equal_weights_and_clamping():
+    flat = {dim: 0.6 for dim in ALL_DIMENSIONS}
+    assert weighted_mean(flat) == pytest.approx(0.6)
+
+    # Out-of-range judge values clamp; missing dims score 0.
+    assert weighted_mean({"business_usefulness": 9.0}) == pytest.approx(1 / 6, abs=1e-4)
+    assert weighted_mean({}) == 0.0
+
+
+def test_reliability_dimension_is_mechanics_not_llm():
+    """The judge never sets reliability -- it is folded in from mechanics."""
+    service = RunVerdictService()
+    watch = _watch_stub()
+    llm = _StubLLM([_judge_json()])
+    verdict = _score(service, watch, _bundle(mech=0.25), llm)
+
+    assert verdict.dimension_scores[MECHANICS_DIMENSION] == 0.25
+    expected = weighted_mean({**{d: 0.9 for d in LLM_DIMENSIONS}, MECHANICS_DIMENSION: 0.25})
+    assert verdict.score == pytest.approx(expected)
+
+
+def test_mission_mechanics_heuristic():
+    all_good = [{"state": "verified", "attempts": 1}] * 4
+    assert mission_mechanics(all_good, "completed") == pytest.approx(1.0)
+
+    half_failed = [
+        {"state": "verified", "attempts": 1},
+        {"state": "failed", "attempts": 3},
+    ]
+    score = mission_mechanics(half_failed, "failed")
+    assert 0.0 <= score < 0.6
+    # Empty task list stays neutral-ish, never crashes.
+    assert 0.0 <= mission_mechanics([], "completed") <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# Threshold boundaries (PRD-204 S6: 0.79 fail / 0.80 pass)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "score,passes",
+    [(0.79, False), (0.80, True), (0.8000001, True), (0.0, False), (1.0, True)],
+)
+def test_threshold_boundary(score, passes):
+    verdict = RunVerdict(score=score)
+    assert verdict.passes(0.8) is passes
+
+
+def test_judge_failed_verdict_never_passes():
+    verdict = RunVerdict(score=None, judge_failed=True)
+    assert verdict.passes(0.0) is False
+    assert "scoring unavailable" in verdict.as_text().lower()
+
+
+# ---------------------------------------------------------------------------
+# Judge flow: parse, retry on non-JSON, fail-soft after retries
+# ---------------------------------------------------------------------------
+
+
+def test_judge_scores_parsed_and_verdict_text_built():
+    service = RunVerdictService()
+    watch = _watch_stub()
+    llm = _StubLLM([_judge_json(business_usefulness=0.7)])
+    verdict = _score(service, watch, _bundle(), llm)
+
+    assert llm.calls == 1
+    assert verdict.judge_failed is False
+    assert verdict.dimension_scores["business_usefulness"] == 0.7
+    assert verdict.tokens_used == 321
+    assert "Solid, grounded output." in verdict.as_text()
+    assert "Caveats:" in verdict.as_text()
+
+
+def test_non_json_then_valid_retries_once():
+    service = RunVerdictService()
+    watch = _watch_stub()
+    llm = _StubLLM(["sorry, no JSON here", _judge_json()])
+    verdict = _score(service, watch, _bundle(text="output " + uuid.uuid4().hex), llm)
+    assert llm.calls == 2
+    assert verdict.score is not None
+
+
+def test_judge_exhaustion_returns_judge_failed():
+    service = RunVerdictService()
+    watch = _watch_stub()
+    llm = _StubLLM([RuntimeError("model down"), RuntimeError("model down")])
+    verdict = _score(service, watch, _bundle(text="output " + uuid.uuid4().hex), llm)
+    assert verdict.judge_failed is True
+    assert verdict.score is None
+
+
+def test_empty_output_scores_deterministic_floor_without_llm():
+    service = RunVerdictService()
+    watch = _watch_stub()
+    llm = _StubLLM([])  # any call would IndexError
+    verdict = _score(service, watch, _bundle(text="", mech=0.6), llm)
+    assert llm.calls == 0
+    assert verdict.dimension_scores[MECHANICS_DIMENSION] == 0.6
+    assert all(verdict.dimension_scores[d] == 0.0 for d in LLM_DIMENSIONS)
+    assert verdict.score == pytest.approx(weighted_mean(verdict.dimension_scores))
+
+
+# ---------------------------------------------------------------------------
+# Output-hash cache (identical output -> zero LLM calls)
+# ---------------------------------------------------------------------------
+
+
+def test_cache_hit_on_identical_output_hash():
+    service = RunVerdictService()
+    watch = _watch_stub()
+    text = "identical output " + uuid.uuid4().hex
+    llm = _StubLLM([_judge_json()])
+
+    first = _score(service, watch, _bundle(text=text), llm)
+    second = _score(service, watch, _bundle(text=text), llm)
+
+    assert llm.calls == 1
+    assert first.cached is False
+    assert second.cached is True
+    assert second.score == first.score
+
+    # Different output on the SAME watch -> fresh judge call.
+    llm.payloads = [_judge_json()]
+    third = _score(service, watch, _bundle(text=text + " changed"), llm)
+    assert llm.calls == 2
+    assert third.cached is False
+
+    assert RunVerdictService.clear_cache(watch.id) >= 2
+
+
+# ---------------------------------------------------------------------------
+# Cost attribution: request_type='watch', watch-scoped execution_id
+# ---------------------------------------------------------------------------
+
+
+def test_default_llm_factory_sets_watch_cost_attribution(monkeypatch):
+    captured = {}
+
+    def _fake_create_llm_manager(**kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(_tracking_ctx=dict(kwargs))
+
+    import core.llm
+
+    monkeypatch.setattr(core.llm, "create_llm_manager", _fake_create_llm_manager)
+
+    watch = _watch_stub()
+    llm = _default_llm_factory(watch, "openai/gpt-4o-mini")
+
+    assert captured["service_name"] == "watch_verdict"
+    assert captured["request_type"] == "watch"
+    assert captured["workspace_id"] == watch.workspace_id
+    assert llm._tracking_ctx["request_type"] == "watch"
+    # Watch-scoped execution id: supervision cost lands on 'watch-<id>' --
+    # NOT on the watched execution's rollup (the S7 rerun estimate sums that).
+    assert llm._tracking_ctx["execution_id"] == f"watch-{watch.id}"
+
+
+def test_judge_prompt_contains_criteria_and_output():
+    prompt = build_run_judge_prompt(
+        success_criteria="Ship the report", bundle=_bundle(text="THE OUTPUT")
+    )
+    assert "Ship the report" in prompt
+    assert "THE OUTPUT" in prompt
+    assert "reliability" in prompt  # mechanics context note
+    assert '"business_usefulness"' in prompt
+
+
+# ---------------------------------------------------------------------------
+# DB-backed: collect (mission + playbook) and apply_verdict round-trip
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def engine():
+    from sqlalchemy import create_engine, text
+
+    from core.database.database import get_database_url
+
+    try:
+        eng = create_engine(get_database_url(), pool_pre_ping=True)
+        with eng.connect() as c:
+            c.execute(text("SELECT 1 FROM watches LIMIT 1"))
+            c.execute(text("SELECT 1 FROM recipe_executions LIMIT 1"))
+    except Exception as exc:  # noqa: BLE001
+        pytest.skip(f"run verdict suite needs a reachable Postgres with schema: {exc}")
+    yield eng
+    eng.dispose()
+
+
+@pytest.fixture
+def new_session(engine):
+    from sqlalchemy.orm import sessionmaker
+
+    return sessionmaker(bind=engine, expire_on_commit=False)
+
+
+@pytest.fixture
+def workspace(new_session):
+    from sqlalchemy import text
+
+    ws_id = str(uuid.uuid4())
+    s = new_session()
+    s.execute(
+        text(
+            "INSERT INTO workspaces (id, name) "
+            "VALUES (CAST(:id AS uuid), :n) ON CONFLICT (id) DO NOTHING"
+        ),
+        {"id": ws_id, "n": "prd204-run-verdict"},
+    )
+    s.commit()
+    s.close()
+
+    yield ws_id
+
+    s = new_session()
+    for stmt in (
+        "DELETE FROM watch_events WHERE watch_id IN "
+        "(SELECT id FROM watches WHERE workspace_id = CAST(:w AS uuid))",
+        "DELETE FROM watches WHERE workspace_id = CAST(:w AS uuid)",
+        "DELETE FROM recipe_executions WHERE workspace_id = CAST(:w AS uuid)",
+        "DELETE FROM workflow_recipes WHERE workspace_id = CAST(:w AS uuid)",
+        "DELETE FROM orchestration_tasks WHERE run_id IN "
+        "(SELECT id FROM orchestration_runs WHERE workspace_id = CAST(:w AS uuid))",
+        "DELETE FROM orchestration_runs WHERE workspace_id = CAST(:w AS uuid)",
+        "DELETE FROM workspaces WHERE id = CAST(:w AS uuid)",
+    ):
+        s.execute(text(stmt), {"w": ws_id})
+    s.commit()
+    s.close()
+
+
+def test_collect_playbook_output_and_mechanics(workspace, new_session):
+    from core.models import WorkflowTemplate
+    from core.models.core import RecipeExecution
+
+    s = new_session()
+    recipe = WorkflowTemplate(
+        template_id=f"prd204-rv-{uuid.uuid4().hex[:10]}",
+        name="verdict test playbook",
+        description="prd204 run verdict",
+        workspace_id=workspace,
+        template_definition={"steps": []},
+        steps=[{"step_id": "s1", "order": 1}],
+        created_by="user_test",  # NOT NULL on workflow_recipes
+    )
+    s.add(recipe)
+    s.commit()
+
+    execution = RecipeExecution(
+        execution_id=f"prd204-rv-{uuid.uuid4().hex[:10]}",
+        recipe_id=recipe.id,
+        workspace_id=workspace,
+        status="completed",
+        input_data={},
+        output_data={"final_output": "Report delivered: revenue up 12%."},
+        step_results=[
+            {"step_id": "s1", "order": 1, "status": "completed",
+             "agent_name": "writer", "output": "done", "retries": 0},
+        ],
+    )
+    s.add(execution)
+    s.commit()
+
+    watch = SimpleNamespace(
+        id=uuid.uuid4(),
+        workspace_id=workspace,
+        target_type="playbook_execution",
+        target_id=execution.execution_id,
+        title="w",
+        success_criteria="deliver report",
+    )
+    bundle = RunVerdictService.collect_run_output(s, watch)
+    assert bundle is not None
+    assert bundle.kind == "playbook_execution"
+    assert "revenue up 12%" in bundle.text
+    assert bundle.terminal_state == "completed"
+    assert 0.0 <= bundle.mechanics_reliability <= 1.0
+    assert bundle.empty is False
+
+    # Missing target -> None (caller parks the watch).
+    gone = SimpleNamespace(
+        id=uuid.uuid4(), workspace_id=workspace,
+        target_type="playbook_execution", target_id="exec-nope",
+    )
+    assert RunVerdictService.collect_run_output(s, gone) is None
+    s.close()
+
+
+def test_collect_mission_output(workspace, new_session):
+    from core.models.orchestration import OrchestrationRun, OrchestrationTask
+
+    s = new_session()
+    run = OrchestrationRun(
+        workspace_id=workspace,
+        goal="produce the launch plan",
+        state="completed",
+        created_by="user_test",
+        output_summary={"headline": "Launch plan produced"},
+    )
+    s.add(run)
+    s.commit()
+    task = OrchestrationTask(
+        run_id=run.id,
+        title="draft plan",
+        description="draft it",
+        sequence_number=1,
+        agent_role="writer",
+        state="verified",
+        state_type="blocked",  # TASK_STATE_TYPE[VERIFIED]
+        output="The launch plan: phase one...",
+    )
+    s.add(task)
+    s.commit()
+
+    watch = SimpleNamespace(
+        id=uuid.uuid4(),
+        workspace_id=workspace,
+        target_type="mission",
+        target_id=str(run.id),
+        title="w",
+        success_criteria="produce the launch plan",
+    )
+    bundle = RunVerdictService.collect_run_output(s, watch)
+    assert bundle is not None
+    assert bundle.kind == "mission"
+    assert "Launch plan produced" in bundle.text
+    assert "The launch plan: phase one" in bundle.text
+    assert bundle.mechanics_reliability == pytest.approx(1.0)
+    s.close()
+
+
+def test_apply_verdict_writes_score_verdict_and_scored_event(workspace, new_session):
+    from core.models.watches import WatchEvent
+    from core.models.watch_enums import WatchEventType
+    from services.watch_service import WatchService
+
+    s = new_session()
+    watch = WatchService.create_watch(
+        s,
+        workspace_id=workspace,
+        watch_type="playbook_execution",
+        target_type="playbook_execution",
+        target_id="exec-verdict-1",
+        title="Watch: apply verdict",
+        success_criteria="deliver",
+        now=FROZEN_NOW,
+    )
+    s.commit()
+
+    verdict = RunVerdict(
+        score=0.83,
+        dimension_scores={d: 0.83 for d in ALL_DIMENSIONS},
+        reasoning="Good output.",
+        caveats=["minor caveat"],
+        output_hash="a" * 64,
+    )
+    event = RunVerdictService.apply_verdict(s, watch, verdict)
+    s.commit()
+
+    assert event is not None
+    s.refresh(watch)
+    assert watch.final_score == pytest.approx(0.83)
+    assert "Good output." in watch.final_verdict
+    assert "minor caveat" in watch.final_verdict
+
+    # Idempotent per output hash: same verdict applied twice -> one event.
+    again = RunVerdictService.apply_verdict(s, watch, verdict)
+    s.commit()
+    assert again is None
+    events = (
+        s.query(WatchEvent)
+        .filter(
+            WatchEvent.watch_id == watch.id,
+            WatchEvent.event_type == WatchEventType.SCORED.value,
+        )
+        .all()
+    )
+    assert len(events) == 1
+    assert events[0].score == pytest.approx(0.83)
+    assert events[0].snapshot["dimension_scores"]["reliability"] == pytest.approx(0.83)
+    s.close()
+
+
+# ---------------------------------------------------------------------------
+# Verdict notification formatting (display edge is the ONLY x10 place)
+# ---------------------------------------------------------------------------
+
+
+def test_verdict_notification_message_formats_score_x10():
+    from services.watch_notifications import build_verdict_message, format_score_display
+
+    assert format_score_display(0.83) == "8.3/10"
+    assert format_score_display(None) == "unscored"
+
+    watch = _watch_stub(quality_threshold=0.8)
+    msg = build_verdict_message(watch, score=0.79, explanation="Close but incomplete.")
+    assert "7.9/10" in msg
+    assert "8.0/10" in msg  # the bar
+    assert "Close but incomplete." in msg
+
+    unscored = build_verdict_message(watch, score=None, explanation=None, terminal_state="failed")
+    assert "failed" in unscored
+
+
+def test_notify_watch_verdict_dispatches_through_shared_seam(monkeypatch):
+    import services.watch_notifications as wn
+
+    sent = []
+
+    async def _capture(db, watch, *, event_type, title, message, status="ok"):
+        sent.append({"event_type": event_type, "title": title,
+                     "message": message, "status": status})
+        return True
+
+    monkeypatch.setattr(wn, "dispatch_watch_notification", _capture)
+
+    watch = _watch_stub()
+    ok = asyncio.run(
+        wn.notify_watch_verdict(
+            db=None, watch=watch, score=0.83, explanation="Nice.", passed=True
+        )
+    )
+    assert ok is True
+    assert sent[0]["event_type"] == "watch_verdict"
+    assert "8.3/10" in sent[0]["message"]
+    assert sent[0]["status"] == "ok"

--- a/orchestrator/tests/test_prd204_silent_holes.py
+++ b/orchestrator/tests/test_prd204_silent_holes.py
@@ -1,4 +1,4 @@
-"""PRD-204 S4 — closing the silent-failure holes.
+"""PRD-204 S4 -- closing the silent-failure holes.
 
 Mock-DB suite (test_prd128_notification_dispatcher.py pattern): each new
 event lands exactly one ``notifications`` row with the right ``event_type``
@@ -161,7 +161,7 @@ def test_failed_mission_board_card_shows_failed():
     from services.orchestration_board_bridge import _RUN_STATE_TO_BOARD_STATUS
 
     assert _RUN_STATE_TO_BOARD_STATUS[RunState.FAILED.value] == "failed"
-    # cancelled stays done — the user deliberately closed it.
+    # cancelled stays done -- the user deliberately closed it.
     assert _RUN_STATE_TO_BOARD_STATUS[RunState.CANCELLED.value] == "done"
     assert _RUN_STATE_TO_BOARD_STATUS[RunState.COMPLETED.value] == "done"
 
@@ -176,7 +176,7 @@ def test_board_failed_status_is_valid_board_status():
 
 
 # ---------------------------------------------------------------------------
-# 5. playbook_benched — once per breaker-open period
+# 5. playbook_benched -- once per breaker-open period
 # ---------------------------------------------------------------------------
 
 

--- a/orchestrator/tests/test_prd204_silent_holes.py
+++ b/orchestrator/tests/test_prd204_silent_holes.py
@@ -1,0 +1,298 @@
+"""PRD-204 S4 — closing the silent-failure holes.
+
+Mock-DB suite (test_prd128_notification_dispatcher.py pattern): each new
+event lands exactly one ``notifications`` row with the right ``event_type``
+and ``link_id``; the board mapping stops lying about failed missions; the
+scheduler benches loudly (once per breaker-open period); the dead
+``notify_budget_exceeded`` stays deleted.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+
+# The imported modules pull core.database.database -> config.py, which needs
+# Postgres env vars at import time. Harmless defaults; no real DB is touched.
+os.environ.setdefault("POSTGRES_USER", "test")
+os.environ.setdefault("POSTGRES_PASSWORD", "test")
+os.environ.setdefault("POSTGRES_HOST", "localhost")
+os.environ.setdefault("POSTGRES_PORT", "5432")
+os.environ.setdefault("POSTGRES_DB", "test")
+
+from unittest.mock import MagicMock  # noqa: E402
+from uuid import uuid4  # noqa: E402
+
+import pytest  # noqa: E402
+
+from core.services.notification_dispatcher import VALID_EVENT_TYPES  # noqa: E402
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _make_db() -> MagicMock:
+    """Mock session: no workspace/user rows, no notification preferences."""
+    db = MagicMock()
+    q = MagicMock()
+    q.filter.return_value = q
+    q.first.return_value = None
+    db.query.return_value = q
+    result = MagicMock()
+    result.fetchall.return_value = []
+    db.execute.return_value = result
+    return db
+
+
+def _insert_params(db: MagicMock) -> list[dict]:
+    """All params dicts from INSERT INTO notifications calls."""
+    found = []
+    for call in db.execute.call_args_list:
+        if not call.args:
+            continue
+        sql_obj = call.args[0]
+        if "INSERT INTO notifications" in str(sql_obj):
+            found.append(call.args[1])
+    return found
+
+
+def _mock_run(**overrides):
+    run = MagicMock()
+    run.id = overrides.get("id", uuid4())
+    run.workspace_id = overrides.get("workspace_id", uuid4())
+    run.created_by = overrides.get("created_by", "user_abc")
+    run.goal = overrides.get("goal", "Compile the weekly market report")
+    run.stop_reason = overrides.get("stop_reason", "coordinator_error")
+    run.stop_detail = overrides.get(
+        "stop_detail", "Task 'research' failed: max_retries_exhausted"
+    )
+    run.budget_spent = overrides.get("budget_spent", {"cost": 1.25, "tokens": 5000})
+    run.budget_config = overrides.get("budget_config", {"max_cost": 1.0})
+    run.tokens_used = overrides.get("tokens_used", 5000)
+    run.token_budget_estimate = overrides.get("token_budget_estimate", 4000)
+    return run
+
+
+# ---------------------------------------------------------------------------
+# 1. Event vocabulary
+# ---------------------------------------------------------------------------
+
+
+def test_valid_event_types_include_prd204_events():
+    for event in (
+        "mission_failed",
+        "mission_budget_paused",
+        "playbook_benched",
+        "watch_verdict",
+        "watch_action",
+        "watch_escalation",
+    ):
+        assert event in VALID_EVENT_TYPES, f"{event} missing from VALID_EVENT_TYPES"
+
+
+# ---------------------------------------------------------------------------
+# 2. mission_failed lands one notifications row
+# ---------------------------------------------------------------------------
+
+
+def test_notify_mission_failed_inserts_row():
+    from services.coordinator_service import notify_mission_failed
+
+    db = _make_db()
+    run = _mock_run()
+    _run(notify_mission_failed(db, run))
+
+    inserts = _insert_params(db)
+    assert len(inserts) == 1, "exactly one notifications row expected"
+    row = inserts[0]
+    assert row["event_type"] == "mission_failed"
+    assert row["link_type"] == "mission"
+    assert row["link_id"] == str(run.id)
+    assert row["status"] == "error"
+    assert "max_retries_exhausted" in row["message"]
+    assert row["title"].startswith("Mission failed:")
+
+
+def test_notify_mission_failed_never_raises(monkeypatch):
+    """The seam is fail-soft: a broken dispatcher must not break the caller."""
+    from services import coordinator_service
+
+    async def _boom(*args, **kwargs):
+        raise RuntimeError("dispatcher down")
+
+    monkeypatch.setattr(
+        "core.services.notification_dispatcher.NotificationDispatcher.dispatch",
+        _boom,
+    )
+    # Must not raise.
+    _run(coordinator_service.notify_mission_failed(_make_db(), _mock_run()))
+
+
+# ---------------------------------------------------------------------------
+# 3. mission_budget_paused lands one notifications row
+# ---------------------------------------------------------------------------
+
+
+def test_notify_mission_budget_paused_inserts_row():
+    from services.coordinator_service import notify_mission_budget_paused
+
+    db = _make_db()
+    run = _mock_run()
+    _run(notify_mission_budget_paused(db, run))
+
+    inserts = _insert_params(db)
+    assert len(inserts) == 1
+    row = inserts[0]
+    assert row["event_type"] == "mission_budget_paused"
+    assert row["link_type"] == "mission"
+    assert row["link_id"] == str(run.id)
+    assert row["status"] == "warning"
+    assert "$1.25" in row["message"]  # spent surfaced
+    assert "resume" in row["message"].lower()
+
+
+# ---------------------------------------------------------------------------
+# 4. Board mapping stops lying (OS-review F023)
+# ---------------------------------------------------------------------------
+
+
+def test_failed_mission_board_card_shows_failed():
+    from core.models.orchestration_enums import RunState
+    from services.orchestration_board_bridge import _RUN_STATE_TO_BOARD_STATUS
+
+    assert _RUN_STATE_TO_BOARD_STATUS[RunState.FAILED.value] == "failed"
+    # cancelled stays done — the user deliberately closed it.
+    assert _RUN_STATE_TO_BOARD_STATUS[RunState.CANCELLED.value] == "done"
+    assert _RUN_STATE_TO_BOARD_STATUS[RunState.COMPLETED.value] == "done"
+
+
+def test_board_failed_status_is_valid_board_status():
+    """Drift guard: the bridge writes only statuses the board accepts."""
+    import api.board_tasks as bt
+    from services.orchestration_board_bridge import _RUN_STATE_TO_BOARD_STATUS
+
+    for status in _RUN_STATE_TO_BOARD_STATUS.values():
+        assert status in bt.VALID_STATUSES, f"bridge writes invalid status {status}"
+
+
+# ---------------------------------------------------------------------------
+# 5. playbook_benched — once per breaker-open period
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def scheduler_service():
+    from services.playbook_scheduler import PlaybookSchedulerService
+
+    return PlaybookSchedulerService()
+
+
+def test_benched_notifies_once_per_open_period(
+    scheduler_service, mock_playbook, monkeypatch
+):
+    """Two skips on one open period -> one notification; breaker closes and
+    reopens -> a second notification."""
+    db = _make_db()
+    mock_playbook.steps = [{"step_id": "s1", "order": 1}]
+
+    # Scheduler-local session factory -> our mock.
+    monkeypatch.setattr("core.database.database.SessionLocal", lambda: db)
+
+    # Playbook lookup returns the fixture playbook.
+    q = MagicMock()
+    q.filter.return_value = q
+    q.first.return_value = mock_playbook
+    db.query.return_value = q
+
+    breaker_states = iter([True, True, False, True])
+    monkeypatch.setattr(
+        "services.playbook_breaker.breaker_is_open",
+        lambda _db, _rid: next(breaker_states),
+    )
+
+    notified = []
+
+    async def _record(_db, playbook, threshold):
+        notified.append(playbook.id)
+
+    monkeypatch.setattr(scheduler_service, "_notify_playbook_benched", _record)
+
+    # Breaker-closed pass-through needs the launch seams stubbed.
+    class _Allowed:
+        allowed = True
+        reason = None
+
+    async def _check_concurrency(_ws, _db):
+        return _Allowed()
+
+    monkeypatch.setattr(
+        "services.concurrency_guard.check_concurrency", _check_concurrency
+    )
+    engine = MagicMock()
+    monkeypatch.setattr(
+        "services.playbook_engine.get_playbook_engine", lambda: engine
+    )
+
+    ws = str(mock_playbook.workspace_id)
+
+    # Open period 1: two skipped fires, ONE notification.
+    _run(scheduler_service._fire_playbook(mock_playbook.id, ws))
+    _run(scheduler_service._fire_playbook(mock_playbook.id, ws))
+    assert notified == [mock_playbook.id]
+
+    # Breaker closes: fire passes through and the latch clears.
+    _run(scheduler_service._fire_playbook(mock_playbook.id, ws))
+    assert engine.launch.called
+    assert mock_playbook.id not in scheduler_service._benched_notified
+
+    # Open period 2: notify again (exactly once more).
+    _run(scheduler_service._fire_playbook(mock_playbook.id, ws))
+    assert notified == [mock_playbook.id, mock_playbook.id]
+
+
+def test_notify_playbook_benched_inserts_row(scheduler_service, mock_playbook):
+    db = _make_db()
+    _run(scheduler_service._notify_playbook_benched(db, mock_playbook, threshold=3))
+
+    inserts = _insert_params(db)
+    assert len(inserts) == 1
+    row = inserts[0]
+    assert row["event_type"] == "playbook_benched"
+    assert row["link_type"] == "playbook"
+    assert row["link_id"] == str(mock_playbook.id)
+    assert row["status"] == "warning"
+    assert "last 3 runs" in row["message"]
+
+
+# ---------------------------------------------------------------------------
+# 6. Reconciler notify seam is fail-soft
+# ---------------------------------------------------------------------------
+
+
+def test_reconciler_notify_run_failed_never_raises(monkeypatch):
+    from modules.coordination.reconciler import MissionReconciler
+
+    async def _boom(*args, **kwargs):
+        raise RuntimeError("notify path down")
+
+    monkeypatch.setattr(
+        "services.coordinator_service.notify_mission_failed", _boom
+    )
+    # Must not raise into reconciliation.
+    _run(MissionReconciler._notify_run_failed(_make_db(), _mock_run()))
+
+
+# ---------------------------------------------------------------------------
+# 7. Dead code stays dead
+# ---------------------------------------------------------------------------
+
+
+def test_notify_budget_exceeded_is_deleted():
+    """PRD-204 S4 chose deletion over wiring: exactly one owner
+    (notify_mission_budget_paused) for the budget-pause boundary."""
+    from services import escalation_service
+
+    assert not hasattr(escalation_service, "notify_budget_exceeded")
+    # The live escalation helpers survive.
+    assert hasattr(escalation_service, "escalate_stalled_task")
+    assert hasattr(escalation_service, "check_blocked_escalations")

--- a/orchestrator/tests/test_prd204_watch_actions.py
+++ b/orchestrator/tests/test_prd204_watch_actions.py
@@ -1,0 +1,597 @@
+"""PRD-204 S8 -- direction-change actions: replan / reassign / spawn_agent /
+escalate.
+
+Each action under full_auto (auto-executes) and always_ask (grant card);
+budget exhaustion -> straight to escalate; reassign excludes the failed
+agent and escalates on no_capable_agent; spawn is ALWAYS grant-gated except
+full_auto, honours blueprint `rules` defaulting (onboarding-wall regression
+guard), and strict-mode blueprint failures roll the spawn back.
+
+The coordinator replan (LLM planner) and AgentMatcher.rank are stubbed;
+notifications are captured at the dispatcher seam. DB-backed, skips cleanly
+without Postgres.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+from core.database.database import get_database_url
+from core.models.core import Agent, BoardTask
+from core.models.approval_grants import ApprovalGrant, SUBJECT_PLAYBOOK_RUN
+from core.models.orchestration import (
+    OrchestrationRun,
+    OrchestrationTask,
+    OrchestrationTaskDependency,
+)
+from core.models.watch_enums import WatchStatus
+from services.watch_service import WatchService
+
+FROZEN_NOW = datetime(2026, 7, 16, 12, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture(scope="module")
+def engine():
+    try:
+        eng = create_engine(get_database_url(), pool_pre_ping=True)
+        with eng.connect() as c:
+            c.execute(text("SELECT 1 FROM watches LIMIT 1"))
+            c.execute(text("SELECT 1 FROM orchestration_runs LIMIT 1"))
+            c.execute(text("SELECT 1 FROM agent_blueprints LIMIT 1"))
+    except Exception as exc:  # noqa: BLE001
+        pytest.skip(f"watch actions suite needs a reachable Postgres with schema: {exc}")
+    yield eng
+    eng.dispose()
+
+
+@pytest.fixture
+def new_session(engine):
+    return sessionmaker(bind=engine, expire_on_commit=False)
+
+
+@pytest.fixture
+def workspace(new_session):
+    ws_id = str(uuid.uuid4())
+    s = new_session()
+    s.execute(
+        text(
+            "INSERT INTO workspaces (id, name) "
+            "VALUES (CAST(:id AS uuid), :n) ON CONFLICT (id) DO NOTHING"
+        ),
+        {"id": ws_id, "n": "prd204-watch-actions"},
+    )
+    s.commit()
+    s.close()
+
+    yield ws_id
+
+    s = new_session()
+    for stmt in (
+        "DELETE FROM watch_events WHERE watch_id IN "
+        "(SELECT id FROM watches WHERE workspace_id = CAST(:w AS uuid))",
+        "DELETE FROM watches WHERE workspace_id = CAST(:w AS uuid)",
+        "DELETE FROM approval_grants WHERE workspace_id = CAST(:w AS uuid)",
+        "DELETE FROM board_tasks WHERE workspace_id = CAST(:w AS uuid)",
+        "DELETE FROM orchestration_events WHERE run_id IN "
+        "(SELECT id FROM orchestration_runs WHERE workspace_id = CAST(:w AS uuid))",
+        "DELETE FROM orchestration_task_dependencies WHERE task_id IN "
+        "(SELECT id FROM orchestration_tasks WHERE run_id IN "
+        "(SELECT id FROM orchestration_runs WHERE workspace_id = CAST(:w AS uuid)))",
+        "DELETE FROM orchestration_tasks WHERE run_id IN "
+        "(SELECT id FROM orchestration_runs WHERE workspace_id = CAST(:w AS uuid))",
+        "DELETE FROM orchestration_runs WHERE workspace_id = CAST(:w AS uuid)",
+        "DELETE FROM agent_blueprints WHERE workspace_id = CAST(:w AS uuid)",
+        "DELETE FROM agents WHERE workspace_id = CAST(:w AS uuid)",
+        "DELETE FROM workspaces WHERE id = CAST(:w AS uuid)",
+    ):
+        s.execute(text(stmt), {"w": ws_id})
+    s.commit()
+    s.close()
+
+
+@pytest.fixture
+def capture_notifications(monkeypatch):
+    from core.services.notification_dispatcher import NotificationDispatcher
+
+    sent = []
+
+    async def _capture(self, event_type, title, message=None, **kwargs):
+        sent.append({"event_type": event_type, "title": title, "message": message})
+        return {"dispatched_to": ["in_app"]}
+
+    monkeypatch.setattr(NotificationDispatcher, "dispatch", _capture)
+    return sent
+
+
+@pytest.fixture
+def stub_replan(monkeypatch):
+    """The coordinator replan path is LLM-backed -- stub it, capture args."""
+    from services.coordinator_service import CoordinatorService
+
+    calls = []
+
+    async def _fake_replan(self, db, run_id, actor_id, notes=None, **kwargs):
+        calls.append({"run_id": run_id, "actor_id": actor_id,
+                      "notes": notes, **kwargs})
+        return db.query(OrchestrationRun).filter(OrchestrationRun.id == run_id).first()
+
+    monkeypatch.setattr(CoordinatorService, "replan_mission", _fake_replan)
+    return calls
+
+
+def _rank_stub(monkeypatch, results):
+    from modules.coordination import agent_matcher
+
+    monkeypatch.setattr(
+        agent_matcher.AgentMatcher,
+        "rank",
+        staticmethod(lambda db, task, agents, task_spec=None, semantic=None: list(results)),
+    )
+
+
+def _match(agent_id, agent_name):
+    from modules.coordination.agent_matcher import MatchResult
+
+    return MatchResult(
+        agent_id=agent_id,
+        agent_name=agent_name,
+        total_score=0.9,
+        tool_coverage=1.0,
+        skill_match=0.8,
+        model_fit=1.0,
+        availability=1.0,
+        history=0.5,
+        reason="stubbed",
+    )
+
+
+def _set_policy(s, ws_id, settings):
+    s.execute(
+        text("UPDATE workspaces SET settings = CAST(:cfg AS jsonb) WHERE id = CAST(:w AS uuid)"),
+        {"cfg": json.dumps(settings), "w": ws_id},
+    )
+    s.commit()
+
+
+FULL_AUTO_SETTINGS = {
+    "approval_policy": {"policy": "full_auto"},
+    "autonomy": {"level": "full"},
+}
+
+
+def _seed_failed_mission(s, ws_id, *, with_dependent=True):
+    run = OrchestrationRun(
+        workspace_id=ws_id,
+        goal="produce the market analysis",
+        state="failed",
+        state_type="terminal",
+        created_by="user_test",
+        budget_spent={"cost": 2.5, "tokens": 5000},
+    )
+    s.add(run)
+    s.commit()
+
+    pred = OrchestrationTask(
+        run_id=run.id,
+        title="gather data",
+        description="collect the inputs",
+        sequence_number=1,
+        agent_role="researcher",
+        state="verified",
+        state_type="blocked",
+        output="data gathered",
+    )
+    failed = OrchestrationTask(
+        run_id=run.id,
+        title="write analysis",
+        description="write the market analysis",
+        sequence_number=2,
+        agent_role="writer",
+        state="failed",
+        state_type="terminal",
+        failure_detail="agent produced empty output",
+        input_context={"agent_match": {"agent_id": 111, "agent_name": "alpha"}},
+    )
+    s.add_all([pred, failed])
+    s.commit()
+
+    dependent = None
+    s.add(OrchestrationTaskDependency(task_id=failed.id, depends_on_task_id=pred.id))
+    if with_dependent:
+        dependent = OrchestrationTask(
+            run_id=run.id,
+            title="publish analysis",
+            description="publish it",
+            sequence_number=3,
+            agent_role="publisher",
+            state="pending",
+            state_type="initial",
+        )
+        s.add(dependent)
+        s.commit()
+        s.add(OrchestrationTaskDependency(task_id=dependent.id, depends_on_task_id=failed.id))
+    s.commit()
+    return run, pred, failed, dependent
+
+
+def _make_watch(s, ws_id, run, **overrides):
+    params = dict(
+        workspace_id=ws_id,
+        watch_type="mission",
+        target_type="mission",
+        target_id=str(run.id),
+        title="Watch: market analysis mission",
+        success_criteria="a complete market analysis",
+        policy="score_and_improve",
+        now=FROZEN_NOW,
+    )
+    params.update(overrides)
+    watch = WatchService.create_watch(s, **params)
+    s.commit()
+    return watch
+
+
+def _run_action(s, watch, action, **kwargs):
+    from services.watch_actions import run_mission_action
+
+    return asyncio.run(run_mission_action(s, watch, action, **kwargs))
+
+
+def _escalation_cards(s, ws_id, watch):
+    return (
+        s.query(BoardTask)
+        .filter(
+            BoardTask.workspace_id == ws_id,
+            BoardTask.tags.contains(["escalation", f"watch:{watch.id}"]),
+        )
+        .all()
+    )
+
+
+# ---------------------------------------------------------------------------
+# replan
+# ---------------------------------------------------------------------------
+
+
+def test_replan_full_auto_executes_and_counts_budget(
+    workspace, new_session, stub_replan, capture_notifications
+):
+    s = new_session()
+    run, _, _, _ = _seed_failed_mission(s, workspace)
+    watch = _make_watch(s, workspace, run)
+    _set_policy(s, workspace, FULL_AUTO_SETTINGS)
+
+    outcome = _run_action(s, watch, "replan", diagnosis="planner missed a data step")
+    s.commit()
+
+    assert outcome.executed is True
+    assert outcome.parked is False
+    assert len(stub_replan) == 1
+    call = stub_replan[0]
+    assert call["run_id"] == run.id
+    assert call["actor_id"] == "watcher"
+    assert call["trigger"] == "watch"
+    assert "planner missed a data step" in call["notes"]
+
+    s.refresh(watch)
+    assert watch.actions_taken == 1
+    assert watch.status == WatchStatus.ACTING.value  # corrective attempt in flight
+    s.close()
+
+
+def test_replan_always_ask_parks_grant(
+    workspace, new_session, stub_replan, capture_notifications
+):
+    s = new_session()
+    run, _, _, _ = _seed_failed_mission(s, workspace)
+    watch = _make_watch(s, workspace, run)
+    # Default policy: always_ask.
+
+    outcome = _run_action(s, watch, "replan", diagnosis="needs a different plan")
+    s.commit()
+
+    assert outcome.parked is True
+    assert outcome.executed is False
+    assert stub_replan == []  # nothing ran
+
+    grant = s.query(ApprovalGrant).get(outcome.grant_id)
+    assert grant.subject_type == SUBJECT_PLAYBOOK_RUN
+    assert grant.subject_id == str(run.id)
+    assert grant.tool_name == "watch_replan"
+    assert grant.details["watch_action"] == "replan"
+    assert grant.details["watch_id"] == str(watch.id)
+    assert grant.details["spec"]["diagnosis"] == "needs a different plan"
+
+    s.refresh(watch)
+    assert watch.status == WatchStatus.AWAITING_APPROVAL.value
+    assert watch.actions_taken == 1  # the attempt is counted at initiation
+
+    pending = [n for n in capture_notifications if n["event_type"] == "approval_pending"]
+    assert len(pending) == 1
+    s.close()
+
+
+def test_granted_replan_resumes_via_playbook_run_branch(
+    workspace, new_session, stub_replan, capture_notifications
+):
+    from core.services.approval_grants import grant_grant
+    from services.watch_rerun import resume_playbook_run_grant
+
+    s = new_session()
+    run, _, _, _ = _seed_failed_mission(s, workspace)
+    watch = _make_watch(s, workspace, run)
+    outcome = _run_action(s, watch, "replan", diagnosis="fix the plan")
+    s.commit()
+    grant = s.query(ApprovalGrant).get(outcome.grant_id)
+
+    grant_grant(grant, granted_by="user:42")
+    asyncio.run(resume_playbook_run_grant(s, grant))
+    s.commit()
+
+    assert grant.details["executed_result"]["success"] is True
+    assert len(stub_replan) == 1  # the stored spec executed
+    s.refresh(watch)
+    assert watch.status == WatchStatus.WATCHING.value
+    assert watch.actions_taken == 1  # no second budget charge on resume
+    s.close()
+
+
+# ---------------------------------------------------------------------------
+# reassign
+# ---------------------------------------------------------------------------
+
+
+def test_reassign_requeues_to_different_capable_agent(
+    workspace, new_session, monkeypatch, capture_notifications
+):
+    s = new_session()
+    run, pred, failed, dependent = _seed_failed_mission(s, workspace)
+    watch = _make_watch(s, workspace, run)
+    _set_policy(s, workspace, FULL_AUTO_SETTINGS)
+    # Prior agent 111 ranks first but MUST be excluded; beta (222) is next.
+    _rank_stub(monkeypatch, [_match(111, "alpha"), _match(222, "beta")])
+
+    outcome = _run_action(s, watch, "reassign", diagnosis="alpha keeps timing out")
+    s.commit()
+
+    assert outcome.executed is True, outcome.error
+    s.refresh(run)
+    assert run.state == "running"
+
+    s.refresh(failed)
+    assert failed.state == "skipped"
+    assert failed.failure_reason_code == "reassigned_by_watch"
+
+    clone = (
+        s.query(OrchestrationTask)
+        .filter(
+            OrchestrationTask.run_id == run.id,
+            OrchestrationTask.title == failed.title,
+            OrchestrationTask.id != failed.id,
+        )
+        .one()
+    )
+    assert clone.agent_role == "beta"  # the explicit-override pin
+    assert clone.state == "queued"
+    assert clone.sequence_number == failed.sequence_number
+    assert clone.input_context["watch_reassign"]["excluded_agent_id"] == 111
+
+    # Dependency wiring: clone inherits the prerequisite; the dependent
+    # task now depends on the clone (not the skipped original).
+    clone_deps = (
+        s.query(OrchestrationTaskDependency)
+        .filter(OrchestrationTaskDependency.task_id == clone.id)
+        .all()
+    )
+    assert [d.depends_on_task_id for d in clone_deps] == [pred.id]
+    dependent_deps = (
+        s.query(OrchestrationTaskDependency)
+        .filter(OrchestrationTaskDependency.task_id == dependent.id)
+        .all()
+    )
+    assert [d.depends_on_task_id for d in dependent_deps] == [clone.id]
+    s.close()
+
+
+def test_reassign_no_capable_agent_escalates(
+    workspace, new_session, monkeypatch, capture_notifications
+):
+    s = new_session()
+    run, _, _, _ = _seed_failed_mission(s, workspace)
+    watch = _make_watch(s, workspace, run)
+    _set_policy(s, workspace, FULL_AUTO_SETTINGS)
+    _rank_stub(monkeypatch, [_match(111, "alpha")])  # only the failed agent
+
+    outcome = _run_action(s, watch, "reassign")
+    s.commit()
+
+    assert outcome.escalated is True
+    assert "no_capable_agent" in (outcome.error or "")
+    s.refresh(watch)
+    assert watch.status == WatchStatus.ESCALATED.value
+    assert len(_escalation_cards(s, workspace, watch)) == 1
+    escalations = [n for n in capture_notifications if n["event_type"] == "watch_escalation"]
+    assert len(escalations) == 1
+    s.close()
+
+
+# ---------------------------------------------------------------------------
+# spawn_agent
+# ---------------------------------------------------------------------------
+
+
+def _seed_blueprint(s, ws_id, rules=None, is_default=True):
+    from core.models.blueprints import AgentBlueprint
+
+    bp = AgentBlueprint(
+        workspace_id=ws_id,
+        name="workspace standard",
+        rules=rules if rules is not None else {},  # handler-default shape
+        is_default=is_default,
+    )
+    s.add(bp)
+    s.commit()
+    return bp
+
+
+def test_spawn_agent_always_grant_gated_even_below_ceiling(
+    workspace, new_session, capture_notifications
+):
+    """Section 8 Q5: auto_below_budget's auto lane must NOT auto-approve a
+    spawn -- only full_auto does."""
+    s = new_session()
+    run, _, _, _ = _seed_failed_mission(s, workspace)
+    watch = _make_watch(s, workspace, run)
+    _seed_blueprint(s, workspace)
+    _set_policy(
+        s,
+        workspace,
+        {"approval_policy": {"policy": "auto_below_budget", "approval_dollar_ceiling": 100.0}},
+    )
+
+    outcome = _run_action(s, watch, "spawn_agent")
+    s.commit()
+
+    assert outcome.parked is True  # would auto-approve for any other action
+    grant = s.query(ApprovalGrant).get(outcome.grant_id)
+    assert grant.tool_name == "watch_spawn_agent"
+    assert s.query(Agent).filter(Agent.workspace_id == workspace).count() == 0
+    s.close()
+
+
+def test_spawn_agent_full_auto_creates_validates_reassigns(
+    workspace, new_session, capture_notifications
+):
+    """Blueprint rules DEFAULTING guard: an empty rules dict (the
+    create_blueprint handler default) must not dead-end the spawn."""
+    s = new_session()
+    run, _, failed, _ = _seed_failed_mission(s, workspace, with_dependent=False)
+    watch = _make_watch(s, workspace, run)
+    _seed_blueprint(s, workspace, rules={})
+    _set_policy(s, workspace, FULL_AUTO_SETTINGS)
+
+    outcome = _run_action(
+        s, watch, "spawn_agent",
+        diagnosis="no capable writer on the roster",
+        spawn_spec={"system_prompt": "You are a precise market analyst."},
+    )
+    s.commit()
+
+    assert outcome.executed is True, outcome.error
+    spawned = s.query(Agent).filter(Agent.workspace_id == workspace).one()
+    assert spawned.tags and "watch-spawned" in spawned.tags
+
+    # The failed task was requeued onto the NEW agent (name pin).
+    clone = (
+        s.query(OrchestrationTask)
+        .filter(
+            OrchestrationTask.run_id == run.id,
+            OrchestrationTask.title == failed.title,
+            OrchestrationTask.id != failed.id,
+        )
+        .one()
+    )
+    assert clone.agent_role == spawned.name
+    assert clone.state == "queued"
+    s.refresh(run)
+    assert run.state == "running"
+    s.close()
+
+
+def test_spawn_agent_without_blueprint_escalates(
+    workspace, new_session, capture_notifications
+):
+    s = new_session()
+    run, _, _, _ = _seed_failed_mission(s, workspace)
+    watch = _make_watch(s, workspace, run)
+    _set_policy(s, workspace, FULL_AUTO_SETTINGS)
+    # No blueprint seeded: spawn is blueprints-only.
+
+    outcome = _run_action(s, watch, "spawn_agent")
+    s.commit()
+
+    assert outcome.escalated is True
+    assert "blueprint" in (outcome.error or "")
+    assert s.query(Agent).filter(Agent.workspace_id == workspace).count() == 0
+    s.refresh(watch)
+    assert watch.status == WatchStatus.ESCALATED.value
+    s.close()
+
+
+def test_spawn_strict_blueprint_failure_rolls_back_agent(
+    workspace, new_session, capture_notifications
+):
+    s = new_session()
+    run, _, _, _ = _seed_failed_mission(s, workspace)
+    watch = _make_watch(s, workspace, run)
+    _seed_blueprint(
+        s, workspace,
+        rules={"min_tools": 5, "enforce_mode": "strict"},  # unmeetable for a fresh spawn
+    )
+    _set_policy(s, workspace, FULL_AUTO_SETTINGS)
+
+    outcome = _run_action(s, watch, "spawn_agent")
+    s.commit()
+
+    assert outcome.escalated is True
+    assert "blueprint validation failed" in (outcome.error or "")
+    # The spawn was rolled back -- validation stays authoritative.
+    assert s.query(Agent).filter(Agent.workspace_id == workspace).count() == 0
+    s.close()
+
+
+# ---------------------------------------------------------------------------
+# Budget rail + escalate
+# ---------------------------------------------------------------------------
+
+
+def test_action_budget_zero_goes_straight_to_escalate(
+    workspace, new_session, stub_replan, capture_notifications
+):
+    s = new_session()
+    run, _, _, _ = _seed_failed_mission(s, workspace)
+    watch = _make_watch(s, workspace, run, action_budget=0)
+    _set_policy(s, workspace, FULL_AUTO_SETTINGS)
+
+    outcome = _run_action(s, watch, "replan")
+    s.commit()
+
+    assert outcome.escalated is True
+    assert "budget" in outcome.detail
+    assert stub_replan == []  # never reached the executor
+    assert (
+        s.query(ApprovalGrant).filter(ApprovalGrant.workspace_id == workspace).count()
+        == 0
+    )
+    s.refresh(watch)
+    assert watch.status == WatchStatus.ESCALATED.value
+    assert len(_escalation_cards(s, workspace, watch)) == 1
+    escalations = [n for n in capture_notifications if n["event_type"] == "watch_escalation"]
+    assert len(escalations) == 1
+    s.close()
+
+
+def test_explicit_escalate_action_is_ungated_and_unbudgeted(
+    workspace, new_session, capture_notifications
+):
+    s = new_session()
+    run, _, _, _ = _seed_failed_mission(s, workspace)
+    watch = _make_watch(s, workspace, run, action_budget=0)  # even at zero budget
+
+    outcome = _run_action(s, watch, "escalate", diagnosis="score below bar twice")
+    s.commit()
+
+    assert outcome.escalated is True
+    s.refresh(watch)
+    assert watch.status == WatchStatus.ESCALATED.value
+    assert watch.actions_taken == 0  # escalate never consumes budget
+    cards = _escalation_cards(s, workspace, watch)
+    assert len(cards) == 1
+    assert "score below bar twice" in cards[0].description
+    s.close()

--- a/orchestrator/tests/test_prd204_watch_decider.py
+++ b/orchestrator/tests/test_prd204_watch_decider.py
@@ -1,0 +1,753 @@
+"""PRD-204 S10 -- the decision step.
+
+Golden-files the policy table; drives the deterministic spine per policy
+with the judge and diagnoser STUBBED (no live model anywhere): terminal ->
+score -> close/notify (run_and_report), below-threshold -> diagnose -> ONE
+tweak+rerun -> rescore -> final (score_and_improve), before/after change
+report (watch_change), meaningful-change observation (persistent), judge
+failure degrades to close-by-outcome, runaway guard (action_budget=0 ->
+straight to escalate), and the new ingest_terminal deferral semantics.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+from core.database.database import get_database_url
+from core.models.core import BoardTask, RecipeExecution, WorkflowTemplate
+from core.models.watches import WatchEvent
+from core.models.watch_enums import WatchEventType, WatchStatus
+from modules.coordination.run_verdict import ALL_DIMENSIONS, RunVerdict
+from services.watch_decider import (
+    DECIDED_ACTED,
+    DECIDED_ESCALATED,
+    DECIDED_FAILED,
+    DECIDED_NOOP,
+    DECIDED_PASSED,
+    DECIDED_RECORDED,
+    DEFAULT_ALLOWED_ACTIONS,
+    POLICY_TABLE,
+    Diagnosis,
+    WatchDecider,
+)
+from services.watch_service import WatchService
+
+FROZEN_NOW = datetime(2026, 7, 16, 12, 0, 0, tzinfo=timezone.utc)
+GOLDEN = Path(__file__).parent / "golden" / "prd204_policy_table.json"
+
+
+# ---------------------------------------------------------------------------
+# Golden file: the policy table is a contract, not an implementation detail
+# ---------------------------------------------------------------------------
+
+
+def test_policy_table_matches_golden_file():
+    golden = json.loads(GOLDEN.read_text())
+    assert golden["policy_table"] == POLICY_TABLE
+    assert golden["default_allowed_actions"] == DEFAULT_ALLOWED_ACTIONS
+
+
+def test_policy_table_covers_every_watch_policy():
+    from core.models.watch_enums import WatchPolicy
+
+    assert set(POLICY_TABLE) == {p.value for p in WatchPolicy}
+    for flags in POLICY_TABLE.values():
+        assert set(flags) == {
+            "scores", "acts_on_low_score", "acts_on_failure", "compares", "recurring",
+        }
+
+
+def test_unknown_policy_falls_back_to_run_and_report():
+    assert WatchDecider.policy_flags("garbage") == POLICY_TABLE["run_and_report"]
+
+
+# ---------------------------------------------------------------------------
+# Stubs
+# ---------------------------------------------------------------------------
+
+
+class _StubVerdicts:
+    """RunVerdictService stand-in: queued verdicts, applies like the real one."""
+
+    def __init__(self, verdicts):
+        self.verdicts = list(verdicts)
+        self.calls = 0
+
+    async def score_run(self, db, watch, **kwargs):
+        self.calls += 1
+        return self.verdicts.pop(0)
+
+    @staticmethod
+    def apply_verdict(db, watch, verdict):
+        from modules.coordination.run_verdict import RunVerdictService
+
+        return RunVerdictService.apply_verdict(db, watch, verdict)
+
+
+class _StubDiagnoser:
+    def __init__(self, diagnosis=None, tweak=None):
+        self.diagnosis = diagnosis
+        self.tweak = tweak
+        self.diagnose_calls = 0
+        self.tweak_calls = 0
+
+    async def diagnose(self, db, watch, **kwargs):
+        self.diagnose_calls += 1
+        return self.diagnosis
+
+    async def draft_tweak(self, db, watch, **kwargs):
+        self.tweak_calls += 1
+        return self.tweak
+
+
+def _verdict(score, reasoning="stub reasoning"):
+    if score is None:
+        return RunVerdict(score=None, reasoning="judge down", judge_failed=True,
+                          output_hash="x" * 64)
+    return RunVerdict(
+        score=score,
+        dimension_scores={d: score for d in ALL_DIMENSIONS},
+        reasoning=reasoning,
+        output_hash=uuid.uuid4().hex * 2,
+    )
+
+
+def _decide(decider, s, watch, state, now=FROZEN_NOW):
+    return asyncio.run(decider.decide_terminal(s, watch, state, now))
+
+
+# ---------------------------------------------------------------------------
+# DB fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def engine():
+    try:
+        eng = create_engine(get_database_url(), pool_pre_ping=True)
+        with eng.connect() as c:
+            c.execute(text("SELECT 1 FROM watches LIMIT 1"))
+            c.execute(text("SELECT 1 FROM recipe_executions LIMIT 1"))
+    except Exception as exc:  # noqa: BLE001
+        pytest.skip(f"decider suite needs a reachable Postgres with schema: {exc}")
+    yield eng
+    eng.dispose()
+
+
+@pytest.fixture
+def new_session(engine):
+    return sessionmaker(bind=engine, expire_on_commit=False)
+
+
+@pytest.fixture
+def workspace(new_session):
+    ws_id = str(uuid.uuid4())
+    s = new_session()
+    s.execute(
+        text(
+            "INSERT INTO workspaces (id, name) "
+            "VALUES (CAST(:id AS uuid), :n) ON CONFLICT (id) DO NOTHING"
+        ),
+        {"id": ws_id, "n": "prd204-decider"},
+    )
+    s.commit()
+    s.close()
+
+    yield ws_id
+
+    s = new_session()
+    for stmt in (
+        "DELETE FROM watch_events WHERE watch_id IN "
+        "(SELECT id FROM watches WHERE workspace_id = CAST(:w AS uuid))",
+        "DELETE FROM watches WHERE workspace_id = CAST(:w AS uuid)",
+        "DELETE FROM approval_grants WHERE workspace_id = CAST(:w AS uuid)",
+        "DELETE FROM board_tasks WHERE workspace_id = CAST(:w AS uuid)",
+        "DELETE FROM recipe_executions WHERE workspace_id = CAST(:w AS uuid)",
+        "DELETE FROM workflow_recipes WHERE workspace_id = CAST(:w AS uuid)",
+        "DELETE FROM workspaces WHERE id = CAST(:w AS uuid)",
+    ):
+        s.execute(text(stmt), {"w": ws_id})
+    s.commit()
+    s.close()
+
+
+@pytest.fixture
+def notifications(monkeypatch):
+    """Capture the SHARED notification seam (decider + ticker + actions)."""
+    import services.watch_notifications as wn
+
+    sent = []
+
+    async def _capture(db, watch, *, event_type, title, message, status="ok"):
+        sent.append({"event_type": event_type, "title": title,
+                     "message": message, "status": status})
+        return True
+
+    monkeypatch.setattr(wn, "dispatch_watch_notification", _capture)
+    return sent
+
+
+def _seed_execution(s, ws_id, *, status="completed"):
+    recipe = WorkflowTemplate(
+        template_id=f"prd204-dc-{uuid.uuid4().hex[:10]}",
+        name="decider test playbook",
+        description="prd204 decider",
+        workspace_id=ws_id,
+        template_definition={"steps": []},
+        steps=[{"step_id": "s1", "order": 1, "prompt_template": "do it"}],
+        created_by="user_test",
+    )
+    s.add(recipe)
+    s.commit()
+    execution = RecipeExecution(
+        execution_id=f"exec-{uuid.uuid4().hex[:12]}",
+        recipe_id=recipe.id,
+        workspace_id=ws_id,
+        status=status,
+        input_data={"topic": "pricing"},
+        output_data={"final_output": "the summary"} if status == "completed" else None,
+    )
+    s.add(execution)
+    s.commit()
+    return recipe, execution
+
+
+def _make_watch(s, ws_id, execution, **overrides):
+    params = dict(
+        workspace_id=ws_id,
+        watch_type="playbook_execution",
+        target_type="playbook_execution",
+        target_id=execution.execution_id,
+        title="Watch: decider test",
+        success_criteria="a clean summary",
+        policy="run_and_report",
+        now=FROZEN_NOW,
+    )
+    params.update(overrides)
+    watch = WatchService.create_watch(s, **params)
+    s.commit()
+    return watch
+
+
+def _events(s, watch, event_type=None):
+    q = s.query(WatchEvent).filter(WatchEvent.watch_id == watch.id)
+    if event_type:
+        q = q.filter(WatchEvent.event_type == event_type)
+    return q.order_by(WatchEvent.created_at).all()
+
+
+# ---------------------------------------------------------------------------
+# ingest_terminal deferral (the S10 seam change)
+# ---------------------------------------------------------------------------
+
+
+def test_ingest_terminal_defers_scorable_and_closes_cancelled(workspace, new_session):
+    s = new_session()
+    _, execution = _seed_execution(s, workspace)
+    watch = _make_watch(s, workspace, execution)
+
+    event = WatchService.ingest_terminal(
+        s,
+        workspace_id=workspace,
+        target_type="playbook_execution",
+        target_id=execution.execution_id,
+        terminal_state="completed",
+        now=FROZEN_NOW,
+    )
+    s.commit()
+    assert event is not None
+    s.refresh(watch)
+    # Scorable terminal: recorded + pulled forward, NOT closed -- the
+    # decision step owns scoring and close.
+    assert watch.status == WatchStatus.WATCHING.value
+    assert watch.closed_at is None
+    assert watch.next_check_at == FROZEN_NOW
+
+    # Cancelled still closes at ingest (nothing to score).
+    _, execution2 = _seed_execution(s, workspace, status="cancelled")
+    watch2 = _make_watch(s, workspace, execution2)
+    WatchService.ingest_terminal(
+        s,
+        workspace_id=workspace,
+        target_type="playbook_execution",
+        target_id=execution2.execution_id,
+        terminal_state="cancelled",
+    )
+    s.commit()
+    s.refresh(watch2)
+    assert watch2.status == WatchStatus.CANCELLED.value
+    assert watch2.closed_at is not None
+
+    # Unknown vocabulary still parks for a human.
+    _, execution3 = _seed_execution(s, workspace)
+    watch3 = _make_watch(s, workspace, execution3)
+    WatchService.ingest_terminal(
+        s,
+        workspace_id=workspace,
+        target_type="playbook_execution",
+        target_id=execution3.execution_id,
+        terminal_state="vanished",
+    )
+    s.commit()
+    s.refresh(watch3)
+    assert watch3.status == WatchStatus.NEEDS_ATTENTION.value
+    s.close()
+
+
+def test_ingest_terminal_duplicate_keeps_repoking_decider(workspace, new_session):
+    """Self-healing: duplicate deliveries pull the check forward again so a
+    crashed decider gets re-poked until the watch closes."""
+    s = new_session()
+    _, execution = _seed_execution(s, workspace)
+    watch = _make_watch(s, workspace, execution)
+
+    first = WatchService.ingest_terminal(
+        s, workspace_id=workspace, target_type="playbook_execution",
+        target_id=execution.execution_id, terminal_state="completed",
+        now=FROZEN_NOW,
+    )
+    later = FROZEN_NOW + timedelta(minutes=10)
+    second = WatchService.ingest_terminal(
+        s, workspace_id=workspace, target_type="playbook_execution",
+        target_id=execution.execution_id, terminal_state="completed",
+        now=later,
+    )
+    s.commit()
+    assert first is not None and second is None  # one event
+    s.refresh(watch)
+    assert watch.status == WatchStatus.WATCHING.value
+    assert watch.next_check_at == later  # re-poked
+    assert len(_events(s, watch, WatchEventType.TERMINAL.value)) == 1
+    s.close()
+
+
+# ---------------------------------------------------------------------------
+# run_and_report: terminal -> score -> notify -> close (no actions)
+# ---------------------------------------------------------------------------
+
+
+def test_run_and_report_pass_closes_passed_and_notifies(
+    workspace, new_session, notifications
+):
+    s = new_session()
+    _, execution = _seed_execution(s, workspace)
+    watch = _make_watch(s, workspace, execution)
+    decider = WatchDecider(verdict_service=_StubVerdicts([_verdict(0.86)]))
+
+    decision = _decide(decider, s, watch, "completed")
+    s.commit()
+
+    assert decision == DECIDED_PASSED
+    s.refresh(watch)
+    assert watch.status == WatchStatus.PASSED.value
+    assert watch.final_score == pytest.approx(0.86)
+    assert "stub reasoning" in watch.final_verdict
+    assert len(_events(s, watch, WatchEventType.SCORED.value)) == 1
+
+    verdicts = [n for n in notifications if n["event_type"] == "watch_verdict"]
+    assert len(verdicts) == 1
+    assert verdicts[0]["status"] == "ok"
+    assert "8.6/10" in verdicts[0]["message"]  # display edge x10
+    s.close()
+
+
+@pytest.mark.parametrize(
+    "score,expected_status",
+    [(0.79, WatchStatus.FAILED), (0.80, WatchStatus.PASSED)],
+)
+def test_run_and_report_threshold_boundary(
+    workspace, new_session, notifications, score, expected_status
+):
+    """0.79 fails the default 0.8 bar; 0.80 passes it."""
+    s = new_session()
+    _, execution = _seed_execution(s, workspace)
+    watch = _make_watch(s, workspace, execution)
+    decider = WatchDecider(verdict_service=_StubVerdicts([_verdict(score)]))
+
+    _decide(decider, s, watch, "completed")
+    s.commit()
+    s.refresh(watch)
+    assert watch.status == expected_status.value
+    s.close()
+
+
+def test_run_and_report_failed_run_closes_failed_without_actions(
+    workspace, new_session, notifications
+):
+    s = new_session()
+    _, execution = _seed_execution(s, workspace, status="failed")
+    watch = _make_watch(s, workspace, execution)
+    decider = WatchDecider(
+        verdict_service=_StubVerdicts([_verdict(0.1)]),
+        diagnoser=_StubDiagnoser(),  # must never be called
+    )
+
+    decision = _decide(decider, s, watch, "failed")
+    s.commit()
+
+    assert decision == DECIDED_FAILED
+    s.refresh(watch)
+    assert watch.status == WatchStatus.FAILED.value
+    assert watch.actions_taken == 0  # no actions under run_and_report
+    assert decider._diagnoser.diagnose_calls == 0
+    verdicts = [n for n in notifications if n["event_type"] == "watch_verdict"]
+    assert verdicts[0]["status"] == "error"
+    s.close()
+
+
+def test_judge_failure_degrades_to_close_by_outcome(
+    workspace, new_session, notifications
+):
+    """A judge_failed verdict must not wedge the watch: completed closes
+    PASSED (v1 outcome semantics), with the degradation noted."""
+    s = new_session()
+    _, execution = _seed_execution(s, workspace)
+    watch = _make_watch(s, workspace, execution)
+    decider = WatchDecider(verdict_service=_StubVerdicts([_verdict(None)]))
+
+    decision = _decide(decider, s, watch, "completed")
+    s.commit()
+
+    assert decision == DECIDED_PASSED
+    s.refresh(watch)
+    assert watch.status == WatchStatus.PASSED.value
+    assert watch.final_score is None
+    assert "scoring unavailable" in watch.final_verdict.lower()
+    s.close()
+
+
+# ---------------------------------------------------------------------------
+# score_and_improve: below-threshold -> diagnose -> ONE tweak+rerun -> final
+# ---------------------------------------------------------------------------
+
+
+def _improve_watch(s, workspace, execution, **overrides):
+    return _make_watch(
+        s, workspace, execution, policy="score_and_improve", **overrides
+    )
+
+
+def test_low_score_diagnoses_and_launches_tweaked_rerun(
+    workspace, new_session, notifications, monkeypatch
+):
+    import services.watch_rerun as wr
+
+    launched = []
+    monkeypatch.setattr(wr, "launch_execution", lambda e: launched.append(e.execution_id))
+
+    s = new_session()
+    recipe, execution = _seed_execution(s, workspace)
+    watch = _improve_watch(s, workspace, execution)
+    # full_auto so the rerun gate auto-approves.
+    s.execute(
+        text("UPDATE workspaces SET settings = CAST(:cfg AS jsonb) WHERE id = CAST(:w AS uuid)"),
+        {"cfg": json.dumps({"approval_policy": {"policy": "full_auto"},
+                            "autonomy": {"level": "full"}}), "w": workspace},
+    )
+    s.commit()
+
+    diagnosis = Diagnosis(
+        cause="step s1 prompt is too vague",
+        proposed_action="tweak_rerun",
+        step_overrides={"s1": {"prompt_template": "do it with citations"}},
+    )
+    decider = WatchDecider(
+        verdict_service=_StubVerdicts([_verdict(0.5)]),
+        diagnoser=_StubDiagnoser(diagnosis=diagnosis),
+    )
+
+    decision = _decide(decider, s, watch, "completed")
+    s.commit()
+
+    assert decision == DECIDED_ACTED
+    assert len(launched) == 1
+    rerun = (
+        s.query(RecipeExecution)
+        .filter(RecipeExecution.retry_of == execution.execution_id)
+        .one()
+    )
+    assert rerun.execution_metadata["step_overrides"] == {
+        "s1": {"prompt_template": "do it with citations"}
+    }
+    assert rerun.triggered_by == "watch_rerun"
+
+    s.refresh(watch)
+    assert watch.target_id == rerun.execution_id  # the watch followed
+    assert watch.actions_taken == 1
+    assert len(_events(s, watch, WatchEventType.DIAGNOSED.value)) == 1
+    actions = [n for n in notifications if n["event_type"] == "watch_action"]
+    assert len(actions) == 1
+    # Diagnosis was one bounded call; no tweak-draft needed (overrides came
+    # with the diagnosis).
+    assert decider._diagnoser.diagnose_calls == 1
+    assert decider._diagnoser.tweak_calls == 0
+    s.close()
+
+
+def test_second_below_threshold_closes_final_no_second_tweak(
+    workspace, new_session, notifications
+):
+    """The ONE-tweak rule: after a corrective attempt, the rescore is FINAL
+    -- below-threshold now closes failed instead of acting again."""
+    s = new_session()
+    _, execution = _seed_execution(s, workspace)
+    watch = _improve_watch(s, workspace, execution)
+    watch.actions_taken = 1  # the improve cycle was already spent
+    s.commit()
+
+    diagnoser = _StubDiagnoser(diagnosis=Diagnosis(cause="still weak", proposed_action="tweak_rerun"))
+    decider = WatchDecider(
+        verdict_service=_StubVerdicts([_verdict(0.5)]),
+        diagnoser=diagnoser,
+    )
+    decision = _decide(decider, s, watch, "completed")
+    s.commit()
+
+    assert decision == DECIDED_FAILED
+    assert diagnoser.diagnose_calls == 0  # no second improve cycle
+    s.refresh(watch)
+    assert watch.status == WatchStatus.FAILED.value
+    assert "corrective attempt was already made" in watch.final_verdict
+    s.close()
+
+
+def test_runaway_guard_budget_zero_straight_to_escalate(
+    workspace, new_session, notifications
+):
+    s = new_session()
+    _, execution = _seed_execution(s, workspace, status="failed")
+    watch = _improve_watch(s, workspace, execution, action_budget=0)
+    decider = WatchDecider(
+        verdict_service=_StubVerdicts([_verdict(0.2)]),
+        diagnoser=_StubDiagnoser(
+            diagnosis=Diagnosis(cause="broken step", proposed_action="rerun")
+        ),
+    )
+
+    decision = _decide(decider, s, watch, "failed")
+    s.commit()
+
+    assert decision == DECIDED_ESCALATED
+    # STRAIGHT to escalate: the diagnosis LLM is never spent when no action
+    # is possible.
+    assert decider._diagnoser.diagnose_calls == 0
+    s.refresh(watch)
+    assert watch.status == WatchStatus.ESCALATED.value
+    # No rerun row was created.
+    assert (
+        s.query(RecipeExecution)
+        .filter(RecipeExecution.retry_of == execution.execution_id)
+        .count()
+        == 0
+    )
+    cards = (
+        s.query(BoardTask)
+        .filter(
+            BoardTask.workspace_id == workspace,
+            BoardTask.tags.contains(["escalation", f"watch:{watch.id}"]),
+        )
+        .count()
+    )
+    assert cards == 1
+    escalations = [n for n in notifications if n["event_type"] == "watch_escalation"]
+    assert len(escalations) == 1
+    s.close()
+
+
+def test_diagnosis_unavailable_falls_back_deterministically(
+    workspace, new_session, notifications, monkeypatch
+):
+    """LLM down -> Diagnosis None -> deterministic fallback action (rerun
+    for playbooks), never a wedge."""
+    import services.watch_rerun as wr
+
+    launched = []
+    monkeypatch.setattr(wr, "launch_execution", lambda e: launched.append(e.execution_id))
+
+    s = new_session()
+    _, execution = _seed_execution(s, workspace, status="failed")
+    watch = _improve_watch(s, workspace, execution)
+    s.execute(
+        text("UPDATE workspaces SET settings = CAST(:cfg AS jsonb) WHERE id = CAST(:w AS uuid)"),
+        {"cfg": json.dumps({"approval_policy": {"policy": "full_auto"},
+                            "autonomy": {"level": "full"}}), "w": workspace},
+    )
+    s.commit()
+
+    decider = WatchDecider(
+        verdict_service=_StubVerdicts([_verdict(0.2)]),
+        diagnoser=_StubDiagnoser(diagnosis=None),
+    )
+    decision = _decide(decider, s, watch, "failed")
+    s.commit()
+
+    assert decision == DECIDED_ACTED
+    assert len(launched) == 1  # plain rerun, no overrides
+    rerun = (
+        s.query(RecipeExecution)
+        .filter(RecipeExecution.retry_of == execution.execution_id)
+        .one()
+    )
+    assert "step_overrides" not in (rerun.execution_metadata or {})
+    s.close()
+
+
+# ---------------------------------------------------------------------------
+# watch_change: compare against the prior attempt, then report
+# ---------------------------------------------------------------------------
+
+
+def test_watch_change_reports_before_after_delta(
+    workspace, new_session, notifications
+):
+    s = new_session()
+    _, execution = _seed_execution(s, workspace)
+    watch = _make_watch(s, workspace, execution, policy="watch_change")
+
+    # Simulate the prior attempt: a SCORED event for the original target,
+    # then the watch followed a rerun.
+    from modules.coordination.run_verdict import RunVerdictService
+
+    prior = _verdict(0.55)
+    RunVerdictService.apply_verdict(s, watch, prior)
+    s.commit()
+    _, rerun_execution = _seed_execution(s, workspace)
+    WatchService.follow(
+        s, watch,
+        new_target_type="playbook_execution",
+        new_target_id=rerun_execution.execution_id,
+        reason="rerun",
+    )
+    s.commit()
+
+    decider = WatchDecider(verdict_service=_StubVerdicts([_verdict(0.9)]))
+    decision = _decide(decider, s, watch, "completed")
+    s.commit()
+
+    assert decision == DECIDED_PASSED
+    changes = _events(s, watch, WatchEventType.CHANGE_REPORT.value)
+    assert len(changes) == 1
+    snap = changes[0].snapshot
+    assert snap["before_score"] == pytest.approx(0.55)
+    assert snap["after_score"] == pytest.approx(0.9)
+    assert snap["delta"] == pytest.approx(0.35)
+    s.close()
+
+
+# ---------------------------------------------------------------------------
+# persistent: record, notify on flip, never close on terminal
+# ---------------------------------------------------------------------------
+
+
+def test_persistent_records_and_notifies_only_on_flip(
+    workspace, new_session, notifications
+):
+    s = new_session()
+    _, execution = _seed_execution(s, workspace)
+    watch = _make_watch(s, workspace, execution, policy="persistent")
+    decider = WatchDecider(verdict_service=_StubVerdicts([]))  # never scores
+
+    first = _decide(decider, s, watch, "completed")
+    s.commit()
+    assert first == DECIDED_RECORDED
+    s.refresh(watch)
+    assert watch.status == WatchStatus.WATCHING.value  # never closes
+    assert notifications == []  # first observation is not a change
+
+    # Same observation again -> dedupe, no noise.
+    again = _decide(decider, s, watch, "completed")
+    assert again == DECIDED_NOOP
+
+    # A flip (completed -> failed) notifies as degradation.
+    flipped = _decide(decider, s, watch, "failed")
+    s.commit()
+    assert flipped == DECIDED_RECORDED
+    escalations = [n for n in notifications if n["event_type"] == "watch_escalation"]
+    assert len(escalations) == 1
+    assert "'completed' -> 'failed'" in escalations[0]["message"]
+    s.refresh(watch)
+    assert watch.status == WatchStatus.WATCHING.value  # still recurring
+    s.close()
+
+
+def test_observe_scheduled_flip_detection(workspace, new_session, notifications):
+    s = new_session()
+    recipe, completed_exec = _seed_execution(s, workspace)  # one completed run
+    s.add(
+        RecipeExecution(
+            execution_id=f"exec-{uuid.uuid4().hex[:12]}",
+            recipe_id=recipe.id,
+            workspace_id=workspace,
+            status="failed",
+            input_data={},
+        )
+    )
+    s.commit()
+    # Deterministic ordering: the completed run happened first, then the
+    # failed one (no wall-clock dependence).
+    s.execute(
+        text(
+            "UPDATE recipe_executions SET started_at = :t "
+            "WHERE execution_id = :e"
+        ),
+        {"t": datetime(2026, 7, 16, 12, 0, 0), "e": completed_exec.execution_id},
+    )
+    s.execute(
+        text(
+            "UPDATE recipe_executions SET started_at = :t "
+            "WHERE recipe_id = :r AND status = 'failed'"
+        ),
+        {"t": datetime(2026, 7, 16, 13, 0, 0), "r": recipe.id},
+    )
+    s.commit()
+    watch = WatchService.create_watch(
+        s,
+        workspace_id=workspace,
+        watch_type="scheduled_playbook",
+        target_type="scheduled_playbook",
+        target_id=str(recipe.id),
+        title="Watch: schedule",
+        policy="persistent",
+        now=FROZEN_NOW,
+    )
+    s.commit()
+
+    playbook = s.query(WorkflowTemplate).filter(WorkflowTemplate.id == recipe.id).one()
+    decider = WatchDecider(verdict_service=_StubVerdicts([]))
+    decision = asyncio.run(decider.observe_scheduled(s, watch, playbook, FROZEN_NOW))
+    s.commit()
+
+    assert decision == DECIDED_RECORDED
+    escalations = [n for n in notifications if n["event_type"] == "watch_escalation"]
+    assert len(escalations) == 1
+    assert "started failing" in escalations[0]["title"]
+
+    # Idempotent per latest execution.
+    again = asyncio.run(decider.observe_scheduled(s, watch, playbook, FROZEN_NOW))
+    assert again == DECIDED_NOOP
+    s.close()
+
+
+# ---------------------------------------------------------------------------
+# Non-claimable watches are never decided
+# ---------------------------------------------------------------------------
+
+
+def test_decider_noops_on_parked_watch(workspace, new_session, notifications):
+    s = new_session()
+    _, execution = _seed_execution(s, workspace)
+    watch = _make_watch(s, workspace, execution)
+    WatchService.transition(s, watch, WatchStatus.NEEDS_ATTENTION)
+    s.commit()
+
+    decider = WatchDecider(verdict_service=_StubVerdicts([_verdict(0.9)]))
+    assert _decide(decider, s, watch, "completed") == DECIDED_NOOP
+    assert notifications == []
+    s.close()

--- a/orchestrator/tests/test_prd204_watch_hooks.py
+++ b/orchestrator/tests/test_prd204_watch_hooks.py
@@ -168,6 +168,9 @@ def _seed_run_and_watch(s, ws_id: str):
 
 
 def test_mission_failed_transition_ingests_watch(workspace, new_session):
+    """S10 semantics: the producer's terminal is RECORDED at the choke point
+    and the watch is handed to the decision step (next check pulled to now)
+    -- the close now belongs to the decider, not the sync hook."""
     s = new_session()
     run, watch = _seed_run_and_watch(s, workspace)
 
@@ -184,8 +187,11 @@ def test_mission_failed_transition_ingests_watch(workspace, new_session):
     s.commit()
 
     s.refresh(watch)
-    assert watch.status == WatchStatus.FAILED.value
-    assert watch.closed_at is not None
+    assert watch.status == WatchStatus.WATCHING.value  # deferred to the decider
+    assert watch.closed_at is None
+    # Pulled forward for the tick: well inside the original +300s cadence.
+    assert watch.next_check_at is not None
+    assert (watch.next_check_at - watch.created_at).total_seconds() < 60
     events = (
         s.query(WatchEvent)
         .filter(WatchEvent.watch_id == watch.id, WatchEvent.event_type == "terminal")

--- a/orchestrator/tests/test_prd204_watch_hooks.py
+++ b/orchestrator/tests/test_prd204_watch_hooks.py
@@ -1,4 +1,4 @@
-"""PRD-204 S3 — fail-soft terminal hooks.
+"""PRD-204 S3 -- fail-soft terminal hooks.
 
 Proves the two contract halves:
 1. every producer terminal path reports into the watch registry, and
@@ -6,7 +6,7 @@ Proves the two contract halves:
    playbook executor, board-task dispatch all complete normally).
 
 Mission-path tests are DB-backed (real Postgres, skip cleanly when absent);
-executor/board hook tests run against mocks — the hook seam is what is under
+executor/board hook tests run against mocks -- the hook seam is what is under
 test, not those modules' heavy internals.
 """
 from __future__ import annotations

--- a/orchestrator/tests/test_prd204_watch_hooks.py
+++ b/orchestrator/tests/test_prd204_watch_hooks.py
@@ -1,0 +1,432 @@
+"""PRD-204 S3 — fail-soft terminal hooks.
+
+Proves the two contract halves:
+1. every producer terminal path reports into the watch registry, and
+2. a RAISING watch service never breaks the producer (mission transition,
+   playbook executor, board-task dispatch all complete normally).
+
+Mission-path tests are DB-backed (real Postgres, skip cleanly when absent);
+executor/board hook tests run against mocks — the hook seam is what is under
+test, not those modules' heavy internals.
+"""
+from __future__ import annotations
+
+import asyncio
+import uuid
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+from core.database.database import get_database_url
+from core.models.orchestration import OrchestrationRun
+from core.models.orchestration_enums import ActorType, RunState
+from core.models.watches import WatchEvent
+from core.models.watch_enums import WatchStatus
+from services.orchestration_state import transition_run
+from services.watch_hooks import watch_ingest_terminal
+from services.watch_service import WatchService
+
+
+# ---------------------------------------------------------------------------
+# Unit: the hook itself is fail-soft
+# ---------------------------------------------------------------------------
+
+
+def test_hook_swallows_raising_watch_service(monkeypatch):
+    """watch_ingest_terminal must never raise, whatever the service does."""
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("watch registry down")
+
+    monkeypatch.setattr(
+        "services.watch_service.WatchService.ingest_terminal", _boom
+    )
+    # Must not raise.
+    watch_ingest_terminal(
+        MagicMock(),
+        workspace_id=str(uuid.uuid4()),
+        target_type="mission",
+        target_id=str(uuid.uuid4()),
+        terminal_state="completed",
+    )
+
+
+def test_hook_noop_without_live_watch_uses_service(monkeypatch):
+    """The hook passes through to WatchService.ingest_terminal once."""
+    calls = []
+
+    def _record(db, **kwargs):
+        calls.append(kwargs)
+        return None
+
+    monkeypatch.setattr(
+        "services.watch_service.WatchService.ingest_terminal",
+        staticmethod(_record),
+    )
+    watch_ingest_terminal(
+        MagicMock(),
+        workspace_id="ws-1",
+        target_type="playbook_execution",
+        target_id="exec-1",
+        terminal_state="failed",
+        summary="boom",
+        cost_snapshot={"total_tokens": 5},
+    )
+    assert len(calls) == 1
+    assert calls[0]["target_type"] == "playbook_execution"
+    assert calls[0]["target_id"] == "exec-1"
+    assert calls[0]["terminal_state"] == "failed"
+    assert calls[0]["cost_snapshot"] == {"total_tokens": 5}
+
+
+# ---------------------------------------------------------------------------
+# Mission choke point (DB-backed): transition_run covers every fail/cancel/
+# complete call site because they all flow through it.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def engine():
+    try:
+        eng = create_engine(get_database_url(), pool_pre_ping=True)
+        with eng.connect() as c:
+            c.execute(text("SELECT 1 FROM watches LIMIT 1"))
+            c.execute(text("SELECT 1 FROM orchestration_runs LIMIT 1"))
+    except Exception as exc:  # noqa: BLE001
+        pytest.skip(f"watch hooks suite needs a reachable Postgres with schema: {exc}")
+    yield eng
+    eng.dispose()
+
+
+@pytest.fixture
+def new_session(engine):
+    return sessionmaker(bind=engine, expire_on_commit=False)
+
+
+@pytest.fixture
+def workspace(new_session):
+    ws_id = str(uuid.uuid4())
+    s = new_session()
+    s.execute(
+        text(
+            "INSERT INTO workspaces (id, name) "
+            "VALUES (CAST(:id AS uuid), :n) ON CONFLICT (id) DO NOTHING"
+        ),
+        {"id": ws_id, "n": "prd204-watch-hooks"},
+    )
+    s.commit()
+    s.close()
+
+    yield ws_id
+
+    s = new_session()
+    s.execute(
+        text(
+            "DELETE FROM watch_events WHERE watch_id IN "
+            "(SELECT id FROM watches WHERE workspace_id = CAST(:w AS uuid))"
+        ),
+        {"w": ws_id},
+    )
+    s.execute(
+        text("DELETE FROM watches WHERE workspace_id = CAST(:w AS uuid)"),
+        {"w": ws_id},
+    )
+    s.execute(
+        text(
+            "DELETE FROM orchestration_runs WHERE workspace_id = CAST(:w AS uuid)"
+        ),
+        {"w": ws_id},
+    )
+    s.execute(
+        text("DELETE FROM workspaces WHERE id = CAST(:w AS uuid)"), {"w": ws_id}
+    )
+    s.commit()
+    s.close()
+
+
+def _seed_run_and_watch(s, ws_id: str):
+    run = OrchestrationRun(
+        workspace_id=ws_id,
+        goal="hooks test mission",
+        state=RunState.PLANNING.value,
+        created_by="user_test",
+    )
+    s.add(run)
+    s.flush()
+    watch = WatchService.create_watch(
+        s,
+        workspace_id=ws_id,
+        watch_type="mission",
+        target_type="mission",
+        target_id=str(run.id),
+        title="Watch: hooks test mission",
+    )
+    s.commit()
+    return run, watch
+
+
+def test_mission_failed_transition_ingests_watch(workspace, new_session):
+    s = new_session()
+    run, watch = _seed_run_and_watch(s, workspace)
+
+    transition_run(
+        db=s,
+        run=run,
+        new_state=RunState.FAILED,
+        actor_type=ActorType.COORDINATOR,
+        actor_id="coordinator",
+        reason="Plan validation failed",
+        stop_reason="coordinator_error",
+        stop_detail="Plan validation failed after all retries",
+    )
+    s.commit()
+
+    s.refresh(watch)
+    assert watch.status == WatchStatus.FAILED.value
+    assert watch.closed_at is not None
+    events = (
+        s.query(WatchEvent)
+        .filter(WatchEvent.watch_id == watch.id, WatchEvent.event_type == "terminal")
+        .all()
+    )
+    assert len(events) == 1
+    assert events[0].snapshot["terminal_state"] == "failed"
+    assert "Plan validation failed" in (events[0].summary or "")
+    s.close()
+
+
+def test_mission_cancelled_transition_ingests_watch(workspace, new_session):
+    s = new_session()
+    run, watch = _seed_run_and_watch(s, workspace)
+
+    transition_run(
+        db=s,
+        run=run,
+        new_state=RunState.CANCELLED,
+        actor_type=ActorType.HUMAN,
+        actor_id="user_test",
+        stop_reason="human_cancelled",
+    )
+    s.commit()
+
+    s.refresh(watch)
+    assert watch.status == WatchStatus.CANCELLED.value
+    s.close()
+
+
+def test_non_terminal_transition_does_not_touch_watch(workspace, new_session):
+    s = new_session()
+    run, watch = _seed_run_and_watch(s, workspace)
+
+    transition_run(
+        db=s,
+        run=run,
+        new_state=RunState.RUNNING,
+        actor_type=ActorType.COORDINATOR,
+        actor_id="coordinator",
+    )
+    s.commit()
+
+    s.refresh(watch)
+    assert watch.status == WatchStatus.WATCHING.value
+    terminal_events = (
+        s.query(WatchEvent)
+        .filter(WatchEvent.watch_id == watch.id, WatchEvent.event_type == "terminal")
+        .count()
+    )
+    assert terminal_events == 0
+    s.close()
+
+
+def test_producer_completes_when_watch_service_raises(
+    workspace, new_session, monkeypatch
+):
+    """THE fail-soft assertion: a raising watch service must not fail the
+    mission transition (the producer)."""
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("watch registry exploded")
+
+    monkeypatch.setattr(
+        "services.watch_service.WatchService.ingest_terminal", _boom
+    )
+
+    s = new_session()
+    run, watch = _seed_run_and_watch(s, workspace)
+
+    transition_run(
+        db=s,
+        run=run,
+        new_state=RunState.FAILED,
+        actor_type=ActorType.COORDINATOR,
+        actor_id="coordinator",
+        stop_reason="coordinator_error",
+    )
+    s.commit()
+
+    s.refresh(run)
+    assert run.state == RunState.FAILED.value  # producer landed its terminal
+    s.refresh(watch)
+    assert watch.status == WatchStatus.WATCHING.value  # ingest was lost, softly
+    s.close()
+
+
+# ---------------------------------------------------------------------------
+# Playbook executor seam (mocked executor internals; real hook seam)
+# ---------------------------------------------------------------------------
+
+
+def _fake_execution(**overrides):
+    execution = MagicMock()
+    execution.execution_id = overrides.get("execution_id", "exec-prd204")
+    execution.workspace_id = overrides.get("workspace_id", str(uuid.uuid4()))
+    execution.output_data = overrides.get(
+        "output_data",
+        {"final_output": "report text", "total_tokens": 42, "total_duration_ms": 1500},
+    )
+    return execution
+
+
+def test_playbook_terminal_helper_reports_completed(monkeypatch):
+    from api.recipe_executor import _ingest_playbook_terminal_watch
+
+    calls = []
+    monkeypatch.setattr(
+        "services.watch_hooks.watch_ingest_terminal",
+        lambda db, **kw: calls.append(kw),
+    )
+
+    execution = _fake_execution()
+    _ingest_playbook_terminal_watch(
+        MagicMock(), execution, terminal_state="completed", summary="3 steps"
+    )
+
+    assert len(calls) == 1
+    kw = calls[0]
+    assert kw["target_type"] == "playbook_execution"
+    assert kw["target_id"] == "exec-prd204"
+    assert kw["terminal_state"] == "completed"
+    assert kw["cost_snapshot"] == {"total_tokens": 42, "total_duration_ms": 1500}
+    assert kw["output_pointer"] == (
+        "recipe_execution:exec-prd204:output_data.final_output"
+    )
+
+
+def test_playbook_terminal_helper_reports_failed_without_output(monkeypatch):
+    from api.recipe_executor import _ingest_playbook_terminal_watch
+
+    calls = []
+    monkeypatch.setattr(
+        "services.watch_hooks.watch_ingest_terminal",
+        lambda db, **kw: calls.append(kw),
+    )
+
+    execution = _fake_execution(output_data=None)
+    _ingest_playbook_terminal_watch(
+        MagicMock(), execution, terminal_state="failed", summary="boom"
+    )
+
+    kw = calls[0]
+    assert kw["terminal_state"] == "failed"
+    assert kw["output_pointer"] is None
+    assert kw["summary"] == "boom"
+
+
+def test_playbook_terminal_helper_is_fail_soft(monkeypatch):
+    """A raising watch service does not raise out of the executor helper."""
+    from api.recipe_executor import _ingest_playbook_terminal_watch
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("registry down")
+
+    monkeypatch.setattr(
+        "services.watch_service.WatchService.ingest_terminal", _boom
+    )
+    # Must not raise (watch_ingest_terminal is the fail-soft wrapper).
+    _ingest_playbook_terminal_watch(
+        MagicMock(), _fake_execution(), terminal_state="completed"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Board-task seam
+# ---------------------------------------------------------------------------
+
+
+def _mock_board_db():
+    db = MagicMock()
+    q = MagicMock()
+    q.filter.return_value = q
+    q.first.return_value = None
+    db.query.return_value = q
+    exec_result = MagicMock()
+    exec_result.fetchall.return_value = []
+    db.execute.return_value = exec_result
+    return db
+
+
+def _fake_board_task():
+    task = MagicMock()
+    task.id = 7
+    task.title = "hooks board task"
+    task.assigned_agent_id = None
+    task.result = "done ok"
+    task.description = None
+    task.error_message = "it broke"
+    return task
+
+
+def test_board_task_complete_reports_watch(monkeypatch):
+    from api.board_tasks import _dispatch_task_complete
+
+    calls = []
+    monkeypatch.setattr(
+        "services.watch_hooks.watch_ingest_terminal",
+        lambda db, **kw: calls.append(kw),
+    )
+
+    asyncio.run(
+        _dispatch_task_complete(_mock_board_db(), str(uuid.uuid4()), _fake_board_task())
+    )
+
+    assert len(calls) == 1
+    assert calls[0]["target_type"] == "board_task"
+    assert calls[0]["target_id"] == "7"
+    assert calls[0]["terminal_state"] == "completed"
+
+
+def test_board_task_failed_reports_watch(monkeypatch):
+    from api.board_tasks import _dispatch_task_failed
+
+    calls = []
+    monkeypatch.setattr(
+        "services.watch_hooks.watch_ingest_terminal",
+        lambda db, **kw: calls.append(kw),
+    )
+
+    asyncio.run(
+        _dispatch_task_failed(_mock_board_db(), str(uuid.uuid4()), _fake_board_task())
+    )
+
+    assert len(calls) == 1
+    assert calls[0]["target_type"] == "board_task"
+    assert calls[0]["terminal_state"] == "failed"
+    assert calls[0]["summary"] == "it broke"
+
+
+def test_board_task_dispatch_survives_raising_watch_service(monkeypatch):
+    """Producer helper completes even when the watch service raises."""
+    from api.board_tasks import _dispatch_task_complete
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("registry down")
+
+    monkeypatch.setattr(
+        "services.watch_service.WatchService.ingest_terminal", _boom
+    )
+    # Must not raise.
+    asyncio.run(
+        _dispatch_task_complete(_mock_board_db(), str(uuid.uuid4()), _fake_board_task())
+    )

--- a/orchestrator/tests/test_prd204_watch_registry.py
+++ b/orchestrator/tests/test_prd204_watch_registry.py
@@ -1,4 +1,4 @@
-"""PRD-204 S1 — watch registry schema: model round-trip, dedup, FK integrity.
+"""PRD-204 S1 -- watch registry schema: model round-trip, dedup, FK integrity.
 
 DB-backed (real Postgres): the partial unique index and ON CONFLICT semantics
 are Postgres-only, so this suite follows the test.yml Postgres pattern
@@ -43,7 +43,7 @@ def new_session(engine):
 
 @pytest.fixture
 def workspace(engine, new_session):
-    """Throwaway workspace (seeded FIRST — PRD-158). Yields workspace_id str."""
+    """Throwaway workspace (seeded FIRST -- PRD-158). Yields workspace_id str."""
     ws_id = str(uuid.uuid4())
     s = new_session()
     s.execute(
@@ -59,7 +59,7 @@ def workspace(engine, new_session):
     yield ws_id
 
     s = new_session()
-    # watch_events cascade off watches; watches cascade off workspaces —
+    # watch_events cascade off watches; watches cascade off workspaces --
     # explicit deletes keep teardown independent of CASCADE behaviour.
     s.execute(
         text(

--- a/orchestrator/tests/test_prd204_watch_registry.py
+++ b/orchestrator/tests/test_prd204_watch_registry.py
@@ -1,0 +1,285 @@
+"""PRD-204 S1 — watch registry schema: model round-trip, dedup, FK integrity.
+
+DB-backed (real Postgres): the partial unique index and ON CONFLICT semantics
+are Postgres-only, so this suite follows the test.yml Postgres pattern
+(test_board_dispatch.py precedent) and skips cleanly when no DB is reachable.
+
+PRD-158 lesson: every test touching FK'd tables seeds ``workspaces`` FIRST.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import sessionmaker
+
+from core.database.database import get_database_url
+from core.models.watches import Watch, WatchEvent
+from core.models.watch_enums import WatchStatus
+
+
+@pytest.fixture(scope="module")
+def engine():
+    """Real Postgres engine; skip the whole module cleanly when none is up."""
+    try:
+        eng = create_engine(get_database_url(), pool_pre_ping=True)
+        with eng.connect() as c:
+            c.execute(text("SELECT 1"))
+            c.execute(text("SELECT 1 FROM watches LIMIT 1"))
+    except Exception as exc:  # noqa: BLE001
+        pytest.skip(f"watch registry suite needs a reachable Postgres with schema: {exc}")
+    yield eng
+    eng.dispose()
+
+
+@pytest.fixture
+def new_session(engine):
+    """A sessionmaker that hands out independent, committing sessions."""
+    return sessionmaker(bind=engine, expire_on_commit=False)
+
+
+@pytest.fixture
+def workspace(engine, new_session):
+    """Throwaway workspace (seeded FIRST — PRD-158). Yields workspace_id str."""
+    ws_id = str(uuid.uuid4())
+    s = new_session()
+    s.execute(
+        text(
+            "INSERT INTO workspaces (id, name) "
+            "VALUES (CAST(:id AS uuid), :n) ON CONFLICT (id) DO NOTHING"
+        ),
+        {"id": ws_id, "n": "prd204-watch-registry"},
+    )
+    s.commit()
+    s.close()
+
+    yield ws_id
+
+    s = new_session()
+    # watch_events cascade off watches; watches cascade off workspaces —
+    # explicit deletes keep teardown independent of CASCADE behaviour.
+    s.execute(
+        text(
+            "DELETE FROM watch_events WHERE watch_id IN "
+            "(SELECT id FROM watches WHERE workspace_id = CAST(:w AS uuid))"
+        ),
+        {"w": ws_id},
+    )
+    s.execute(
+        text("DELETE FROM watches WHERE workspace_id = CAST(:w AS uuid)"),
+        {"w": ws_id},
+    )
+    s.execute(
+        text("DELETE FROM workspaces WHERE id = CAST(:w AS uuid)"),
+        {"w": ws_id},
+    )
+    s.commit()
+    s.close()
+
+
+def _make_watch(ws_id: str, **overrides) -> Watch:
+    defaults = dict(
+        workspace_id=ws_id,
+        created_by="user_test",
+        watch_type="mission",
+        target_type="mission",
+        target_id=str(uuid.uuid4()),
+        title="Watch: test mission",
+        success_criteria="The mission produces a report",
+    )
+    defaults.update(overrides)
+    return Watch(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Model round-trip + defaults
+# ---------------------------------------------------------------------------
+
+
+def test_watch_round_trip_and_defaults(workspace, new_session):
+    s = new_session()
+    watch = _make_watch(workspace)
+    s.add(watch)
+    s.commit()
+    watch_id = watch.id
+    s.close()
+
+    s = new_session()
+    loaded = s.query(Watch).filter(Watch.id == watch_id).one()
+    assert str(loaded.workspace_id) == workspace
+    assert loaded.status == WatchStatus.WATCHING.value
+    assert loaded.quality_threshold == pytest.approx(0.8)
+    assert loaded.check_interval_seconds == 300
+    assert loaded.policy == "run_and_report"
+    assert loaded.action_budget == 2
+    assert loaded.actions_taken == 0
+    assert loaded.lineage == []
+    assert loaded.version_id == 1
+    assert loaded.closed_at is None
+    assert loaded.created_at is not None
+    s.close()
+
+
+def test_watch_event_round_trip(workspace, new_session):
+    s = new_session()
+    watch = _make_watch(workspace)
+    s.add(watch)
+    s.commit()
+
+    event = WatchEvent(
+        watch_id=watch.id,
+        event_type="terminal",
+        summary="mission completed",
+        snapshot={"tokens_used": 1200, "output_pointer": "mission:x:output_summary"},
+        event_key="terminal:mission:abc",
+    )
+    s.add(event)
+    s.commit()
+    event_id = event.id
+    s.close()
+
+    s = new_session()
+    loaded = s.query(WatchEvent).filter(WatchEvent.id == event_id).one()
+    assert loaded.event_type == "terminal"
+    assert loaded.snapshot["tokens_used"] == 1200
+    assert loaded.requires_attention is False
+    assert loaded.score is None
+    s.close()
+
+
+# ---------------------------------------------------------------------------
+# Dedup indexes
+# ---------------------------------------------------------------------------
+
+
+def test_one_live_watch_per_target(workspace, new_session):
+    """Partial unique index: a second NON-terminal watch on the same target
+    is rejected; once the first closes, a new watch on the target is fine."""
+    target = str(uuid.uuid4())
+
+    s = new_session()
+    s.add(_make_watch(workspace, target_id=target))
+    s.commit()
+
+    s.add(_make_watch(workspace, target_id=target))
+    with pytest.raises(IntegrityError):
+        s.commit()
+    s.rollback()
+
+    # Close the live watch -> the partial index no longer applies to it.
+    s.execute(
+        text(
+            "UPDATE watches SET status = 'passed', closed_at = NOW() "
+            "WHERE workspace_id = CAST(:w AS uuid) AND target_id = :t"
+        ),
+        {"w": workspace, "t": target},
+    )
+    s.commit()
+
+    s.add(_make_watch(workspace, target_id=target))
+    s.commit()  # must not raise
+
+    live = s.execute(
+        text(
+            "SELECT COUNT(*) FROM watches "
+            "WHERE workspace_id = CAST(:w AS uuid) AND target_id = :t"
+        ),
+        {"w": workspace, "t": target},
+    ).scalar()
+    assert live == 2
+    s.close()
+
+
+def test_event_key_unique_per_watch(workspace, new_session):
+    """UNIQUE(watch_id, event_key): the same observation lands exactly once,
+    but the same key on a DIFFERENT watch is allowed."""
+    s = new_session()
+    w1 = _make_watch(workspace)
+    w2 = _make_watch(workspace)
+    s.add_all([w1, w2])
+    s.commit()
+
+    s.add(WatchEvent(watch_id=w1.id, event_type="terminal", event_key="k1"))
+    s.commit()
+
+    s.add(WatchEvent(watch_id=w1.id, event_type="terminal", event_key="k1"))
+    with pytest.raises(IntegrityError):
+        s.commit()
+    s.rollback()
+
+    # Same key, different watch -> fine.
+    s.add(WatchEvent(watch_id=w2.id, event_type="terminal", event_key="k1"))
+    s.commit()
+    s.close()
+
+
+# ---------------------------------------------------------------------------
+# FK integrity
+# ---------------------------------------------------------------------------
+
+
+def test_watch_requires_existing_workspace(new_session):
+    s = new_session()
+    s.add(_make_watch(str(uuid.uuid4())))  # workspace never seeded
+    with pytest.raises(IntegrityError):
+        s.commit()
+    s.rollback()
+    s.close()
+
+
+def test_workspace_delete_cascades_watches_and_events(engine, new_session):
+    ws_id = str(uuid.uuid4())
+    s = new_session()
+    s.execute(
+        text("INSERT INTO workspaces (id, name) VALUES (CAST(:id AS uuid), :n)"),
+        {"id": ws_id, "n": "prd204-cascade"},
+    )
+    s.commit()
+
+    watch = _make_watch(ws_id)
+    s.add(watch)
+    s.commit()
+    s.add(WatchEvent(watch_id=watch.id, event_type="created", event_key="created"))
+    s.commit()
+    watch_id = str(watch.id)
+
+    s.execute(
+        text("DELETE FROM workspaces WHERE id = CAST(:w AS uuid)"), {"w": ws_id}
+    )
+    s.commit()
+
+    remaining_watches = s.execute(
+        text("SELECT COUNT(*) FROM watches WHERE id = CAST(:i AS uuid)"),
+        {"i": watch_id},
+    ).scalar()
+    remaining_events = s.execute(
+        text("SELECT COUNT(*) FROM watch_events WHERE watch_id = CAST(:i AS uuid)"),
+        {"i": watch_id},
+    ).scalar()
+    assert remaining_watches == 0
+    assert remaining_events == 0
+    s.close()
+
+
+# ---------------------------------------------------------------------------
+# Deadline / scheduling columns behave as timestamps
+# ---------------------------------------------------------------------------
+
+
+def test_schedule_columns_round_trip(workspace, new_session):
+    now = datetime.now(timezone.utc)
+    s = new_session()
+    watch = _make_watch(
+        workspace,
+        next_check_at=now + timedelta(seconds=300),
+        deadline_at=now + timedelta(hours=4),
+    )
+    s.add(watch)
+    s.commit()
+    loaded = s.query(Watch).filter(Watch.id == watch.id).one()
+    assert loaded.next_check_at > now
+    assert loaded.deadline_at > loaded.next_check_at
+    s.close()

--- a/orchestrator/tests/test_prd204_watch_service.py
+++ b/orchestrator/tests/test_prd204_watch_service.py
@@ -260,6 +260,41 @@ def test_ingest_terminal_outcome_mapping(
     s.close()
 
 
+def test_ingest_terminal_recovers_lost_close(workspace, new_session):
+    """Self-healing idempotency: if a prior attempt committed the terminal
+    EVENT but lost the CLOSE (version conflict), the next delivery still
+    closes the watch instead of being blocked by the duplicate event."""
+    from core.models.watches import WatchEvent
+
+    s = new_session()
+    watch = _create(s, workspace)
+    # Simulate the half-landed prior attempt: event row exists, watch open.
+    s.add(
+        WatchEvent(
+            watch_id=watch.id,
+            event_type=WatchEventType.TERMINAL.value,
+            event_key=f"terminal:mission:{watch.target_id}",
+            summary="first attempt",
+        )
+    )
+    s.commit()
+
+    result = WatchService.ingest_terminal(
+        s,
+        workspace_id=workspace,
+        target_type="mission",
+        target_id=watch.target_id,
+        terminal_state="completed",
+    )
+    s.commit()
+
+    assert result is None  # not the first writer of the event...
+    s.refresh(watch)
+    assert watch.status == WatchStatus.PASSED.value  # ...but the close lands
+    assert watch.closed_at is not None
+    s.close()
+
+
 def test_ingest_terminal_without_live_watch_is_noop(workspace, new_session):
     s = new_session()
     result = WatchService.ingest_terminal(

--- a/orchestrator/tests/test_prd204_watch_service.py
+++ b/orchestrator/tests/test_prd204_watch_service.py
@@ -1,0 +1,427 @@
+"""PRD-204 S2 — WatchService: transition guard, idempotent ingest, budget
+hard-stop, lineage repoint, SKIP LOCKED claim.
+
+DB-backed (real Postgres) — savepoint-swallowed unique violations, the
+partial unique index and FOR UPDATE SKIP LOCKED are Postgres semantics.
+Skips cleanly when no DB is reachable (test_board_dispatch.py precedent).
+
+PRD-158 lesson: workspaces seeded FIRST for every FK-touching test.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+from core.database.database import get_database_url
+from core.models.watches import Watch, WatchEvent
+from core.models.watch_enums import WatchEventType, WatchStatus
+from services.orchestration_state import InvalidTransitionError
+from services.watch_service import WatchAlreadyExistsError, WatchService
+
+
+FROZEN_NOW = datetime(2026, 7, 16, 12, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture(scope="module")
+def engine():
+    try:
+        eng = create_engine(get_database_url(), pool_pre_ping=True)
+        with eng.connect() as c:
+            c.execute(text("SELECT 1 FROM watches LIMIT 1"))
+    except Exception as exc:  # noqa: BLE001
+        pytest.skip(f"watch service suite needs a reachable Postgres with schema: {exc}")
+    yield eng
+    eng.dispose()
+
+
+@pytest.fixture
+def new_session(engine):
+    return sessionmaker(bind=engine, expire_on_commit=False)
+
+
+@pytest.fixture
+def workspace(new_session):
+    ws_id = str(uuid.uuid4())
+    s = new_session()
+    s.execute(
+        text(
+            "INSERT INTO workspaces (id, name) "
+            "VALUES (CAST(:id AS uuid), :n) ON CONFLICT (id) DO NOTHING"
+        ),
+        {"id": ws_id, "n": "prd204-watch-service"},
+    )
+    s.commit()
+    s.close()
+
+    yield ws_id
+
+    s = new_session()
+    s.execute(
+        text(
+            "DELETE FROM watch_events WHERE watch_id IN "
+            "(SELECT id FROM watches WHERE workspace_id = CAST(:w AS uuid))"
+        ),
+        {"w": ws_id},
+    )
+    s.execute(
+        text("DELETE FROM watches WHERE workspace_id = CAST(:w AS uuid)"),
+        {"w": ws_id},
+    )
+    s.execute(
+        text("DELETE FROM workspaces WHERE id = CAST(:w AS uuid)"), {"w": ws_id}
+    )
+    s.commit()
+    s.close()
+
+
+def _create(db, ws_id: str, **overrides) -> Watch:
+    params = dict(
+        workspace_id=ws_id,
+        watch_type="mission",
+        target_type="mission",
+        target_id=str(uuid.uuid4()),
+        title="Watch: service test",
+        success_criteria="produce the report",
+        now=FROZEN_NOW,
+    )
+    params.update(overrides)
+    return WatchService.create_watch(db, **params)
+
+
+# ---------------------------------------------------------------------------
+# create + duplicate guard
+# ---------------------------------------------------------------------------
+
+
+def test_create_watch_writes_created_event_and_lineage(workspace, new_session):
+    s = new_session()
+    watch = _create(s, workspace)
+    s.commit()
+
+    assert watch.status == WatchStatus.WATCHING.value
+    assert watch.next_check_at == FROZEN_NOW + timedelta(seconds=300)
+    assert len(watch.lineage) == 1
+    assert watch.lineage[-1]["target_id"] == watch.target_id
+
+    events = s.query(WatchEvent).filter(WatchEvent.watch_id == watch.id).all()
+    assert [e.event_type for e in events] == [WatchEventType.CREATED.value]
+    s.close()
+
+
+def test_create_duplicate_live_watch_rejected(workspace, new_session):
+    s = new_session()
+    watch = _create(s, workspace)
+    s.commit()
+
+    with pytest.raises(WatchAlreadyExistsError):
+        _create(s, workspace, target_id=watch.target_id)
+    s.rollback()
+    s.close()
+
+
+# ---------------------------------------------------------------------------
+# transition guard
+# ---------------------------------------------------------------------------
+
+
+def test_transition_guard_allows_and_blocks(workspace, new_session):
+    s = new_session()
+    watch = _create(s, workspace)
+
+    WatchService.transition(s, watch, WatchStatus.ACTING)
+    assert watch.status == WatchStatus.ACTING.value
+
+    WatchService.transition(s, watch, WatchStatus.PASSED)
+    assert watch.status == WatchStatus.PASSED.value
+    assert watch.closed_at is not None
+
+    # Terminal is terminal (except the escalated renewal).
+    with pytest.raises(InvalidTransitionError):
+        WatchService.transition(s, watch, WatchStatus.WATCHING)
+    s.rollback()
+    s.close()
+
+
+def test_escalated_can_renew_to_watching(workspace, new_session):
+    s = new_session()
+    watch = _create(s, workspace)
+    WatchService.transition(s, watch, WatchStatus.ESCALATED)
+    assert watch.closed_at is not None
+
+    WatchService.transition(s, watch, WatchStatus.WATCHING)
+    assert watch.status == WatchStatus.WATCHING.value
+    assert watch.closed_at is None
+    s.commit()
+    s.close()
+
+
+# ---------------------------------------------------------------------------
+# idempotent ingest
+# ---------------------------------------------------------------------------
+
+
+def test_double_ingest_swallowed_and_transaction_survives(workspace, new_session):
+    s = new_session()
+    watch = _create(s, workspace)
+
+    first = WatchService.ingest(
+        s, watch, event_type="terminal", event_key="k-dup", summary="one"
+    )
+    second = WatchService.ingest(
+        s, watch, event_type="terminal", event_key="k-dup", summary="two"
+    )
+    assert first is not None
+    assert second is None
+
+    # The savepoint swallow must leave the outer transaction usable.
+    third = WatchService.ingest(
+        s, watch, event_type="status_change", event_key="k-other"
+    )
+    assert third is not None
+    s.commit()
+
+    keys = [
+        e.event_key
+        for e in s.query(WatchEvent).filter(WatchEvent.watch_id == watch.id).all()
+    ]
+    assert sorted(keys) == ["created", "k-dup", "k-other"]
+    s.close()
+
+
+# ---------------------------------------------------------------------------
+# ingest_terminal
+# ---------------------------------------------------------------------------
+
+
+def test_ingest_terminal_closes_watch_by_outcome(workspace, new_session):
+    s = new_session()
+    watch = _create(s, workspace)
+    s.commit()
+
+    event = WatchService.ingest_terminal(
+        s,
+        workspace_id=workspace,
+        target_type="mission",
+        target_id=watch.target_id,
+        terminal_state="completed",
+        summary="All tasks verified",
+        cost_snapshot={"tokens_used": 900},
+        output_pointer=f"mission:{watch.target_id}:output_summary",
+    )
+    s.commit()
+
+    assert event is not None
+    assert event.snapshot["cost"]["tokens_used"] == 900
+    s.refresh(watch)
+    assert watch.status == WatchStatus.PASSED.value
+    assert watch.closed_at is not None
+    assert "completed" in (watch.final_verdict or "")
+
+    # Second delivery of the same terminal is a no-op.
+    again = WatchService.ingest_terminal(
+        s,
+        workspace_id=workspace,
+        target_type="mission",
+        target_id=watch.target_id,
+        terminal_state="completed",
+    )
+    assert again is None
+    s.close()
+
+
+@pytest.mark.parametrize(
+    "terminal_state,expected_status",
+    [
+        ("failed", WatchStatus.FAILED.value),
+        ("cancelled", WatchStatus.CANCELLED.value),
+    ],
+)
+def test_ingest_terminal_outcome_mapping(
+    workspace, new_session, terminal_state, expected_status
+):
+    s = new_session()
+    watch = _create(s, workspace)
+    s.commit()
+
+    WatchService.ingest_terminal(
+        s,
+        workspace_id=workspace,
+        target_type="mission",
+        target_id=watch.target_id,
+        terminal_state=terminal_state,
+    )
+    s.commit()
+    s.refresh(watch)
+    assert watch.status == expected_status
+    s.close()
+
+
+def test_ingest_terminal_without_live_watch_is_noop(workspace, new_session):
+    s = new_session()
+    result = WatchService.ingest_terminal(
+        s,
+        workspace_id=workspace,
+        target_type="mission",
+        target_id=str(uuid.uuid4()),
+        terminal_state="completed",
+    )
+    assert result is None
+    s.close()
+
+
+# ---------------------------------------------------------------------------
+# action budget hard-stop
+# ---------------------------------------------------------------------------
+
+
+def test_record_action_hard_stops_at_budget(workspace, new_session):
+    s = new_session()
+    watch = _create(s, workspace, action_budget=2)
+
+    _, ok1 = WatchService.record_action(s, watch, action="rerun")
+    _, ok2 = WatchService.record_action(s, watch, action="tweak")
+    assert (ok1, ok2) == (True, True)
+    assert watch.actions_taken == 2
+    assert watch.status == WatchStatus.ACTING.value
+
+    _, ok3 = WatchService.record_action(s, watch, action="rerun")
+    assert ok3 is False
+    assert watch.actions_taken == 2  # refused action not counted
+    assert watch.status == WatchStatus.NEEDS_ATTENTION.value
+    s.commit()
+
+    exhausted = (
+        s.query(WatchEvent)
+        .filter(
+            WatchEvent.watch_id == watch.id,
+            WatchEvent.event_type == WatchEventType.BUDGET_EXHAUSTED.value,
+        )
+        .all()
+    )
+    assert len(exhausted) == 1
+    assert exhausted[0].requires_attention is True
+    s.close()
+
+
+def test_zero_budget_refuses_first_action(workspace, new_session):
+    s = new_session()
+    watch = _create(s, workspace, action_budget=0)
+    _, ok = WatchService.record_action(s, watch, action="rerun")
+    assert ok is False
+    assert watch.status == WatchStatus.NEEDS_ATTENTION.value
+    s.commit()
+    s.close()
+
+
+# ---------------------------------------------------------------------------
+# lineage repoint
+# ---------------------------------------------------------------------------
+
+
+def test_follow_repoints_target_and_appends_lineage(workspace, new_session):
+    s = new_session()
+    watch = _create(s, workspace)
+    original_target = watch.target_id
+    new_target = str(uuid.uuid4())
+
+    WatchService.follow(
+        s,
+        watch,
+        new_target_type="mission",
+        new_target_id=new_target,
+        reason="rerun after failure",
+        now=FROZEN_NOW + timedelta(minutes=10),
+    )
+    s.commit()
+
+    assert watch.target_id == new_target
+    assert len(watch.lineage) == 2
+    assert watch.lineage[0]["target_id"] == original_target
+    assert watch.lineage[-1]["target_id"] == new_target
+    assert watch.next_check_at == FROZEN_NOW + timedelta(minutes=10)
+
+    # Terminal ingest for the NEW target closes the same watch.
+    WatchService.ingest_terminal(
+        s,
+        workspace_id=workspace,
+        target_type="mission",
+        target_id=new_target,
+        terminal_state="completed",
+    )
+    s.commit()
+    s.refresh(watch)
+    assert watch.status == WatchStatus.PASSED.value
+    s.close()
+
+
+def test_follow_on_closed_watch_raises(workspace, new_session):
+    s = new_session()
+    watch = _create(s, workspace)
+    WatchService.transition(s, watch, WatchStatus.CANCELLED)
+    with pytest.raises(InvalidTransitionError):
+        WatchService.follow(
+            s, watch, new_target_type="mission", new_target_id=str(uuid.uuid4())
+        )
+    s.rollback()
+    s.close()
+
+
+# ---------------------------------------------------------------------------
+# SKIP LOCKED claim
+# ---------------------------------------------------------------------------
+
+
+def test_claim_due_watches_claims_and_reschedules(workspace, new_session):
+    s = new_session()
+    due_a = _create(s, workspace)
+    due_b = _create(s, workspace)
+    future = _create(s, workspace)
+    parked = _create(s, workspace)
+    WatchService.transition(s, parked, WatchStatus.NEEDS_ATTENTION)
+    s.commit()
+
+    now = FROZEN_NOW + timedelta(seconds=600)
+    s.execute(
+        text(
+            "UPDATE watches SET next_check_at = :due "
+            "WHERE id IN (CAST(:a AS uuid), CAST(:b AS uuid), CAST(:p AS uuid))"
+        ),
+        {
+            "due": now - timedelta(seconds=1),
+            "a": str(due_a.id),
+            "b": str(due_b.id),
+            "p": str(parked.id),
+        },
+    )
+    s.execute(
+        text("UPDATE watches SET next_check_at = :f WHERE id = CAST(:i AS uuid)"),
+        {"f": now + timedelta(hours=1), "i": str(future.id)},
+    )
+    s.commit()
+    s.close()
+
+    s = new_session()
+    claimed = WatchService.claim_due_watches(s, now=now)
+    claimed_ids = {str(w.id) for w in claimed}
+    # Both due watches claimed; the future one and the parked
+    # (needs_attention) one are not.
+    assert {str(due_a.id), str(due_b.id)} <= claimed_ids
+    assert str(future.id) not in claimed_ids
+    assert str(parked.id) not in claimed_ids
+
+    for w in claimed:
+        if str(w.id) in {str(due_a.id), str(due_b.id)}:
+            assert w.last_checked_at == now
+            assert w.next_check_at == now + timedelta(
+                seconds=w.check_interval_seconds
+            )
+
+    # Idempotence: an immediate second claim at the same instant finds nothing
+    # (the first claim already rescheduled next_check_at).
+    reclaimed = WatchService.claim_due_watches(s, now=now)
+    assert {str(w.id) for w in reclaimed} & {str(due_a.id), str(due_b.id)} == set()
+    s.close()

--- a/orchestrator/tests/test_prd204_watch_service.py
+++ b/orchestrator/tests/test_prd204_watch_service.py
@@ -1,7 +1,7 @@
-"""PRD-204 S2 — WatchService: transition guard, idempotent ingest, budget
+"""PRD-204 S2 -- WatchService: transition guard, idempotent ingest, budget
 hard-stop, lineage repoint, SKIP LOCKED claim.
 
-DB-backed (real Postgres) — savepoint-swallowed unique violations, the
+DB-backed (real Postgres) -- savepoint-swallowed unique violations, the
 partial unique index and FOR UPDATE SKIP LOCKED are Postgres semantics.
 Skips cleanly when no DB is reachable (test_board_dispatch.py precedent).
 

--- a/orchestrator/tests/test_prd204_watch_service.py
+++ b/orchestrator/tests/test_prd204_watch_service.py
@@ -197,11 +197,17 @@ def test_double_ingest_swallowed_and_transaction_survives(workspace, new_session
 # ---------------------------------------------------------------------------
 
 
-def test_ingest_terminal_closes_watch_by_outcome(workspace, new_session):
+def test_ingest_terminal_records_and_defers_scorable_to_decider(
+    workspace, new_session
+):
+    """PRD-204 S10 semantics (replaces the v1 close-by-outcome): a scorable
+    terminal (completed/failed) records the event and pulls next_check_at
+    to now -- the DECISION STEP (ticker) owns scoring and close."""
     s = new_session()
     watch = _create(s, workspace)
     s.commit()
 
+    moment = FROZEN_NOW + timedelta(minutes=5)
     event = WatchService.ingest_terminal(
         s,
         workspace_id=workspace,
@@ -211,38 +217,38 @@ def test_ingest_terminal_closes_watch_by_outcome(workspace, new_session):
         summary="All tasks verified",
         cost_snapshot={"tokens_used": 900},
         output_pointer=f"mission:{watch.target_id}:output_summary",
+        now=moment,
     )
     s.commit()
 
     assert event is not None
     assert event.snapshot["cost"]["tokens_used"] == 900
     s.refresh(watch)
-    assert watch.status == WatchStatus.PASSED.value
-    assert watch.closed_at is not None
-    assert "completed" in (watch.final_verdict or "")
+    assert watch.status == WatchStatus.WATCHING.value  # NOT closed here
+    assert watch.closed_at is None
+    assert watch.final_verdict is None  # the verdict is the decider's job
+    assert watch.next_check_at == moment  # handed to the tick immediately
 
-    # Second delivery of the same terminal is a no-op.
+    # Second delivery: duplicate event swallowed, but the watch is
+    # re-poked (self-healing for a crashed decider).
+    later = moment + timedelta(minutes=10)
     again = WatchService.ingest_terminal(
         s,
         workspace_id=workspace,
         target_type="mission",
         target_id=watch.target_id,
         terminal_state="completed",
+        now=later,
     )
+    s.commit()
     assert again is None
+    s.refresh(watch)
+    assert watch.status == WatchStatus.WATCHING.value
+    assert watch.next_check_at == later
     s.close()
 
 
-@pytest.mark.parametrize(
-    "terminal_state,expected_status",
-    [
-        ("failed", WatchStatus.FAILED.value),
-        ("cancelled", WatchStatus.CANCELLED.value),
-    ],
-)
-def test_ingest_terminal_outcome_mapping(
-    workspace, new_session, terminal_state, expected_status
-):
+def test_ingest_terminal_failed_also_defers(workspace, new_session):
     s = new_session()
     watch = _create(s, workspace)
     s.commit()
@@ -252,46 +258,53 @@ def test_ingest_terminal_outcome_mapping(
         workspace_id=workspace,
         target_type="mission",
         target_id=watch.target_id,
-        terminal_state=terminal_state,
+        terminal_state="failed",
     )
     s.commit()
     s.refresh(watch)
-    assert watch.status == expected_status
+    # Failed runs are scored/diagnosed by the decision step too.
+    assert watch.status == WatchStatus.WATCHING.value
+    assert watch.closed_at is None
     s.close()
 
 
-def test_ingest_terminal_recovers_lost_close(workspace, new_session):
-    """Self-healing idempotency: if a prior attempt committed the terminal
-    EVENT but lost the CLOSE (version conflict), the next delivery still
-    closes the watch instead of being blocked by the duplicate event."""
-    from core.models.watches import WatchEvent
-
+def test_ingest_terminal_cancelled_closes_immediately(workspace, new_session):
+    """Cancelled work has nothing to score -- the v1 close survives."""
     s = new_session()
     watch = _create(s, workspace)
-    # Simulate the half-landed prior attempt: event row exists, watch open.
-    s.add(
-        WatchEvent(
-            watch_id=watch.id,
-            event_type=WatchEventType.TERMINAL.value,
-            event_key=f"terminal:mission:{watch.target_id}",
-            summary="first attempt",
-        )
-    )
     s.commit()
 
-    result = WatchService.ingest_terminal(
+    WatchService.ingest_terminal(
         s,
         workspace_id=workspace,
         target_type="mission",
         target_id=watch.target_id,
-        terminal_state="completed",
+        terminal_state="cancelled",
     )
     s.commit()
-
-    assert result is None  # not the first writer of the event...
     s.refresh(watch)
-    assert watch.status == WatchStatus.PASSED.value  # ...but the close lands
+    assert watch.status == WatchStatus.CANCELLED.value
     assert watch.closed_at is not None
+    assert "cancelled" in (watch.final_verdict or "")
+    s.close()
+
+
+def test_ingest_terminal_unknown_vocabulary_parks(workspace, new_session):
+    s = new_session()
+    watch = _create(s, workspace)
+    s.commit()
+
+    WatchService.ingest_terminal(
+        s,
+        workspace_id=workspace,
+        target_type="mission",
+        target_id=watch.target_id,
+        terminal_state="vaporised",
+    )
+    s.commit()
+    s.refresh(watch)
+    assert watch.status == WatchStatus.NEEDS_ATTENTION.value
+    assert "vaporised" in (watch.final_verdict or "")
     s.close()
 
 
@@ -379,17 +392,18 @@ def test_follow_repoints_target_and_appends_lineage(workspace, new_session):
     assert watch.lineage[-1]["target_id"] == new_target
     assert watch.next_check_at == FROZEN_NOW + timedelta(minutes=10)
 
-    # Terminal ingest for the NEW target closes the same watch.
+    # Terminal ingest for the NEW target hits the SAME watch (cancelled is
+    # the still-closing-at-ingest state under S10 semantics).
     WatchService.ingest_terminal(
         s,
         workspace_id=workspace,
         target_type="mission",
         target_id=new_target,
-        terminal_state="completed",
+        terminal_state="cancelled",
     )
     s.commit()
     s.refresh(watch)
-    assert watch.status == WatchStatus.PASSED.value
+    assert watch.status == WatchStatus.CANCELLED.value
     s.close()
 
 

--- a/orchestrator/tests/test_prd204_watch_ticker.py
+++ b/orchestrator/tests/test_prd204_watch_ticker.py
@@ -149,6 +149,7 @@ def _seed_recipe(s, ws_id: str, cron: str = "0 9 * * *") -> WorkflowTemplate:
         template_definition={"steps": []},
         steps=[{"step_id": "s1", "order": 1}],
         schedule_config={"type": "cron", "cron_expression": cron},
+        created_by="user_test",  # NOT NULL on workflow_recipes
     )
     s.add(recipe)
     s.commit()

--- a/orchestrator/tests/test_prd204_watch_ticker.py
+++ b/orchestrator/tests/test_prd204_watch_ticker.py
@@ -1,0 +1,462 @@
+"""PRD-204 S5 — watcher tick: sweep fallback, missed-cron detection with a
+frozen clock, benched recording, expiry, and the no-noise rule.
+
+DB-backed (real Postgres; skips cleanly when absent). All clocks are
+injected (``tick_once(db, now=...)``) — no wall-clock dependence.
+Notifications are captured at the ticker's dispatch seam (the
+``notifications`` table itself is migration-only and not present in the
+create_all test schema; the row shape is covered by the S4 mock suite).
+"""
+from __future__ import annotations
+
+import asyncio
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+from core.database.database import get_database_url
+from core.models.core import RecipeExecution, WorkflowTemplate
+from core.models.orchestration import OrchestrationRun
+from core.models.orchestration_enums import RunState
+from core.models.watches import WatchEvent
+from core.models.watch_enums import WatchEventType, WatchStatus
+from services.watch_service import WatchService
+from services.watch_ticker import WatchTicker
+
+
+FROZEN_NOW = datetime(2026, 7, 16, 12, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture(scope="module")
+def engine():
+    try:
+        eng = create_engine(get_database_url(), pool_pre_ping=True)
+        with eng.connect() as c:
+            c.execute(text("SELECT 1 FROM watches LIMIT 1"))
+            c.execute(text("SELECT 1 FROM recipe_executions LIMIT 1"))
+    except Exception as exc:  # noqa: BLE001
+        pytest.skip(f"watch ticker suite needs a reachable Postgres with schema: {exc}")
+    yield eng
+    eng.dispose()
+
+
+@pytest.fixture
+def new_session(engine):
+    return sessionmaker(bind=engine, expire_on_commit=False)
+
+
+@pytest.fixture
+def workspace(new_session):
+    ws_id = str(uuid.uuid4())
+    s = new_session()
+    s.execute(
+        text(
+            "INSERT INTO workspaces (id, name) "
+            "VALUES (CAST(:id AS uuid), :n) ON CONFLICT (id) DO NOTHING"
+        ),
+        {"id": ws_id, "n": "prd204-watch-ticker"},
+    )
+    s.commit()
+    s.close()
+
+    yield ws_id
+
+    s = new_session()
+    s.execute(
+        text(
+            "DELETE FROM watch_events WHERE watch_id IN "
+            "(SELECT id FROM watches WHERE workspace_id = CAST(:w AS uuid))"
+        ),
+        {"w": ws_id},
+    )
+    s.execute(
+        text("DELETE FROM watches WHERE workspace_id = CAST(:w AS uuid)"),
+        {"w": ws_id},
+    )
+    s.execute(
+        text(
+            "DELETE FROM recipe_executions WHERE workspace_id = CAST(:w AS uuid)"
+        ),
+        {"w": ws_id},
+    )
+    s.execute(
+        text(
+            "DELETE FROM workflow_recipes WHERE workspace_id = CAST(:w AS uuid)"
+        ),
+        {"w": ws_id},
+    )
+    s.execute(
+        text(
+            "DELETE FROM orchestration_runs WHERE workspace_id = CAST(:w AS uuid)"
+        ),
+        {"w": ws_id},
+    )
+    s.execute(
+        text("DELETE FROM workspaces WHERE id = CAST(:w AS uuid)"), {"w": ws_id}
+    )
+    s.commit()
+    s.close()
+
+
+@pytest.fixture
+def ticker(monkeypatch):
+    """A WatchTicker whose notification seam records instead of dispatching."""
+    t = WatchTicker()
+    t.dispatched = []
+
+    async def _record(self, db, watch, *, event_type, title, message, status="ok"):
+        self.dispatched.append(
+            {"watch_id": str(watch.id), "event_type": event_type, "status": status}
+        )
+
+    monkeypatch.setattr(WatchTicker, "_dispatch_watch_event", _record)
+    return t
+
+
+def _tick(ticker, db, now):
+    return asyncio.run(ticker.tick_once(db, now=now))
+
+
+def _make_due(s, watch, now):
+    s.execute(
+        text("UPDATE watches SET next_check_at = :d WHERE id = CAST(:i AS uuid)"),
+        {"d": now - timedelta(seconds=1), "i": str(watch.id)},
+    )
+    s.commit()
+
+
+def _seed_run(s, ws_id: str, state: str) -> OrchestrationRun:
+    run = OrchestrationRun(
+        workspace_id=ws_id,
+        goal="ticker test mission",
+        state=state,
+        created_by="user_test",
+    )
+    s.add(run)
+    s.commit()
+    return run
+
+
+def _seed_recipe(s, ws_id: str, cron: str = "0 9 * * *") -> WorkflowTemplate:
+    recipe = WorkflowTemplate(
+        template_id=f"prd204-{uuid.uuid4().hex[:10]}",
+        name="ticker test playbook",
+        description="prd204 watch ticker test",
+        workspace_id=ws_id,
+        template_definition={"steps": []},
+        steps=[{"step_id": "s1", "order": 1}],
+        schedule_config={"type": "cron", "cron_expression": cron},
+    )
+    s.add(recipe)
+    s.commit()
+    return recipe
+
+
+def _watch_events(s, watch, event_type=None):
+    q = s.query(WatchEvent).filter(WatchEvent.watch_id == watch.id)
+    if event_type:
+        q = q.filter(WatchEvent.event_type == event_type)
+    return q.all()
+
+
+# ---------------------------------------------------------------------------
+# Sweep fallback: a terminal state the hooks missed
+# ---------------------------------------------------------------------------
+
+
+def test_sweep_ingests_missed_terminal_and_notifies_once(
+    workspace, new_session, ticker
+):
+    s = new_session()
+    # Run already terminal in the DB — simulates a hook that never fired
+    # (crash between the terminal write and the hook's transaction).
+    run = _seed_run(s, workspace, state=RunState.FAILED.value)
+    watch = WatchService.create_watch(
+        s,
+        workspace_id=workspace,
+        watch_type="mission",
+        target_type="mission",
+        target_id=str(run.id),
+        title="Watch: sweep fallback",
+        now=FROZEN_NOW - timedelta(minutes=30),
+    )
+    s.commit()
+    _make_due(s, watch, FROZEN_NOW)
+
+    processed = _tick(ticker, s, FROZEN_NOW)
+    assert processed >= 1
+
+    s.refresh(watch)
+    assert watch.status == WatchStatus.FAILED.value
+    assert len(_watch_events(s, watch, "terminal")) == 1
+
+    verdicts = [d for d in ticker.dispatched if d["watch_id"] == str(watch.id)]
+    assert [d["event_type"] for d in verdicts] == ["watch_verdict"]
+    assert verdicts[0]["status"] == "error"
+
+    # Tick idempotence: the closed watch is never claimed again — two ticks,
+    # one event, one notification.
+    _tick(ticker, s, FROZEN_NOW + timedelta(seconds=600))
+    assert len(_watch_events(s, watch, "terminal")) == 1
+    assert len([d for d in ticker.dispatched if d["watch_id"] == str(watch.id)]) == 1
+    s.close()
+
+
+# ---------------------------------------------------------------------------
+# No-noise: running -> running writes nothing
+# ---------------------------------------------------------------------------
+
+
+def test_running_target_writes_nothing(workspace, new_session, ticker):
+    s = new_session()
+    run = _seed_run(s, workspace, state=RunState.RUNNING.value)
+    watch = WatchService.create_watch(
+        s,
+        workspace_id=workspace,
+        watch_type="mission",
+        target_type="mission",
+        target_id=str(run.id),
+        title="Watch: no-noise",
+        now=FROZEN_NOW - timedelta(minutes=30),
+    )
+    s.commit()
+    _make_due(s, watch, FROZEN_NOW)
+
+    _tick(ticker, s, FROZEN_NOW)
+
+    s.refresh(watch)
+    assert watch.status == WatchStatus.WATCHING.value
+    # Only the creation event exists — the sweep added no noise.
+    assert [e.event_type for e in _watch_events(s, watch)] == [
+        WatchEventType.CREATED.value
+    ]
+    assert [d for d in ticker.dispatched if d["watch_id"] == str(watch.id)] == []
+    # And the claim rescheduled the next check.
+    assert watch.next_check_at == FROZEN_NOW + timedelta(
+        seconds=watch.check_interval_seconds
+    )
+    s.close()
+
+
+# ---------------------------------------------------------------------------
+# Missed-cron detection (frozen clock) + idempotence
+# ---------------------------------------------------------------------------
+
+
+def test_missed_cron_detected_with_frozen_clock(workspace, new_session, ticker):
+    s = new_session()
+    recipe = _seed_recipe(s, workspace, cron="0 9 * * *")
+    watch = WatchService.create_watch(
+        s,
+        workspace_id=workspace,
+        watch_type="scheduled_playbook",
+        target_type="scheduled_playbook",
+        target_id=str(recipe.id),
+        title="Watch: nightly playbook",
+        policy="persistent",
+        now=FROZEN_NOW - timedelta(hours=12),
+    )
+    s.commit()
+    # Baseline = watch.created_at (no executions exist): 00:00 -> expected
+    # fire 09:00; now is 12:00 -> 3h overdue, no execution row -> MISSED.
+    s.execute(
+        text("UPDATE watches SET created_at = :c WHERE id = CAST(:i AS uuid)"),
+        {"c": FROZEN_NOW - timedelta(hours=12), "i": str(watch.id)},
+    )
+    s.commit()
+    _make_due(s, watch, FROZEN_NOW)
+
+    _tick(ticker, s, FROZEN_NOW)
+
+    missed = _watch_events(s, watch, WatchEventType.MISSED_RUN.value)
+    assert len(missed) == 1
+    assert missed[0].requires_attention is True
+    assert "09:00" in missed[0].snapshot["expected_fire"]
+
+    escalations = [
+        d
+        for d in ticker.dispatched
+        if d["watch_id"] == str(watch.id) and d["event_type"] == "watch_escalation"
+    ]
+    assert len(escalations) == 1
+
+    # Second tick at the same frozen instant: the event_key (expected fire
+    # time) dedupes — still exactly one event, one notification.
+    _make_due(s, watch, FROZEN_NOW)
+    _tick(ticker, s, FROZEN_NOW)
+    assert len(_watch_events(s, watch, WatchEventType.MISSED_RUN.value)) == 1
+    assert (
+        len(
+            [
+                d
+                for d in ticker.dispatched
+                if d["watch_id"] == str(watch.id)
+                and d["event_type"] == "watch_escalation"
+            ]
+        )
+        == 1
+    )
+    # The watch stays live — a missed run is attention-worthy, not terminal.
+    s.refresh(watch)
+    assert watch.status == WatchStatus.WATCHING.value
+    s.close()
+
+
+def test_recent_run_within_grace_is_not_missed(workspace, new_session, ticker):
+    s = new_session()
+    recipe = _seed_recipe(s, workspace, cron="0 9 * * *")
+    # An execution actually started at 09:00 today.
+    s.add(
+        RecipeExecution(
+            execution_id=f"prd204-{uuid.uuid4().hex[:10]}",
+            recipe_id=recipe.id,
+            workspace_id=workspace,
+            status="completed",
+            input_data={},
+            started_at=FROZEN_NOW.replace(hour=9, minute=0).replace(tzinfo=None),
+            triggered_by="cron_scheduler",
+        )
+    )
+    s.commit()
+    watch = WatchService.create_watch(
+        s,
+        workspace_id=workspace,
+        watch_type="scheduled_playbook",
+        target_type="scheduled_playbook",
+        target_id=str(recipe.id),
+        title="Watch: healthy playbook",
+        now=FROZEN_NOW - timedelta(hours=12),
+    )
+    s.commit()
+    _make_due(s, watch, FROZEN_NOW)
+
+    _tick(ticker, s, FROZEN_NOW)
+
+    # Baseline is the 09:00 run -> next expected fire is tomorrow -> nothing.
+    assert _watch_events(s, watch, WatchEventType.MISSED_RUN.value) == []
+    assert [d for d in ticker.dispatched if d["watch_id"] == str(watch.id)] == []
+    s.close()
+
+
+# ---------------------------------------------------------------------------
+# Benched: recorded on the watch, NOT notified by the tick (S4 scheduler owns
+# the playbook_benched notification)
+# ---------------------------------------------------------------------------
+
+
+def test_open_breaker_records_benched_event_once(workspace, new_session, ticker):
+    s = new_session()
+    recipe = _seed_recipe(s, workspace, cron="0 9 * * *")
+    # Three consecutive failures trip the breaker (threshold default 3).
+    for i in range(3):
+        s.add(
+            RecipeExecution(
+                execution_id=f"prd204-fail-{i}-{uuid.uuid4().hex[:8]}",
+                recipe_id=recipe.id,
+                workspace_id=workspace,
+                status="failed",
+                input_data={},
+                started_at=(
+                    FROZEN_NOW.replace(hour=8, minute=50) + timedelta(minutes=i)
+                ).replace(tzinfo=None),
+                triggered_by="cron_scheduler",
+            )
+        )
+    s.commit()
+    watch = WatchService.create_watch(
+        s,
+        workspace_id=workspace,
+        watch_type="scheduled_playbook",
+        target_type="scheduled_playbook",
+        target_id=str(recipe.id),
+        title="Watch: benched playbook",
+        now=FROZEN_NOW - timedelta(minutes=30),
+    )
+    s.commit()
+    # 09:01 -> the 09:00 expected fire is only 60s overdue (inside the
+    # missed-run grace window), so ONLY the benched path is exercised.
+    now = FROZEN_NOW.replace(hour=9, minute=1)
+    _make_due(s, watch, now)
+
+    _tick(ticker, s, now)
+
+    benched = _watch_events(s, watch, WatchEventType.BENCHED.value)
+    assert len(benched) == 1
+    assert benched[0].requires_attention is True
+    # The tick records; the SCHEDULER notifies (once per open period). No
+    # tick-side dispatch for benched.
+    assert [d for d in ticker.dispatched if d["watch_id"] == str(watch.id)] == []
+
+    # Same open period -> same latest-terminal key -> still one event.
+    _make_due(s, watch, now)
+    _tick(ticker, s, now)
+    assert len(_watch_events(s, watch, WatchEventType.BENCHED.value)) == 1
+    s.close()
+
+
+# ---------------------------------------------------------------------------
+# Deadline expiry
+# ---------------------------------------------------------------------------
+
+
+def test_deadline_expires_watch_and_escalates(workspace, new_session, ticker):
+    s = new_session()
+    run = _seed_run(s, workspace, state=RunState.RUNNING.value)
+    watch = WatchService.create_watch(
+        s,
+        workspace_id=workspace,
+        watch_type="mission",
+        target_type="mission",
+        target_id=str(run.id),
+        title="Watch: deadline",
+        deadline_at=FROZEN_NOW - timedelta(minutes=5),
+        now=FROZEN_NOW - timedelta(hours=2),
+    )
+    s.commit()
+    _make_due(s, watch, FROZEN_NOW)
+
+    _tick(ticker, s, FROZEN_NOW)
+
+    s.refresh(watch)
+    assert watch.status == WatchStatus.EXPIRED.value
+    assert watch.closed_at is not None
+    assert len(_watch_events(s, watch, WatchEventType.EXPIRED.value)) == 1
+
+    escalations = [
+        d
+        for d in ticker.dispatched
+        if d["watch_id"] == str(watch.id) and d["event_type"] == "watch_escalation"
+    ]
+    assert len(escalations) == 1
+    s.close()
+
+
+# ---------------------------------------------------------------------------
+# Missing target parks the watch for a human
+# ---------------------------------------------------------------------------
+
+
+def test_missing_target_parks_watch(workspace, new_session, ticker):
+    s = new_session()
+    watch = WatchService.create_watch(
+        s,
+        workspace_id=workspace,
+        watch_type="mission",
+        target_type="mission",
+        target_id=str(uuid.uuid4()),  # no such run
+        title="Watch: lost target",
+        now=FROZEN_NOW - timedelta(minutes=30),
+    )
+    s.commit()
+    _make_due(s, watch, FROZEN_NOW)
+
+    _tick(ticker, s, FROZEN_NOW)
+
+    s.refresh(watch)
+    assert watch.status == WatchStatus.NEEDS_ATTENTION.value
+    events = _watch_events(s, watch, WatchEventType.TARGET_MISSING.value)
+    assert len(events) == 1
+    s.close()

--- a/orchestrator/tests/test_prd204_watch_ticker.py
+++ b/orchestrator/tests/test_prd204_watch_ticker.py
@@ -103,16 +103,23 @@ def workspace(new_session):
 
 @pytest.fixture
 def ticker(monkeypatch):
-    """A WatchTicker whose notification seam records instead of dispatching."""
+    """A WatchTicker with the SHARED notification seam recording instead of
+    dispatching. S10 note: the decider (terminal verdicts) and the ticker
+    (missed run / expiry) both flow through
+    services.watch_notifications.dispatch_watch_notification -- patching
+    that one seam captures every watcher-plane notification."""
+    import services.watch_notifications as wn
+
     t = WatchTicker()
     t.dispatched = []
 
-    async def _record(self, db, watch, *, event_type, title, message, status="ok"):
-        self.dispatched.append(
+    async def _record(db, watch, *, event_type, title, message, status="ok"):
+        t.dispatched.append(
             {"watch_id": str(watch.id), "event_type": event_type, "status": status}
         )
+        return True
 
-    monkeypatch.setattr(WatchTicker, "_dispatch_watch_event", _record)
+    monkeypatch.setattr(wn, "dispatch_watch_notification", _record)
     return t
 
 
@@ -168,9 +175,13 @@ def _watch_events(s, watch, event_type=None):
 # ---------------------------------------------------------------------------
 
 
-def test_sweep_ingests_missed_terminal_and_notifies_once(
+def test_sweep_ingests_missed_terminal_and_decider_closes_once(
     workspace, new_session, ticker
 ):
+    """S10 flow: the sweep records the terminal the hook missed and the
+    DECISION STEP (run_and_report default) closes the watch with a
+    watch_verdict notification. A failed run with no output scores on the
+    deterministic floor -- no LLM anywhere in this path."""
     s = new_session()
     # Run already terminal in the DB -- simulates a hook that never fired
     # (crash between the terminal write and the hook's transaction).
@@ -192,6 +203,8 @@ def test_sweep_ingests_missed_terminal_and_notifies_once(
 
     s.refresh(watch)
     assert watch.status == WatchStatus.FAILED.value
+    assert watch.closed_at is not None
+    assert watch.final_verdict  # the decider wrote a verdict
     assert len(_watch_events(s, watch, "terminal")) == 1
 
     verdicts = [d for d in ticker.dispatched if d["watch_id"] == str(watch.id)]

--- a/orchestrator/tests/test_prd204_watch_ticker.py
+++ b/orchestrator/tests/test_prd204_watch_ticker.py
@@ -1,8 +1,8 @@
-"""PRD-204 S5 — watcher tick: sweep fallback, missed-cron detection with a
+"""PRD-204 S5 -- watcher tick: sweep fallback, missed-cron detection with a
 frozen clock, benched recording, expiry, and the no-noise rule.
 
 DB-backed (real Postgres; skips cleanly when absent). All clocks are
-injected (``tick_once(db, now=...)``) — no wall-clock dependence.
+injected (``tick_once(db, now=...)``) -- no wall-clock dependence.
 Notifications are captured at the ticker's dispatch seam (the
 ``notifications`` table itself is migration-only and not present in the
 create_all test schema; the row shape is covered by the S4 mock suite).
@@ -171,7 +171,7 @@ def test_sweep_ingests_missed_terminal_and_notifies_once(
     workspace, new_session, ticker
 ):
     s = new_session()
-    # Run already terminal in the DB — simulates a hook that never fired
+    # Run already terminal in the DB -- simulates a hook that never fired
     # (crash between the terminal write and the hook's transaction).
     run = _seed_run(s, workspace, state=RunState.FAILED.value)
     watch = WatchService.create_watch(
@@ -197,7 +197,7 @@ def test_sweep_ingests_missed_terminal_and_notifies_once(
     assert [d["event_type"] for d in verdicts] == ["watch_verdict"]
     assert verdicts[0]["status"] == "error"
 
-    # Tick idempotence: the closed watch is never claimed again — two ticks,
+    # Tick idempotence: the closed watch is never claimed again -- two ticks,
     # one event, one notification.
     _tick(ticker, s, FROZEN_NOW + timedelta(seconds=600))
     assert len(_watch_events(s, watch, "terminal")) == 1
@@ -229,7 +229,7 @@ def test_running_target_writes_nothing(workspace, new_session, ticker):
 
     s.refresh(watch)
     assert watch.status == WatchStatus.WATCHING.value
-    # Only the creation event exists — the sweep added no noise.
+    # Only the creation event exists -- the sweep added no noise.
     assert [e.event_type for e in _watch_events(s, watch)] == [
         WatchEventType.CREATED.value
     ]
@@ -284,7 +284,7 @@ def test_missed_cron_detected_with_frozen_clock(workspace, new_session, ticker):
     assert len(escalations) == 1
 
     # Second tick at the same frozen instant: the event_key (expected fire
-    # time) dedupes — still exactly one event, one notification.
+    # time) dedupes -- still exactly one event, one notification.
     _make_due(s, watch, FROZEN_NOW)
     _tick(ticker, s, FROZEN_NOW)
     assert len(_watch_events(s, watch, WatchEventType.MISSED_RUN.value)) == 1
@@ -299,7 +299,7 @@ def test_missed_cron_detected_with_frozen_clock(workspace, new_session, ticker):
         )
         == 1
     )
-    # The watch stays live — a missed run is attention-worthy, not terminal.
+    # The watch stays live -- a missed run is attention-worthy, not terminal.
     s.refresh(watch)
     assert watch.status == WatchStatus.WATCHING.value
     s.close()

--- a/orchestrator/tests/test_prd204_watch_tools.py
+++ b/orchestrator/tests/test_prd204_watch_tools.py
@@ -1,0 +1,518 @@
+"""PRD-204 S9 -- Auto's watch tools + auto-create.
+
+Locks the tool-schema/handler contract (required[] lists ONLY fields the
+handler cannot default -- the blueprint-rules-wall regression class),
+exercises the four handlers workspace-scoped against a real DB, and covers
+the launch-handler auto-create gate (watch_auto_create default ON, OFF
+respected, idempotent, run_and_report policy, criteria = request text).
+"""
+from __future__ import annotations
+
+import asyncio
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+from core.database.database import get_database_url
+from core.models.core import RecipeExecution, WorkflowTemplate
+from core.models.orchestration import OrchestrationRun
+from core.models.watches import Watch
+from core.models.watch_enums import WatchPolicy, WatchStatus
+from modules.tools.discovery.action_registry import ActionRegistry
+from modules.tools.discovery.actions_watches import register_watch_actions
+from modules.tools.discovery.handlers_watches import (
+    auto_create_watch,
+    cancel_watch,
+    create_watch,
+    get_watch,
+    list_watches,
+)
+
+FROZEN_NOW = datetime(2026, 7, 16, 12, 0, 0, tzinfo=timezone.utc)
+
+WATCH_TOOLS = (
+    "platform_create_watch",
+    "platform_list_watches",
+    "platform_get_watch",
+    "platform_cancel_watch",
+)
+
+
+# ---------------------------------------------------------------------------
+# Schema contract (no DB)
+# ---------------------------------------------------------------------------
+
+
+def _registry():
+    registry = ActionRegistry()
+    register_watch_actions(registry)
+    return registry
+
+
+def test_all_four_tools_register():
+    registry = _registry()
+    for name in WATCH_TOOLS:
+        assert registry.get(name) is not None, name
+
+
+def test_required_lists_only_undefaultable_fields():
+    """The onboarding-wall guard: a required field the handler defaults
+    dead-ends the LLM. Only identity fields may be required."""
+    registry = _registry()
+
+    assert registry.get("platform_create_watch").parameters["required"] == [
+        "target_type",
+        "target_id",
+    ]
+    assert registry.get("platform_list_watches").parameters["required"] == []
+    assert registry.get("platform_get_watch").parameters["required"] == ["watch_id"]
+    assert registry.get("platform_cancel_watch").parameters["required"] == ["watch_id"]
+
+    # Every required key must exist in properties (schema self-consistency).
+    for name in WATCH_TOOLS:
+        params = registry.get(name).parameters
+        for req in params["required"]:
+            assert req in params["properties"], f"{name}.{req}"
+
+
+def test_permission_levels():
+    registry = _registry()
+    assert registry.get("platform_create_watch").permission_level == "write"
+    assert registry.get("platform_cancel_watch").permission_level == "write"
+    assert registry.get("platform_list_watches").permission_level == "read"
+    assert registry.get("platform_get_watch").permission_level == "read"
+    for name in WATCH_TOOLS:
+        action = registry.get(name)
+        assert action.requires_confirmation is False
+        assert action.admin_only is False
+
+
+# ---------------------------------------------------------------------------
+# DB fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def engine():
+    try:
+        eng = create_engine(get_database_url(), pool_pre_ping=True)
+        with eng.connect() as c:
+            c.execute(text("SELECT 1 FROM watches LIMIT 1"))
+            c.execute(text("SELECT 1 FROM orchestration_runs LIMIT 1"))
+    except Exception as exc:  # noqa: BLE001
+        pytest.skip(f"watch tools suite needs a reachable Postgres with schema: {exc}")
+    yield eng
+    eng.dispose()
+
+
+@pytest.fixture
+def new_session(engine):
+    return sessionmaker(bind=engine, expire_on_commit=False)
+
+
+@pytest.fixture
+def workspace(new_session):
+    ws_id = str(uuid.uuid4())
+    s = new_session()
+    s.execute(
+        text(
+            "INSERT INTO workspaces (id, name) "
+            "VALUES (CAST(:id AS uuid), :n) ON CONFLICT (id) DO NOTHING"
+        ),
+        {"id": ws_id, "n": "prd204-watch-tools"},
+    )
+    s.commit()
+    s.close()
+
+    yield ws_id
+
+    s = new_session()
+    for stmt in (
+        "DELETE FROM watch_events WHERE watch_id IN "
+        "(SELECT id FROM watches WHERE workspace_id = CAST(:w AS uuid))",
+        "DELETE FROM watches WHERE workspace_id = CAST(:w AS uuid)",
+        "DELETE FROM recipe_executions WHERE workspace_id = CAST(:w AS uuid)",
+        "DELETE FROM workflow_recipes WHERE workspace_id = CAST(:w AS uuid)",
+        "DELETE FROM orchestration_runs WHERE workspace_id = CAST(:w AS uuid)",
+        "DELETE FROM workspaces WHERE id = CAST(:w AS uuid)",
+    ):
+        s.execute(text(stmt), {"w": ws_id})
+    s.commit()
+    s.close()
+
+
+def _seed_run(s, ws_id, goal="ship the quarterly report"):
+    run = OrchestrationRun(
+        workspace_id=ws_id,
+        goal=goal,
+        state="running",
+        state_type="active",
+        created_by="user_test",
+    )
+    s.add(run)
+    s.commit()
+    return run
+
+
+def _seed_execution(s, ws_id):
+    recipe = WorkflowTemplate(
+        template_id=f"prd204-wt-{uuid.uuid4().hex[:10]}",
+        name="tools test playbook",
+        description="prd204 watch tools",
+        workspace_id=ws_id,
+        template_definition={"steps": []},
+        steps=[{"step_id": "s1", "order": 1}],
+        created_by="user_test",
+    )
+    s.add(recipe)
+    s.commit()
+    execution = RecipeExecution(
+        execution_id=f"exec-{uuid.uuid4().hex[:12]}",
+        recipe_id=recipe.id,
+        workspace_id=ws_id,
+        status="running",
+        input_data={},
+    )
+    s.add(execution)
+    s.commit()
+    return recipe, execution
+
+
+def _call(handler, s, ws_id, params):
+    return asyncio.run(handler(s, ws_id, params))
+
+
+# ---------------------------------------------------------------------------
+# create: defaults, validation, workspace scoping, duplicate friendliness
+# ---------------------------------------------------------------------------
+
+
+def test_create_with_only_required_fields_defaults_everything(workspace, new_session):
+    """Required-only call must succeed -- proof every optional field has a
+    handler default (the contract the schema test locks)."""
+    s = new_session()
+    run = _seed_run(s, workspace)
+
+    result = _call(create_watch, s, workspace,
+                   {"target_type": "mission", "target_id": str(run.id)})
+    s.commit()
+
+    assert result["success"] is True, result
+    watch = result["watch"]
+    assert watch["policy"] == WatchPolicy.RUN_AND_REPORT.value
+    assert watch["quality_threshold"] == pytest.approx(0.8)
+    assert watch["action_budget"] == 2
+    assert watch["deadline_at"] is None
+    # Title/criteria derived from the mission's goal (the request text).
+    assert "quarterly report" in watch["title"]
+    assert watch["success_criteria"] == "ship the quarterly report"
+    s.close()
+
+
+def test_create_validates_target_type_and_existence(workspace, new_session):
+    s = new_session()
+    bad_type = _call(create_watch, s, workspace,
+                     {"target_type": "banana", "target_id": "1"})
+    assert bad_type["success"] is False
+    assert "target_type" in bad_type["error"]
+
+    missing = _call(create_watch, s, workspace,
+                    {"target_type": "mission", "target_id": str(uuid.uuid4())})
+    assert missing["success"] is False
+    assert "found" in missing["error"]
+
+    no_id = _call(create_watch, s, workspace, {"target_type": "mission"})
+    assert no_id["success"] is False
+
+    bad_policy = _call(create_watch, s, workspace,
+                       {"target_type": "mission", "target_id": str(uuid.uuid4()),
+                        "policy": "yolo"})
+    assert bad_policy["success"] is False
+    s.close()
+
+
+def test_create_is_workspace_scoped(workspace, new_session):
+    """A mission in ANOTHER workspace is invisible here."""
+    s = new_session()
+    other_ws = str(uuid.uuid4())
+    s.execute(
+        text("INSERT INTO workspaces (id, name) VALUES (CAST(:id AS uuid), :n)"),
+        {"id": other_ws, "n": "prd204-other"},
+    )
+    s.commit()
+    foreign_run = _seed_run(s, other_ws)
+
+    result = _call(create_watch, s, workspace,
+                   {"target_type": "mission", "target_id": str(foreign_run.id)})
+    assert result["success"] is False
+
+    # cleanup the second workspace
+    s.execute(text("DELETE FROM orchestration_runs WHERE workspace_id = CAST(:w AS uuid)"),
+              {"w": other_ws})
+    s.execute(text("DELETE FROM workspaces WHERE id = CAST(:w AS uuid)"), {"w": other_ws})
+    s.commit()
+    s.close()
+
+
+def test_duplicate_create_returns_existing_not_dead_end(workspace, new_session):
+    s = new_session()
+    run = _seed_run(s, workspace)
+    params = {"target_type": "mission", "target_id": str(run.id)}
+
+    first = _call(create_watch, s, workspace, params)
+    s.commit()
+    second = _call(create_watch, s, workspace, params)
+
+    assert second["success"] is True
+    assert second["existing"] is True
+    assert second["watch"]["id"] == first["watch"]["id"]
+    s.close()
+
+
+def test_create_on_playbook_execution_and_options(workspace, new_session):
+    s = new_session()
+    _, execution = _seed_execution(s, workspace)
+
+    result = _call(
+        create_watch, s, workspace,
+        {
+            "target_type": "playbook_execution",
+            "target_id": execution.execution_id,
+            "policy": "score_and_improve",
+            "quality_threshold": 0.9,
+            "deadline_hours": 4,
+            "action_budget": 1,
+            "success_criteria": "a clean summary with citations",
+        },
+    )
+    s.commit()
+    assert result["success"] is True, result
+    watch = result["watch"]
+    assert watch["policy"] == "score_and_improve"
+    assert watch["quality_threshold"] == pytest.approx(0.9)
+    assert watch["action_budget"] == 1
+    assert watch["deadline_at"] is not None
+    assert watch["success_criteria"] == "a clean summary with citations"
+    s.close()
+
+
+# ---------------------------------------------------------------------------
+# list / get / cancel round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_list_get_cancel_round_trip(workspace, new_session):
+    s = new_session()
+    run = _seed_run(s, workspace)
+    created = _call(create_watch, s, workspace,
+                    {"target_type": "mission", "target_id": str(run.id)})
+    s.commit()
+    watch_id = created["watch"]["id"]
+
+    listed = _call(list_watches, s, workspace, {})
+    assert listed["success"] is True
+    assert [w["id"] for w in listed["watches"]] == [watch_id]
+
+    detail = _call(get_watch, s, workspace, {"watch_id": watch_id})
+    assert detail["success"] is True
+    assert detail["watch"]["id"] == watch_id
+    assert detail["watch"]["lineage"][0]["target_id"] == str(run.id)
+    assert [e["event_type"] for e in detail["recent_events"]] == ["created"]
+
+    cancelled = _call(cancel_watch, s, workspace,
+                      {"watch_id": watch_id, "reason": "user changed their mind"})
+    s.commit()
+    assert cancelled["success"] is True
+    assert cancelled["watch"]["status"] == WatchStatus.CANCELLED.value
+
+    # Live-only list no longer shows it; include_closed does.
+    assert _call(list_watches, s, workspace, {})["watches"] == []
+    closed = _call(list_watches, s, workspace, {"include_closed": True})
+    assert [w["id"] for w in closed["watches"]] == [watch_id]
+
+    # Cancelling again is a clean error, not a crash.
+    again = _call(cancel_watch, s, workspace, {"watch_id": watch_id})
+    assert again["success"] is False
+    assert "closed" in again["error"]
+    s.close()
+
+
+def test_get_and_cancel_are_workspace_scoped(workspace, new_session):
+    s = new_session()
+    run = _seed_run(s, workspace)
+    created = _call(create_watch, s, workspace,
+                    {"target_type": "mission", "target_id": str(run.id)})
+    s.commit()
+    watch_id = created["watch"]["id"]
+
+    foreign_ws = str(uuid.uuid4())
+    assert _call(get_watch, s, foreign_ws, {"watch_id": watch_id})["success"] is False
+    assert _call(cancel_watch, s, foreign_ws, {"watch_id": watch_id})["success"] is False
+    s.close()
+
+
+# ---------------------------------------------------------------------------
+# Auto-create (Q1)
+# ---------------------------------------------------------------------------
+
+
+def test_auto_create_default_on_run_and_report(workspace, new_session):
+    s = new_session()
+    run = _seed_run(s, workspace, goal="research competitor pricing")
+
+    watch = auto_create_watch(
+        s, workspace,
+        target_type="mission",
+        target_id=str(run.id),
+        title="Watch: research competitor pricing",
+        success_criteria="research competitor pricing",
+        created_by="user_abc",
+    )
+    s.commit()
+
+    assert watch is not None
+    assert watch.policy == WatchPolicy.RUN_AND_REPORT.value
+    assert watch.success_criteria == "research competitor pricing"
+    assert watch.created_by == "user_abc"
+
+    # Idempotent: a second auto-create on the same live target is a no-op.
+    assert auto_create_watch(
+        s, workspace,
+        target_type="mission", target_id=str(run.id),
+        title="dup", success_criteria="dup",
+    ) is None
+    assert (
+        s.query(Watch).filter(Watch.workspace_id == workspace).count() == 1
+    )
+    s.close()
+
+
+def test_auto_create_respects_workspace_setting_off(workspace, new_session):
+    s = new_session()
+    run = _seed_run(s, workspace)
+    s.execute(
+        text(
+            "UPDATE workspaces SET settings = CAST(:cfg AS jsonb) "
+            "WHERE id = CAST(:w AS uuid)"
+        ),
+        {"cfg": '{"watch_auto_create": false}', "w": workspace},
+    )
+    s.commit()
+
+    assert auto_create_watch(
+        s, workspace,
+        target_type="mission", target_id=str(run.id),
+        title="t", success_criteria="c",
+    ) is None
+    assert s.query(Watch).filter(Watch.workspace_id == workspace).count() == 0
+    s.close()
+
+
+def test_auto_create_never_raises(workspace, new_session, monkeypatch):
+    """A broken watcher must not break a launch (fail-soft contract)."""
+    from services import watch_service
+
+    s = new_session()
+    run = _seed_run(s, workspace)
+    monkeypatch.setattr(
+        watch_service.WatchService,
+        "create_watch",
+        staticmethod(lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom"))),
+    )
+    result = auto_create_watch(
+        s, workspace,
+        target_type="mission", target_id=str(run.id),
+        title="t", success_criteria="c",
+    )
+    assert result is None  # swallowed, logged
+    s.close()
+
+
+def test_execute_playbook_tool_auto_creates_watch(workspace, new_session, monkeypatch):
+    """The playbook-execute tool wires auto-create for real (engine stubbed)."""
+    import services.concurrency_guard as cg
+    import services.playbook_engine as pe
+    from types import SimpleNamespace
+
+    from modules.tools.discovery.handlers_playbooks import execute_playbook
+
+    async def _allow(workspace_id, db):
+        return SimpleNamespace(allowed=True, reason=None, limits={})
+
+    launched = []
+    monkeypatch.setattr(cg, "check_concurrency", _allow)
+    monkeypatch.setattr(
+        pe, "get_playbook_engine",
+        lambda: SimpleNamespace(launch=lambda **kw: launched.append(kw)),
+    )
+
+    s = new_session()
+    recipe, _ = _seed_execution(s, workspace)
+
+    result = asyncio.run(
+        execute_playbook(
+            s, uuid.UUID(workspace),
+            {"playbook_id": recipe.id, "input_data": {"topic": "pricing"},
+             "_created_by": "user_abc"},
+        )
+    )
+    assert result["success"] is True, result
+    assert launched  # engine seam fired
+
+    watch = (
+        s.query(Watch)
+        .filter(
+            Watch.workspace_id == workspace,
+            Watch.target_type == "playbook_execution",
+            Watch.target_id == result["execution_id"],
+        )
+        .one()
+    )
+    assert watch.policy == WatchPolicy.RUN_AND_REPORT.value
+    assert recipe.name[:20] in watch.title
+    assert "pricing" in watch.success_criteria  # request text seeded
+    assert watch.created_by == "user_abc"
+    s.close()
+
+
+def test_create_mission_tool_auto_creates_watch(workspace, new_session, monkeypatch):
+    """The mission tool wires auto-create for real (coordinator stubbed --
+    the planner is an LLM)."""
+    from services.coordinator_service import CoordinatorService
+    from modules.tools.discovery.handlers_missions import create_mission
+
+    s = new_session()
+    seeded_run = _seed_run(s, workspace, goal="draft the launch narrative")
+    seeded_run.state = "awaiting_approval"
+    seeded_run.state_type = "blocked"
+    seeded_run.plan = {"tasks": []}
+    s.commit()
+
+    async def _fake_create_mission(self, db, workspace_id, goal, created_by, config=None):
+        return seeded_run
+
+    monkeypatch.setattr(CoordinatorService, "create_mission", _fake_create_mission)
+
+    result = asyncio.run(
+        create_mission(
+            s, uuid.UUID(workspace),
+            {"goal": "draft the launch narrative", "_created_by": "user_abc"},
+        )
+    )
+    assert result["success"] is True, result
+
+    watch = (
+        s.query(Watch)
+        .filter(
+            Watch.workspace_id == workspace,
+            Watch.target_type == "mission",
+            Watch.target_id == str(seeded_run.id),
+        )
+        .one()
+    )
+    assert watch.policy == WatchPolicy.RUN_AND_REPORT.value
+    assert watch.success_criteria == "draft the launch narrative"
+    s.close()

--- a/orchestrator/tests/test_prd204_watchlist_api.py
+++ b/orchestrator/tests/test_prd204_watchlist_api.py
@@ -1,0 +1,253 @@
+"""PRD-204 S11 -- the watchlist API (api/watches.py).
+
+The HTTP read/cancel surface over the watch registry. Locks the S11
+guarantees:
+
+* list is workspace-scoped and live-only by default (``include_closed`` /
+  ``status`` widen it);
+* detail carries the S9 serializer shape plus recent events newest-first;
+* cross-workspace, unknown, and malformed ids all read as 404 (no DB-cast
+  500s);
+* cancel closes a live watch, refuses a closed one (422).
+
+Auth rides the app-level dependency overrides: the hybrid context is stubbed
+to an anonymous principal (the local-edition posture -- owner of its resolved
+workspace), so the ``require_workspace_permission`` gates run for real and
+grant through the PRD-195 matrix.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+from core.database.database import get_database_url
+
+
+# ---------------------------------------------------------------------------
+# DB fixtures (house idiom of test_prd204_watch_tools)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def engine():
+    try:
+        eng = create_engine(get_database_url(), pool_pre_ping=True)
+        with eng.connect() as c:
+            c.execute(text("SELECT 1 FROM watches LIMIT 1"))
+            c.execute(text("SELECT 1 FROM watch_events LIMIT 1"))
+    except Exception as exc:  # noqa: BLE001
+        pytest.skip(f"watchlist API suite needs a reachable Postgres with schema: {exc}")
+    yield eng
+    eng.dispose()
+
+
+@pytest.fixture
+def new_session(engine):
+    return sessionmaker(bind=engine, expire_on_commit=False)
+
+
+def _seed_workspace(new_session, name: str) -> str:
+    ws_id = str(uuid.uuid4())
+    s = new_session()
+    s.execute(
+        text(
+            "INSERT INTO workspaces (id, name) "
+            "VALUES (CAST(:id AS uuid), :n) ON CONFLICT (id) DO NOTHING"
+        ),
+        {"id": ws_id, "n": name},
+    )
+    s.commit()
+    s.close()
+    return ws_id
+
+
+def _drop_workspace(new_session, ws_id: str) -> None:
+    s = new_session()
+    for stmt in (
+        "DELETE FROM watch_events WHERE watch_id IN "
+        "(SELECT id FROM watches WHERE workspace_id = CAST(:w AS uuid))",
+        "DELETE FROM watches WHERE workspace_id = CAST(:w AS uuid)",
+        "DELETE FROM workspaces WHERE id = CAST(:w AS uuid)",
+    ):
+        s.execute(text(stmt), {"w": ws_id})
+    s.commit()
+    s.close()
+
+
+@pytest.fixture
+def workspace(new_session):
+    ws_id = _seed_workspace(new_session, "prd204-watchlist-api")
+    yield ws_id
+    _drop_workspace(new_session, ws_id)
+
+
+@pytest.fixture
+def other_workspace(new_session):
+    ws_id = _seed_workspace(new_session, "prd204-watchlist-api-other")
+    yield ws_id
+    _drop_workspace(new_session, ws_id)
+
+
+# ---------------------------------------------------------------------------
+# App factory -- real router + real permission gate, stubbed hybrid context
+# ---------------------------------------------------------------------------
+
+
+def _make_client(new_session, ws_id: str):
+    from api.watches import router
+    from core.auth.dependencies import RequestContext, UserContext
+    from core.auth.hybrid import get_request_context_hybrid
+    from core.database.database import get_db
+
+    app = FastAPI()
+    app.include_router(router)
+
+    session = new_session()
+
+    def _override_db():
+        yield session
+
+    ctx = RequestContext(
+        workspace_id=uuid.UUID(ws_id),
+        user=UserContext(),
+        auth_type="anonymous",
+    )
+    app.dependency_overrides[get_db] = _override_db
+    app.dependency_overrides[get_request_context_hybrid] = lambda: ctx
+    return TestClient(app), session
+
+
+def _create_watch(session, ws_id: str, *, title: str = "Watch me") -> str:
+    from services.watch_service import WatchService
+
+    watch = WatchService.create_watch(
+        session,
+        workspace_id=ws_id,
+        watch_type="mission",
+        target_type="mission",
+        target_id=str(uuid.uuid4()),
+        title=title,
+    )
+    session.commit()
+    return str(watch.id)
+
+
+# ---------------------------------------------------------------------------
+# List
+# ---------------------------------------------------------------------------
+
+
+def test_list_is_workspace_scoped(new_session, workspace, other_workspace):
+    client, session = _make_client(new_session, workspace)
+    try:
+        mine = _create_watch(session, workspace, title="Mine")
+        _create_watch(session, other_workspace, title="Not mine")
+
+        resp = client.get("/api/v1/watches")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert [w["id"] for w in body["watches"]] == [mine]
+        assert body["total"] == 1
+        # The S9 serializer shape rides through unchanged.
+        row = body["watches"][0]
+        for key in ("status", "policy", "final_score_display", "action_budget"):
+            assert key in row
+    finally:
+        session.close()
+
+
+def test_list_live_only_unless_widened(new_session, workspace):
+    from services.watch_service import WatchService
+
+    client, session = _make_client(new_session, workspace)
+    try:
+        live_id = _create_watch(session, workspace, title="Live")
+        closed_id = _create_watch(session, workspace, title="Closed")
+        WatchService.cancel_watch(session, workspace, closed_id)
+        session.commit()
+
+        default = client.get("/api/v1/watches").json()
+        assert [w["id"] for w in default["watches"]] == [live_id]
+
+        widened = client.get("/api/v1/watches?include_closed=true").json()
+        assert {w["id"] for w in widened["watches"]} == {live_id, closed_id}
+
+        filtered = client.get("/api/v1/watches?status=cancelled").json()
+        assert [w["id"] for w in filtered["watches"]] == [closed_id]
+    finally:
+        session.close()
+
+
+# ---------------------------------------------------------------------------
+# Detail
+# ---------------------------------------------------------------------------
+
+
+def test_detail_returns_recent_events_newest_first(new_session, workspace):
+    from core.models.watches import WatchEvent
+
+    client, session = _make_client(new_session, workspace)
+    try:
+        watch_id = _create_watch(session, workspace)
+        session.add(
+            WatchEvent(
+                watch_id=uuid.UUID(watch_id),
+                event_type="terminal",
+                summary="Target finished",
+                event_key="terminal:mission:x",
+                created_at=datetime(2099, 1, 1, tzinfo=timezone.utc),
+            )
+        )
+        session.commit()
+
+        resp = client.get(f"/api/v1/watches/{watch_id}")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["watch"]["id"] == watch_id
+        assert "lineage" in body["watch"]
+        types = [e["event_type"] for e in body["recent_events"]]
+        assert types == ["terminal", "created"]
+    finally:
+        session.close()
+
+
+def test_detail_404_for_cross_workspace_unknown_and_malformed(
+    new_session, workspace, other_workspace
+):
+    client, session = _make_client(new_session, workspace)
+    try:
+        foreign_id = _create_watch(session, other_workspace)
+
+        assert client.get(f"/api/v1/watches/{foreign_id}").status_code == 404
+        assert client.get(f"/api/v1/watches/{uuid.uuid4()}").status_code == 404
+        assert client.get("/api/v1/watches/not-a-uuid").status_code == 404
+    finally:
+        session.close()
+
+
+# ---------------------------------------------------------------------------
+# Cancel
+# ---------------------------------------------------------------------------
+
+
+def test_cancel_closes_then_refuses(new_session, workspace):
+    client, session = _make_client(new_session, workspace)
+    try:
+        watch_id = _create_watch(session, workspace)
+
+        resp = client.post(f"/api/v1/watches/{watch_id}/cancel")
+        assert resp.status_code == 200
+        assert resp.json()["watch"]["status"] == "cancelled"
+
+        again = client.post(f"/api/v1/watches/{watch_id}/cancel")
+        assert again.status_code == 422
+
+        assert client.post(f"/api/v1/watches/{uuid.uuid4()}/cancel").status_code == 404
+    finally:
+        session.close()


### PR DESCRIPTION
## Summary
Builds **PRD-204 Auto Watcher** (doc in this PR: `docs/PRDS/PRD-204-AUTO-WATCHER.md`): a workspace-scoped **watch** supervises each launched mission / playbook execution / scheduled playbook to a verdict — event hooks at the terminal choke points + a heartbeat sweep, run-level output scoring via the existing cross-model judge, and policy-gated corrective actions (rerun, per-run prompt tweak, replan, reassign, spawn-agent-from-blueprint), all through `evaluate_approval` + ApprovalGrant. Also closes the standing silent-failure holes independent of the registry: no `mission_failed` notification, silent budget-pause, failed-mission board card rendering **done**, silent breaker trips, undetected missed cron ticks.

Grounded @ `8e0543211`. §8 decision-box recommendations applied as build defaults — flag at review to flip any.

## Stories
S1 registry schema · S2 WatchService · S3 fail-soft terminal hooks · S4 silent-hole notifications + board-mapping fix · S5 watcher tick (UnifiedScheduler, `WATCHER_ENABLED`) · S6 run-level verdict (0–1 internal / 0–10 display) · S7 rerun + `step_overrides` + `SUBJECT_PLAYBOOK_RUN` wiring · S8 replan/reassign/spawn actions · S9 `platform_*_watch` tools + auto-create · S10 decision step · S11 watchlist API/UI + route-manifest · S12 CI hardening

## Test plan
- [ ] orchestrator-tests lane green (unit + integration per story; workspaces FK seeded)
- [ ] migrations: single alembic head, additive-only, boots via entrypoint `upgrade heads`
- [ ] route-contract lane green against updated committed manifest
- [ ] CodeQL / security / malware-scan lanes clean
- [ ] Producer fail-soft: watch-ingest raising never fails mission/playbook completion
- [ ] Grant flow: rerun under `always_ask` parks + resumes via approvals inbox; `full_auto` under-ceiling auto-runs

Testable on this branch before merge per Gerard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Auto Watcher” with persistent, workspace-scoped supervision and a background watcher ticker (configurable via `WATCHER_ENABLED` / `WATCHER_TICK_SECONDS`), including missed-run and deadline-expiry handling.
  * Added watch registry + rerun/tweak support, watch corrective actions, and new watch tools (create/list/get/cancel).
  * Added watchlist API and command-center Watchlist UI.
* **Notifications**
  * Added watch/flavored verdict and escalation notifications; improved mission failure alerts.
  * Failed missions now show as **failed** on the board.
* **Tests**
  * Added integration and fail-soft coverage for watches, ticker, verdict scoring, and watchlist APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->