### PR TITLE
fix(manifest): route_count 769 (post #550×#554 merge)

### DIFF
--- a/orchestrator/reports/route-manifest.json
+++ b/orchestrator/reports/route-manifest.json
@@ -1,5 +1,5 @@
 {
-  "route_count": 768,
+  "route_count": 769,
   "routes": [
     {
       "method": "GET",


### PR DESCRIPTION
One-liner: both #550 and #554 added a route (+1 each) and both set `route_count: 768`; the merge kept **both entries** (769 real routes, sorted, correct) but one count line. This syncs the field. Predicted in both PR bodies as the one trivial conflict.