### PR TITLE
feat(prd-220): persistent & multi-threaded widget chat

### DIFF
--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -73,12 +73,13 @@ This is why the same Auto can be CEO-voice for a Shopify operator and Casual-Sid
 Auto is **always present**. He is the product's spine.
 
 - **Chat page** — Auto, full-screen. Focused conversation. No distractions.
-- **Every other page** — Auto as a widget docked in the corner. Page-aware. `[Context: User is on the Agent Management page]` is surfaced visibly in the widget — a trust receipt, so the user never wonders whether Auto knows what they're looking at.
+- **Every other page** — Auto as a widget docked in the corner. Page-aware: the widget names the current page up front ("Ask me anything about Agent Management…") — a trust receipt, so the user never wonders whether Auto knows what they're looking at. The page context itself travels server-side with each request (PRD-220), so it never pollutes the saved conversation or its title.
 
 ### Widget behaviour
 
-- **Ephemeral by default.** Widget chats reset on page navigation. No "history graveyard" to curate.
-- **Promote to persist.** "Open in full chat" escalates the widget thread into the full Chat page, where it becomes a permanent thread.
+- **Persistent across navigation (PRD-220).** The widget remembers its active conversation (per workspace + user) and reconnects to it on the next page — Auto doesn't forget you exist because you clicked a link. The resume window is 24h of inactivity; after that the widget starts fresh.
+- **Multi-threaded.** A lightweight thread switcher (up to 5 recent conversations, with previews and unread dots) lets Chat A build playbooks while Chat B discusses a report. Closing a thread hides it from the widget; the conversation itself stays in full-chat history.
+- **Promote to persist.** "Open in full chat" deep-links the widget thread into the full Chat page (`/chat?chatId=…`) — same conversation, bigger surface.
 - **Bypass is legitimate.** Power users `@mention` a specific agent to skip Auto's routing — when you know the target, skipping the orchestrator saves tokens.
 
 ### Bug report surface (pilot only)

--- a/frontend/app/chat/page.tsx
+++ b/frontend/app/chat/page.tsx
@@ -65,21 +65,6 @@ export default function ChatPage() {
     setIsHistoryOpen(false)
   }
 
