### PR TITLE
feat(prd-198): S1 — Graphiti-vs-baseline gate + S10 freeze kit (S2–S6 behind the spec's PENDING-BASELINE box)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -307,6 +307,40 @@ jobs:
         run: |
           python -m evals.memory_recall --json
 
+  # PRD-198 S1 — the Graphiti-vs-baseline A/B gate. NON-REQUIRED, exit-0:
+  # prints the honest verdict — PENDING until the S10 memory baseline is
+  # frozen (docs/runbooks/S10-MEMORY-BASELINE-FREEZE.md) and a graphiti
+  # treatment run exists (S2-gated); uplift-vs-margin after. Pure stdlib +
+  # committed artifacts — no Postgres, no LLM, no graph store. The gate can
+  # NEVER read green ahead of the measurement (the PRD's whole discipline).
+  graphiti-gate:
+    name: Graphiti-vs-baseline gate (non-required)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    defaults:
+      run:
+        working-directory: orchestrator
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Run the gate self-tests
+        run: |
+          python -m pip install --upgrade pip pytest
+          pytest tests/test_prd198_graphiti_gate.py -q -p no:cacheprovider
+
+      - name: Emit the gate verdict (informational)
+        continue-on-error: true
+        run: |
+          python -m evals.graphiti_vs_baseline
+
   # PRD-188 S5 (P2-07) — the RAG quality number: document-level recall@5 / MRR
   # per retrieval variant (dense proxy, BM25, hybrid RRF) over a labelled
   # workspace gold-set, including the Internal-Audit-v1 phrasing-sensitivity

--- a/docs/runbooks/S10-MEMORY-BASELINE-FREEZE.md
+++ b/docs/runbooks/S10-MEMORY-BASELINE-FREEZE.md
@@ -1,0 +1,56 @@
+# Runbook — Freeze the S10 Memory-Recall Baseline (PRD-198's ⏸ gate)
+
+**Why:** PRD-198's own §8 box blocks the Graphiti build (S2–S6) until two
+numbers are frozen. The retrieval half landed with PRD-186 (#547 —
+`evals/baseline/kg_retrieval_2026-07.json`, pilot-a, tenant-aliased). The
+**S10 memory-recall baseline is the remaining half**, and it must come from
+a live workspace snapshot with the production retriever — the bundled
+synthetic snapshot is a harness fixture, not a baseline.
+
+**Who runs it:** Gerard (live data access is human-run by policy; agents
+prepare, never execute against prod).
+
+**⚠️ Public repo rules:** the live gold set and raw memory corpus contain
+tenant content — they stay **LOCAL, never committed**. Only the
+tenant-aliased numbers artifact (`pilot-a` style, zero identifiers) is
+committed, exactly like the retrieval freeze.
+
+## Steps
+
+1. **Corpus snapshot.** The 2026-07-16 capture (231 durable memories) is at
+   `_worktree-backup-2026-07-16/baseline-freeze/` (local). To re-capture,
+   export the durable store per workspace (`modules/memory/durable_store.py`
+   namespaces `mem:{workspace}`) to a local jsonl in the harness's
+   `MemoryDoc` shape (`evals/memory_recall.py` docstring).
+2. **Gold set.** Author ~50 labelled queries over that corpus (LongMemEval
+   category shape — the harness's `GoldQuery`), locally. Aliased tenants
+   only in any file that might ever be shared.
+3. **Run the harness against the snapshot with the production retriever:**
+
+   ```bash
+   cd orchestrator
+   python -m evals.memory_recall \
+     --corpus /LOCAL/path/memory_corpus.jsonl \
+     --gold /LOCAL/path/memory_gold.jsonl \
+     --json /LOCAL/path/memory_recall_raw.json
+   ```
+
+   (`--corpus` + the `retriever_factory` injection point drive the REAL
+   retriever; the offline bag-of-words proxy is only the CI stand-in. If the
+   run must happen against prod Qdrant, use the established `railway ssh`
+   heredoc-in-arg wrapper pattern — agent-driven railway ssh is blocked.)
+4. **Alias + freeze.** Strip identifiers, alias tenants (pilot-a/b), and
+   commit the numbers as `orchestrator/evals/baseline/memory_recall_2026-07.json`
+   with the same `{<alias>: {variants: {<variant>: {mean_recall_at_5: …}}}}`
+   shape as the retrieval freeze (plus `frozen_at`/`provenance`/`caveats`
+   header keys). An honest sub-target number is still the baseline — the
+   trial must beat *the real number*, not a hoped-for one.
+5. **Verify the gate sees it:**
+
+   ```bash
+   python -m evals.graphiti_vs_baseline
+   ```
+
+   The verdict should move from `PENDING (memory_baseline_s10 …)` to
+   pending only on the graphiti treatment. That is the state in which the
+   PRD-198 S2–S6 build may start (margin + credit + cohort boxes permitting).

--- a/orchestrator/alembic/versions/prd204_w3_join_heads.py
+++ b/orchestrator/alembic/versions/prd204_w3_join_heads.py
@@ -1,0 +1,43 @@
+"""Join the re-forked revision heads left by #545 x #548 landing together.
+
+PR #545 (``prd204_merge_heads``) and PR #548 (``w3_post201_merge_heads``)
+each independently merged the SAME two heads (``prd201_s1_msg_context_trace``
++ ``prd203_merge_heads``) — they were built in parallel from the same base
+and both landed on 2026-07-16. Merging both re-forked the graph:
+
+    - w3_post201_merge_heads   (leaf — nothing chains onto it)
+    - prd204_watch_registry    (chains onto prd204_merge_heads)
+
+Neither file can simply be deleted: the deploy entrypoint runs
+``alembic upgrade heads`` on boot, so deployed databases have already
+recorded both lineages in ``alembic_version`` — removing either revision
+would break every such environment on its next boot. The safe repair is
+this third merge revision joining the two current heads, restoring the
+CI "exactly one head" gate.
+
+This is a **merge revision only** -- no schema operations. Do NOT add
+``CREATE``/``ALTER`` here -- a merge revision that mutates schema is exactly
+what makes a later from-zero squash lossy (mirrors prd176_merge_heads /
+prd203_merge_heads / prd204_merge_heads).
+
+Revision ID: prd204_w3_join_heads
+Revises: w3_post201_merge_heads, prd204_watch_registry
+Create Date: 2026-07-16
+"""
+
+# A pure merge point -- no operations.
+revision = "prd204_w3_join_heads"
+down_revision = (
+    "w3_post201_merge_heads",
+    "prd204_watch_registry",
+)
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """No-op: this revision only merges lineages."""
+
+
+def downgrade() -> None:
+    """No-op: splitting back into two heads needs no schema change."""

--- a/orchestrator/evals/graphiti_vs_baseline.py
+++ b/orchestrator/evals/graphiti_vs_baseline.py
@@ -1,0 +1,184 @@
+"""PRD-198 S1 — the Graphiti-vs-baseline A/B gate (the trial's instrument).
+
+Built BEFORE any Graphiti code by design (§5: S1 first and blocking). The
+whole PRD is eval-gated: Graphiti is adopted only if it beats the repaired
+baseline by the stated margin, so the gate must exist first and must read
+an honest **PENDING** — never a false green — until every input it needs
+exists:
+
+- **retrieval baseline** — ``evals/baseline/kg_retrieval_2026-07.json``:
+  the pilot-a live freeze (FROZEN, landed with PRD-186 #547).
+- **memory baseline (S10)** — ``evals/baseline/memory_recall_2026-07.json``:
+  NOT yet frozen; Gerard's live run per
+  ``docs/runbooks/S10-MEMORY-BASELINE-FREEZE.md``. Its absence is the
+  ⏸ PENDING BASELINE gate that blocks S2–S6.
+- **graphiti treatment** — ``evals/results/graphiti_recall.json``: produced
+  by a live retrieval-recall run with the graphiti lever once S2 stands the
+  trial up. Same artifact shape as the frozen baseline, so freezing once
+  serves the whole wave.
+
+Verdict shape reuses the ``operating_graph_uplift`` honest gate:
+``uplift_points = (treatment − best_baseline) × 100``, mean across tenant
+aliases, published, **exit 0 always** — a sub-margin uplift is a valid,
+honest outcome (the flag stays OFF and the trial is a documented no-op).
+
+Margin: ≥ +5.0 points recall@5 (§8-Q1 proposal — Gerard confirms; the
+capability-slice gates — dup-rate, contradiction, multi-hop — land with
+S3/S4 and are listed here as pending slices so the verdict never
+overstates what has been measured).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+_HERE = Path(__file__).resolve().parent
+
+TREATMENT_VARIANT = "graphiti"
+UPLIFT_MARGIN_POINTS = 5.0  # §8-Q1 proposal — confirm before the verdict binds
+DEFAULT_TENANT_ALIASES: Sequence[str] = ("pilot-a",)
+
+DEFAULT_RETRIEVAL_BASELINE = _HERE / "baseline" / "kg_retrieval_2026-07.json"
+DEFAULT_MEMORY_BASELINE = _HERE / "baseline" / "memory_recall_2026-07.json"
+DEFAULT_TREATMENT = _HERE / "results" / "graphiti_recall.json"
+
+# Slices the verdict must eventually include (S3/S4); listed as pending so
+# a bare recall win can never silently read as "all criteria met".
+PENDING_SLICES = (
+    "duplicate_node_rate",
+    "contradicted_fact_resolution",
+    "multi_hop_answer_quality",
+)
+
+
+def load_artifact(path: Path) -> Optional[Dict[str, Any]]:
+    """Load a frozen/treatment artifact; None when absent (→ PENDING)."""
+    if not path.exists():
+        return None
+    with path.open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def best_baseline_recall(artifact: Dict[str, Any], tenant_alias: str) -> Optional[float]:
+    """Best shipped-variant recall@5 for one tenant alias — the honest-gate
+    ``best_baseline`` (the treatment must beat the best of what already
+    ships, not a strawman). The graphiti variant itself is excluded."""
+    variants = ((artifact.get(tenant_alias) or {}).get("variants") or {})
+    scores = [
+        float(row.get("mean_recall_at_5", 0.0))
+        for name, row in variants.items()
+        if name != TREATMENT_VARIANT and row
+    ]
+    return max(scores) if scores else None
+
+
+def treatment_recall(artifact: Dict[str, Any], tenant_alias: str) -> Optional[float]:
+    """The graphiti variant's recall@5 for one tenant alias, if measured."""
+    variants = ((artifact.get(tenant_alias) or {}).get("variants") or {})
+    row = variants.get(TREATMENT_VARIANT)
+    if not row:
+        return None
+    return float(row.get("mean_recall_at_5", 0.0))
+
+
+def uplift_points(treatment: float, baseline: float) -> float:
+    """treatment − baseline, in points (the operating_graph_uplift shape)."""
+    return round((treatment - baseline) * 100.0, 2)
+
+
+def compute_gate(
+    retrieval_baseline: Optional[Dict[str, Any]],
+    memory_baseline: Optional[Dict[str, Any]],
+    treatment: Optional[Dict[str, Any]],
+    tenant_aliases: Sequence[str] = DEFAULT_TENANT_ALIASES,
+    margin_points: float = UPLIFT_MARGIN_POINTS,
+) -> Dict[str, Any]:
+    """The gate. PENDING while any input is missing; otherwise the verdict.
+
+    A PENDING gate is not a failure — it is the ⏸ state the PRD's own §8
+    box defines: the build (S2–S6) does not start until the baselines are
+    frozen, and the adopt decision does not exist until the treatment ran.
+    """
+    missing: List[str] = []
+    if retrieval_baseline is None:
+        missing.append("retrieval_baseline (evals/baseline/kg_retrieval_2026-07.json)")
+    if memory_baseline is None:
+        missing.append(
+            "memory_baseline_s10 (evals/baseline/memory_recall_2026-07.json — "
+            "docs/runbooks/S10-MEMORY-BASELINE-FREEZE.md)"
+        )
+    if treatment is None:
+        missing.append("graphiti_treatment (evals/results/graphiti_recall.json — S2 gated)")
+
+    if missing:
+        return {
+            "verdict": "PENDING",
+            "reason": "baseline not frozen / treatment not run — no false greens",
+            "missing": missing,
+            "margin_points": margin_points,
+            "pending_slices": list(PENDING_SLICES),
+        }
+
+    tenants: List[Dict[str, Any]] = []
+    for alias in tenant_aliases:
+        baseline_r5 = best_baseline_recall(retrieval_baseline, alias)
+        treat_r5 = treatment_recall(treatment, alias)
+        if baseline_r5 is None or treat_r5 is None:
+            return {
+                "verdict": "PENDING",
+                "reason": f"tenant '{alias}' lacks a baseline or treatment number",
+                "missing": [alias],
+                "margin_points": margin_points,
+                "pending_slices": list(PENDING_SLICES),
+            }
+        tenants.append(
+            {
+                "tenant": alias,
+                "best_baseline_recall_at_5": round(baseline_r5, 4),
+                "graphiti_recall_at_5": round(treat_r5, 4),
+                "uplift_points": uplift_points(treat_r5, baseline_r5),
+            }
+        )
+
+    mean_uplift = round(sum(t["uplift_points"] for t in tenants) / len(tenants), 2)
+    beats = mean_uplift >= margin_points
+    return {
+        "verdict": "ADOPT_UNBLOCKED" if beats else "DO_NOT_ADOPT",
+        "mean_uplift_points": mean_uplift,
+        "margin_points": margin_points,
+        "tenants": tenants,
+        "pending_slices": list(PENDING_SLICES),
+        "note": (
+            "recall margin met — the S3/S4 capability slices must also move "
+            "before the adopt follow-through (§8-Q1 slice-gate)"
+            if beats
+            else "below margin — flag stays OFF; a documented no-op is a valid outcome"
+        ),
+    }
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Graphiti-vs-baseline A/B gate (PRD-198 S1 — exit 0 always)"
+    )
+    parser.add_argument("--retrieval-baseline", type=Path, default=DEFAULT_RETRIEVAL_BASELINE)
+    parser.add_argument("--memory-baseline", type=Path, default=DEFAULT_MEMORY_BASELINE)
+    parser.add_argument("--treatment", type=Path, default=DEFAULT_TREATMENT)
+    parser.add_argument("--margin", type=float, default=UPLIFT_MARGIN_POINTS)
+    args = parser.parse_args(argv)
+
+    gate = compute_gate(
+        load_artifact(args.retrieval_baseline),
+        load_artifact(args.memory_baseline),
+        load_artifact(args.treatment),
+        margin_points=args.margin,
+    )
+    print(json.dumps(gate, indent=2))
+    return 0  # the number (or the PENDING) is the deliverable
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/orchestrator/tests/test_prd198_graphiti_gate.py
+++ b/orchestrator/tests/test_prd198_graphiti_gate.py
@@ -1,0 +1,91 @@
+"""PRD-198 S1 — the Graphiti-vs-baseline A/B gate.
+
+The instrument lands before any Graphiti code: the gate must read an
+honest PENDING until both baselines are frozen and a treatment run
+exists, and its arithmetic must be the operating_graph_uplift honest
+shape (treatment − best_baseline, in points). Pure — bundled/fabricated
+artifacts + stdlib; no Postgres, no LLM, no graph store.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+_orchestrator_root = Path(__file__).resolve().parent.parent
+if str(_orchestrator_root) not in sys.path:
+    sys.path.insert(0, str(_orchestrator_root))
+
+from evals.graphiti_vs_baseline import (  # noqa: E402
+    DEFAULT_MEMORY_BASELINE,
+    DEFAULT_RETRIEVAL_BASELINE,
+    TREATMENT_VARIANT,
+    compute_gate,
+    load_artifact,
+    uplift_points,
+)
+
+
+def _artifact(alias: str, variants: dict) -> dict:
+    return {alias: {"variants": {k: {"mean_recall_at_5": v} for k, v in variants.items()}}}
+
+
+def test_graphiti_variant_registered():
+    """The treatment variant is 'graphiti' and the gate consumes artifacts
+    in the exact frozen-baseline shape — freezing once serves the wave."""
+    assert TREATMENT_VARIANT == "graphiti"
+    gate = compute_gate(
+        _artifact("pilot-a", {"baseline": 0.65, "hybrid_rrf": 0.692}),
+        {"any": "memory-baseline"},
+        _artifact("pilot-a", {"graphiti": 0.80}),
+    )
+    assert gate["verdict"] in ("ADOPT_UNBLOCKED", "DO_NOT_ADOPT")
+    assert gate["tenants"][0]["graphiti_recall_at_5"] == 0.80
+
+
+def test_uplift_gate_pending_without_frozen_baseline():
+    """Absent inputs ⇒ PENDING, naming what is missing — never a false
+    green, and never a verdict computed from a strawman."""
+    gate = compute_gate(None, None, None)
+    assert gate["verdict"] == "PENDING"
+    assert any("retrieval_baseline" in m for m in gate["missing"])
+    assert any("memory_baseline_s10" in m for m in gate["missing"])
+    assert any("graphiti_treatment" in m for m in gate["missing"])
+
+    # A frozen retrieval baseline alone is still PENDING (S10 + treatment).
+    gate = compute_gate(
+        _artifact("pilot-a", {"hybrid_rrf": 0.692}), None, None
+    )
+    assert gate["verdict"] == "PENDING"
+    assert not any("retrieval_baseline" in m for m in gate["missing"])
+
+
+def test_uplift_points_treatment_minus_baseline():
+    """The honest-gate arithmetic: points = (treatment − BEST baseline)×100;
+    the margin decides adopt-vs-no-op."""
+    assert uplift_points(0.75, 0.692) == pytest.approx(5.8)
+
+    retrieval = _artifact("pilot-a", {"baseline": 0.65, "rerank": 0.769, "hybrid_rrf": 0.692})
+    memory = {"frozen": True}
+
+    winning = compute_gate(retrieval, memory, _artifact("pilot-a", {"graphiti": 0.83}))
+    # best baseline is rerank (0.769), not the plain baseline — no strawman
+    assert winning["tenants"][0]["best_baseline_recall_at_5"] == 0.769
+    assert winning["tenants"][0]["uplift_points"] == pytest.approx(6.1)
+    assert winning["verdict"] == "ADOPT_UNBLOCKED"
+    assert winning["pending_slices"]  # a recall win alone never claims the slices
+
+    losing = compute_gate(retrieval, memory, _artifact("pilot-a", {"graphiti": 0.78}))
+    assert losing["verdict"] == "DO_NOT_ADOPT"
+    assert losing["tenants"][0]["uplift_points"] == pytest.approx(1.1)
+
+
+def test_repo_state_is_honest_today():
+    """Pins the current truth: the retrieval baseline is FROZEN on main
+    (#547), the S10 memory baseline and the treatment are not — so the
+    committed default state of the gate is PENDING."""
+    retrieval = load_artifact(DEFAULT_RETRIEVAL_BASELINE)
+    assert retrieval is not None, "the #547 frozen retrieval baseline should exist"
+
+    gate = compute_gate(retrieval, load_artifact(DEFAULT_MEMORY_BASELINE), None)
+    assert gate["verdict"] == "PENDING"
+    assert any("graphiti_treatment" in m for m in gate["missing"])


### PR DESCRIPTION
## Summary

**PRD-198 (spec #539) — S1 only, by the spec's own design.** The Graphiti trial is eval-gated: its §8 box says *"do not start the Graphiti build (S2–S6) until the S10 memory-eval number exists and the repaired-hybrid retrieval baseline is frozen. Only S1 (the harness + freeze wiring) may proceed."* The retrieval half of that gate is already satisfied (#547 froze pilot-a onto main); this PR lands S1 and the kit that unblocks the rest. **S2–S6 are the spec's ⏸, not a deferral.**

### S1 · The Graphiti-vs-baseline gate — the instrument before the bet
[evals/graphiti_vs_baseline.py](orchestrator/evals/graphiti_vs_baseline.py):
- **PENDING while any input is missing, never a false green.** Inputs: the frozen retrieval baseline (✅ on main via #547), the **S10 memory baseline** (`evals/baseline/memory_recall_2026-07.json` — ❌ not yet frozen, your run), and a **graphiti treatment** artifact (❌ S2-gated). Today's committed state honestly reads PENDING — a test pins that.
- Once all exist: the `operating_graph_uplift` honest-gate arithmetic — `uplift_points = (treatment − BEST shipped variant) × 100`, mean across tenant aliases, vs the **§8-Q1 proposed ≥ +5.0-point margin** → `ADOPT_UNBLOCKED` / `DO_NOT_ADOPT`, exit 0 always (a sub-margin number is a valid, documented no-op).
- The S3/S4 capability slices (dup-node-rate ↓, contradicted-fact → one live fact, multi-hop answer quality ↑) ride as `pending_slices` so a recall win alone can never overstate what was measured.
- Treatment artifacts use the **exact frozen-baseline shape** — freeze once, serve the whole wave (P2-16/17/18 measure against the same number).

### The S10 freeze kit (what unblocks S2–S6)
[docs/runbooks/S10-MEMORY-BASELINE-FREEZE.md](docs/runbooks/S10-MEMORY-BASELINE-FREEZE.md) — your run: local corpus snapshot (the 2026-07-16 231-memory capture is in the local backup dir) → ~50-question gold set (LOCAL, never committed — public repo) → `evals/memory_recall.py --corpus … --gold …` with the production retriever → commit only the tenant-aliased numbers artifact → `python -m evals.graphiti_vs_baseline` flips its missing-list. An honest sub-target number is still the baseline.

### CI
A non-required `graphiti-gate` lane (self-tests + informational verdict emit), sibling posture to the memory/retrieval eval lanes. This PR also carries the byte-identical #551 heads-join commit so its alembic gate is green regardless of merge order.

## §8 boxes still yours (they gate S2–S6)
1. **Margin** — +5 pts + which slices must move (recommendation: aggregate **and** the contradiction slice).
2. **Credit precondition** — Graphiti ingestion is 1.36–2.25× more LLM-hungry; is the OpenRouter ceiling fixed, or does it gate S2?
3. **FalkorDB-Lite vs server** (recommendation: Lite for trial + local edition).
4. **Trial cohort** — name the opt-in workspaces (needs contradiction-bearing, evolving content).
5. **Adopt follow-through stays post-verdict** (recommendation: agreed).
