### PR TITLE
feat(prd-205): Auto Speaks — background→chat delivery (the build)

### DIFF
--- a/frontend/components/__tests__/prd205-auto-speaks.test.ts
+++ b/frontend/components/__tests__/prd205-auto-speaks.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+
+// PRD-205 S7 — the frontend half of background→chat delivery:
+// * the SSE parser yields chat_changed frames intact (the hook fans them
+//   out as window events);
+// * getChatMessages maps the persisted messages.source.label into the
+//   existing metadata badge slot, so "Auto · background" survives reload.
+
+import { parseSSEFrames } from '@/hooks/use-board-event-stream'
+
+describe('PRD-205 — SSE chat_changed frames', () => {
+  it('parses a chat_changed frame with its payload', () => {
+    const buffer =
+      'event: chat_changed\n' +
+      'data: {"workspace_id":"ws-1","chat_id":"c-9","user_id":3,"event":"chat_changed"}\n\n'
+    const { events, rest } = parseSSEFrames(buffer)
+    expect(rest).toBe('')
+    expect(events).toHaveLength(1)
+    expect(events[0].event).toBe('chat_changed')
+    expect((events[0].data as { chat_id: string }).chat_id).toBe('c-9')
+  })
+
+  it('keeps board_changed frames working beside chat frames', () => {
+    const buffer =
+      'event: board_changed\ndata: {"workspace_id":"ws-1"}\n\n' +
+      'event: chat_changed\ndata: {"workspace_id":"ws-1","chat_id":"c-1"}\n\n'
+    const { events } = parseSSEFrames(buffer)
+    expect(events.map((e) => e.event)).toEqual(['board_changed', 'chat_changed'])
+  })
+})
+
+describe('PRD-205 — persisted source → badge slot', () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  it('maps messages.source.label into metadata.source (survives reload)', async () => {
+    const { apiClient } = await import('@/lib/api-client')
+    vi.spyOn(apiClient, 'request').mockResolvedValue([
+      {
+        id: 'm1',
+        role: 'assistant',
+        parts: [{ type: 'text', text: 'Watched it. 8.4/10, passed.' }],
+        source: { origin: 'watcher', label: 'Auto · background' },
+      },
+      {
+        id: 'm2',
+        role: 'user',
+        parts: [{ type: 'text', text: 'run this and watch it' }],
+        source: null,
+      },
+    ] as never)
+
+    const { getChatMessages } = await import('@/lib/chat/api')
+    const messages = await getChatMessages('c-9')
+
+    expect(messages[0].metadata?.source).toBe('Auto · background')
+    expect(messages[1].metadata?.source).toBeUndefined()
+  })
+})

