### PR TITLE
fix(rag): query enhancement defaults OFF + rerank client rebinds per loop

### DIFF
--- a/orchestrator/api/documents.py
+++ b/orchestrator/api/documents.py
@@ -1465,7 +1465,6 @@ async def rag_retrieve(
             config_kwargs['min_similarity'] = min_similarity
         
         config = RAGConfig(
-            enable_query_enhancement=True,
             enable_rrf_fusion=True,
             **config_kwargs
         )

--- a/orchestrator/config.py
+++ b/orchestrator/config.py
@@ -1128,6 +1128,24 @@ class Config:
             return os.getenv("RAG_HYBRID_ENABLED", "true").lower() == "true"
 
     @property
+    def RAG_QUERY_ENHANCEMENT_ENABLED(self) -> bool:
+        """LLM query enhancement — HyDE, decomposition, expansion — on the
+        retrieval hot path (default: OFF).
+
+        The 2026-07 live retrieval baseline measured enhancement at −26.9
+        recall@5 points versus plain dense retrieval while adding ~4 LLM
+        calls per query (evals/baseline/kg_retrieval_2026-07.json). OFF
+        until an eval shows a variant that pays; the setting keeps it one
+        flip away, and the eval lever grid still exercises it explicitly.
+        """
+        try:
+            from core.llm.manager import get_system_setting
+            val = get_system_setting("rag", "query_enhancement_enabled", "false")
+            return str(val).lower() == "true" if val else False
+        except Exception:
+            return os.getenv("RAG_QUERY_ENHANCEMENT_ENABLED", "false").lower() == "true"
+
+    @property
     def RAG_CONTEXTUAL_ANNOTATIONS_ENABLED(self) -> bool:
         """Contextual chunk annotations at ingestion (default: OFF — PRD-188 S2).
 

--- a/orchestrator/core/llm/rerank_manager.py
+++ b/orchestrator/core/llm/rerank_manager.py
@@ -8,6 +8,7 @@ Uses httpx (already in requirements) — no cohere SDK dependency.
 Graceful degradation: if no API key configured, returns documents unchanged.
 """
 
+import asyncio
 import logging
 import threading
 from dataclasses import dataclass
@@ -40,6 +41,7 @@ class RerankManager:
         self._model: str = config.RAG_RERANK_MODEL
         self._loaded = False
         self._client: Optional[httpx.AsyncClient] = None
+        self._client_loop: Optional[asyncio.AbstractEventLoop] = None
 
     def _load_config(self):
         """Lazy-load API key and model from system_settings, fallback to env."""
@@ -86,8 +88,21 @@ class RerankManager:
         return bool(self._api_key)
 
     def _get_client(self) -> httpx.AsyncClient:
-        if self._client is None:
+        # httpx binds a client's connection pool to the loop its connections
+        # open on. This singleton outlives request loops (thread bridges,
+        # per-run asyncio.run callers), so a process-wide cached client raises
+        # "Event loop is closed" for every caller on a later loop — silently
+        # degrading rerank to identity order. Rebind per running loop instead;
+        # a client stranded on a dead loop can't be awaited closed from here,
+        # so its reference is dropped for GC to reclaim.
+        loop = asyncio.get_running_loop()
+        if (
+            self._client is None
+            or self._client.is_closed
+            or self._client_loop is not loop
+        ):
             self._client = httpx.AsyncClient(timeout=30.0)
+            self._client_loop = loop
         return self._client
 
     async def rerank(

--- a/orchestrator/modules/rag/service.py
+++ b/orchestrator/modules/rag/service.py
@@ -125,7 +125,12 @@ class RAGConfig:
     min_similarity: float = None
     
     # Phase 2: Advanced retrieval options
-    enable_query_enhancement: bool = True
+    # None = "caller didn't choose" → resolved in __post_init__ from the
+    # canonical config accessor (default OFF — the 2026-07 live baseline
+    # measured enhancement at −26.9 recall@5 vs plain retrieval while paying
+    # ~4 extra LLM calls per query). An explicit True/False wins: the eval
+    # lever grid relies on that.
+    enable_query_enhancement: Optional[bool] = None
     enable_rrf_fusion: bool = True
     # None = "caller didn't choose" → resolved in __post_init__ from the
     # canonical config accessor (default ON). An explicit True/False wins.
@@ -163,12 +168,20 @@ class RAGConfig:
         # PRD-136 renamed that settings key, so the lookup always missed,
         # always returned "false", and silently pinned the pipeline's
         # highest-precision stage off.
-        if self.enable_reranking is None or self.hybrid_search_enabled is None:
+        if (
+            self.enable_reranking is None
+            or self.hybrid_search_enabled is None
+            or self.enable_query_enhancement is None
+        ):
             from config import config as app_config
             if self.enable_reranking is None:
                 self.enable_reranking = bool(app_config.RAG_RERANK_ENABLED)
             if self.hybrid_search_enabled is None:
                 self.hybrid_search_enabled = bool(app_config.RAG_HYBRID_ENABLED)
+            if self.enable_query_enhancement is None:
+                self.enable_query_enhancement = bool(
+                    app_config.RAG_QUERY_ENHANCEMENT_ENABLED
+                )
 
         logger.info(f"RAGConfig loaded: max_tokens={self.max_tokens}, diversity={self.diversity}, min_similarity={self.min_similarity}, reranking={self.enable_reranking}")
 

--- a/orchestrator/tests/test_w3_freeze_fixes.py
+++ b/orchestrator/tests/test_w3_freeze_fixes.py
@@ -1,0 +1,142 @@
+"""Freeze-findings fixes — the two measured actions from the 2026-07 live
+retrieval baseline (evals/baseline/kg_retrieval_2026-07.json):
+
+1. Query enhancement (HyDE + decomposition + expansion) measured −26.9
+   recall@5 points versus plain dense retrieval on pilot-a while paying ~4
+   extra LLM calls per query. It now defaults OFF via the canonical config
+   accessor: admin/env control kept, an explicit caller value (the eval
+   lever grid) still wins, and the documents.py search endpoint no longer
+   hardcodes it on.
+
+2. The rerank manager cached one httpx.AsyncClient for the process's
+   lifetime; httpx pools bind connections to the loop they open on, so any
+   caller on a later loop (thread bridges, per-run asyncio.run) hit "Event
+   loop is closed" and the stage silently degraded to identity order — 30
+   such failures in the baseline run, on the one lever that measured
+   positive (+7.7 recall@5). The client now rebinds per running loop.
+
+All pure — no network, no DB.
+"""
+import asyncio
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+
+_orchestrator_root = str(Path(__file__).resolve().parent.parent)
+if _orchestrator_root not in sys.path:
+    sys.path.insert(0, _orchestrator_root)
+
+import core.llm.manager as llm_manager_mod  # noqa: E402
+import core.llm.rerank_manager as rerank_manager_mod  # noqa: E402
+import modules.rag.service as rag_service_mod  # noqa: E402
+from modules.rag.service import RAGConfig  # noqa: E402
+
+
+@pytest.fixture
+def hermetic_settings(monkeypatch):
+    """No DB, no env: the flat rag-settings blob is empty and the canonical
+    get_system_setting returns its passed default — so tests read the shipped
+    defaults, not this machine's state."""
+    monkeypatch.setattr(rag_service_mod, "_load_rag_settings", lambda force=False: {})
+    monkeypatch.setattr(
+        llm_manager_mod, "get_system_setting", lambda group, key, default=None: default
+    )
+    monkeypatch.delenv("RAG_QUERY_ENHANCEMENT_ENABLED", raising=False)
+    monkeypatch.delenv("RAG_RERANK_ENABLED", raising=False)
+
+
+# ---------------------------------------------------------------------------
+# The enhancement default flip (ON → OFF)
+# ---------------------------------------------------------------------------
+
+def test_enhancement_off_by_default(hermetic_settings):
+    assert RAGConfig().enable_query_enhancement is False
+
+
+def test_explicit_caller_value_wins(hermetic_settings):
+    assert RAGConfig(enable_query_enhancement=True).enable_query_enhancement is True
+    assert RAGConfig(enable_query_enhancement=False).enable_query_enhancement is False
+
+
+def test_admin_setting_on_is_respected(hermetic_settings, monkeypatch):
+    def _setting(group, key, default=None):
+        if (group, key) == ("rag", "query_enhancement_enabled"):
+            return "true"
+        return default
+
+    monkeypatch.setattr(llm_manager_mod, "get_system_setting", _setting)
+    assert RAGConfig().enable_query_enhancement is True
+
+
+def test_search_endpoint_does_not_force_enhancement_on():
+    documents_src = (Path(_orchestrator_root) / "api" / "documents.py").read_text()
+    assert "enable_query_enhancement=True" not in documents_src
+
+
+def test_eval_lever_grid_pins_enhancement_explicitly():
+    """The freeze instrument sets every variant's enhancement lever explicitly
+    (never the default), so the default flip cannot change what it measures."""
+    src = (Path(_orchestrator_root) / "evals" / "retrieval_recall.py").read_text()
+    assert "enable_query_enhancement=True" in src
+    assert "enable_query_enhancement=False" in src
+
+
+# ---------------------------------------------------------------------------
+# The rerank client loop binding
+# ---------------------------------------------------------------------------
+
+def test_rerank_client_stable_within_a_loop():
+    mgr = rerank_manager_mod.RerankManager()
+
+    async def grab_twice():
+        return mgr._get_client(), mgr._get_client()
+
+    a, b = asyncio.run(grab_twice())
+    assert a is b
+
+
+def test_rerank_client_rebinds_across_loops():
+    """A client cached on a finished loop must never be handed to the next
+    loop — that is exactly the 'Event loop is closed' degradation."""
+    mgr = rerank_manager_mod.RerankManager()
+
+    async def grab():
+        return mgr._get_client()
+
+    first = asyncio.run(grab())
+    second = asyncio.run(grab())
+    assert first is not second
+
+
+def test_rerank_completes_after_prior_loop_closed(monkeypatch):
+    """End-to-end rerank on two successive loops returns real Cohere scores
+    both times — not the zero-score identity fallback of the swallowed path."""
+    mgr = rerank_manager_mod.RerankManager()
+    mgr._api_key = "test-key"
+    mgr._loaded = True
+
+    def handler(request):
+        return httpx.Response(
+            200,
+            json={
+                "results": [
+                    {"index": 1, "relevance_score": 0.9},
+                    {"index": 0, "relevance_score": 0.2},
+                ]
+            },
+        )
+
+    real_async_client = httpx.AsyncClient
+    monkeypatch.setattr(
+        rerank_manager_mod.httpx,
+        "AsyncClient",
+        lambda **kw: real_async_client(transport=httpx.MockTransport(handler), **kw),
+    )
+
+    out1 = asyncio.run(mgr.rerank("q", ["a", "b"], top_n=2))
+    out2 = asyncio.run(mgr.rerank("q", ["a", "b"], top_n=2))
+    for out in (out1, out2):
+        assert [r.index for r in out] == [1, 0]
+        assert out[0].relevance_score == 0.9


### PR DESCRIPTION
## Summary

The two measured actions from the 2026-07 live retrieval baseline (`orchestrator/evals/baseline/kg_retrieval_2026-07.json` — frozen from the pilot-a live grid, 26 paired queries × 5 variants):

| Variant | recall@5 | vs baseline |
|---|---|---|
| live_baseline | 69.2 | — |
| live_rerank | **76.9** | **+7.7** (the one lever that pays) |
| live_enhancement | **42.3** | **−26.9** |

**1. Query enhancement now defaults OFF.** HyDE + decomposition + expansion measured −26.9 recall@5 vs plain dense retrieval while paying ~4 extra LLM calls per query on an unbounded path. The default moves to the canonical config accessor `RAG_QUERY_ENHANCEMENT_ENABLED` (system_settings `rag.query_enhancement_enabled`, then env, default `false`), mirroring the PRD-188 S1 rerank/hybrid None-sentinel pattern exactly: explicit caller values still win (the eval lever grid pins every variant explicitly, so the instrument is unchanged), and one admin-setting flip turns it back on if a future eval shows a variant that pays. The `documents.py` search endpoint's hardcoded `enable_query_enhancement=True` is removed — it now follows config like the rest of the pipeline.

**2. Rerank httpx client rebinds per running loop.** `RerankManager` (a process-lifetime singleton) cached one `httpx.AsyncClient`; httpx pools bind to the loop their connections open on, so any caller on a later loop — thread bridges, per-run `asyncio.run` (exactly the eval's retrieve pattern) — hit `Event loop is closed` and the stage silently degraded to identity order. The baseline run logged **30** such failures, degrading `live_rerank`/`live_full_stack`, so rerank's true ceiling is above +7.7. `_get_client()` now rebinds when the running loop changes (or the client is closed); a client stranded on a dead loop is dropped for GC.

## Test plan
- [x] `tests/test_w3_freeze_fixes.py` (pure, no network/DB — mirrors the PRD-188 flip-test shape):
  - enhancement OFF on a fresh `RAGConfig` (hermetic settings)
  - explicit caller value wins, both directions
  - admin setting `true` re-enables (default flipped, control kept)
  - `documents.py` no longer forces enhancement on (source pin)
  - eval lever grid pins the lever explicitly in both directions (source pin)
  - rerank client: stable within one loop · rebinds across loops · end-to-end rerank succeeds on two successive loops with real scores (MockTransport)
- [ ] CI green (orchestrator tests + guards) — CI is the gate, no local runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)