### PR TITLE
fix(prd-204): post-merge green — savepoint-guard grant dispatch, probe P2-16 tag, revert capture diagnostic

### DIFF
--- a/orchestrator/pytest.ini
+++ b/orchestrator/pytest.ini
@@ -23,13 +23,6 @@ testpaths =
     modules
     integrations
 
-# TEMPORARY DIAGNOSTIC (PR #545 hang hunt) -- REVERT ONCE GREEN.
-# With capture on, pytest redirects the real stderr fd into a buffer, so the
-# `-o faulthandler_timeout=90` watchdog dump the CI lane arms never reaches
-# the job log when the suite freezes. Capture off lets any further hang
-# print its exact stack into the log.
-addopts = --capture=no
-
 # pytest-asyncio 1.x already defaults to strict; pin it so a future default
 # flip can't silently change collection of @pytest.mark.asyncio tests.
 asyncio_mode = strict

--- a/orchestrator/scripts/probe_document_vectors.py
+++ b/orchestrator/scripts/probe_document_vectors.py
@@ -112,7 +112,7 @@ def recommend(verdict: str, active_backend: str) -> str:
                     "(S3_VECTORS_BUCKET set — shared or {workspace_id}-templated, "
                     "both valid — plus AWS creds) and re-embed via "
                     "scripts/migrate_to_s3_vectors.py. RAG-quality work is gated "
-                    "on this either way.")
+                    "on this either way (P2-16).")
         return ("Plane is DARK — pgvector holds no embedded documents. Ingestion "
                 "has not populated the vector store; re-embed before relying on "
                 "document grounding.")

--- a/orchestrator/services/watch_rerun.py
+++ b/orchestrator/services/watch_rerun.py
@@ -216,18 +216,25 @@ async def _notify_approval_pending(
         from core.services.notification_dispatcher import NotificationDispatcher
 
         dispatcher = NotificationDispatcher(db, str(workspace_id))
-        await dispatcher.dispatch(
-            event_type="approval_pending",
-            title=f"Approval needed: rerun '{recipe.name}'",
-            message=(
-                f"A rerun of playbook '{recipe.name}' is waiting for approval "
-                f"(estimated ${float(grant.estimated_cost_usd or 0):.2f}). "
-                "Review it in the approvals inbox."
-            ),
-            link_type="approval_grant",
-            link_id=str(grant.id),
-            status="warning",
-        )
+        # Land the caller's pending writes (the grant INSERT) BEFORE the
+        # savepoint, then dispatch inside it: a dispatch that dies mid-SQL
+        # aborts only the savepoint, never the caller's transaction. Without
+        # this, a dispatcher failure poisons the tx and the later commit
+        # silently rolls back the grant (found via test_prd204_rerun).
+        db.flush()
+        with db.begin_nested():
+            await dispatcher.dispatch(
+                event_type="approval_pending",
+                title=f"Approval needed: rerun '{recipe.name}'",
+                message=(
+                    f"A rerun of playbook '{recipe.name}' is waiting for approval "
+                    f"(estimated ${float(grant.estimated_cost_usd or 0):.2f}). "
+                    "Review it in the approvals inbox."
+                ),
+                link_type="approval_grant",
+                link_id=str(grant.id),
+                status="warning",
+            )
     except Exception:
         logger.error(
             "[WatchRerun] approval_pending dispatch failed for grant %s",
@@ -468,6 +475,13 @@ async def resume_playbook_run_grant(db: Session, grant) -> None:
         logger.error(
             "[WatchRerun] playbook_run grant %s resume failed", grant.id, exc_info=True
         )
+        # A flush that died mid-resume leaves the session unusable (every
+        # later statement raises PendingRollbackError, poisoning the grant
+        # endpoint). Roll back ONLY in that state so the failure lands on
+        # the grant's executed_result; in the normal error case the caller's
+        # uncommitted grant mutation is preserved.
+        if not db.is_active:
+            db.rollback()
         result = {"success": False, "error": str(exc)[:500]}
 
     grant.details = {

--- a/orchestrator/tests/test_prd204_rerun.py
+++ b/orchestrator/tests/test_prd204_rerun.py
@@ -541,7 +541,9 @@ def test_grant_deny_no_launch_watch_needs_attention(
     s.close()
 
 
-def test_resume_with_missing_target_parks_watch(workspace, new_session, stub_launch):
+def test_resume_with_missing_target_parks_watch(
+    workspace, new_session, stub_launch, capture_notifications
+):
     """Self-healing: a granted rerun whose recipe/execution vanished parks
     the watch instead of crashing the grant endpoint."""
     from services.watch_rerun import resume_playbook_run_grant


### PR DESCRIPTION
Post-merge cleanup for #545/#552 — takes `orchestrator-tests` from 2 failed / 3,760 passed to green.

## What
1. **Grant-dispatch transaction safety (product fix):** `_notify_approval_pending` now flushes caller writes and dispatches inside a SAVEPOINT — a dispatcher failure mid-SQL previously aborted the whole transaction, and the later commit **silently rolled back the grant INSERT** (identity-map ghost → `StaleDataError` 0-row UPDATE → `PendingRollbackError`). The resume containment handler also rolls back a dead session before writing `executed_result`.
2. **Test alignment:** `test_resume_with_missing_target_parks_watch` was the one grant-parking test not patching the dispatcher seam, so the real dispatcher hit the migration-only `notification_preferences` table and aborted the tx.
3. **#547 drift:** restore the `P2-16` tag to the S3-DARK probe recommendation — `test_p2w0_s8_vector_probe::test_recommendation_tracks_verdict` asserts it; #547's rewrite dropped it (this failure exists on main today).
4. **Revert the temporary `--capture=no`** pytest diagnostic that shipped in #552 (it was the instrument that exposed the hang; no longer needed).

## Context
The original 30-min hang (root-caused in `2b86dfeda`): bad `AgentAppAssignment` import → ImportError mid-transaction → pytest pinned the failed frames + session via `sys.last_traceback` → leaked row locks blocked the workspace teardown sweep forever, with pytest-timeout's timer already cancelled by `pytest_exception_interact`.

## Test plan
- [ ] orchestrator-tests green (the two failures above are the only reds on main's push run)
- [ ] No behavior change on the happy dispatch path (savepoint releases into the caller's tx)

Note: **PR #551 (alembic heads join) still needs to merge** to restore the single-head gate — this PR deliberately does not touch migrations.