### PR TITLE
fix(tests): generalize leaked-session teardown guard (silent-hang class)

### DIFF
--- a/orchestrator/tests/conftest.py
+++ b/orchestrator/tests/conftest.py
@@ -333,3 +333,79 @@ def mock_ctx(mock_agent):
     ctx.user.id = "user_123"
     ctx.auth_type = "clerk"
     return ctx
+
+
+# ---- Real-DB teardown guard: leaked sessions + bounded sweep locks ----
+#
+# Anatomy of the silent-hang class this kills (first hit: a 30-minute CI hang,
+# fixed for one file in 2b86dfeda): a test that dies mid-transaction (e.g. an
+# ImportError between flush and commit) abandons its session; pytest pins the
+# failed frames -- and with them the session and its uncommitted row locks --
+# via ``sys.last_traceback``. pytest-timeout cancels its per-item timer on any
+# failure (pytest_exception_interact), so when a later fixture teardown's
+# DELETE sweep blocks on the leaked lock, nothing kills the wait: the lane
+# hangs silently to the job cap.
+#
+# ``new_session`` below is the shared cure: it REMEMBERS every session it
+# hands out, and ``new_session.sweep()`` rolls them all back before returning
+# a fresh session whose transaction carries a bounded lock_timeout -- so a
+# future leak fails LOUDLY in seconds instead of hanging the lane.
+
+TEARDOWN_LOCK_TIMEOUT = "5s"
+
+
+def _release_sessions(sessions) -> None:
+    """Roll back + close every recorded session. Never raises: a teardown
+    must always reach its DELETE sweep."""
+    for leaked in list(sessions):
+        try:
+            leaked.rollback()
+            leaked.close()
+        except Exception:  # noqa: BLE001
+            pass
+
+
+@pytest.fixture
+def new_session(engine):
+    """Tracking session factory shared by the real-DB test files.
+
+    Each file keeps its own module-scoped ``engine`` fixture (schema probes
+    and skip messages differ per suite); pytest resolves it per-module.
+
+    * ``new_session()`` -- an independent, committing session
+      (``expire_on_commit=False``), recorded so teardown can reclaim it.
+    * ``new_session.sweep()`` -- for fixture teardowns that DELETE-sweep
+      rows: rolls back + closes every session this factory issued (releasing
+      locks a failed test left behind), then returns a fresh session whose
+      transaction runs under ``SET LOCAL lock_timeout`` so any residual
+      blocker raises instead of hanging. Keep the sweep to a single commit;
+      ``SET LOCAL`` lasts only until the first COMMIT/ROLLBACK.
+
+    SQLAlchemy is imported lazily so pure-stdlib collection stays possible
+    (see the root conftest).
+    """
+    from sqlalchemy import text
+    from sqlalchemy.orm import sessionmaker
+
+    maker = sessionmaker(bind=engine, expire_on_commit=False)
+    created = []
+
+    def factory(**kwargs):
+        s = maker(**kwargs)
+        created.append(s)
+        return s
+
+    def sweep():
+        _release_sessions(created)
+        s = factory()
+        s.execute(text(f"SET LOCAL lock_timeout = '{TEARDOWN_LOCK_TIMEOUT}'"))
+        return s
+
+    factory.created = created
+    factory.sweep = sweep
+
+    yield factory
+
+    # Files with no sweep of their own must still not pin row locks for the
+    # rest of the run -- a leak here would hang a LATER module's sweep.
+    _release_sessions(created)

--- a/orchestrator/tests/test_board_dispatch.py
+++ b/orchestrator/tests/test_board_dispatch.py
@@ -16,7 +16,6 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 from sqlalchemy import create_engine, text
-from sqlalchemy.orm import sessionmaker
 
 from core.database.database import get_database_url
 from core.models.core import BoardTask
@@ -34,12 +33,6 @@ def engine():
         pytest.skip(f"dispatch suite needs a reachable Postgres: {exc}")
     yield eng
     eng.dispose()
-
-
-@pytest.fixture
-def new_session(engine):
-    """A sessionmaker that hands out independent, committing sessions."""
-    return sessionmaker(bind=engine, expire_on_commit=False)
 
 
 @pytest.fixture
