### PR TITLE
fix(migrations): merge the two post-wave-3 alembic heads back to one

### DIFF
--- a/orchestrator/alembic/versions/w3_post201_merge_heads.py
+++ b/orchestrator/alembic/versions/w3_post201_merge_heads.py
@@ -1,0 +1,40 @@
+"""Wave-3 close-out: collapse the two-headed revision forest back to one head.
+
+After PRD-201 (#543) merged alongside the PRD-203 merge revision (#542),
+``alembic heads`` returned two divergent heads:
+
+    - prd201_s1_msg_context_trace  (PRD-201 S1, message context trace)
+    - prd203_merge_heads           (the PRD-203 three-way merge point)
+
+Both PRs were cut from the same parent window and merged separately without a
+joining revision, so main carries two heads and the from-zero "exactly one
+head" CI bar has been red on every PR since. This is a **merge revision
+only** — no schema operations — joining the two lineages so ``alembic heads``
+returns exactly one revision (the deploy entrypoint's ``alembic upgrade
+heads`` applied both lineages regardless, so prod state is unaffected).
+
+Do NOT add ``CREATE``/``ALTER`` here — a merge revision that mutates schema is
+exactly what makes a later from-zero squash lossy (mirrors prd176_merge_heads
+and prd203_merge_heads).
+
+Revision ID: w3_post201_merge_heads
+Revises: prd201_s1_msg_context_trace, prd203_merge_heads
+Create Date: 2026-07-16
+"""
+
+# A pure merge point — no operations.
+revision = "w3_post201_merge_heads"
+down_revision = (
+    "prd201_s1_msg_context_trace",
+    "prd203_merge_heads",
+)
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """No-op: this revision only merges lineages."""
+
+
+def downgrade() -> None:
+    """No-op: splitting back into two heads needs no schema change."""


### PR DESCRIPTION
Main's `test` workflow has been red since #542/#543 merged: PRD-201's migration and the PRD-203 merge revision left **two alembic heads** (`prd201_s1_msg_context_trace` + `prd203_merge_heads`), failing the from-zero "exactly one head" lane on **every open PR**.

Pure merge revision — no schema operations. `alembic upgrade heads` (the deploy entrypoint) already applied both lineages, so prod state is unaffected; this only rejoins the graph (mirrors `prd176_merge_heads` / `prd203_merge_heads`).

## Test plan
- [x] File-graph parse: heads 2 → 1 (`w3_post201_merge_heads`)
- [ ] The "Alembic from-zero — exactly one head" lane goes green on this PR (that lane IS the test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)