### PR TITLE
feat(prd-205): port the three #560 deltas missing from merged main

### DIFF
--- a/frontend/components/chatbot/chat-widget.tsx
+++ b/frontend/components/chatbot/chat-widget.tsx
@@ -314,6 +314,12 @@ function AutoChatTab({ currentPage, onClose }: { currentPage: string; onClose?: 
                       <span className="min-w-0 flex-1 truncate text-xs font-medium text-foreground">
                         {thread.title}
                       </span>
+                      {/* PRD-205 S7: mark the thread where Auto speaks unprompted */}
+                      {thread.kind === 'auto' && (
+                        <span className="shrink-0 rounded-full border border-warning/20 bg-warning/10 px-1.5 text-[9px] leading-4 text-warning">
+                          Auto
+                        </span>
+                      )}
                       <span className="shrink-0 text-[10px] text-muted-foreground">
                         {threadTimeAgo(thread.updatedAt)}
                       </span>

--- a/frontend/components/chatbot/sidebar-history-item.tsx
+++ b/frontend/components/chatbot/sidebar-history-item.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 import { MessageSquare, Trash2 } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { deleteChat } from '@/lib/chat/api'
 import { truncate } from '@/lib/utils'
@@ -67,7 +68,13 @@ export function SidebarHistoryItem({ chat, onDelete, onSelect, isActive = false 
     >
       <MessageSquare className="w-4 h-4 flex-shrink-0" />
       <span className="flex-1 text-sm truncate">{truncate(chat.title, 30)}</span>
-      
+      {/* PRD-205 S7: subtle marker for the thread where Auto speaks unprompted */}
+      {chat.kind === 'auto' && (
+        <Badge variant="outline" className="shrink-0 px-1.5 py-0 text-[10px] bg-warning/10 border-warning/20 text-warning">
+          Auto
+        </Badge>
+      )}
+
       <Button
         variant="ghost"
         size="sm"

--- a/frontend/components/chatbot/studio-chat-shell.tsx
+++ b/frontend/components/chatbot/studio-chat-shell.tsx
@@ -218,6 +218,10 @@ export function StudioChatShell({
                         aria-hidden
                       />
                       <span className="sh-chat-thread-title">{t.title}</span>
+                      {/* PRD-205 S7: mark the thread where Auto speaks unprompted */}
+                      {t.kind === 'auto' && (
+                        <span className="sh-chat-pill brand">Auto</span>
+                      )}
                       <span className="sh-chat-thread-ts">
                         {isOpening ? '…' : rel}
                       </span>

--- a/frontend/types/chat.ts
+++ b/frontend/types/chat.ts
@@ -211,6 +211,8 @@ export interface Chat {
   lastContext?: AppUsage
   /** PRD-220: latest message text (truncated server-side) for thread lists. */
   lastMessagePreview?: string | null
+  /** PRD-205: 'auto' marks the per-user thread where Auto speaks unprompted. */
+  kind?: 'user' | 'auto'
 }
 
 /**

--- a/orchestrator/api/chat.py
+++ b/orchestrator/api/chat.py
@@ -589,7 +589,9 @@ async def get_chat_history(
             "updatedAt": chat.updated_at.isoformat(),
             "visibility": chat.visibility,
             "lastContext": chat.last_context,
-            "lastMessagePreview": previews.get(str(chat.id))
+            "lastMessagePreview": previews.get(str(chat.id)),
+            # PRD-205 S7: 'auto' marks the thread where Auto speaks unprompted.
+            "kind": chat.kind,
         }
         for chat in chats
     ]
@@ -769,7 +771,9 @@ async def get_chat(
         "createdAt": chat.created_at.isoformat(),
         "updatedAt": chat.updated_at.isoformat(),
         "visibility": chat.visibility,
-        "lastContext": chat.last_context
+        "lastContext": chat.last_context,
+        # PRD-205 S7: 'auto' marks the thread where Auto speaks unprompted.
+        "kind": chat.kind,
     }
 
 

--- a/orchestrator/modules/tools/discovery/platform_executor.py
+++ b/orchestrator/modules/tools/discovery/platform_executor.py
@@ -1007,8 +1007,11 @@ class PlatformActionExecutor:
         # PRD-205 S4: capture the originating conversation for watch-creating
         # actions (direct create + the launches whose handlers auto-create a
         # watch) so verdicts post back into that chat. Server-injected from
-        # caller_context; an LLM-supplied param of the same name is OVERWRITTEN
-        # -- the origin is never spoofable via tool args.
+        # caller_context; a caller-supplied param of the same name is ALWAYS
+        # stripped first -- inject-on-truthy alone would let a spoofed tool
+        # arg survive the headless paths (board dispatcher, workflows) where
+        # caller_context carries no conversation_id. The origin is never
+        # spoofable via tool args.
         _WATCH_ORIGIN_ACTIONS = (
             "platform_create_watch",
             "platform_create_mission",
@@ -1017,6 +1020,7 @@ class PlatformActionExecutor:
             "platform_schedule_task",
         )
         if action_name in _WATCH_ORIGIN_ACTIONS:
+            params = {k: v for k, v in params.items() if k != "_origin_chat_id"}
             _origin_chat = (caller_context or {}).get("conversation_id")
             if _origin_chat:
                 params = {**params, "_origin_chat_id": str(_origin_chat)}

--- a/orchestrator/tests/test_prd205_auto_speaks.py
+++ b/orchestrator/tests/test_prd205_auto_speaks.py
@@ -249,6 +249,64 @@ def test_executor_injects_and_overwrites_origin():
     assert '"_origin_chat_id" not in params' not in block.group("body")
 
 
+def test_executor_strips_spoofed_origin_without_context(monkeypatch):
+    """A caller-supplied _origin_chat_id must never reach a handler: the
+    headless paths (board dispatcher, workflows) carry no conversation_id in
+    caller_context, so inject-on-truthy alone would let the spoofed tool arg
+    survive there. The executor strips the key FIRST, then injects only the
+    context value."""
+    import modules.tools.discovery as discovery_pkg
+    from modules.tools.discovery.platform_executor import PlatformActionExecutor
+
+    registry = MagicMock()
+    registry.get.return_value = None  # no action_def -> permission gates no-op
+    monkeypatch.setattr(discovery_pkg, "get_action_registry", lambda: registry)
+
+    seen = []
+
+    async def _handler(db, workspace_id, params):
+        seen.append(params)
+        return {"success": True}
+
+    executor = PlatformActionExecutor(MagicMock(), uuid.uuid4())
+    executor._handlers["platform_create_watch"] = _handler
+
+    spoofed = str(uuid.uuid4())
+
+    # Headless: no caller_context at all -> the spoofed arg is dropped.
+    result = asyncio.run(
+        executor.execute(
+            "platform_create_watch",
+            {"title": "w", "_origin_chat_id": spoofed},
+            caller_context=None,
+        )
+    )
+    assert result == {"success": True}
+    assert "_origin_chat_id" not in seen[0]
+    assert seen[0]["title"] == "w"
+
+    # Context without a conversation (board dispatcher shape) -> still dropped.
+    asyncio.run(
+        executor.execute(
+            "platform_create_watch",
+            {"title": "w", "_origin_chat_id": spoofed},
+            caller_context={"user_id": "user_abc"},
+        )
+    )
+    assert "_origin_chat_id" not in seen[1]
+
+    # Chat path: the context value wins over the spoofed arg.
+    origin = str(uuid.uuid4())
+    asyncio.run(
+        executor.execute(
+            "platform_create_watch",
+            {"title": "w", "_origin_chat_id": spoofed},
+            caller_context={"conversation_id": origin},
+        )
+    )
+    assert seen[2]["_origin_chat_id"] == origin
+
+
 # ---------------------------------------------------------------------------
 # S5 — the watcher speaks (bell first, chat second, both fail-soft)
 # ---------------------------------------------------------------------------

--- a/orchestrator/tests/test_prd205_auto_speaks.py
+++ b/orchestrator/tests/test_prd205_auto_speaks.py
@@ -480,6 +480,41 @@ def test_notify_chat_event_emits_payload():
     }
 
 
+def test_history_and_get_chat_surface_kind(workspace_and_user, new_session):
+    """S7 passthrough: /history rows and GET /{chat_id} carry ``chats.kind``
+    so the UI can mark the Auto thread ('user' for ordinary chats)."""
+    from api.chat import get_chat, get_chat_history
+    from consumers.chatbot.service import ChatService
+    from services.chat_messenger import find_or_create_auto_chat
+
+    ws_id, _clerk, user_int_id = workspace_and_user
+    db = new_session()
+    try:
+        regular = ChatService(db).create_chat(
+            user_id=user_int_id,
+            title="regular-kind",
+            workspace_id=uuid.UUID(ws_id),
+        )
+        auto = find_or_create_auto_chat(db, ws_id, user_int_id)
+
+        # get_user_id's fast path takes an integer ctx.user.id as-is, so a
+        # SimpleNamespace principal exercises the real endpoint bodies.
+        ctx = SimpleNamespace(
+            workspace_id=uuid.UUID(ws_id),
+            user=SimpleNamespace(id=user_int_id),
+        )
+
+        rows = asyncio.run(get_chat_history(limit=50, ctx=ctx, db=db))
+        by_id = {row["id"]: row for row in rows}
+        assert by_id[str(auto.id)]["kind"] == "auto"
+        assert by_id[str(regular.id)]["kind"] == "user"
+
+        payload = asyncio.run(get_chat(str(auto.id), ctx=ctx, db=db))
+        assert payload["kind"] == "auto"
+    finally:
+        db.close()
+
+
 # ---------------------------------------------------------------------------
 # S8 — /vote and /agents resolve (the PRD-220 /search regression class)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

PR #561 (parallel build) merged PRD-205 to main; PR #560 is closed as superseded. Three deltas from #560 were missing on merged main — this PR ports them, adapted by hand onto main's current file state (source: closed-branch commits `1a7404be4` / `b604b82d9`).

### 1. fix — executor anti-spoof strip (`platform_executor.py`)
Merged main injected `_origin_chat_id` only when `caller_context` carried a `conversation_id`, so on headless paths (board dispatcher, workflows) an LLM-supplied `_origin_chat_id` tool arg survived into handlers — contradicting the comment's "never spoofable" claim. Now the key is ALWAYS stripped from params for `_WATCH_ORIGIN_ACTIONS`, then injected from context when present. Behavioral test added (spoofed arg dropped with `caller_context=None`, dropped with a context lacking `conversation_id`, and context value wins on the chat path). `_origin_chat_id` has no legitimate params-side producer anywhere (grepped), so the strip cannot break an internal caller.

`_created_by` (the `_MISSION_ATTRIBUTED` block above) was checked for the same hole: its `"_created_by" not in params` guard is caller-preserving even when context IS present — different, deliberate semantics (PRD-163 vintage, pinned as "deliberately caller-preserving" by `test_executor_injects_and_overwrites_origin`'s docstring). Left as-is per that documented policy; flagging here in case Gerard wants it hardened too.

### 2. feat — `chats.kind` passthrough (`api/chat.py`)
`/api/chat/history` rows and `GET /api/chat/{chat_id}` now include `kind` (`'user'|'auto'`; column + model shipped in #561's migration). Payload-only change, no new route — committed route-manifest untouched. Endpoint-level test added to `test_prd205_auto_speaks.py` on its live-Postgres fixtures (skips cleanly without the 205 schema).

### 3. feat — Auto thread markers (frontend)
`Chat` type gains `kind?: 'user' | 'auto'`; `kind === 'auto'` rows render a subtle "Auto" chip in each surface's existing idiom:
- classic sidebar rows (`sidebar-history-item.tsx`): `Badge variant="outline"` with warning tints
- widget thread switcher (`chat-widget.tsx`): pill span
- studio shell thread ledger (`studio-chat-shell.tsx`): `sh-chat-pill brand`

NOT ported (deliberate): #560's `lib/chat/live-events` module + `useChatChangedListener` refetch wiring — merged main has its own S7 live-receive (`use-board-event-stream` -> `automatos:chat-changed` -> `lib/chat/hooks`); only the markers were missing. `sidebar.tsx` itself is untouched (its only #560 delta was that out-of-scope listener). No frontend marker tests existed on #560 to port; tsc/eslint/vitest lanes gate.

## Test plan
- [ ] CI orchestrator-tests: new S4 spoof-strip test + S7 kind-passthrough test green
- [ ] CI frontend lanes (tsc/eslint/vitest) green
- [ ] Existing S4 source-pin test still green (strip keeps overwrite semantics)

🤖 Generated with [Claude Code](https://claude.com/claude-code)