--- a/frontend/hooks/use-board-event-stream.ts
+++ b/frontend/hooks/use-board-event-stream.ts
@@ -123,6 +123,15 @@ export function useBoardEventStream(enabled: boolean = true): void {
           buffer = rest
           for (const evt of events) {
             if (evt.event === 'board_changed') invalidateBoard()
+            // PRD-205 S7: a background message landed in a chat. Fan out as a
+            // window event — the open conversation (useChat) merges it in and
+            // history surfaces refresh. Payload carries user_id; consumers
+            // drop events for other users (workspace filtering is server-side).
+            else if (evt.event === 'chat_changed') {
+              window.dispatchEvent(
+                new CustomEvent('automatos:chat-changed', { detail: evt.data }),
+              )
+            }
           }
         }
       } catch (err) {

--- a/frontend/lib/chat/api.ts
+++ b/frontend/lib/chat/api.ts
@@ -54,7 +54,16 @@ export async function voteMessage(
  * Get chat messages
  */
 export async function getChatMessages(chatId: string): Promise<ChatMessage[]> {
-  return apiClient.request<ChatMessage[]>(`/api/chat/${chatId}/messages`)
+  const rows = await apiClient.request<Array<ChatMessage & { source?: { label?: string } | null }>>(
+    `/api/chat/${chatId}/messages`,
+  )
+  // PRD-205 S7: persisted background provenance (messages.source) → the
+  // existing metadata badge slot, so "Auto · background" survives reload.
+  return rows.map((row) =>
+    row.source?.label
+      ? { ...row, metadata: { ...(row.metadata ?? {}), source: row.source.label } }
+      : row,
+  )
 }
 
 /**

--- a/frontend/lib/chat/hooks.ts
+++ b/frontend/lib/chat/hooks.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useCallback, useRef } from 'react'
+import { useState, useCallback, useEffect, useRef } from 'react'
 import { useAuth } from '@clerk/nextjs'
 import type { ChatMessage, AppUsage, ToolCall, RoutingInfo } from '@/types'
 import { toast } from 'sonner'
@@ -43,6 +43,34 @@ export function useChat({
       setStatus('idle')
     }
   }, [])
+
+  // PRD-205 S7: a background producer posted into a chat (watcher verdict,
+  // scheduled-task output). The SSE lane fans it out as a window event; when
+  // it targets THIS conversation, refetch and merge missing messages by id.
+  // Append-only: an in-flight streaming placeholder has an id the server
+  // doesn't know, so it is never clobbered.
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const onChatChanged = (event: Event) => {
+      const detail = (event as CustomEvent).detail as { chat_id?: string } | undefined
+      if (!detail?.chat_id || !chatId || detail.chat_id !== chatId) return
+      void (async () => {
+        try {
+          const { getChatMessages } = await import('@/lib/chat/api')
+          const serverMessages = await getChatMessages(chatId)
+          setMessages((prev) => {
+            const known = new Set(prev.map((m) => m.id))
+            const missing = serverMessages.filter((m) => !known.has(m.id))
+            return missing.length > 0 ? [...prev, ...missing] : prev
+          })
+        } catch {
+          // Best-effort: the message still appears on next open/reload.
+        }
+      })()
+    }
+    window.addEventListener('automatos:chat-changed', onChatChanged)
+    return () => window.removeEventListener('automatos:chat-changed', onChatChanged)
+  }, [chatId])
 
   const reload = useCallback(() => {
     const lastUserMessageIndex = messages.findLastIndex(m => m.role === 'user')

--- a/frontend/types/chat.ts
+++ b/frontend/types/chat.ts
@@ -123,7 +123,10 @@ export interface RoutingInfo {
 export interface MessageMetadata {
   intent?: string
   confidence?: number
-  source?: 'rag' | 'semantic' | 'codegraph' | 'llm' | 'database'
+  // PRD-205 S7: background-authored messages carry their persisted
+  // source.label ("Auto · background") through this slot — any string
+  // renders as a neutral badge; the literals keep their colour branches.
+  source?: 'rag' | 'semantic' | 'codegraph' | 'llm' | 'database' | (string & {})
   processing_time?: number
   tools_used?: string[]
   database_count?: number

--- a/orchestrator/alembic/versions/prd205_auto_speaks.py
+++ b/orchestrator/alembic/versions/prd205_auto_speaks.py
@@ -7,6 +7,8 @@ Additive only:
   one per (workspace, user) via a partial unique index.
 - ``watches.origin_chat_id`` UUID — the conversation a watched launch came
   from, so verdicts post back into it.
+- ``agent_scheduled_tasks.origin_chat_id`` UUID — same capture for scheduled
+  tasks, whose rows are agent-created (no user to fall back to).
 
 Chains single-parent on prd199_drop_fake_stats (the current single head —
 the §8-Q7 rule: never author a second join of the same parents).
@@ -50,8 +52,17 @@ def upgrade() -> None:
         "watches", sa.Column("origin_chat_id", UUID(as_uuid=True), nullable=True)
     )
 
+    # S6: scheduled tasks are agent-created (created_by_agent_id — no human,
+    # no chat on the row), so without a captured origin the delivered output
+    # has no target. Same capture pattern as watches.
+    op.add_column(
+        "agent_scheduled_tasks",
+        sa.Column("origin_chat_id", UUID(as_uuid=True), nullable=True),
+    )
+
 
 def downgrade() -> None:
+    op.drop_column("agent_scheduled_tasks", "origin_chat_id")
     op.drop_column("watches", "origin_chat_id")
     op.drop_index("uq_chats_auto_thread", table_name="chats")
     op.drop_constraint("check_chat_kind", "chats", type_="check")

--- a/orchestrator/alembic/versions/prd205_auto_speaks.py
+++ b/orchestrator/alembic/versions/prd205_auto_speaks.py
@@ -1,0 +1,59 @@
+"""PRD-205 S3: Auto Speaks — background→chat delivery columns.
+
+Additive only:
+- ``messages.source`` JSONB — background-author provenance
+  ({origin, label, link_type, link_id}); NULL on every in-turn message.
+- ``chats.kind`` ('user'|'auto') — the per-user per-workspace Auto thread,
+  one per (workspace, user) via a partial unique index.
+- ``watches.origin_chat_id`` UUID — the conversation a watched launch came
+  from, so verdicts post back into it.
+
+Chains single-parent on prd199_drop_fake_stats (the current single head —
+the §8-Q7 rule: never author a second join of the same parents).
+
+Revision ID: prd205_auto_speaks
+Revises: prd199_drop_fake_stats
+Create Date: 2026-07-17
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+revision = "prd205_auto_speaks"
+down_revision = "prd199_drop_fake_stats"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("messages", sa.Column("source", JSONB(), nullable=True))
+
+    op.add_column(
+        "chats",
+        sa.Column(
+            "kind", sa.String(length=20), nullable=False, server_default="user"
+        ),
+    )
+    op.create_check_constraint(
+        "check_chat_kind", "chats", "kind IN ('user', 'auto')"
+    )
+    op.create_index(
+        "uq_chats_auto_thread",
+        "chats",
+        ["workspace_id", "user_id"],
+        unique=True,
+        postgresql_where=sa.text("kind = 'auto'"),
+    )
+
+    op.add_column(
+        "watches", sa.Column("origin_chat_id", UUID(as_uuid=True), nullable=True)
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("watches", "origin_chat_id")
+    op.drop_index("uq_chats_auto_thread", table_name="chats")
+    op.drop_constraint("check_chat_kind", "chats", type_="check")
+    op.drop_column("chats", "kind")
+    op.drop_column("messages", "source")

--- a/orchestrator/api/chat.py
+++ b/orchestrator/api/chat.py
@@ -653,6 +653,98 @@ async def search_chat_history(
     return {"query": q, "total": len(results), "results": results}
 
 
+# PRD-205 S8: /vote and /agents MUST be declared before the /{chat_id}
+# routes below — declared after, FastAPI matched chat_id="vote"/"agents"
+# and both endpoints were dead (the exact PRD-220 /search failure mode).
+# Locked by route-order regression tests.
+@router.patch("/vote", dependencies=[Depends(require_workspace_permission("agents:execute"))])
+async def vote_message(
+    request: VoteRequest,
+    ctx: RequestContext = Depends(get_request_context_hybrid),
+    db: Session = Depends(get_db)
+):
+    """Vote on a message (workspace-scoped)"""
+    chat_service = ChatService(db)
+    user_id = get_user_id(db, ctx)
+
+    chat = chat_service.get_chat(request.chatId, workspace_id=ctx.workspace_id)
+    if not chat:
+        raise HTTPException(status_code=404, detail="Chat not found")
+    
+    if chat.user_id != user_id:
+        raise HTTPException(status_code=403, detail="Access denied")
+    
+    success = chat_service.vote_message(
+        request.chatId,
+        request.messageId,
+        request.isUpvoted
+    )
+
+    # PRD-185 S7: feed the RAG feedback loop. Write a rag_feedback row from the
+    # voted assistant message's retrieved doc ids so the PRD-179 live ranker can
+    # learn from thumbs. Best-effort — never fail the vote — but log loudly if it
+    # breaks (this wave exists because of silent swallows).
+    if success:
+        try:
+            from modules.rag.feedback_writer import feedback_from_retrieval_context
+            message = chat_service.get_message(request.chatId, request.messageId)
+            if message is not None:
+                feedback_from_retrieval_context(
+                    db,
+                    retrieval_context=message.retrieval_context,
+                    is_upvoted=request.isUpvoted,
+                    workspace_id=ctx.workspace_id,
+                    user_id=user_id,
+                )
+        except Exception:
+            # The vote itself is already committed; roll back only the failed
+            # feedback partial so the per-request session isn't left poisoned.
+            db.rollback()
+            logger.warning(
+                "[PRD-185 S7] rag_feedback write from chat vote failed "
+                "(chat=%s message=%s)",
+                request.chatId, request.messageId, exc_info=True,
+            )
+
+    return {"success": success}
+
+
+# PRD: Unified Agent-Chat System - Agent Endpoints
+@router.get("/agents")
+async def get_available_agents(
+    status: str = "active",
+    ctx: RequestContext = Depends(get_request_context_hybrid),
+    db: Session = Depends(get_db)
+):
+    """Get list of available agents for chat selection."""
+    from core.models import Agent
+    
+    query = db.query(Agent).filter(Agent.status == status, Agent.workspace_id == ctx.workspace_id)
+    agents = query.all()
+    
+    return {
+        "agents": [
+            {
+                "id": agent.id,
+                "name": agent.name,
+                "agent_type": agent.agent_type,
+                "description": agent.description,
+                "status": agent.status,
+                "skills": agent.configuration.get("skills", []) if agent.configuration else [],
+                "model_config": agent.model_config or {},
+                "is_default": agent.id == 1,
+                "tags": agent.tags or []
+            }
+            for agent in agents
+        ]
+    }
+
+
+class SwitchAgentRequest(BaseModel):
+    newAgentId: int
+    reason: Optional[str] = None
+
+
 @router.get("/{chat_id}")
 async def get_chat(
     chat_id: str,
@@ -758,94 +850,6 @@ async def update_chat(
     
     success = chat_service.update_chat_title(chat_id, request.title)
     return {"success": success}
-
-
-@router.patch("/vote", dependencies=[Depends(require_workspace_permission("agents:execute"))])
-async def vote_message(
-    request: VoteRequest,
-    ctx: RequestContext = Depends(get_request_context_hybrid),
-    db: Session = Depends(get_db)
-):
-    """Vote on a message (workspace-scoped)"""
-    chat_service = ChatService(db)
-    user_id = get_user_id(db, ctx)
-
-    chat = chat_service.get_chat(request.chatId, workspace_id=ctx.workspace_id)
-    if not chat:
-        raise HTTPException(status_code=404, detail="Chat not found")
-    
-    if chat.user_id != user_id:
-        raise HTTPException(status_code=403, detail="Access denied")
-    
-    success = chat_service.vote_message(
-        request.chatId,
-        request.messageId,
-        request.isUpvoted
-    )
-
-    # PRD-185 S7: feed the RAG feedback loop. Write a rag_feedback row from the
-    # voted assistant message's retrieved doc ids so the PRD-179 live ranker can
-    # learn from thumbs. Best-effort — never fail the vote — but log loudly if it
-    # breaks (this wave exists because of silent swallows).
-    if success:
-        try:
-            from modules.rag.feedback_writer import feedback_from_retrieval_context
-            message = chat_service.get_message(request.chatId, request.messageId)
-            if message is not None:
-                feedback_from_retrieval_context(
-                    db,
-                    retrieval_context=message.retrieval_context,
-                    is_upvoted=request.isUpvoted,
-                    workspace_id=ctx.workspace_id,
-                    user_id=user_id,
-                )
-        except Exception:
-            # The vote itself is already committed; roll back only the failed
-            # feedback partial so the per-request session isn't left poisoned.
-            db.rollback()
-            logger.warning(
-                "[PRD-185 S7] rag_feedback write from chat vote failed "
-                "(chat=%s message=%s)",
-                request.chatId, request.messageId, exc_info=True,
-            )
-
-    return {"success": success}
-
-
-# PRD: Unified Agent-Chat System - Agent Endpoints
-@router.get("/agents")
-async def get_available_agents(
-    status: str = "active",
-    ctx: RequestContext = Depends(get_request_context_hybrid),
-    db: Session = Depends(get_db)
-):
-    """Get list of available agents for chat selection."""
-    from core.models import Agent
-    
-    query = db.query(Agent).filter(Agent.status == status, Agent.workspace_id == ctx.workspace_id)
-    agents = query.all()
-    
-    return {
-        "agents": [
-            {
-                "id": agent.id,
-                "name": agent.name,
-                "agent_type": agent.agent_type,
-                "description": agent.description,
-                "status": agent.status,
-                "skills": agent.configuration.get("skills", []) if agent.configuration else [],
-                "model_config": agent.model_config or {},
-                "is_default": agent.id == 1,
-                "tags": agent.tags or []
-            }
-            for agent in agents
-        ]
-    }
-
-
-class SwitchAgentRequest(BaseModel):
-    newAgentId: int
-    reason: Optional[str] = None
 
 
 @router.post("/{chat_id}/switch-agent", dependencies=[Depends(require_workspace_permission("agents:execute"))])

--- a/orchestrator/api/chat.py
+++ b/orchestrator/api/chat.py
@@ -707,6 +707,10 @@ async def get_chat_messages(
             "role": msg.role,
             "parts": msg.parts,
             "attachments": msg.attachments,
+            # PRD-205 S3: background-author provenance — the frontend maps it
+            # into the message badge slot ("Auto · background"). null for
+            # every in-turn message, incl. all rows predating the column.
+            "source": msg.source,
             "createdAt": msg.created_at.isoformat()
         }
         for msg in messages

--- a/orchestrator/consumers/chatbot/service.py
+++ b/orchestrator/consumers/chatbot/service.py
@@ -397,6 +397,7 @@ class ChatService:
         workspace_id: Optional[str] = None,
         retrieval_context: Optional[Dict[str, Any]] = None,
         context_trace: Optional[Dict[str, Any]] = None,
+        source: Optional[Dict[str, Any]] = None,
     ) -> Message:
         """Save a message to the database.
 
@@ -407,6 +408,11 @@ class ChatService:
         ``context_trace`` (PRD-201 S1) carries the turn's context-assembly trace
         (mode, per-section token/trim detail, model, budget ceiling) so "what did
         Auto know?" is answerable; NULL for turns built before it shipped.
+
+        ``source`` (PRD-205 S3) carries background-author provenance
+        ({origin, label, link_type, link_id}) when the message was posted by
+        a server-side producer (watcher, scheduled task) rather than a turn;
+        NULL for every in-turn message.
         """
         try:
             chat_uuid = uuid.UUID(chat_id)
@@ -452,6 +458,7 @@ class ChatService:
             attachments=attachments or [],
             retrieval_context=retrieval_context,
             context_trace=context_trace,
+            source=source,
             created_at=datetime.utcnow()
         )
         self.db.add(message)

--- a/orchestrator/core/models/core.py
+++ b/orchestrator/core/models/core.py
@@ -6,7 +6,7 @@ Database Models for Automotas AI System
 Comprehensive data models for agents, skills, workflows, documents, and system configuration.
 """
 
-from sqlalchemy import Column, Integer, String, Text, DateTime, Boolean, Float, JSON, ForeignKey, Table, CheckConstraint, UniqueConstraint, Index
+from sqlalchemy import Column, Integer, String, Text, DateTime, Boolean, Float, JSON, ForeignKey, Table, CheckConstraint, UniqueConstraint, Index, text
 from sqlalchemy.dialects.postgresql import ARRAY as PG_ARRAY, JSONB, UUID
 # Base moved to core/database/base.py to avoid circular imports
 from core.database.base import Base
@@ -1109,6 +1109,11 @@ class Chat(Base):
     updated_at = Column(DateTime, nullable=False, server_default=func.now(), onupdate=func.now())
     visibility = Column(String(20), default='private', nullable=False)
     last_context = Column(JSONB, default=dict, server_default='{}')
+    # PRD-205 S2/S3: 'user' = ordinary conversation; 'auto' = the per-user
+    # per-workspace thread where Auto speaks unprompted (background verdicts,
+    # scheduled-task output). One 'auto' thread per (workspace, user) —
+    # enforced by the partial unique index below; ordinary in every other way.
+    kind = Column(String(20), nullable=False, default='user', server_default='user')
 
     # Relationships
     messages = relationship("Message", back_populates="chat", cascade="all, delete-orphan")
@@ -1117,7 +1122,13 @@ class Chat(Base):
 
     __table_args__ = (
         CheckConstraint("visibility IN ('private', 'public')", name='check_chat_visibility'),
+        CheckConstraint("kind IN ('user', 'auto')", name='check_chat_kind'),
         Index('ix_chats_workspace_user', 'workspace_id', 'user_id'),
+        Index(
+            'uq_chats_auto_thread', 'workspace_id', 'user_id',
+            unique=True,
+            postgresql_where=text("kind = 'auto'"),
+        ),
         {'extend_existing': True}
     )
 
@@ -1164,6 +1175,11 @@ class Message(Base):
     # by non-chat planes. Kept off `parts` so it never reaches the AI-SDK render
     # contract (same discipline as retrieval_context).
     context_trace = Column(JSONB, nullable=True)
+    # PRD-205 S3: background-author provenance — {origin: 'watcher'|
+    # 'scheduled_task', label: 'Auto · background', link_type, link_id}.
+    # NULL for every in-turn message. Kept off `parts` so it never reaches
+    # the AI-SDK render contract (same discipline as retrieval_context).
+    source = Column(JSONB, nullable=True)
     created_at = Column(DateTime, nullable=False, server_default=func.now())
 
     # Relationships

--- a/orchestrator/core/models/watches.py
+++ b/orchestrator/core/models/watches.py
@@ -80,6 +80,12 @@ class Watch(Base):
         nullable=True,
     )
 
+    # PRD-205 S4: the conversation the launch came from (captured from
+    # caller_context at watch creation; injected server-side, never an
+    # LLM-supplied arg). Verdicts/actions/escalations post back here; NULL
+    # (e.g. heartbeat/API launches) falls back to the owner's Auto thread.
+    origin_chat_id = Column(UUID(as_uuid=True), nullable=True)
+
     # What is being watched
     watch_type = Column(String(32), nullable=False)   # WatchType
     target_type = Column(String(32), nullable=False)  # WatchTargetType (current target)

--- a/orchestrator/modules/tools/discovery/handlers_missions.py
+++ b/orchestrator/modules/tools/discovery/handlers_missions.py
@@ -129,7 +129,10 @@ async def create_mission(db: Session, workspace_id: UUID, params: Dict[str, Any]
         # by default (workspace setting watch_auto_create, default ON);
         # success_criteria is the user's request text. Fail-soft -- a broken
         # watcher never breaks a launch.
-        from modules.tools.discovery.handlers_watches import auto_create_watch
+        from modules.tools.discovery.handlers_watches import (
+            _origin_chat_id,
+            auto_create_watch,
+        )
 
         auto_create_watch(
             db,
@@ -138,6 +141,7 @@ async def create_mission(db: Session, workspace_id: UUID, params: Dict[str, Any]
             target_id=str(run.id),
             title=f"Watch: {goal[:80]}",
             success_criteria=goal,
+            origin_chat_id=_origin_chat_id(params),
             created_by=params.get("_created_by"),
             owner_agent_id=(
                 int(params["_agent_id"])

--- a/orchestrator/modules/tools/discovery/handlers_playbooks.py
+++ b/orchestrator/modules/tools/discovery/handlers_playbooks.py
@@ -487,7 +487,10 @@ async def execute_playbook(db: Session, workspace_id: UUID, params: Dict[str, An
     # committed separately AFTER the execution row so a watch problem can
     # never poison the launch transaction.
     try:
-        from modules.tools.discovery.handlers_watches import auto_create_watch
+        from modules.tools.discovery.handlers_watches import (
+            _origin_chat_id,
+            auto_create_watch,
+        )
 
         criteria = f"Playbook '{playbook.name}' completes and delivers its expected output."
         if input_data:
@@ -503,6 +506,7 @@ async def execute_playbook(db: Session, workspace_id: UUID, params: Dict[str, An
             target_type="playbook_execution",
             target_id=execution_id,
             title=f"Watch: {playbook.name[:80]}",
+            origin_chat_id=_origin_chat_id(params),
             success_criteria=criteria,
             created_by=(str(params.get("_created_by")) if params.get("_created_by") else None),
             owner_agent_id=(

--- a/orchestrator/modules/tools/discovery/handlers_scheduling.py
+++ b/orchestrator/modules/tools/discovery/handlers_scheduling.py
@@ -47,6 +47,9 @@ async def schedule_task(db: Session, workspace_id: UUID, params: Dict[str, Any])
         description=description,
         schedule=schedule,
         max_runs=params.get("max_runs"),
+        # PRD-205 S6: server-injected originating conversation (never an
+        # LLM-supplied arg) — the delivered output posts back here.
+        origin_chat_id=params.get("_origin_chat_id"),
     )
 
 

--- a/orchestrator/modules/tools/discovery/handlers_watches.py
+++ b/orchestrator/modules/tools/discovery/handlers_watches.py
@@ -30,6 +30,18 @@ def _actor(params: Dict[str, Any]) -> Optional[str]:
     return str(created_by) if created_by else None
 
 
+def _origin_chat_id(params: Dict[str, Any]) -> Optional[UUID]:
+    """PRD-205 S4: the server-injected originating conversation (never an
+    LLM-supplied arg -- the executor overwrites it from caller_context)."""
+    raw = params.get("_origin_chat_id")
+    if not raw:
+        return None
+    try:
+        return UUID(str(raw))
+    except (ValueError, AttributeError, TypeError):
+        return None
+
+
 def _owner_agent_id(params: Dict[str, Any]) -> Optional[int]:
     raw = params.get("_agent_id")
     try:
@@ -228,6 +240,7 @@ async def create_watch(db: Session, workspace_id: UUID, params: Dict[str, Any]) 
             title=(params.get("title") or resolved["title"])[:500],
             created_by=_actor(params),
             owner_agent_id=_owner_agent_id(params),
+            origin_chat_id=_origin_chat_id(params),
             success_criteria=params.get("success_criteria") or resolved["criteria"],
             quality_threshold=threshold,
             deadline_at=deadline_at,
@@ -374,6 +387,7 @@ def auto_create_watch(
     success_criteria: str,
     created_by: Optional[str] = None,
     owner_agent_id: Optional[int] = None,
+    origin_chat_id: Optional[UUID] = None,
 ):
     """Create the default run_and_report watch on Auto-launched work.
 
@@ -408,6 +422,7 @@ def auto_create_watch(
             created_by=created_by,
             owner_agent_id=owner_agent_id,
             success_criteria=success_criteria,
+            origin_chat_id=origin_chat_id,
         )
         logger.info(
             "[Watches] auto-created watch %s on %s:%s",

--- a/orchestrator/modules/tools/discovery/platform_executor.py
+++ b/orchestrator/modules/tools/discovery/platform_executor.py
@@ -1014,6 +1014,7 @@ class PlatformActionExecutor:
             "platform_create_mission",
             "platform_execute_playbook",
             "platform_execute_recipe",
+            "platform_schedule_task",
         )
         if action_name in _WATCH_ORIGIN_ACTIONS:
             _origin_chat = (caller_context or {}).get("conversation_id")

--- a/orchestrator/modules/tools/discovery/platform_executor.py
+++ b/orchestrator/modules/tools/discovery/platform_executor.py
@@ -1004,6 +1004,22 @@ class PlatformActionExecutor:
             if _driver and "_created_by" not in params:
                 params = {**params, "_created_by": str(_driver)}
 
+        # PRD-205 S4: capture the originating conversation for watch-creating
+        # actions (direct create + the launches whose handlers auto-create a
+        # watch) so verdicts post back into that chat. Server-injected from
+        # caller_context; an LLM-supplied param of the same name is OVERWRITTEN
+        # -- the origin is never spoofable via tool args.
+        _WATCH_ORIGIN_ACTIONS = (
+            "platform_create_watch",
+            "platform_create_mission",
+            "platform_execute_playbook",
+            "platform_execute_recipe",
+        )
+        if action_name in _WATCH_ORIGIN_ACTIONS:
+            _origin_chat = (caller_context or {}).get("conversation_id")
+            if _origin_chat:
+                params = {**params, "_origin_chat_id": str(_origin_chat)}
+
         try:
             result = await handler(self.db, self.workspace_id, params)
             # PRD-143 S8: an invocation that ran only because the full-autonomy

--- a/orchestrator/services/board_events.py
+++ b/orchestrator/services/board_events.py
@@ -224,6 +224,10 @@ def frame_for_payload(payload: str, workspace_id: str) -> Optional[str]:
     data = _parse_payload(payload)
     if data is None or data.get("workspace_id") != workspace_id:
         return None
+    # PRD-205 S7: chat events keep their name so the client can route them
+    # to the open conversation; everything else stays the board refresh.
+    if data.get("event") == "chat_changed":
+        return _frame("chat_changed", data)
     return _frame("board_changed", data)
 
 

--- a/orchestrator/services/board_events.py
+++ b/orchestrator/services/board_events.py
@@ -68,6 +68,39 @@ def notify_board_event(
         )
 
 
+def notify_chat_event(
+    db: Session,
+    *,
+    workspace_id,
+    chat_id: str,
+    user_id: int,
+    event: str = "chat_changed",
+) -> None:
+    """PRD-205 S7: fire ``pg_notify`` when a background message lands in a
+    chat, on the SAME channel the Command Centre already LISTENs - one new
+    event value, zero new transport. The payload carries ``user_id`` so the
+    client drops events for other users (the SSE lane's workspace filter is
+    unchanged). Best-effort like its sibling: never raises into the caller.
+    """
+    try:
+        payload = json.dumps(
+            {
+                "workspace_id": str(workspace_id),
+                "chat_id": str(chat_id),
+                "user_id": int(user_id),
+                "event": event,
+            }
+        )
+        db.execute(
+            text("SELECT pg_notify(:chan, :payload)"),
+            {"chan": NOTIFY_CHANNEL, "payload": payload},
+        )
+    except Exception:  # noqa: BLE001 - NOTIFY is an optimisation, not a guarantee
+        logger.debug(
+            "[board_events] pg_notify failed for chat %s", chat_id, exc_info=True
+        )
+
+
 class _SSEListener(threading.Thread):
     """Holds one raw LISTEN connection and pushes notifications onto a queue.
 

--- a/orchestrator/services/chat_messenger.py
+++ b/orchestrator/services/chat_messenger.py
@@ -1,0 +1,202 @@
+"""PRD-205 S1/S2 — ChatMessenger: the background→chat delivery seam.
+
+The one way a server-side producer (the watcher, scheduled tasks — later
+anything) posts an assistant-authored message into a conversation after
+the originating HTTP turn is gone. Targeting: the originating chat when
+known and valid for the workspace; otherwise the per-user per-workspace
+**Auto thread** (``chats.kind='auto'`` — the canonical place Auto speaks
+unprompted, an ordinary chat in every other way).
+
+Rules enforced here, once:
+- ``chats.user_id`` is INTEGER ``users.id`` — Clerk strings are resolved
+  via ``User.clerk_user_id`` (the #513 lesson), never written raw.
+- A ``chat_id`` is honoured only if it belongs to the workspace; anything
+  else falls back to the Auto thread rather than leaking across chats.
+- Producers call ``deliver_background_message`` (fail-soft): a chat
+  failure must never break a watcher tick or a scheduled task.
+- After a successful post, a ``chat_changed`` NOTIFY rides the existing
+  ``board_events`` LISTEN/NOTIFY lane so an open chat receives the
+  message live (PRD-205 S7).
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Any, Dict, Optional
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+AUTO_CHAT_TITLE = "Auto"
+BACKGROUND_LABEL = "Auto · background"
+
+
+def _resolve_user_int_id(db: Session, clerk_user_id: Optional[str]) -> Optional[int]:
+    """Clerk string → integer users.id (the coordinator pattern; #513)."""
+    if not clerk_user_id:
+        return None
+    from core.models.core import User
+
+    row = db.query(User.id).filter(User.clerk_user_id == str(clerk_user_id)).first()
+    return int(row[0]) if row else None
+
+
+def find_or_create_auto_chat(db: Session, workspace_id, user_int_id: int):
+    """The per-(workspace, user) Auto thread — find it or create it.
+
+    Race-safe: the partial unique index ``uq_chats_auto_thread`` makes the
+    concurrent-create loser IntegrityError; we rollback and re-select.
+    Deleting the thread is allowed — it is simply recreated on the next
+    background post.
+    """
+    from core.models.core import Chat
+
+    ws_uuid = workspace_id if isinstance(workspace_id, uuid.UUID) else uuid.UUID(str(workspace_id))
+
+    def _select():
+        return (
+            db.query(Chat)
+            .filter(
+                Chat.workspace_id == ws_uuid,
+                Chat.user_id == int(user_int_id),
+                Chat.kind == "auto",
+            )
+            .first()
+        )
+
+    existing = _select()
+    if existing:
+        return existing
+
+    try:
+        chat = Chat(
+            id=uuid.uuid4(),
+            user_id=int(user_int_id),
+            workspace_id=ws_uuid,
+            title=AUTO_CHAT_TITLE,
+            visibility="private",
+            kind="auto",
+        )
+        db.add(chat)
+        db.commit()
+        db.refresh(chat)
+        logger.info(
+            "[ChatMessenger] Created Auto thread %s for user %s in workspace %s",
+            chat.id, user_int_id, ws_uuid,
+        )
+        return chat
+    except IntegrityError:
+        db.rollback()
+        return _select()
+
+
+def post_background_message(
+    db: Session,
+    *,
+    workspace_id,
+    text: str,
+    source: Dict[str, Any],
+    chat_id: Optional[str] = None,
+    clerk_user_id: Optional[str] = None,
+    link_type: Optional[str] = None,
+    link_id: Optional[str] = None,
+):
+    """Post one assistant message from a background producer. Raises on
+    hard failures (callers wanting fail-soft use ``deliver_background_message``).
+
+    Returns the saved Message, or None when no target is resolvable
+    (no valid chat AND no resolvable user for an Auto thread).
+    """
+    from consumers.chatbot.service import ChatService
+    from core.models.core import Chat
+
+    if not text or not str(text).strip():
+        return None
+
+    ws_uuid = workspace_id if isinstance(workspace_id, uuid.UUID) else uuid.UUID(str(workspace_id))
+
+    # 1. Resolve the target chat: originating chat if valid for this
+    #    workspace, else the user's Auto thread.
+    target_chat = None
+    if chat_id:
+        try:
+            target_chat = (
+                db.query(Chat)
+                .filter(Chat.id == uuid.UUID(str(chat_id)), Chat.workspace_id == ws_uuid)
+                .first()
+            )
+        except ValueError:
+            target_chat = None
+        if target_chat is None:
+            logger.warning(
+                "[ChatMessenger] chat_id %s invalid or outside workspace %s — "
+                "falling back to the Auto thread", chat_id, ws_uuid,
+            )
+
+    if target_chat is None:
+        user_int_id = _resolve_user_int_id(db, clerk_user_id)
+        if user_int_id is None:
+            logger.warning(
+                "[ChatMessenger] No valid chat and no resolvable user "
+                "(clerk_user_id=%r) — dropping background message", clerk_user_id,
+            )
+            return None
+        target_chat = find_or_create_auto_chat(db, ws_uuid, user_int_id)
+
+    # 2. Persisted provenance — the badge that survives reload.
+    source_doc = {
+        "label": BACKGROUND_LABEL,
+        **{k: v for k, v in (source or {}).items() if v is not None},
+    }
+    if link_type is not None:
+        source_doc["link_type"] = link_type
+    if link_id is not None:
+        source_doc["link_id"] = str(link_id)
+
+    # 3. Append via the one existing write path (parts shape identical to
+    #    the in-turn assistant writes; bumps chat.updated_at → history
+    #    re-sort ships free via PRD-220).
+    message = ChatService(db).save_message(
+        chat_id=str(target_chat.id),
+        role="assistant",
+        parts=[{"type": "text", "text": str(text)}],
+        workspace_id=str(ws_uuid),
+        source=source_doc,
+    )
+
+    # 4. Live receive (S7): best-effort NOTIFY on the existing lane.
+    try:
+        from services.board_events import notify_chat_event
+
+        notify_chat_event(
+            db,
+            workspace_id=ws_uuid,
+            chat_id=str(target_chat.id),
+            user_id=int(target_chat.user_id),
+        )
+    except Exception:  # noqa: BLE001 — the NOTIFY is an optimisation
+        logger.debug("[ChatMessenger] chat_changed notify failed", exc_info=True)
+
+    return message
+
+
+def deliver_background_message(db: Session, **kwargs) -> Optional[object]:
+    """Fail-soft wrapper — what producers call. A raising messenger must
+    never propagate into a watcher tick or a scheduled task (the
+    knowledge_flywheel pattern)."""
+    try:
+        return post_background_message(db, **kwargs)
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "[ChatMessenger] background delivery failed (source=%s)",
+            (kwargs.get("source") or {}).get("origin"),
+            exc_info=True,
+        )
+        try:
+            db.rollback()
+        except Exception:  # noqa: BLE001
+            pass
+        return None

--- a/orchestrator/services/scheduled_task_service.py
+++ b/orchestrator/services/scheduled_task_service.py
@@ -45,6 +45,7 @@ class ScheduledTaskService:
         description: str,
         schedule: str,
         max_runs: Optional[int] = None,
+        origin_chat_id: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Create a new scheduled task.
@@ -129,10 +130,12 @@ class ScheduledTaskService:
             text("""
                 INSERT INTO agent_scheduled_tasks
                     (workspace_id, created_by_agent_id, target_agent_id,
-                     task_type, description, schedule, max_runs, next_run_at)
+                     task_type, description, schedule, max_runs, next_run_at,
+                     origin_chat_id)
                 VALUES
                     (:ws_id, :created_by, :target,
-                     :task_type, :description, :schedule, :max_runs, :next_run_at)
+                     :task_type, :description, :schedule, :max_runs, :next_run_at,
+                     CAST(:origin_chat_id AS uuid))
                 RETURNING id, created_at
             """),
             {
@@ -144,6 +147,7 @@ class ScheduledTaskService:
                 "schedule": schedule,
                 "max_runs": max_runs,
                 "next_run_at": next_run_at,
+                "origin_chat_id": str(origin_chat_id) if origin_chat_id else None,
             },
         )
         row = result.fetchone()
@@ -367,6 +371,8 @@ class ScheduledTaskService:
                 agent_id=task.target_agent_id,
                 message=f"[Scheduled Task #{task_id}] {task.description}",
                 db=db,
+                origin_chat_id=getattr(task, "origin_chat_id", None),
+                task_id=task_id,
             )
 
         except Exception as e:
@@ -389,6 +395,8 @@ class ScheduledTaskService:
         agent_id: int,
         message: str,
         db: Session,
+        origin_chat_id: Optional[str] = None,
+        task_id: Optional[int] = None,
     ) -> None:
         """
         Execute a task on the target agent via AgentFactory.
@@ -417,6 +425,27 @@ class ScheduledTaskService:
                 "[ScheduledTask] Agent %d completed task: %s",
                 agent_id, str(llm_text)[:200],
             )
+
+            # PRD-205 S6: the output is DELIVERED, not discarded (the PRD-77
+            # defect: this used to be a 200-char logger.info and nothing
+            # else). Target = the conversation the task was created from
+            # (origin_chat_id, captured at platform_schedule_task time) --
+            # scheduled-task rows are agent-created, so there is no user to
+            # fall back to; a task with no captured origin (pre-205 rows, API
+            # creations) keeps the log-only behaviour honestly. Fail-soft: a
+            # chat failure never fails the scheduled run.
+            if str(llm_text).strip() and origin_chat_id:
+                from services.chat_messenger import deliver_background_message
+
+                deliver_background_message(
+                    db,
+                    workspace_id=workspace_id,
+                    text=str(llm_text),
+                    source={"origin": "scheduled_task"},
+                    chat_id=str(origin_chat_id),
+                    link_type="scheduled_task",
+                    link_id=str(task_id) if task_id is not None else None,
+                )
         except Exception as e:
             logger.error("[ScheduledTask] Failed to trigger agent chat: %s", e, exc_info=True)
             raise

--- a/orchestrator/services/watch_notifications.py
+++ b/orchestrator/services/watch_notifications.py
@@ -77,6 +77,27 @@ async def dispatch_watch_notification(
             status=status,
             user_id=user_id,
         )
+
+        # PRD-205 S5: verdicts/actions/escalations also land IN the
+        # conversation -- the originating chat when captured at watch
+        # creation, else the creator's Auto thread. Both surfaces fire in v1
+        # (Q3: the bell and the chat serve different attention models).
+        # Fail-soft AFTER the bell: a chat failure never costs the
+        # notification (deliver_background_message never raises).
+        if event_type in ("watch_verdict", "watch_action", "watch_escalation"):
+            from services.chat_messenger import deliver_background_message
+
+            origin_chat = getattr(watch, "origin_chat_id", None)
+            deliver_background_message(
+                db,
+                workspace_id=workspace_id,
+                text=f"{title}\n\n{message}" if message else title,
+                source={"origin": "watcher", "event": event_type},
+                chat_id=str(origin_chat) if origin_chat else None,
+                clerk_user_id=created_by,
+                link_type="watch",
+                link_id=str(getattr(watch, "id", "")) or None,
+            )
         return True
     except Exception:
         logger.error(

--- a/orchestrator/services/watch_service.py
+++ b/orchestrator/services/watch_service.py
@@ -130,6 +130,7 @@ class WatchService:
         policy: str = WatchPolicy.RUN_AND_REPORT.value,
         allowed_actions: Optional[List[str]] = None,
         action_budget: int = DEFAULT_ACTION_BUDGET,
+        origin_chat_id: Optional[UUID] = None,
         now: Optional[datetime] = None,
     ) -> Watch:
         """Create a watch on a target. One live watch per target.
@@ -154,6 +155,8 @@ class WatchService:
             workspace_id=str(workspace_id),
             created_by=created_by,
             owner_agent_id=owner_agent_id,
+            # PRD-205 S4: server-captured originating conversation (nullable).
+            origin_chat_id=origin_chat_id,
             watch_type=watch_type,
             target_type=target_type,
             target_id=target_id,

--- a/orchestrator/tests/test_prd205_auto_speaks.py
+++ b/orchestrator/tests/test_prd205_auto_speaks.py
@@ -1,0 +1,472 @@
+"""PRD-205 — Auto Speaks: background→chat delivery.
+
+* S1/S2 — ChatMessenger posts assistant messages from background producers:
+  Clerk-string resolution at the seam (#513), workspace-scoped chat
+  validation, per-(workspace,user) Auto-thread fallback, fail-soft wrapper.
+* S3 — additive columns exist and surface (messages.source, chats.kind,
+  watches.origin_chat_id, agent_scheduled_tasks.origin_chat_id).
+* S4 — origin capture is server-injected and unspoofable.
+* S5 — watcher verdicts/actions/escalations also land in the conversation.
+* S6 — scheduled-task output is delivered, not discarded (the PRD-77 fix).
+* S7 — chat_changed frames route by name; notify_chat_event emits.
+* S8 — /vote and /agents resolve (route-order regression, the PRD-220
+  /search class).
+
+DB-backed where the seam is the DB (messenger/thread) — skips cleanly
+without Postgres; everything else pure/monkeypatched at the boundary.
+"""
+from __future__ import annotations
+
+import asyncio
+import re
+import sys
+import uuid
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy import create_engine, text
+
+_orchestrator_root = Path(__file__).resolve().parent.parent
+if str(_orchestrator_root) not in sys.path:
+    sys.path.insert(0, str(_orchestrator_root))
+
+from core.database.database import get_database_url  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures (the PRD-204 suite idiom: skip without Postgres, sweep on teardown)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def engine():
+    try:
+        eng = create_engine(get_database_url(), pool_pre_ping=True)
+        with eng.connect() as c:
+            c.execute(text("SELECT kind FROM chats LIMIT 1"))
+            c.execute(text("SELECT source FROM messages LIMIT 1"))
+    except Exception as exc:  # noqa: BLE001
+        pytest.skip(f"auto-speaks suite needs Postgres with the 205 schema: {exc}")
+    yield eng
+    eng.dispose()
+
+
+@pytest.fixture
+def workspace_and_user(engine, new_session):
+    ws_id = str(uuid.uuid4())
+    clerk_id = f"user_test_{uuid.uuid4().hex[:10]}"
+    s = new_session()
+    s.execute(
+        text(
+            "INSERT INTO workspaces (id, name) "
+            "VALUES (CAST(:id AS uuid), :n) ON CONFLICT (id) DO NOTHING"
+        ),
+        {"id": ws_id, "n": "prd205-auto-speaks"},
+    )
+    row = s.execute(
+        text(
+            "INSERT INTO users (username, email, clerk_user_id) "
+            "VALUES (:u, :e, :c) RETURNING id"
+        ),
+        {"u": clerk_id, "e": f"{clerk_id}@test.local", "c": clerk_id},
+    ).first()
+    user_int_id = int(row[0])
+    s.commit()
+    s.close()
+
+    yield ws_id, clerk_id, user_int_id
+
+    s = new_session.sweep()
+    for stmt in (
+        "DELETE FROM messages WHERE workspace_id = CAST(:w AS uuid)",
+        "DELETE FROM chats WHERE workspace_id = CAST(:w AS uuid)",
+        "DELETE FROM users WHERE clerk_user_id = :c",
+        "DELETE FROM workspaces WHERE id = CAST(:w AS uuid)",
+    ):
+        s.execute(text(stmt), {"w": ws_id, "c": clerk_id})
+    s.commit()
+    s.close()
+
+
+# ---------------------------------------------------------------------------
+# S1/S2 — the messenger seam and the Auto thread
+# ---------------------------------------------------------------------------
+
+def test_auto_thread_find_or_create_is_idempotent(workspace_and_user, new_session):
+    from services.chat_messenger import AUTO_CHAT_TITLE, find_or_create_auto_chat
+
+    ws_id, _clerk, user_int_id = workspace_and_user
+    db = new_session()
+    try:
+        first = find_or_create_auto_chat(db, ws_id, user_int_id)
+        second = find_or_create_auto_chat(db, ws_id, user_int_id)
+        assert first.id == second.id
+        assert first.kind == "auto"
+        assert first.title == AUTO_CHAT_TITLE
+        assert first.visibility == "private"
+    finally:
+        db.close()
+
+
+def test_post_background_message_falls_back_to_auto_thread(workspace_and_user, new_session):
+    """No chat_id + resolvable Clerk id → the Auto thread; the message
+    carries the persisted badge source and the exact in-turn parts shape."""
+    from core.models.core import Message
+    from services.chat_messenger import BACKGROUND_LABEL, post_background_message
+
+    ws_id, clerk_id, _user = workspace_and_user
+    db = new_session()
+    try:
+        message = post_background_message(
+            db,
+            workspace_id=ws_id,
+            text="Watched it. 8.4/10, passed.",
+            source={"origin": "watcher", "event": "watch_verdict"},
+            clerk_user_id=clerk_id,
+            link_type="watch",
+            link_id="w-1",
+        )
+        assert message is not None
+        saved = db.query(Message).filter(Message.id == message.id).first()
+        assert saved.role == "assistant"
+        assert saved.parts == [{"type": "text", "text": "Watched it. 8.4/10, passed."}]
+        assert saved.source["label"] == BACKGROUND_LABEL
+        assert saved.source["origin"] == "watcher"
+        assert saved.source["link_type"] == "watch"
+
+        chat = saved.chat
+        assert chat.kind == "auto"
+        assert str(chat.workspace_id) == ws_id
+    finally:
+        db.close()
+
+
+def test_post_background_message_rejects_foreign_workspace_chat(
+    workspace_and_user, new_session
+):
+    """A chat_id outside the workspace is never written to — it falls back
+    to the Auto thread instead of leaking across chats."""
+    from services.chat_messenger import post_background_message
+
+    ws_id, clerk_id, _user = workspace_and_user
+    db = new_session()
+    try:
+        foreign_chat_id = str(uuid.uuid4())  # not a chat in this workspace
+        message = post_background_message(
+            db,
+            workspace_id=ws_id,
+            text="hello",
+            source={"origin": "watcher"},
+            chat_id=foreign_chat_id,
+            clerk_user_id=clerk_id,
+        )
+        assert message is not None
+        assert str(message.chat_id) != foreign_chat_id
+        assert message.chat.kind == "auto"
+    finally:
+        db.close()
+
+
+def test_post_background_message_drops_without_target(workspace_and_user, new_session):
+    """No valid chat AND no resolvable user → dropped (returns None), never
+    a guessatorial write."""
+    from services.chat_messenger import post_background_message
+
+    ws_id, _clerk, _user = workspace_and_user
+    db = new_session()
+    try:
+        assert (
+            post_background_message(
+                db,
+                workspace_id=ws_id,
+                text="orphan",
+                source={"origin": "watcher"},
+                clerk_user_id="user_does_not_exist",
+            )
+            is None
+        )
+    finally:
+        db.close()
+
+
+def test_deliver_background_message_never_raises():
+    """The producer entrypoint is fail-soft: a poisoned db never propagates
+    into a watcher tick or scheduled task."""
+    from services.chat_messenger import deliver_background_message
+
+    boom = MagicMock()
+    boom.query.side_effect = RuntimeError("db down")
+    assert (
+        deliver_background_message(
+            boom,
+            workspace_id=str(uuid.uuid4()),
+            text="x",
+            source={"origin": "watcher"},
+            clerk_user_id="user_x",
+        )
+        is None
+    )
+
+
+# ---------------------------------------------------------------------------
+# S4 — origin capture is server-injected and unspoofable
+# ---------------------------------------------------------------------------
+
+def test_origin_chat_id_parser():
+    from modules.tools.discovery.handlers_watches import _origin_chat_id
+
+    good = uuid.uuid4()
+    assert _origin_chat_id({"_origin_chat_id": str(good)}) == good
+    assert _origin_chat_id({"_origin_chat_id": "not-a-uuid"}) is None
+    assert _origin_chat_id({}) is None
+
+
+def test_executor_injects_and_overwrites_origin():
+    """Source-level pin: the origin comes from caller_context and OVERWRITES
+    any LLM-supplied param (no `not in params` guard — unlike _created_by,
+    which is deliberately caller-preserving)."""
+    src = (
+        _orchestrator_root
+        / "modules" / "tools" / "discovery" / "platform_executor.py"
+    ).read_text()
+    block = re.search(
+        r"_WATCH_ORIGIN_ACTIONS = \((?P<actions>[^)]*)\).*?"
+        r"if action_name in _WATCH_ORIGIN_ACTIONS:(?P<body>.*?)\n\n",
+        src,
+        re.S,
+    )
+    assert block, "origin injection block missing"
+    for action in (
+        "platform_create_watch",
+        "platform_create_mission",
+        "platform_execute_playbook",
+        "platform_execute_recipe",
+        "platform_schedule_task",
+    ):
+        assert action in block.group("actions")
+    assert 'caller_context or {}).get("conversation_id")' in block.group("body")
+    assert '"_origin_chat_id" not in params' not in block.group("body")
+
+
+# ---------------------------------------------------------------------------
+# S5 — the watcher speaks (bell first, chat second, both fail-soft)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("event_type", ["watch_verdict", "watch_action", "watch_escalation"])
+def test_watch_events_post_to_chat(monkeypatch, event_type):
+    import services.chat_messenger as messenger
+    from core.services.notification_dispatcher import NotificationDispatcher
+    from services.watch_notifications import dispatch_watch_notification
+
+    async def _dispatch(self, **kwargs):
+        return {"dispatched_to": ["in_app"]}
+
+    monkeypatch.setattr(NotificationDispatcher, "dispatch", _dispatch)
+
+    delivered = []
+    monkeypatch.setattr(
+        messenger, "deliver_background_message",
+        lambda db, **kw: delivered.append(kw) or None,
+    )
+
+    origin = uuid.uuid4()
+    watch = SimpleNamespace(
+        id=uuid.uuid4(),
+        workspace_id=uuid.uuid4(),
+        created_by="user_abc",
+        origin_chat_id=origin,
+        title="Watch: nightly report",
+        quality_threshold=0.7,
+    )
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = None  # clerk unresolvable → workspace-wide bell
+
+    ok = asyncio.run(
+        dispatch_watch_notification(
+            db, watch, event_type=event_type, title="t", message="m", status="ok"
+        )
+    )
+    assert ok is True
+    assert len(delivered) == 1
+    assert delivered[0]["chat_id"] == str(origin)
+    assert delivered[0]["clerk_user_id"] == "user_abc"
+    assert delivered[0]["source"]["event"] == event_type
+    assert delivered[0]["link_type"] == "watch"
+
+
+def test_non_watch_events_do_not_post_to_chat(monkeypatch):
+    import services.chat_messenger as messenger
+    from core.services.notification_dispatcher import NotificationDispatcher
+    from services.watch_notifications import dispatch_watch_notification
+
+    async def _dispatch(self, **kwargs):
+        return {}
+
+    monkeypatch.setattr(NotificationDispatcher, "dispatch", _dispatch)
+    delivered = []
+    monkeypatch.setattr(
+        messenger, "deliver_background_message",
+        lambda db, **kw: delivered.append(kw),
+    )
+    watch = SimpleNamespace(id=1, workspace_id=uuid.uuid4(), created_by=None)
+    db = MagicMock()
+    asyncio.run(
+        dispatch_watch_notification(
+            db, watch, event_type="watch_created", title="t", message=None
+        )
+    )
+    assert delivered == []
+
+
+# ---------------------------------------------------------------------------
+# S6 — scheduled-task output is delivered, not discarded
+# ---------------------------------------------------------------------------
+
+def _run_trigger(monkeypatch, *, result, origin_chat_id, task_id=7):
+    import modules.agents.factory.agent_factory as factory_mod
+    import services.chat_messenger as messenger
+    from services.scheduled_task_service import ScheduledTaskService
+
+    class FakeFactory:
+        def __init__(self, db_session):
+            pass
+
+        async def execute_with_prompt(self, **kwargs):
+            return result
+
+    monkeypatch.setattr(factory_mod, "AgentFactory", FakeFactory)
+    delivered = []
+    monkeypatch.setattr(
+        messenger, "deliver_background_message",
+        lambda db, **kw: delivered.append(kw),
+    )
+    asyncio.run(
+        ScheduledTaskService._trigger_agent_chat(
+            workspace_id=str(uuid.uuid4()),
+            agent_id=1,
+            message="[Scheduled Task #7] do the thing",
+            db=MagicMock(),
+            origin_chat_id=origin_chat_id,
+            task_id=task_id,
+        )
+    )
+    return delivered
+
+
+def test_scheduled_output_delivered_to_origin_chat(monkeypatch):
+    origin = str(uuid.uuid4())
+    delivered = _run_trigger(
+        monkeypatch, result={"result": "Here is the weekly digest."}, origin_chat_id=origin
+    )
+    assert len(delivered) == 1
+    assert delivered[0]["chat_id"] == origin
+    assert delivered[0]["text"] == "Here is the weekly digest."
+    assert delivered[0]["source"] == {"origin": "scheduled_task"}
+    assert delivered[0]["link_id"] == "7"
+
+
+def test_scheduled_output_without_origin_stays_log_only(monkeypatch):
+    delivered = _run_trigger(
+        monkeypatch, result={"result": "text"}, origin_chat_id=None
+    )
+    assert delivered == []
+
+
+def test_scheduled_empty_output_posts_nothing(monkeypatch):
+    delivered = _run_trigger(
+        monkeypatch, result={"result": "   "}, origin_chat_id=str(uuid.uuid4())
+    )
+    assert delivered == []
+
+
+# ---------------------------------------------------------------------------
+# S7 — frame routing + the NOTIFY emitter
+# ---------------------------------------------------------------------------
+
+def test_frame_for_payload_routes_chat_changed():
+    import json
+
+    from services.board_events import frame_for_payload
+
+    ws = str(uuid.uuid4())
+    chat_payload = json.dumps(
+        {"workspace_id": ws, "chat_id": "c1", "user_id": 5, "event": "chat_changed"}
+    )
+    board_payload = json.dumps({"workspace_id": ws, "task_id": 1, "event": "task_changed"})
+    foreign_payload = json.dumps(
+        {"workspace_id": str(uuid.uuid4()), "event": "chat_changed"}
+    )
+
+    assert "event: chat_changed" in frame_for_payload(chat_payload, ws)
+    assert "event: board_changed" in frame_for_payload(board_payload, ws)
+    assert frame_for_payload(foreign_payload, ws) is None  # tenant gate holds
+
+
+def test_notify_chat_event_emits_payload():
+    import json
+
+    from services.board_events import notify_chat_event
+
+    db = MagicMock()
+    ws = uuid.uuid4()
+    notify_chat_event(db, workspace_id=ws, chat_id="c-9", user_id=3)
+    args = db.execute.call_args
+    params = args.args[1]
+    payload = json.loads(params["payload"])
+    assert payload == {
+        "workspace_id": str(ws),
+        "chat_id": "c-9",
+        "user_id": 3,
+        "event": "chat_changed",
+    }
+
+
+# ---------------------------------------------------------------------------
+# S8 — /vote and /agents resolve (the PRD-220 /search regression class)
+# ---------------------------------------------------------------------------
+
+def test_chat_router_literal_routes_precede_param_routes():
+    """Declaration order IS the dispatch order in FastAPI: every literal
+    chat route must be declared before the /{chat_id} catch-alls for its
+    method, or it is dead (matched as chat_id='vote'/'agents'/'search')."""
+    from api.chat import router
+
+    order = [
+        (sorted(r.methods)[0], r.path)
+        for r in router.routes
+        if hasattr(r, "methods")
+    ]
+
+    def index_of(method, path):
+        return order.index((method, path))
+
+    assert index_of("GET", "/api/chat/search") < index_of("GET", "/api/chat/{chat_id}")
+    assert index_of("GET", "/api/chat/agents") < index_of("GET", "/api/chat/{chat_id}")
+    assert index_of("PATCH", "/api/chat/vote") < index_of("PATCH", "/api/chat/{chat_id}")
+
+
+# ---------------------------------------------------------------------------
+# S3 — the additive columns exist on the models and in the one migration
+# ---------------------------------------------------------------------------
+
+def test_models_carry_the_205_columns():
+    from core.models.core import Chat, Message
+    from core.models.watches import Watch
+
+    assert "kind" in Chat.__table__.columns
+    assert Chat.__table__.columns["kind"].nullable is False
+    assert "source" in Message.__table__.columns
+    assert Message.__table__.columns["source"].nullable is True
+    assert "origin_chat_id" in Watch.__table__.columns
+
+
+def test_migration_is_additive_and_single_parent():
+    src = (
+        _orchestrator_root / "alembic" / "versions" / "prd205_auto_speaks.py"
+    ).read_text()
+    assert 'down_revision = "prd199_drop_fake_stats"' in src
+    for col in ("source", "kind", "origin_chat_id"):
+        assert col in src
+    assert "agent_scheduled_tasks" in src
+    assert "drop_table" not in src  # additive only


### PR DESCRIPTION
## Summary

**Builds PRD-205 "Auto Speaks"** (spec merged in #557 — that PR landed the document only; this is the code). Background producers can finally talk: watcher verdicts/actions/escalations and scheduled-task outputs land **in the conversation** — the originating chat when known, else the per-user **Auto thread** — with a persisted `Auto · background` badge and live receive in open chats. The PRD-77 output discard is dead. Built to the spec's §8 recommendations (applied as defaults per its header).

### S1+S2 · ChatMessenger + the Auto thread
`services/chat_messenger.py` — the one seam. Clerk strings resolve to integer `users.id` at the seam (#513 lesson, never written raw); a `chat_id` is honoured only if it belongs to the workspace, else Auto-thread fallback (`chats.kind='auto'`, one per (workspace,user) via partial unique index, race-safe find-or-create, ordinary chat otherwise — deletable, recreated on next post). Parts shape identical to in-turn assistant writes; posting bumps `updated_at` so PRD-220's history re-sort ships free. `deliver_background_message` is the fail-soft producer entrypoint.

### S3 · One additive migration
`messages.source` JSONB (off `parts` — the `retrieval_context`/`context_trace` discipline) · `chats.kind` + CHECK + partial unique index · `watches.origin_chat_id` · **`agent_scheduled_tasks.origin_chat_id`** (builder-verified per the spec: the row is agent-created — `created_by_agent_id`, no human — so without a captured origin the delivery has no target; same capture pattern as watches). Chains single-parent on the current head (`prd199_drop_fake_stats`) — §8-Q7, no second join of the same parents. `GET /{chat_id}/messages` returns `source` (null for all historical rows).

### S4 · Origin capture, unspoofable
The executor lifts `caller_context['conversation_id']` into `params['_origin_chat_id']` for the five origin-capturing actions (watch create, mission create, playbook execute ×2 aliases, schedule task) — server-injected and **overwriting** any LLM-supplied value (unlike `_created_by`, which is deliberately caller-preserving; a test pins the difference). Both watch-creation paths and the scheduled-task INSERT persist it.

### S5 · The watcher speaks
`dispatch_watch_notification` (the one PRD-204 seam all three event types flow through) also posts `watch_verdict` / `watch_action` / `watch_escalation` into the conversation. Bell first, chat second, both fail-soft (§8-Q3: both surfaces in v1; escalations always keep the bell).

### S6 · Scheduled tasks deliver — the PRD-77 discard dies
`_trigger_agent_chat` posts non-empty output to the task's captured origin chat with `source.origin="scheduled_task"`. A task with **no** captured origin (pre-205 rows, API creations) keeps log-only behaviour honestly rather than guessing a target — new tasks created from chat get delivery from their first run. Raw-SQL bind uses `CAST(:origin_chat_id AS uuid)` (the SQLAlchemy 2.0 lesson).

### S7 · Live receive + the badge that survives reload
`notify_chat_event` rides the existing `board_events` NOTIFY channel; `frame_for_payload` preserves `chat_changed` frames (tenant gate unchanged, test-pinned). The always-mounted board SSE hook fans them out as a window event; `useChat` merges missing messages **by id, append-only** (an in-flight streaming placeholder has an id the server doesn't know — never clobbered); `getChatMessages` maps persisted `source.label` into the existing metadata badge slot. No react-query migration (spec §9). Chat pages outside the Command Center shell fall back to on-open fetch (§8-Q4, accepted v1).

### S8 · Two dead chat routes resolve
`PATCH /vote` and `GET /agents` were declared after `/{chat_id}` and never matched (the PRD-220 `/search` failure mode). Moved above; a route-order regression test locks `/search`, `/vote`, `/agents` together. **No manifest delta** (paths unchanged, none added).

## Test plan
- Backend suite `tests/test_prd205_auto_speaks.py`: messenger scoping/fallback/fail-soft + Auto-thread idempotence (DB-backed, PRD-204 idiom, skips without Postgres); origin parser + injection-overwrite source pin; watcher delivery ×3 event types at the dispatcher seam; scheduled delivery / no-origin / empty-output; frame routing + tenant gate + emitter payload; model + migration shape guards; route order.
- Frontend `prd205-auto-speaks.test.ts`: `chat_changed` SSE frame parse; persisted-source→badge mapping.
- Migration additive-only, single head maintained; self-applies on boot.

## Post-merge smoke (2 minutes, in the UI)
1. In a chat: "run the [any playbook] and watch it" → the verdict should arrive back **in that chat** with the `Auto · background` badge (live if the Command Center shell is mounted; on next open otherwise).
2. "schedule a task for yourself in 2 minutes: summarise today's board" → output lands in the same conversation when it fires.
3. An "Auto" thread appears in chat history the first time a background message has no originating chat.