@@ -65,7 +58,7 @@ def seeded(engine, new_session):
 
     yield ws_id, agent_id
 
-    s = new_session()
+    s = new_session.sweep()
     s.execute(text("DELETE FROM board_tasks WHERE workspace_id = CAST(:id AS uuid)"), {"id": ws_id})
     s.execute(text("DELETE FROM agents WHERE workspace_id = CAST(:id AS uuid)"), {"id": ws_id})
     s.execute(text("DELETE FROM workspaces WHERE id = CAST(:id AS uuid)"), {"id": ws_id})

--- a/orchestrator/tests/test_board_sse_listen_notify.py
+++ b/orchestrator/tests/test_board_sse_listen_notify.py
@@ -26,7 +26,6 @@ from pathlib import Path
 
 import pytest
 from sqlalchemy import create_engine, text
-from sqlalchemy.orm import sessionmaker
 
 # ``board_events`` imports its DB connection lazily (inside the listener thread),
 # so importing it does NOT touch Postgres — the pure tests below run with no DB.
@@ -59,12 +58,6 @@ def engine():
         pytest.skip(f"board SSE suite needs a reachable Postgres: {exc}")
     yield eng
     eng.dispose()
-
-
-@pytest.fixture
-def new_session(engine):
-    """A sessionmaker handing out independent, committing sessions."""
-    return sessionmaker(bind=engine, expire_on_commit=False)
 
 
 def test_notify_board_event_reaches_a_raw_listener(new_session, engine):

--- a/orchestrator/tests/test_p2w2_audit_retention.py
+++ b/orchestrator/tests/test_p2w2_audit_retention.py
@@ -74,13 +74,6 @@ def engine():
 
 
 @pytest.fixture
-def new_session(engine):
-    from sqlalchemy.orm import sessionmaker
-
-    return sessionmaker(bind=engine, expire_on_commit=False)
-
-
-@pytest.fixture
 def workspace(engine, new_session):
     from sqlalchemy import text
 
@@ -93,7 +86,7 @@ def workspace(engine, new_session):
     s.commit()
     s.close()
     yield ws
-    s = new_session()
+    s = new_session.sweep()
     s.execute(text("DELETE FROM audit_logs WHERE workspace_id = CAST(:id AS uuid)"), {"id": ws})
     s.execute(text("DELETE FROM workspaces WHERE id = CAST(:id AS uuid)"), {"id": ws})
     s.commit()

--- a/orchestrator/tests/test_p2w2_governance_audit.py
+++ b/orchestrator/tests/test_p2w2_governance_audit.py
@@ -84,13 +84,6 @@ def engine():
 
 
 @pytest.fixture
-def new_session(engine):
-    from sqlalchemy.orm import sessionmaker
-
-    return sessionmaker(bind=engine, expire_on_commit=False)
-
-
-@pytest.fixture
 def two_workspaces(engine, new_session):
     from sqlalchemy import text
 
@@ -104,7 +97,7 @@ def two_workspaces(engine, new_session):
     s.commit()
     s.close()
     yield ws_a, ws_b
-    s = new_session()
+    s = new_session.sweep()
     for ws in (ws_a, ws_b):
         s.execute(text("DELETE FROM audit_logs WHERE workspace_id = CAST(:id AS uuid)"), {"id": ws})
         s.execute(text("DELETE FROM approval_grants WHERE workspace_id = CAST(:id AS uuid)"), {"id": ws})

--- a/orchestrator/tests/test_p2w2_governance_policy_budget.py
+++ b/orchestrator/tests/test_p2w2_governance_policy_budget.py
@@ -77,13 +77,6 @@ def engine():
 
 
 @pytest.fixture
-def new_session(engine):
-    from sqlalchemy.orm import sessionmaker
-
-    return sessionmaker(bind=engine, expire_on_commit=False)
-
-
-@pytest.fixture
 def workspace(engine, new_session):
     from sqlalchemy import text
 
@@ -96,7 +89,7 @@ def workspace(engine, new_session):
     s.commit()
     s.close()
     yield ws
