### PR TITLE
fix(prd-204): unhang orchestrator-tests -- validator import + teardow…

### DIFF
--- a/orchestrator/pytest.ini
+++ b/orchestrator/pytest.ini
@@ -23,6 +23,13 @@ testpaths =
     modules
     integrations
 
+# TEMPORARY DIAGNOSTIC (PR #545 hang hunt) -- REVERT ONCE GREEN.
+# With capture on, pytest redirects the real stderr fd into a buffer, so the
+# `-o faulthandler_timeout=90` watchdog dump the CI lane arms never reaches
+# the job log when the suite freezes. Capture off lets any further hang
+# print its exact stack into the log.
+addopts = --capture=no
+
 # pytest-asyncio 1.x already defaults to strict; pin it so a future default
 # flip can't silently change collection of @pytest.mark.asyncio tests.
 asyncio_mode = strict

--- a/orchestrator/services/blueprint_validator.py
+++ b/orchestrator/services/blueprint_validator.py
@@ -87,7 +87,11 @@ def validate_agent(
     # Rule: min_tools
     min_tools = rules.get("min_tools")
     if min_tools is not None:
-        from core.models.tool_assignments import AgentAppAssignment
+        # AgentAppAssignment lives in core.models.composio_cache (schema v2);
+        # core.models.tool_assignments only defines WorkspaceToolConfig. The
+        # old import raised ImportError on the FIRST min_tools evaluation --
+        # no test exercised this rule until PRD-204 S8's strict-spawn test.
+        from core.models.composio_cache import AgentAppAssignment
 
         tool_count = (
             db.query(AgentAppAssignment)

--- a/orchestrator/tests/test_prd204_watch_actions.py
+++ b/orchestrator/tests/test_prd204_watch_actions.py
@@ -52,7 +52,26 @@ def engine():
 
 @pytest.fixture
 def new_session(engine):
-    return sessionmaker(bind=engine, expire_on_commit=False)
+    """Session factory that REMEMBERS every session it hands out.
+
+    A test that dies mid-transaction (an exception between flush and commit)
+    abandons its session; pytest pins the failed frames -- and with them the
+    session and its uncommitted row locks -- via ``sys.last_traceback``. The
+    workspace teardown rolls these back before its DELETE sweep; without
+    that, the sweep blocks on the leaked lock FOREVER (pytest-timeout cancels
+    its per-item timer on any failure via pytest_exception_interact, so
+    nothing kills the wait -- the CI 30-minute silent hang on PR #545).
+    """
+    maker = sessionmaker(bind=engine, expire_on_commit=False)
+    created = []
+
+    def factory():
+        s = maker()
+        created.append(s)
+        return s
+
+    factory.created = created
+    return factory
 
 
 @pytest.fixture
@@ -71,7 +90,18 @@ def workspace(new_session):
 
     yield ws_id
 
+    # Release locks a failed test left behind (see new_session docstring).
+    for leaked in list(getattr(new_session, "created", [])):
+        try:
+            leaked.rollback()
+            leaked.close()
+        except Exception:  # noqa: BLE001 -- teardown must reach the sweep
+            pass
+
     s = new_session()
+    # Belt and braces: if anything else still holds a lock, fail LOUDLY in
+    # seconds instead of hanging the lane to the 30-minute job cap.
+    s.execute(text("SET LOCAL lock_timeout = '5s'"))
     for stmt in (
         "DELETE FROM watch_events WHERE watch_id IN "
         "(SELECT id FROM watches WHERE workspace_id = CAST(:w AS uuid))",


### PR DESCRIPTION
…n lock hygiene

Root cause of the 30-minute CI hang on test_spawn_strict_blueprint_failure_ rolls_back_agent: it is the FIRST test ever to evaluate a blueprint min_tools rule, and blueprint_validator imported AgentAppAssignment from core.models.tool_assignments -- which only defines WorkspaceToolConfig. The resulting ImportError killed the test mid-transaction (flushed watch UPDATE + agent INSERT, no commit). pytest pins failed frames via sys.last_traceback, so the session and its row locks never released, and pytest-timeout cancels its per-item timer on any failure (pytest_exception_interact), leaving the workspace teardown's DELETE FROM watches to block on the leaked lock until the job cap. The faulthandler dump went into the captured stderr fd, hence total silence.

- import AgentAppAssignment from core.models.composio_cache (the class's real home; matches handlers_agents.py)
- new_session fixture now tracks sessions; workspace teardown rolls back leaked sessions before the DELETE sweep and sets lock_timeout=5s so any residual blocker fails loudly instead of hanging the lane
- TEMPORARY pytest.ini addopts --capture=no so a further hang would print the faulthandler_timeout stack into the job log (revert once green)