-  // Pick up conversation context handed off from the Auto widget
-  useEffect(() => {
-    try {
-      const raw = sessionStorage.getItem('auto-widget-handoff')
-      if (raw) {
-        sessionStorage.removeItem('auto-widget-handoff')
-        const handoffMessages: ChatMessage[] = JSON.parse(raw)
-        if (handoffMessages.length > 0) {
-          setCurrentMessages(handoffMessages)
-          setChatInstance((v) => v + 1)
-        }
-      }
-    } catch { /* corrupt data — start fresh */ }
-  }, [])
-
   // Toggle chat history from main Automatos sidebar (chat-only menu item)
   useEffect(() => {
     const handler = () => setIsHistoryOpen((v) => !v)

--- a/frontend/components/chatbot/chat-widget.tsx
+++ b/frontend/components/chatbot/chat-widget.tsx
@@ -14,6 +14,8 @@ import {
   Bug,
   Loader2,
   ArrowUpRight,
+  ChevronDown,
+  Plus,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -30,6 +32,22 @@ import {
 import { useUser } from '@clerk/nextjs'
 import { useSubmitBugReport, type BugReportRequest } from '@/hooks/use-bug-report-api'
 import { useChat } from '@/lib/chat/hooks'
+import { getChatHistory, getChatMessages } from '@/lib/chat/api'
+import {
+  EMPTY_WIDGET_SESSION,
+  isThreadUnread,
+  loadWidgetSession,
+  saveWidgetSession,
+  threadTimeAgo,
+  visibleThreads,
+  widgetSessionKey,
+  withActiveChat,
+  withThreadClosed,
+  withThreadRead,
+  withoutActiveChat,
+  type WidgetChatSession,
+} from '@/lib/chat/widget-session'
+import type { Chat, ChatMessage } from '@/types'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { useRouter } from 'next/navigation'
@@ -62,11 +80,302 @@ const PAGE_LABELS: Record<string, string> = {
 }
 
 // =============================================================================
-// Mini Auto Chat Tab
+// Mini Auto Chat Tab — persistent & multi-threaded (PRD-220)
 // =============================================================================
+
+function widgetWorkspaceId(): string | null {
+  if (typeof window === 'undefined') return null
+  return localStorage.getItem('last_active_workspace')
+}
 
 function AutoChatTab({ currentPage, onClose }: { currentPage: string; onClose?: () => void }) {
   const router = useRouter()
+  const { user, isLoaded: userLoaded } = useUser()
+
+  // Session key is workspace+user scoped; until Clerk resolves, run ephemeral.
+  const storageKey = userLoaded ? widgetSessionKey(widgetWorkspaceId(), user?.id) : null
+
+  const [session, setSession] = useState<WidgetChatSession | null>(null)
+  const [activeChatId, setActiveChatId] = useState<string | null>(null)
+  const [seedMessages, setSeedMessages] = useState<ChatMessage[]>([])
+  const [reconnecting, setReconnecting] = useState(false)
+  const [threads, setThreads] = useState<Chat[]>([])
+  const [threadsOpen, setThreadsOpen] = useState(false)
+  // Bumped only on explicit thread changes — remounts the conversation below.
+  const [conversationInstance, setConversationInstance] = useState(0)
+  // Monotonic token so a slow history fetch can't stomp a newer thread change.
+  const loadSeqRef = useRef(0)
+
+  const updateSession = useCallback(
+    (mutate: (s: WidgetChatSession) => WidgetChatSession) => {
+      if (!storageKey) return
+      setSession((prev) => {
+        const next = mutate(prev ?? EMPTY_WIDGET_SESSION)
+        saveWidgetSession(storageKey, next)
+        return next
+      })
+    },
+    [storageKey]
+  )
+
+  const refreshThreads = useCallback(async () => {
+    try {
+      setThreads(await getChatHistory(10))
+    } catch {
+      // Thread list is best-effort — the active conversation still works.
+    }
+  }, [])
+
+  // S1: restore the session and reconnect to the active thread on mount.
+  useEffect(() => {
+    if (!storageKey) return
+    const restored = loadWidgetSession(storageKey)
+    setSession(restored)
+    refreshThreads().catch(() => {})
+    if (!restored.activeChatId) return
+
+    const chatId = restored.activeChatId
+    setReconnecting(true)
+    const seq = ++loadSeqRef.current
+    let cancelled = false
+    ;(async () => {
+      try {
+        const history = await getChatMessages(chatId)
+        if (cancelled || seq !== loadSeqRef.current) return
+        setSeedMessages(history)
+        setActiveChatId(chatId)
+        setConversationInstance((v) => v + 1)
+      } catch {
+        // Stale or inaccessible chat (deleted, workspace switch) — start fresh.
+        if (!cancelled && seq === loadSeqRef.current) updateSession((s) => withoutActiveChat(s))
+      } finally {
+        if (!cancelled && seq === loadSeqRef.current) setReconnecting(false)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [storageKey])
+
+  // Backend assigned (or confirmed) the conversation id — persist it. Fires
+  // each turn, which also keeps the active thread's read marker current.
+  const handleChatIdAssigned = useCallback(
+    (chatId: string) => {
+      setActiveChatId(chatId)
+      updateSession((s) => withActiveChat(s, chatId))
+      refreshThreads().catch(() => {})
+    },
+    [updateSession, refreshThreads]
+  )
+
+  const switchThread = useCallback(
+    async (thread: Chat) => {
+      setThreadsOpen(false)
+      if (thread.id === activeChatId) return
+      // Leaving a thread the user was just viewing — stamp it read.
+      updateSession((s) => withActiveChat(withThreadRead(s, activeChatId), thread.id))
+      setReconnecting(true)
+      const seq = ++loadSeqRef.current
+      try {
+        const history = await getChatMessages(thread.id)
+        if (seq !== loadSeqRef.current) return
+        setSeedMessages(history)
+        setActiveChatId(thread.id)
+        setConversationInstance((v) => v + 1)
+      } catch {
+        if (seq === loadSeqRef.current) updateSession((s) => withoutActiveChat(s))
+      } finally {
+        if (seq === loadSeqRef.current) setReconnecting(false)
+      }
+    },
+    [activeChatId, updateSession]
+  )
+
+  const startNewThread = useCallback(() => {
+    setThreadsOpen(false)
+    loadSeqRef.current++ // invalidate any in-flight thread load
+    setReconnecting(false)
+    updateSession((s) => withoutActiveChat(withThreadRead(s, activeChatId)))
+    setActiveChatId(null)
+    setSeedMessages([])
+    setConversationInstance((v) => v + 1)
+  }, [activeChatId, updateSession])
+
+  // Hides the thread from the switcher — the conversation stays in full chat.
+  const closeThread = useCallback(
+    (thread: Chat, e: React.MouseEvent) => {
+      e.stopPropagation()
+      updateSession((s) => withThreadClosed(s, thread.id))
+      if (thread.id === activeChatId) {
+        loadSeqRef.current++ // invalidate any in-flight thread load
+        setReconnecting(false)
+        setActiveChatId(null)
+        setSeedMessages([])
+        setConversationInstance((v) => v + 1)
+      }
+    },
+    [activeChatId, updateSession]
+  )
+
+  // S3: promote — the full chat page loads the thread via ?chatId= deep-link.
+  const openFullChat = useCallback(() => {
+    setThreadsOpen(false)
+    onClose?.()
+    router.push(activeChatId ? `/chat?chatId=${activeChatId}` : '/chat')
+  }, [activeChatId, onClose, router])
+
+  const effectiveSession = session ?? EMPTY_WIDGET_SESSION
+  const listedThreads = visibleThreads(threads, effectiveSession)
+  const activeThread = threads.find((t) => t.id === activeChatId)
+  const hasUnread = listedThreads.some((t) => isThreadUnread(effectiveSession, t))
+  const pageLabel = PAGE_LABELS[currentPage] || currentPage
+
+  return (
+    <div className="flex flex-col h-[400px]">
+      {/* Thread switcher toolbar (S2) */}
+      <div className="relative px-3 pb-1.5">
+        <div className="flex items-center gap-1">
+          <button
+            onClick={() => {
+              setThreadsOpen((v) => !v)
+              if (!threadsOpen) refreshThreads().catch(() => {})
+            }}
+            className="flex min-w-0 flex-1 items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+            title="Conversations"
+          >
+            <ChevronDown
+              className={`w-3 h-3 shrink-0 transition-transform ${threadsOpen ? 'rotate-180' : ''}`}
+            />
+            <span className="truncate">
+              {activeThread?.title || (activeChatId ? 'Conversation' : 'New conversation')}
+            </span>
+            {hasUnread && (
+              <span
+                className="w-1.5 h-1.5 rounded-full bg-primary shrink-0"
+                aria-label="Unread messages"
+              />
+            )}
+          </button>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={startNewThread}
+            className="h-6 w-6 p-0 shrink-0 text-muted-foreground hover:text-foreground"
+            title="New thread"
+          >
+            <Plus className="w-3.5 h-3.5" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={openFullChat}
+            className="h-6 w-6 p-0 shrink-0 text-muted-foreground hover:text-foreground"
+            title="Open in full chat"
+          >
+            <ArrowUpRight className="w-3.5 h-3.5" />
+          </Button>
+        </div>
+
+        {threadsOpen && (
+          <>
+            {/* Click-outside catcher */}
+            <div className="fixed inset-0 z-10" onClick={() => setThreadsOpen(false)} />
+            <div className="absolute left-2 right-2 top-7 z-20 overflow-hidden rounded-xl border border-border/60 bg-background/95 backdrop-blur-xl shadow-xl">
+              <button
+                onClick={startNewThread}
+                className="flex w-full items-center gap-2 px-3 py-2 text-xs text-foreground hover:bg-secondary/40 transition-colors"
+              >
+                <Plus className="w-3 h-3" />
+                New thread
+              </button>
+              {listedThreads.length > 0 && <div className="h-px bg-border/50" />}
+              <div className="max-h-56 overflow-y-auto">
+                {listedThreads.map((thread) => (
+                  <div
+                    key={thread.id}
+                    role="button"
+                    tabIndex={0}
+                    onClick={() => switchThread(thread)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault()
+                        switchThread(thread)
+                      }
+                    }}
+                    className={`group flex w-full cursor-pointer flex-col gap-0.5 px-3 py-2 text-left transition-colors hover:bg-secondary/40 ${
+                      thread.id === activeChatId ? 'bg-secondary/30' : ''
+                    }`}
+                  >
+                    <div className="flex items-center gap-1.5">
+                      {isThreadUnread(effectiveSession, thread) && (
+                        <span className="w-1.5 h-1.5 rounded-full bg-primary shrink-0" />
+                      )}
+                      <span className="min-w-0 flex-1 truncate text-xs font-medium text-foreground">
+                        {thread.title}
+                      </span>
+                      <span className="shrink-0 text-[10px] text-muted-foreground">
+                        {threadTimeAgo(thread.updatedAt)}
+                      </span>
+                      <button
+                        onClick={(e) => closeThread(thread, e)}
+                        className="shrink-0 text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-hover:opacity-100"
+                        title="Close thread"
+                        aria-label={`Close thread ${thread.title}`}
+                      >
+                        <X className="w-3 h-3" />
+                      </button>
+                    </div>
+                    {thread.lastMessagePreview && (
+                      <p className="truncate text-[11px] text-muted-foreground">
+                        {thread.lastMessagePreview}
+                      </p>
+                    )}
+                  </div>
+                ))}
+              </div>
+              <div className="h-px bg-border/50" />
+              <button
+                onClick={openFullChat}
+                className="flex w-full items-center gap-2 px-3 py-2 text-xs text-muted-foreground hover:bg-secondary/40 hover:text-foreground transition-colors"
+              >
+                <ArrowUpRight className="w-3 h-3" />
+                Open in full chat
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+
+      {reconnecting ? (
+        <div className="flex flex-1 flex-col items-center justify-center gap-2 text-muted-foreground">
+          <Loader2 className="w-4 h-4 animate-spin" />
+          <p className="text-xs">Continuing conversation…</p>
+        </div>
+      ) : (
+        <WidgetConversation
+          key={conversationInstance}
+          initialChatId={activeChatId}
+          initialMessages={seedMessages}
+          pageLabel={pageLabel}
+          onChatIdAssigned={handleChatIdAssigned}
+        />
+      )}
+    </div>
+  )
+}
+
+function WidgetConversation({
+  initialChatId,
+  initialMessages,
+  pageLabel,
+  onChatIdAssigned,
+}: {
+  initialChatId: string | null
+  initialMessages: ChatMessage[]
+  pageLabel: string
+  onChatIdAssigned: (chatId: string) => void
+}) {
   const inputRef = useRef<HTMLInputElement>(null)
   const scrollRef = useRef<HTMLDivElement>(null)
   const [inputValue, setInputValue] = useState('')
@@ -77,20 +386,13 @@ function AutoChatTab({ currentPage, onClose }: { currentPage: string; onClose?: 
     sendMessage,
     stop,
   } = useChat({
-    id: 'auto-widget',
+    // Empty id → the backend creates the chat and streams its id back.
+    id: initialChatId ?? '',
+    initialMessages,
     selectedAgentId: undefined, // Routes to Auto (default agent)
+    pageContext: pageLabel,
+    onChatIdUpdate: onChatIdAssigned,
   })
-
-  const handleOpenFullChat = () => {
-    // Stash widget messages so the full chat page can pick them up
-    if (messages.length > 0) {
-      try {
-        sessionStorage.setItem('auto-widget-handoff', JSON.stringify(messages))
-      } catch { /* quota exceeded — navigate anyway */ }
-    }
-    onClose?.()
-    router.push('/chat')
-  }
 
   // Auto-scroll on new messages
   useEffect(() => {
@@ -102,14 +404,7 @@ function AutoChatTab({ currentPage, onClose }: { currentPage: string; onClose?: 
   const handleSend = () => {
     const text = inputValue.trim()
     if (!text || isLoading) return
-
-    // Prepend page context as a quiet hint on first message
-    const pageLabel = PAGE_LABELS[currentPage] || currentPage
-    const contextHint = messages.length === 0
-      ? `[Context: User is on the ${pageLabel} page]\n\n${text}`
-      : text
-
-    sendMessage(contextHint)
+    sendMessage(text)
     setInputValue('')
   }
 
@@ -121,7 +416,7 @@ function AutoChatTab({ currentPage, onClose }: { currentPage: string; onClose?: 
   }
 
   return (
-    <div className="flex flex-col h-[400px]">
+    <div className="flex min-h-0 flex-1 flex-col">
       {/* Messages area */}
       <div
         ref={scrollRef}
@@ -134,7 +429,7 @@ function AutoChatTab({ currentPage, onClose }: { currentPage: string; onClose?: 
             </div>
             <p className="text-sm font-medium text-foreground mb-1">Hey, I'm Auto</p>
             <p className="text-xs text-muted-foreground">
-              Ask me anything about {PAGE_LABELS[currentPage] || 'this page'}, or tell me what you need help with.
+              Ask me anything about {pageLabel || 'this page'}, or tell me what you need help with.
             </p>
           </div>
         )}
@@ -172,19 +467,6 @@ function AutoChatTab({ currentPage, onClose }: { currentPage: string; onClose?: 
           </div>
         )}
       </div>
-
-      {/* Open in full chat — carries conversation context */}
-      {messages.length > 0 && (
-        <div className="px-3 pb-1">
-          <button
-            onClick={handleOpenFullChat}
-            className="flex items-center gap-1 text-xs text-muted-foreground hover:text-primary transition-colors"
-          >
-            <ArrowUpRight className="w-3 h-3" />
-            Open in full chat
-          </button>
-        </div>
-      )}
 
       {/* Input area */}
       <div className="px-3 pb-3 pt-1">

--- a/frontend/lib/chat/hooks.ts
+++ b/frontend/lib/chat/hooks.ts
@@ -11,6 +11,7 @@ export function useChat({
   selectedAgentId,
   missionMode = false,
   planMode = false,
+  pageContext,
   onData,
   onChatIdUpdate,
   onRoutingDecision,
@@ -20,6 +21,9 @@ export function useChat({
   selectedAgentId?: number | null
   missionMode?: boolean
   planMode?: boolean
+  // PRD-220: where the user is (widget). Sent as request context, injected
+  // prompt-side by the backend — never stored in the message or the title.
+  pageContext?: string
   onData?: (data: any) => void
   onChatIdUpdate?: (chatId: string) => void
   onRoutingDecision?: (info: RoutingInfo) => void
@@ -120,6 +124,8 @@ export function useChat({
             ...(missionMode ? { missionMode: true } : {}),
             // Plan mode — research and strategy, no execution
             ...(planMode ? { planMode: true } : {}),
+            // PRD-220: page context for the widget (prompt-only server-side)
+            ...(pageContext ? { context: { page: pageContext } } : {}),
           }),
           signal: abortControllerRef.current.signal,
         })
@@ -377,7 +383,7 @@ export function useChat({
         setIsLoading(false)
       }
     },
-    [chatId, isLoading, selectedAgentId, missionMode, planMode, onData, onChatIdUpdate, onRoutingDecision]
+    [chatId, isLoading, selectedAgentId, missionMode, planMode, pageContext, onData, onChatIdUpdate, onRoutingDecision]
   )
 
   return {

--- a/frontend/lib/chat/widget-session.test.ts
+++ b/frontend/lib/chat/widget-session.test.ts
@@ -1,0 +1,143 @@
+/**
+ * PRD-220: widget chat session persistence — storage semantics.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  EMPTY_WIDGET_SESSION,
+  MAX_WIDGET_THREADS,
+  WIDGET_SESSION_TTL_MS,
+  isThreadUnread,
+  loadWidgetSession,
+  saveWidgetSession,
+  threadTimeAgo,
+  visibleThreads,
+  widgetSessionKey,
+  withActiveChat,
+  withThreadClosed,
+  withThreadRead,
+  withoutActiveChat,
+  type WidgetChatSession,
+} from './widget-session'
+
+const NOW = 1_800_000_000_000
+const KEY = widgetSessionKey('ws-1', 'user-1')
+
+describe('widgetSessionKey', () => {
+  it('scopes by workspace and user', () => {
+    expect(widgetSessionKey('ws-1', 'u-1')).not.toBe(widgetSessionKey('ws-2', 'u-1'))
+    expect(widgetSessionKey('ws-1', 'u-1')).not.toBe(widgetSessionKey('ws-1', 'u-2'))
+  })
+
+  it('falls back for missing scope parts', () => {
+    expect(widgetSessionKey(null, undefined)).toBe('automatos:widget:chat:default:anon')
+  })
+})
+
+describe('load/save round-trip', () => {
+  beforeEach(() => localStorage.clear())
+
+  it('returns the empty session when nothing is stored', () => {
+    expect(loadWidgetSession(KEY, NOW)).toEqual(EMPTY_WIDGET_SESSION)
+  })
+
+  it('round-trips a saved session', () => {
+    const session = withActiveChat(EMPTY_WIDGET_SESSION, 'chat-1', NOW)
+    saveWidgetSession(KEY, session)
+    expect(loadWidgetSession(KEY, NOW)).toEqual(session)
+  })
+
+  it('drops corrupt JSON and invalid shapes', () => {
+    localStorage.setItem(KEY, '{not json')
+    expect(loadWidgetSession(KEY, NOW)).toEqual(EMPTY_WIDGET_SESSION)
+
+    localStorage.setItem(KEY, JSON.stringify({ activeChatId: 7, lastActiveAt: 'x' }))
+    expect(loadWidgetSession(KEY, NOW)).toEqual(EMPTY_WIDGET_SESSION)
+  })
+
+  it('expires only the resume pointer after the TTL, keeping read markers', () => {
+    const session = withActiveChat(EMPTY_WIDGET_SESSION, 'chat-1', NOW)
+    saveWidgetSession(KEY, session)
+
+    const later = NOW + WIDGET_SESSION_TTL_MS + 1
+    const loaded = loadWidgetSession(KEY, later)
+    expect(loaded.activeChatId).toBeNull()
+    expect(loaded.lastReadAt['chat-1']).toBe(NOW)
+  })
+
+  it('resumes within the TTL', () => {
+    saveWidgetSession(KEY, withActiveChat(EMPTY_WIDGET_SESSION, 'chat-1', NOW))
+    expect(loadWidgetSession(KEY, NOW + WIDGET_SESSION_TTL_MS - 1).activeChatId).toBe('chat-1')
+  })
+})
+
+describe('immutable updaters', () => {
+  it('withActiveChat never mutates and reopens closed threads', () => {
+    const closed = withThreadClosed(EMPTY_WIDGET_SESSION, 'chat-1', NOW)
+    const before = JSON.parse(JSON.stringify(closed)) as WidgetChatSession
+
+    const next = withActiveChat(closed, 'chat-1', NOW + 1)
+
+    expect(closed).toEqual(before)
+    expect(next.activeChatId).toBe('chat-1')
+    expect(next.closedThreadIds).not.toContain('chat-1')
+    expect(next.lastReadAt['chat-1']).toBe(NOW + 1)
+  })
+
+  it('withoutActiveChat clears the pointer only', () => {
+    const active = withActiveChat(EMPTY_WIDGET_SESSION, 'chat-1', NOW)
+    const next = withoutActiveChat(active, NOW + 5)
+    expect(next.activeChatId).toBeNull()
+    expect(next.lastReadAt).toEqual(active.lastReadAt)
+    expect(active.activeChatId).toBe('chat-1')
+  })
+
+  it('withThreadClosed clears the active pointer when closing the active thread', () => {
+    const active = withActiveChat(EMPTY_WIDGET_SESSION, 'chat-1', NOW)
+    const next = withThreadClosed(active, 'chat-1', NOW + 1)
+    expect(next.activeChatId).toBeNull()
+    expect(next.closedThreadIds).toContain('chat-1')
+  })
+
+  it('withThreadRead is a no-op for null ids', () => {
+    expect(withThreadRead(EMPTY_WIDGET_SESSION, null, NOW)).toBe(EMPTY_WIDGET_SESSION)
+  })
+})
+
+describe('isThreadUnread', () => {
+  const at = (ms: number) => new Date(ms).toISOString()
+
+  it('flags threads that moved since last read', () => {
+    const session = withThreadRead(EMPTY_WIDGET_SESSION, 'chat-1', NOW)
+    expect(isThreadUnread(session, { id: 'chat-1', updatedAt: at(NOW + 1000) })).toBe(true)
+    expect(isThreadUnread(session, { id: 'chat-1', updatedAt: at(NOW - 1000) })).toBe(false)
+  })
+
+  it('never flags the active thread or never-opened threads', () => {
+    const session = withActiveChat(EMPTY_WIDGET_SESSION, 'chat-1', NOW)
+    expect(isThreadUnread(session, { id: 'chat-1', updatedAt: at(NOW + 9999) })).toBe(false)
+    // chat-2 has no baseline — no badge.
+    expect(isThreadUnread(session, { id: 'chat-2', updatedAt: at(NOW + 9999) })).toBe(false)
+  })
+})
+
+describe('visibleThreads', () => {
+  const threads = Array.from({ length: 8 }, (_, i) => ({ id: `chat-${i}` }))
+
+  it('filters closed threads and caps the list', () => {
+    const session = withThreadClosed(EMPTY_WIDGET_SESSION, 'chat-0', NOW)
+    const visible = visibleThreads(threads, session)
+    expect(visible).toHaveLength(MAX_WIDGET_THREADS)
+    expect(visible.map((t) => t.id)).not.toContain('chat-0')
+    expect(visible[0].id).toBe('chat-1')
+  })
+})
+
+describe('threadTimeAgo', () => {
+  it('formats compact relative times', () => {
+    expect(threadTimeAgo(new Date(NOW - 30_000).toISOString(), NOW)).toBe('now')
+    expect(threadTimeAgo(new Date(NOW - 5 * 60_000).toISOString(), NOW)).toBe('5m')
+    expect(threadTimeAgo(new Date(NOW - 3 * 3_600_000).toISOString(), NOW)).toBe('3h')
+    expect(threadTimeAgo(new Date(NOW - 49 * 3_600_000).toISOString(), NOW)).toBe('2d')
+    expect(threadTimeAgo('garbage', NOW)).toBe('')
+  })
+})

--- a/frontend/lib/chat/widget-session.ts
+++ b/frontend/lib/chat/widget-session.ts
@@ -1,0 +1,180 @@
+/**
+ * Widget chat session persistence (PRD-220).
+ *
+ * The Auto widget remounts on every navigation (MainLayout is instantiated
+ * per page), so which conversation it was in must live outside React. Only
+ * identifiers and timestamps are stored — never message content.
+ *
+ * All updaters return new objects; nothing here mutates its inputs.
+ */
+
+/** Resume window — an active thread older than this starts fresh (S1). */
+export const WIDGET_SESSION_TTL_MS = 24 * 60 * 60 * 1000
+
+/** Thread rows shown in the switcher; older threads live in full chat (S2). */
+export const MAX_WIDGET_THREADS = 5
+
+/** Cap on tracked read/closed entries so the storage entry can't grow unbounded. */
+const MAX_TRACKED_THREADS = 50
+
+const STORAGE_PREFIX = 'automatos:widget:chat'
+
+export interface WidgetChatSession {
+  /** Conversation the widget reconnects to on mount; null = start fresh. */
+  activeChatId: string | null
+  /** Last interaction (ms epoch) — drives the 24h resume window. */
+  lastActiveAt: number
+  /** Per-thread last-viewed timestamps (ms epoch) — drives unread badges. */
+  lastReadAt: Record<string, number>
+  /** Threads hidden from the switcher (conversation itself is never deleted). */
+  closedThreadIds: string[]
+}
+
+export const EMPTY_WIDGET_SESSION: WidgetChatSession = Object.freeze({
+  activeChatId: null,
+  lastActiveAt: 0,
+  lastReadAt: {},
+  closedThreadIds: [],
+})
+
+/** Storage key scoped to workspace + user so sessions never leak across either. */
+export function widgetSessionKey(
+  workspaceId: string | null | undefined,
+  userId: string | null | undefined
+): string {
+  return `${STORAGE_PREFIX}:${workspaceId || 'default'}:${userId || 'anon'}`
+}
+
+function isValidSession(value: unknown): value is WidgetChatSession {
+  if (typeof value !== 'object' || value === null) return false
+  const v = value as Record<string, unknown>
+  if (v.activeChatId !== null && typeof v.activeChatId !== 'string') return false
+  if (typeof v.lastActiveAt !== 'number' || !Number.isFinite(v.lastActiveAt)) return false
+  if (typeof v.lastReadAt !== 'object' || v.lastReadAt === null) return false
+  if (!Object.values(v.lastReadAt as Record<string, unknown>).every((t) => typeof t === 'number')) return false
+  if (!Array.isArray(v.closedThreadIds)) return false
+  if (!(v.closedThreadIds as unknown[]).every((id) => typeof id === 'string')) return false
+  return true
+}
+
+export function loadWidgetSession(key: string, now: number = Date.now()): WidgetChatSession {
+  if (typeof window === 'undefined') return EMPTY_WIDGET_SESSION
+  try {
+    const raw = window.localStorage.getItem(key)
+    if (!raw) return EMPTY_WIDGET_SESSION
+    const parsed: unknown = JSON.parse(raw)
+    if (!isValidSession(parsed)) return EMPTY_WIDGET_SESSION
+    // Only the resume pointer expires; read markers are kept so unread
+    // badges stay honest across the expiry.
+    if (parsed.activeChatId && now - parsed.lastActiveAt > WIDGET_SESSION_TTL_MS) {
+      return { ...parsed, activeChatId: null }
+    }
+    return parsed
+  } catch {
+    return EMPTY_WIDGET_SESSION
+  }
+}
+
+export function saveWidgetSession(key: string, session: WidgetChatSession): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(key, JSON.stringify(session))
+  } catch {
+    // Quota exceeded / private mode — the widget degrades to ephemeral.
+  }
+}
+
+/** Switch to (or land in) a thread — also reopens it if previously closed. */
+export function withActiveChat(
+  session: WidgetChatSession,
+  chatId: string,
+  now: number = Date.now()
+): WidgetChatSession {
+  return {
+    ...session,
+    activeChatId: chatId,
+    lastActiveAt: now,
+    lastReadAt: capRecord({ ...session.lastReadAt, [chatId]: now }),
+    closedThreadIds: session.closedThreadIds.filter((id) => id !== chatId),
+  }
+}
+
+export function withoutActiveChat(
+  session: WidgetChatSession,
+  now: number = Date.now()
+): WidgetChatSession {
+  return { ...session, activeChatId: null, lastActiveAt: now }
+}
+
+export function withThreadRead(
+  session: WidgetChatSession,
+  chatId: string | null,
+  now: number = Date.now()
+): WidgetChatSession {
+  if (!chatId) return session
+  return {
+    ...session,
+    lastActiveAt: now,
+    lastReadAt: capRecord({ ...session.lastReadAt, [chatId]: now }),
+  }
+}
+
+/** Hide a thread from the switcher; clears the active pointer if it was active. */
+export function withThreadClosed(
+  session: WidgetChatSession,
+  chatId: string,
+  now: number = Date.now()
+): WidgetChatSession {
+  const closedThreadIds = [
+    chatId,
+    ...session.closedThreadIds.filter((id) => id !== chatId),
+  ].slice(0, MAX_TRACKED_THREADS)
+  const next = { ...session, closedThreadIds }
+  return session.activeChatId === chatId
+    ? { ...next, activeChatId: null, lastActiveAt: now }
+    : next
+}
+
+/**
+ * Unread = the thread moved since the user last viewed it in the widget.
+ * Threads never opened in the widget have no baseline and show no badge.
+ */
+export function isThreadUnread(
+  session: WidgetChatSession,
+  thread: { id: string; updatedAt: string }
+): boolean {
+  if (thread.id === session.activeChatId) return false
+  const lastRead = session.lastReadAt[thread.id]
+  if (!lastRead) return false
+  const updated = Date.parse(thread.updatedAt)
+  return Number.isFinite(updated) && updated > lastRead
+}
+
+/** Switcher rows: closed threads filtered out, capped at `max`. */
+export function visibleThreads<T extends { id: string }>(
+  threads: T[],
+  session: WidgetChatSession,
+  max: number = MAX_WIDGET_THREADS
+): T[] {
+  const closed = new Set(session.closedThreadIds)
+  return threads.filter((t) => !closed.has(t.id)).slice(0, max)
+}
+
+/** Compact relative timestamp for thread rows ("now", "5m", "3h", "2d"). */
+export function threadTimeAgo(iso: string, now: number = Date.now()): string {
+  const then = Date.parse(iso)
+  if (!Number.isFinite(then)) return ''
+  const diffMinutes = Math.floor((now - then) / 60_000)
+  if (diffMinutes < 1) return 'now'
+  if (diffMinutes < 60) return `${diffMinutes}m`
+  const diffHours = Math.floor(diffMinutes / 60)
+  if (diffHours < 24) return `${diffHours}h`
+  return `${Math.floor(diffHours / 24)}d`
+}
+
+function capRecord(record: Record<string, number>): Record<string, number> {
+  const keys = Object.keys(record)
+  if (keys.length <= MAX_TRACKED_THREADS) return record
+  const keep = keys.sort((a, b) => record[b] - record[a]).slice(0, MAX_TRACKED_THREADS)
+  return Object.fromEntries(keep.map((k) => [k, record[k]]))
+}

--- a/frontend/types/chat.ts
+++ b/frontend/types/chat.ts
@@ -206,6 +206,8 @@ export interface Chat {
   updatedAt: string
   visibility: VisibilityType
   lastContext?: AppUsage
+  /** PRD-220: latest message text (truncated server-side) for thread lists. */
+  lastMessagePreview?: string | null
 }
 
 /**

--- a/orchestrator/api/chat.py
+++ b/orchestrator/api/chat.py
@@ -172,6 +172,70 @@ def get_default_agent_id(db: Session, workspace_id) -> int:
     )
 
 
+def _parts_text(parts) -> str:
+    """Flatten a message's ``parts`` JSONB into plain text."""
+    if not isinstance(parts, list):
+        return ""
+    return " ".join(
+        p.get("text", "") for p in parts if isinstance(p, dict) and p.get("text")
+    ).strip()
+
+
+_PREVIEW_MAX_CHARS = 80
+
+
+def _last_message_previews(db: Session, chat_ids: List[str]) -> dict:
+    """Latest message text per chat, truncated — one query for the whole page (PRD-220 S2)."""
+    if not chat_ids:
+        return {}
+    rows = db.execute(
+        text("""
+            SELECT DISTINCT ON (m.chat_id) m.chat_id, m.parts
+            FROM messages m
+            WHERE m.chat_id = ANY(CAST(:ids AS uuid[]))
+            ORDER BY m.chat_id, m.created_at DESC
+        """),
+        {"ids": chat_ids},
+    ).fetchall()
+    previews = {}
+    for r in rows:
+        content = _parts_text(r.parts)
+        if len(content) > _PREVIEW_MAX_CHARS:
+            content = content[: _PREVIEW_MAX_CHARS - 1] + "…"
+        previews[str(r.chat_id)] = content
+    return previews
+
+
+_PAGE_CONTEXT_MAX_LEN = 80
+
+
+def _inject_page_context(message_history: List[dict], page: Optional[str]) -> List[dict]:
+    """Return ``message_history`` with an ephemeral page-context part on the last
+    user message (PRD-220).
+
+    The widget used to prepend "[Context: …]" into the message text itself, so
+    the hint leaked into the saved message AND the auto-generated chat title.
+    Now the client sends ``request.context = {"page": <label>}`` and the hint is
+    added prompt-side only, AFTER the clean save. Entries are rebuilt, never
+    mutated — ``parts`` here is the ORM row's JSONB list, and an in-place append
+    could flush the hint into the ``messages`` table.
+    """
+    if not page or not isinstance(page, str):
+        return message_history
+    label = page.strip()[:_PAGE_CONTEXT_MAX_LEN]
+    if not label:
+        return message_history
+    for i in range(len(message_history) - 1, -1, -1):
+        entry = message_history[i]
+        if entry.get("role") != "user":
+            continue
+        parts = entry.get("parts") if isinstance(entry.get("parts"), list) else []
+        hint = {"type": "text", "text": f"[Context: the user is currently on the {label} page]"}
+        rebuilt = {**entry, "parts": [*parts, hint]}
+        return [*message_history[:i], rebuilt, *message_history[i + 1:]]
+    return message_history
+
+
 # Endpoints
 @router.post("", dependencies=[Depends(require_workspace_permission("agents:execute"))])
 async def stream_chat(
@@ -309,7 +373,13 @@ async def stream_chat(
                     f"into message_history[{_i}]"
                 )
                 break
-    
+
+    # PRD-220: page context rides in request.context = {"page": <label>} and is
+    # injected prompt-side only — the user message was already saved clean above,
+    # so chat titles and reloaded history never show the hint.
+    _page_ctx = request.context.get("page") if isinstance(request.context, dict) else None
+    message_history = _inject_page_context(message_history, _page_ctx)
+
     # DEBUG: Log incoming request
     logger.info(f"Chat request - agentId: {request.agentId}")
 
@@ -508,7 +578,8 @@ async def get_chat_history(
     user_id = get_user_id(db, ctx)
 
     chats = chat_service.get_chat_history(user_id=user_id, limit=limit, workspace_id=ctx.workspace_id)
-    
+    previews = _last_message_previews(db, [str(chat.id) for chat in chats])
+
     return [
         {
             "id": str(chat.id),
@@ -517,10 +588,69 @@ async def get_chat_history(
             "createdAt": chat.created_at.isoformat(),
             "updatedAt": chat.updated_at.isoformat(),
             "visibility": chat.visibility,
-            "lastContext": chat.last_context
+            "lastContext": chat.last_context,
+            "lastMessagePreview": previews.get(str(chat.id))
         }
         for chat in chats
     ]
+
+
+@router.get("/search")
+async def search_chat_history(
+    q: str,
+    limit: int = 20,
+    days: int = 30,
+    ctx: RequestContext = Depends(get_request_context_hybrid),
+    db: Session = Depends(get_db),
+):
+    """Search across chat messages by keyword (workspace-scoped).
+
+    MUST be registered before ``GET /{chat_id}`` — routes match in declaration
+    order, so with this below the param route ``/api/chat/search`` resolved as
+    ``chat_id="search"`` and 404'd (PRD-220 drive-by fix).
+    """
+    from datetime import datetime, timedelta
+
+    user_id = get_user_id(db, ctx)
+    since = datetime.utcnow() - timedelta(days=min(days, 365))
+    search_term = f"%{q}%"
+
+    rows = db.execute(
+        text("""
+            SELECT m.id, m.chat_id, m.role, m.parts, m.created_at,
+                   c.title AS chat_title
+            FROM messages m
+            JOIN chats c ON c.id = m.chat_id
+            WHERE c.user_id = :user_id
+              AND c.workspace_id = :workspace_id
+              AND m.created_at >= :since
+              AND EXISTS (
+                  SELECT 1 FROM jsonb_array_elements(m.parts) AS p
+                  WHERE p->>'text' ILIKE :search
+              )
+            ORDER BY m.created_at DESC
+            LIMIT :lim
+        """),
+        {"user_id": user_id, "workspace_id": str(ctx.workspace_id), "since": since, "search": search_term, "lim": min(limit, 100)},
+    ).fetchall()
+
+    results = []
+    for r in rows:
+        # Extract text content from parts
+        parts = r.parts if isinstance(r.parts, list) else []
+        text_content = " ".join(
+            p.get("text", "") for p in parts if isinstance(p, dict) and p.get("text")
+        )
+        results.append({
+            "message_id": str(r.id),
+            "chat_id": str(r.chat_id),
+            "chat_title": r.chat_title,
+            "role": r.role,
+            "content": text_content[:500],
+            "created_at": r.created_at.isoformat() if r.created_at else None,
+        })
+
+    return {"query": q, "total": len(results), "results": results}
 
 
 @router.get("/{chat_id}")
@@ -581,59 +711,6 @@ async def get_chat_messages(
         }
         for msg in messages
     ]
-
-
-@router.get("/search")
-async def search_chat_history(
-    q: str,
-    limit: int = 20,
-    days: int = 30,
-    ctx: RequestContext = Depends(get_request_context_hybrid),
-    db: Session = Depends(get_db),
-):
-    """Search across chat messages by keyword (workspace-scoped)."""
-    from datetime import datetime, timedelta
-
-    user_id = get_user_id(db, ctx)
-    since = datetime.utcnow() - timedelta(days=min(days, 365))
-    search_term = f"%{q}%"
-
-    rows = db.execute(
-        text("""
-            SELECT m.id, m.chat_id, m.role, m.parts, m.created_at,
-                   c.title AS chat_title
-            FROM messages m
-            JOIN chats c ON c.id = m.chat_id
-            WHERE c.user_id = :user_id
-              AND c.workspace_id = :workspace_id
-              AND m.created_at >= :since
-              AND EXISTS (
-                  SELECT 1 FROM jsonb_array_elements(m.parts) AS p
-                  WHERE p->>'text' ILIKE :search
-              )
-            ORDER BY m.created_at DESC
-            LIMIT :lim
-        """),
-        {"user_id": user_id, "workspace_id": str(ctx.workspace_id), "since": since, "search": search_term, "lim": min(limit, 100)},
-    ).fetchall()
-
-    results = []
-    for r in rows:
-        # Extract text content from parts
-        parts = r.parts if isinstance(r.parts, list) else []
-        text_content = " ".join(
-            p.get("text", "") for p in parts if isinstance(p, dict) and p.get("text")
-        )
-        results.append({
-            "message_id": str(r.id),
-            "chat_id": str(r.chat_id),
-            "chat_title": r.chat_title,
-            "role": r.role,
-            "content": text_content[:500],
-            "created_at": r.created_at.isoformat() if r.created_at else None,
-        })
-
-    return {"query": q, "total": len(results), "results": results}
 
 
 @router.delete("/{chat_id}", dependencies=[Depends(require_workspace_permission("agents:execute"))])

--- a/orchestrator/consumers/chatbot/service.py
+++ b/orchestrator/consumers/chatbot/service.py
@@ -318,13 +318,19 @@ class ChatService:
         starting_after: Optional[datetime] = None,
         workspace_id: Optional[uuid.UUID] = None,
     ) -> List[Chat]:
-        """Get chat history for a user within a workspace."""
+        """Get chat history for a user within a workspace.
+
+        Ordered by most recent activity (``updated_at`` — bumped on every
+        ``save_message``), not creation time, so a thread that just received a
+        message surfaces first (PRD-220 S2). ``starting_after`` pages on the
+        same key.
+        """
         query = self.db.query(Chat).filter(Chat.user_id == user_id)
         if workspace_id is not None:
             query = query.filter(Chat.workspace_id == workspace_id)
         if starting_after:
-            query = query.filter(Chat.created_at < starting_after)
-        return query.order_by(desc(Chat.created_at)).limit(limit).all()
+            query = query.filter(Chat.updated_at < starting_after)
+        return query.order_by(desc(Chat.updated_at)).limit(limit).all()
 
     def update_chat_title(self, chat_id: str, title: str) -> bool:
         """Update chat title, handling unique constraint violations."""

--- a/orchestrator/tests/test_p3_widget_chat_persistence.py
+++ b/orchestrator/tests/test_p3_widget_chat_persistence.py
@@ -1,0 +1,151 @@
+"""PRD-220: persistent & multi-threaded widget chat — backend seams.
+
+Covers the three backend changes:
+
+1. Route order — ``GET /api/chat/search`` must be registered BEFORE
+   ``GET /api/chat/{chat_id}``. Routes match in declaration order, so the old
+   placement resolved ``/api/chat/search`` as ``chat_id="search"`` and 404'd.
+2. ``_inject_page_context`` — the widget's page hint is added prompt-side only,
+   AFTER the clean save, by rebuilding (never mutating) the history entries.
+3. ``_last_message_previews`` — thread-list previews for ``GET /api/chat/history``.
+
+Pure unit tests — no DB / network (db is mocked), matching
+``test_p2w0_chat_identity.py``.
+"""
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _api_chat():
+    try:
+        import api.chat as chat_module
+    except Exception as e:  # env without the heavy router deps
+        pytest.skip(f"api.chat not importable in this env: {e}")
+    return chat_module
+
+
+# ---------------------------------------------------------------------------
+# 1. Route order — /search before /{chat_id}
+# ---------------------------------------------------------------------------
+
+def test_search_route_registered_before_chat_id_param_route():
+    chat_module = _api_chat()
+    get_paths = [
+        r.path
+        for r in chat_module.router.routes
+        if "GET" in (getattr(r, "methods", None) or set())
+    ]
+    assert "/api/chat/search" in get_paths, get_paths
+    assert "/api/chat/{chat_id}" in get_paths, get_paths
+    assert get_paths.index("/api/chat/search") < get_paths.index("/api/chat/{chat_id}"), (
+        "GET /search must be declared before GET /{chat_id} or it resolves as "
+        f"chat_id='search'. Current GET order: {get_paths}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. _inject_page_context
+# ---------------------------------------------------------------------------
+
+def test_page_context_appended_to_last_user_message_only():
+    chat_module = _api_chat()
+    history = [
+        {"role": "user", "parts": [{"type": "text", "text": "first"}]},
+        {"role": "assistant", "parts": [{"type": "text", "text": "reply"}]},
+        {"role": "user", "parts": [{"type": "text", "text": "second"}]},
+    ]
+    out = chat_module._inject_page_context(history, "Dashboard")
+
+    assert len(out) == 3
+    # Earlier messages untouched (same objects — no rebuild needed for them).
+    assert out[0] is history[0]
+    assert out[1] is history[1]
+    # Last user message got exactly one extra part carrying the hint.
+    assert len(out[2]["parts"]) == 2
+    assert out[2]["parts"][0] == {"type": "text", "text": "second"}
+    assert "Dashboard" in out[2]["parts"][1]["text"]
+    assert out[2]["parts"][1]["type"] == "text"
+
+
+def test_page_context_never_mutates_inputs():
+    """The parts list is the ORM row's JSONB — in-place edits could get flushed."""
+    chat_module = _api_chat()
+    original_parts = [{"type": "text", "text": "hello"}]
+    history = [{"role": "user", "parts": original_parts}]
+
+    out = chat_module._inject_page_context(history, "Agent Management")
+
+    assert original_parts == [{"type": "text", "text": "hello"}]
+    assert history[0]["parts"] is original_parts
+    assert out[0] is not history[0]
+    assert len(out[0]["parts"]) == 2
+
+
+def test_page_context_noop_when_absent_blank_or_no_user_message():
+    chat_module = _api_chat()
+    history = [{"role": "user", "parts": [{"type": "text", "text": "hi"}]}]
+
+    assert chat_module._inject_page_context(history, None) is history
+    assert chat_module._inject_page_context(history, "") is history
+    assert chat_module._inject_page_context(history, "   ") is history
+    assert chat_module._inject_page_context(history, 42) is history
+
+    assistant_only = [{"role": "assistant", "parts": [{"type": "text", "text": "yo"}]}]
+    assert chat_module._inject_page_context(assistant_only, "Dashboard") is assistant_only
+
+
+def test_page_context_label_is_truncated():
+    chat_module = _api_chat()
+    history = [{"role": "user", "parts": [{"type": "text", "text": "hi"}]}]
+    out = chat_module._inject_page_context(history, "x" * 500)
+    hint_text = out[0]["parts"][1]["text"]
+    assert "x" * chat_module._PAGE_CONTEXT_MAX_LEN in hint_text
+    assert "x" * (chat_module._PAGE_CONTEXT_MAX_LEN + 1) not in hint_text
+
+
+# ---------------------------------------------------------------------------
+# 3. _last_message_previews
+# ---------------------------------------------------------------------------
+
+def test_previews_empty_ids_short_circuits_without_query():
+    chat_module = _api_chat()
+    db = MagicMock()
+    assert chat_module._last_message_previews(db, []) == {}
+    db.execute.assert_not_called()
+
+
+def test_previews_maps_and_truncates():
+    chat_module = _api_chat()
+    long_text = "a" * 200
+    row_long = MagicMock()
+    row_long.chat_id = "11111111-1111-1111-1111-111111111111"
+    row_long.parts = [{"type": "text", "text": long_text}]
+    row_multi = MagicMock()
+    row_multi.chat_id = "22222222-2222-2222-2222-222222222222"
+    row_multi.parts = [
+        {"type": "text", "text": "I've created"},
+        {"type": "tool", "text": None},
+        {"type": "text", "text": "the playbook"},
+    ]
+    db = MagicMock()
+    db.execute.return_value.fetchall.return_value = [row_long, row_multi]
+
+    previews = chat_module._last_message_previews(db, [str(row_long.chat_id), str(row_multi.chat_id)])
+
+    assert previews[str(row_multi.chat_id)] == "I've created the playbook"
+    truncated = previews[str(row_long.chat_id)]
+    assert len(truncated) == chat_module._PREVIEW_MAX_CHARS
+    assert truncated.endswith("…")
+
+
+def test_previews_tolerates_non_list_parts():
+    chat_module = _api_chat()
+    row = MagicMock()
+    row.chat_id = "33333333-3333-3333-3333-333333333333"
+    row.parts = None
+    db = MagicMock()
+    db.execute.return_value.fetchall.return_value = [row]
+
+    previews = chat_module._last_message_previews(db, [str(row.chat_id)])
+    assert previews[str(row.chat_id)] == ""


### PR DESCRIPTION
## PRD-220 — Persistent & Multi-Threaded Widget Chat

The Auto widget now survives page navigation, supports multiple concurrent conversation threads, and promotes to full chat via a real deep-link. Built on the existing chat surface — **no new endpoints, no data-model changes, no route-manifest churn**.

### Why the build is smaller than the PRD's spec

Grounding the PRD against the live code moved most of the "new" surface to reuse:

- `GET /api/chat/history` already lists the user's workspace-scoped chats (auth-derived — the PRD's proposed `GET /api/conversations?user_id=` query-param contract would have been an IDOR vector). Extended in place instead of building a new endpoint.
- `GET /api/chat/{chat_id}/messages`, `PATCH /{chat_id}` (rename), and title auto-generation already exist.
- `useChat` already streams the server-assigned chat id via `onChatIdUpdate` — the widget just never passed it, sending a throwaway `'auto-widget'` id that orphaned a new chat row on every page load.
- The full chat page already supports `?chatId=` deep-links (client-side load, added to dodge the `/chat/[id]` server-fetch 404 problem).

### S1 — session persistence

- `frontend/lib/chat/widget-session.ts` (new): localStorage session scoped `automatos:widget:chat:<workspace>:<user>` — active chat id, 24h resume window, per-thread read markers, closed-thread list. Pure immutable updaters, shape-validated on load, corrupt data degrades to ephemeral.
- Widget reconnects on mount via `getChatMessages()` with a "Continuing conversation…" indicator; stale/inaccessible ids (deleted chat, workspace switch) clear the pointer and start fresh.
- Only the conversation id is stored — never message content.

### S2 — thread switcher

- Toolbar in the widget chat tab: current thread title, unread dot, new-thread, open-in-full-chat. Dropdown lists up to 5 recent threads (title, `lastMessagePreview`, compact timestamp, unread dot, close-on-hover).
- `GET /api/chat/history` now returns `lastMessagePreview` (one `DISTINCT ON` query per page) and orders by `updated_at` (most recent activity) instead of `created_at` — `save_message` already bumps `updated_at`.
- Unread = thread moved since last viewed **in the widget** (client-side markers; no schema change). Closing a thread hides it from the switcher only — the conversation stays in full-chat history.

### S3 — promote to full chat

- "Open in full chat" now navigates to `/chat?chatId=<id>` — same conversation, loaded from the DB.
- The `sessionStorage` `auto-widget-handoff` hack is **deleted on both sides** (widget writer + chat-page consumer).

### Page-context fix

The widget used to prepend `[Context: User is on the X page]` into the first message's text — which became the chat title and a visible message once threads persist. Now the client sends `context: {page}` on `ChatRequest` (field already existed, was unread) and `stream_chat` injects the hint prompt-side only, after the clean save, by rebuilding (never mutating) the in-memory history — an in-place edit of the ORM's JSONB list could flush the hint into the `messages` table.

### Drive-by fix

`GET /api/chat/search` was registered **after** `GET /{chat_id}`, so it resolved as `chat_id="search"` and 404'd — dead since birth (no frontend callers; Auto's internal search goes through the service layer). Moved above the param route with a structural regression test asserting registration order.

### Test plan

- [x] `orchestrator/tests/test_p3_widget_chat_persistence.py` — route-order regression, `_inject_page_context` (placement, immutability, no-ops, truncation), `_last_message_previews` (mapping, truncation, empty short-circuit, malformed parts)
- [x] `frontend/lib/chat/widget-session.test.ts` — key scoping, load/save round-trip, corrupt-data handling, 24h expiry (pointer only), immutable updaters, reopen-on-switch, unread logic, visible-thread capping, relative timestamps
- [ ] CI: orchestrator pytest (Postgres), frontend vitest + baselined tsc + eslint + route-contract (no new routes → no manifest change)
- [ ] Manual: chat in widget → navigate → conversation continues · start thread B → flip A/B intact · close thread → gone from switcher, present in full chat · promote → `/chat?chatId=` loads the thread · widget-started chats have clean titles (no `[Context:` prefix)

### Docs

`docs/VISION.md` §2 updated — "ephemeral by default" replaced with the persistent/multi-thread behaviour, and the trust-receipt line now describes the server-side context mechanism.