-    s = new_session()
+    s = new_session.sweep()
     s.execute(text("DELETE FROM audit_logs WHERE workspace_id = CAST(:id AS uuid)"), {"id": ws})
     s.execute(text("DELETE FROM workspaces WHERE id = CAST(:id AS uuid)"), {"id": ws})
     s.commit()

--- a/orchestrator/tests/test_prd164_flywheel.py
+++ b/orchestrator/tests/test_prd164_flywheel.py
@@ -407,6 +407,10 @@ def _cleanup_workspace(engine, ws_id):
     from sqlalchemy import text as sa_text
 
     with engine.begin() as conn:
+        # Bounded sweep (see tests/conftest.py teardown-guard note): if a test
+        # died mid-transaction and pinned row locks, fail loudly in seconds
+        # instead of hanging the lane to the job cap.
+        conn.execute(sa_text("SET LOCAL lock_timeout = '5s'"))
         conn.execute(
             sa_text(
                 "DELETE FROM document_chunks WHERE document_id IN "

--- a/orchestrator/tests/test_prd204_rerun.py
+++ b/orchestrator/tests/test_prd204_rerun.py
@@ -18,7 +18,6 @@ from datetime import datetime, timezone
 
 import pytest
 from sqlalchemy import create_engine, text
-from sqlalchemy.orm import sessionmaker
 
 from core.database.database import get_database_url
 from core.models import WorkflowTemplate
@@ -112,11 +111,6 @@ def engine():
 
 
 @pytest.fixture
-def new_session(engine):
-    return sessionmaker(bind=engine, expire_on_commit=False)
-
-
-@pytest.fixture
 def workspace(new_session):
     ws_id = str(uuid.uuid4())
     s = new_session()
@@ -132,7 +126,7 @@ def workspace(new_session):
 
     yield ws_id
 
-    s = new_session()
+    s = new_session.sweep()
     for stmt in (
         "DELETE FROM watch_events WHERE watch_id IN "
         "(SELECT id FROM watches WHERE workspace_id = CAST(:w AS uuid))",

--- a/orchestrator/tests/test_prd204_run_verdict.py
+++ b/orchestrator/tests/test_prd204_run_verdict.py
@@ -299,13 +299,6 @@ def engine():
 
 
 @pytest.fixture
-def new_session(engine):
-    from sqlalchemy.orm import sessionmaker
-
-    return sessionmaker(bind=engine, expire_on_commit=False)
-
-
-@pytest.fixture
 def workspace(new_session):
     from sqlalchemy import text
 
@@ -323,7 +316,7 @@ def workspace(new_session):
 
     yield ws_id
 
-    s = new_session()
+    s = new_session.sweep()
     for stmt in (
         "DELETE FROM watch_events WHERE watch_id IN "
         "(SELECT id FROM watches WHERE workspace_id = CAST(:w AS uuid))",

--- a/orchestrator/tests/test_prd204_watch_actions.py
+++ b/orchestrator/tests/test_prd204_watch_actions.py
@@ -20,7 +20,6 @@ from datetime import datetime, timezone
 
 import pytest
 from sqlalchemy import create_engine, text
-from sqlalchemy.orm import sessionmaker
 
 from core.database.database import get_database_url
 from core.models.core import Agent, BoardTask
@@ -51,30 +50,6 @@ def engine():
 
 
 @pytest.fixture
-def new_session(engine):
-    """Session factory that REMEMBERS every session it hands out.
-
-    A test that dies mid-transaction (an exception between flush and commit)
-    abandons its session; pytest pins the failed frames -- and with them the
-    session and its uncommitted row locks -- via ``sys.last_traceback``. The
-    workspace teardown rolls these back before its DELETE sweep; without
-    that, the sweep blocks on the leaked lock FOREVER (pytest-timeout cancels
-    its per-item timer on any failure via pytest_exception_interact, so
-    nothing kills the wait -- the CI 30-minute silent hang on PR #545).
-    """
-    maker = sessionmaker(bind=engine, expire_on_commit=False)
-    created = []
-
-    def factory():
-        s = maker()
-        created.append(s)
-        return s
-
-    factory.created = created
-    return factory
-
-
-@pytest.fixture
 def workspace(new_session):
     ws_id = str(uuid.uuid4())
     s = new_session()
@@ -90,18 +65,9 @@ def workspace(new_session):
 
     yield ws_id
 
-    # Release locks a failed test left behind (see new_session docstring).
-    for leaked in list(getattr(new_session, "created", [])):
-        try:
-            leaked.rollback()
-            leaked.close()
-        except Exception:  # noqa: BLE001 -- teardown must reach the sweep
-            pass
-
-    s = new_session()
-    # Belt and braces: if anything else still holds a lock, fail LOUDLY in
-    # seconds instead of hanging the lane to the 30-minute job cap.
-    s.execute(text("SET LOCAL lock_timeout = '5s'"))
+    # Shared guard (tests/conftest.py): releases leaked sessions, then opens
+    # a lock_timeout-bounded sweep session so a future leak fails loudly.
+    s = new_session.sweep()
     for stmt in (
         "DELETE FROM watch_events WHERE watch_id IN "
         "(SELECT id FROM watches WHERE workspace_id = CAST(:w AS uuid))",

--- a/orchestrator/tests/test_prd204_watch_decider.py
+++ b/orchestrator/tests/test_prd204_watch_decider.py
@@ -18,7 +18,6 @@ from pathlib import Path
 
 import pytest
 from sqlalchemy import create_engine, text
-from sqlalchemy.orm import sessionmaker
 
 from core.database.database import get_database_url
 from core.models.core import BoardTask, RecipeExecution, WorkflowTemplate
@@ -142,11 +141,6 @@ def engine():
 
 
 @pytest.fixture
-def new_session(engine):
-    return sessionmaker(bind=engine, expire_on_commit=False)
-
-
-@pytest.fixture
 def workspace(new_session):
     ws_id = str(uuid.uuid4())
     s = new_session()
@@ -162,7 +156,7 @@ def workspace(new_session):
 
     yield ws_id
 
-    s = new_session()
+    s = new_session.sweep()
     for stmt in (
         "DELETE FROM watch_events WHERE watch_id IN "
         "(SELECT id FROM watches WHERE workspace_id = CAST(:w AS uuid))",

--- a/orchestrator/tests/test_prd204_watch_hooks.py
+++ b/orchestrator/tests/test_prd204_watch_hooks.py
@@ -17,7 +17,6 @@ from unittest.mock import MagicMock
 
 import pytest
 from sqlalchemy import create_engine, text
-from sqlalchemy.orm import sessionmaker
 
 from core.database.database import get_database_url
 from core.models.orchestration import OrchestrationRun
@@ -101,11 +100,6 @@ def engine():
 
 
 @pytest.fixture
-def new_session(engine):
-    return sessionmaker(bind=engine, expire_on_commit=False)
-
-
-@pytest.fixture
 def workspace(new_session):
     ws_id = str(uuid.uuid4())
     s = new_session()
@@ -121,7 +115,7 @@ def workspace(new_session):
 
     yield ws_id
 
-    s = new_session()
+    s = new_session.sweep()
     s.execute(
         text(
             "DELETE FROM watch_events WHERE watch_id IN "

--- a/orchestrator/tests/test_prd204_watch_registry.py
+++ b/orchestrator/tests/test_prd204_watch_registry.py
@@ -14,7 +14,6 @@ from datetime import datetime, timedelta, timezone
 import pytest
 from sqlalchemy import create_engine, text
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import sessionmaker
 
 from core.database.database import get_database_url
 from core.models.watches import Watch, WatchEvent
@@ -36,12 +35,6 @@ def engine():
 
 
 @pytest.fixture
-def new_session(engine):
-    """A sessionmaker that hands out independent, committing sessions."""
-    return sessionmaker(bind=engine, expire_on_commit=False)
-
-
-@pytest.fixture
 def workspace(engine, new_session):
     """Throwaway workspace (seeded FIRST -- PRD-158). Yields workspace_id str."""
     ws_id = str(uuid.uuid4())
@@ -58,7 +51,7 @@ def workspace(engine, new_session):
 
     yield ws_id
 
-    s = new_session()
+    s = new_session.sweep()
     # watch_events cascade off watches; watches cascade off workspaces --
     # explicit deletes keep teardown independent of CASCADE behaviour.
     s.execute(

--- a/orchestrator/tests/test_prd204_watch_service.py
+++ b/orchestrator/tests/test_prd204_watch_service.py
@@ -14,7 +14,6 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 from sqlalchemy import create_engine, text
-from sqlalchemy.orm import sessionmaker
 
 from core.database.database import get_database_url
 from core.models.watches import Watch, WatchEvent
@@ -39,11 +38,6 @@ def engine():
 
 
 @pytest.fixture
-def new_session(engine):
-    return sessionmaker(bind=engine, expire_on_commit=False)
-
-
-@pytest.fixture
 def workspace(new_session):
     ws_id = str(uuid.uuid4())
     s = new_session()
@@ -59,7 +53,7 @@ def workspace(new_session):
 
     yield ws_id
 
-    s = new_session()
+    s = new_session.sweep()
     s.execute(
         text(
             "DELETE FROM watch_events WHERE watch_id IN "

--- a/orchestrator/tests/test_prd204_watch_ticker.py
+++ b/orchestrator/tests/test_prd204_watch_ticker.py
@@ -15,7 +15,6 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 from sqlalchemy import create_engine, text
-from sqlalchemy.orm import sessionmaker
 
 from core.database.database import get_database_url
 from core.models.core import RecipeExecution, WorkflowTemplate
@@ -44,11 +43,6 @@ def engine():
 
 
 @pytest.fixture
-def new_session(engine):
-    return sessionmaker(bind=engine, expire_on_commit=False)
-
-
-@pytest.fixture
 def workspace(new_session):
     ws_id = str(uuid.uuid4())
     s = new_session()
@@ -64,7 +58,7 @@ def workspace(new_session):
 
     yield ws_id
 
-    s = new_session()
+    s = new_session.sweep()
     s.execute(
         text(
             "DELETE FROM watch_events WHERE watch_id IN "

--- a/orchestrator/tests/test_prd204_watch_tools.py
+++ b/orchestrator/tests/test_prd204_watch_tools.py
@@ -14,7 +14,6 @@ from datetime import datetime, timezone
 
 import pytest
 from sqlalchemy import create_engine, text
-from sqlalchemy.orm import sessionmaker
 
 from core.database.database import get_database_url
 from core.models.core import RecipeExecution, WorkflowTemplate
@@ -109,11 +108,6 @@ def engine():
 
 
 @pytest.fixture
-def new_session(engine):
-    return sessionmaker(bind=engine, expire_on_commit=False)
-
-
-@pytest.fixture
 def workspace(new_session):
     ws_id = str(uuid.uuid4())
     s = new_session()
@@ -129,7 +123,7 @@ def workspace(new_session):
 
     yield ws_id
 
-    s = new_session()
+    s = new_session.sweep()
     for stmt in (
         "DELETE FROM watch_events WHERE watch_id IN "
         "(SELECT id FROM watches WHERE workspace_id = CAST(:w AS uuid))",

--- a/orchestrator/tests/test_prd204_watchlist_api.py
+++ b/orchestrator/tests/test_prd204_watchlist_api.py
@@ -24,7 +24,6 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine, text
-from sqlalchemy.orm import sessionmaker
 
 from core.database.database import get_database_url
 
@@ -47,11 +46,6 @@ def engine():
     eng.dispose()
 
 
-@pytest.fixture
-def new_session(engine):
-    return sessionmaker(bind=engine, expire_on_commit=False)
-
-
 def _seed_workspace(new_session, name: str) -> str:
     ws_id = str(uuid.uuid4())
     s = new_session()
@@ -68,7 +62,7 @@ def _seed_workspace(new_session, name: str) -> str:
 
 
 def _drop_workspace(new_session, ws_id: str) -> None:
-    s = new_session()
+    s = new_session.sweep()
     for stmt in (
         "DELETE FROM watch_events WHERE watch_id IN "
         "(SELECT id FROM watches WHERE workspace_id = CAST(:w AS uuid))",

--- a/orchestrator/tests/test_slo_metrics.py
+++ b/orchestrator/tests/test_slo_metrics.py
@@ -17,7 +17,6 @@ from pathlib import Path
 
 import pytest
 from sqlalchemy import create_engine, text
-from sqlalchemy.orm import sessionmaker
 
 # ``slo_metrics`` imports ``config`` + models but opens no DB connection at import;
 # ``get_database_url`` is imported lazily in the engine fixture so the pure tests
@@ -49,11 +48,6 @@ def engine():
 
 
 @pytest.fixture
-def new_session(engine):
-    return sessionmaker(bind=engine, expire_on_commit=False)
-
-
-@pytest.fixture
 def workspace(engine, new_session):
     """Throwaway workspace; cleans up its telemetry + itself on teardown."""
     ws_id = str(uuid.uuid4())
@@ -70,7 +64,7 @@ def workspace(engine, new_session):
 
     yield ws_id
 
-    s = new_session()
+    s = new_session.sweep()
     s.execute(text("DELETE FROM tool_execution_logs WHERE workspace_id = CAST(:id AS uuid)"), {"id": ws_id})
     s.execute(text("DELETE FROM board_tasks WHERE workspace_id = CAST(:id AS uuid)"), {"id": ws_id})
     s.execute(text("DELETE FROM workspaces WHERE id = CAST(:id AS uuid)"), {"id": ws_id})


### PR DESCRIPTION
## The hang, in three sentences

A test that dies mid-transaction (e.g. an ImportError between flush and commit) abandons its session, and pytest pins the failed frames -- and with them the session and its uncommitted row locks -- via `sys.last_traceback`. pytest-timeout cancels its per-item timer on any failure (`pytest_exception_interact`), so nothing bounds the wait when a later fixture teardown's DELETE sweep blocks on the leaked lock. The lane then hangs silently to the 30-minute job cap -- 2b86dfeda shipped the cure for one file (`test_prd204_watch_actions`); every other real-DB file with the same `new_session` + sweep-on-teardown shape was still exposed.

## What is guarded now

`tests/conftest.py` provides the shared `new_session` fixture (each file keeps its own module-scoped `engine`; pytest resolves it per-module):

- **Tracking factory** -- records every session it hands out; its own teardown rolls back + closes leftovers, so even files with no sweep of their own cannot pin locks that would hang a LATER module's sweep.
- **`new_session.sweep()`** -- for teardown DELETE sweeps: releases all factory-issued sessions FIRST, then returns a fresh session under `SET LOCAL lock_timeout = '5s'` so any residual blocker fails loudly in seconds instead of hanging the lane.

**On the shared guard (15 sweeps + 1 tracking-only):** all nine DB-backed prd204 files (watch_actions, watch_service, watch_ticker, watch_hooks, watch_decider, watch_tools, watch_registry, watchlist_api, rerun, run_verdict), test_slo_metrics, test_board_dispatch, test_p2w2_audit_retention, test_p2w2_governance_policy_budget, test_p2w2_governance_audit, and test_board_sse_listen_notify (tracking only -- it has no sweep). Their identical per-file `new_session` fixtures and now-unused `sessionmaker` imports are deleted (net -51 lines).

**Kept its own shape:** `test_prd164_flywheel` -- cleanup runs over `engine.begin()` in test-body `finally` blocks against the root-conftest `db_session`/ad-hoc sessionmakers, so it only gains the bounded `lock_timeout` on its sweep transaction.

**Untouched (pattern does not apply):** nl2sql validator suites, `test_graph_single_store`, `test_p2w1_agent_skills_repair` (DELETE strings are assertions/mocks), `test_hierarchy_permissions` (in-memory SQLite), `test_prd204_silent_holes` (pure mock), and the root-conftest `db_session` (transactional, finalizer-rolled-back -- cannot leak this way).

No production code, no pytest.ini, no CI workflow changes. SQLAlchemy stays lazily imported inside the fixture so the stdlib-only eval lanes still collect `tests/conftest.py` without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)