### PR TITLE
fix(widgets): CORS preflights honour per-key allowed_domains — unblocks the Academy tutor (PRD-TUTOR-LIVE S0)

### DIFF
--- a/orchestrator/api/widgets/cors.py
+++ b/orchestrator/api/widgets/cors.py
@@ -17,9 +17,16 @@ P2-13) aborts boot on an empty allowlist, and this module fails CLOSED if
 that state is ever reached anyway. The actual security boundary on
 /api/sites is the JWT in cookies, not CORS — CORS just lets the dashboard
 browser issue the request in the first place.
+
+Origins named on an active public SDK key's ``allowed_domains`` are honoured
+too (PRD-TUTOR-LIVE S0): preflights carry no Authorization, so a key-scoped
+origin used to die at OPTIONS with 403 before ``widget_auth`` ever saw the
+request it would have approved. See ``_origin_allowed_dynamic``.
 """
 
 import logging
+import time
+from starlette.concurrency import run_in_threadpool
 from starlette.types import ASGIApp, Receive, Scope, Send
 from config import config
 
@@ -63,6 +70,59 @@ def _origin_allowed(origin: str) -> bool:
     return origin.rstrip("/") in WIDGET_ORIGIN_ALLOWLIST
 
 
+# ── Key-allowlist fallback (PRD-TUTOR-LIVE S0) ──────────────────────────
+# A browser preflight carries no Authorization header, so this middleware
+# cannot know WHICH ak_pub_ key the actual request will present — but it can
+# ask whether the origin is explicitly named on ANY active public key's
+# ``allowed_domains``. Without this, an origin that widget_auth would approve
+# (academy.automatos.app, a provisioned storefront) 403s at OPTIONS unless it
+# is duplicated into WIDGET_ORIGIN_ALLOWLIST. The lookup reuses the exact
+# matcher widget_auth uses (``ApiKeyService.check_domain``) so the preflight
+# and the request can never disagree, and it is cached per origin: one DB
+# scan per origin per TTL, cache bounded so origin-scanning clients cannot
+# grow it without limit. Negative verdicts are cached; lookup FAILURES are
+# not (fail closed now, retry on the next preflight).
+
+_DYNAMIC_TTL_SECONDS = 60.0
+_DYNAMIC_CACHE_MAX = 512
+_dynamic_origin_cache: dict[str, tuple[bool, float]] = {}
+
+
+def _origin_allowed_by_key_sync(origin: str) -> bool:
+    # Imported lazily: cors.py loads during app import, before the DB layer
+    # is necessarily ready, and tests monkeypatch this function wholesale.
+    from core.database.database import SessionLocal
+    from core.services.api_key_service import ApiKeyService
+
+    db = SessionLocal()
+    try:
+        return ApiKeyService.origin_allowed_by_any_key(db, origin)
+    finally:
+        db.close()
+
+
+async def _origin_allowed_dynamic(origin: str) -> bool:
+    """Env allowlist fast path, then the cached key-allowlist fallback."""
+    if _origin_allowed(origin):
+        return True
+    now = time.monotonic()
+    cached = _dynamic_origin_cache.get(origin)
+    if cached and cached[1] > now:
+        return cached[0]
+    try:
+        allowed = await run_in_threadpool(_origin_allowed_by_key_sync, origin)
+    except Exception:
+        logger.exception(
+            "widget CORS: key-allowlist lookup failed for origin %s — failing closed",
+            origin,
+        )
+        return False
+    if len(_dynamic_origin_cache) >= _DYNAMIC_CACHE_MAX:
+        _dynamic_origin_cache.pop(next(iter(_dynamic_origin_cache)))
+    _dynamic_origin_cache[origin] = (allowed, now + _DYNAMIC_TTL_SECONDS)
+    return allowed
+
+
 def _path_is_covered(path: str) -> bool:
     return any(path.startswith(prefix) for prefix in COVERED_PATH_PREFIXES)
 
@@ -89,7 +149,7 @@ class WidgetCORSMiddleware:
 
         # Handle OPTIONS preflight
         if scope["method"] == "OPTIONS":
-            if not origin or not _origin_allowed(origin):
+            if not origin or not await _origin_allowed_dynamic(origin):
                 response_headers = [
                     (b"content-type", b"text/plain"),
                     (b"vary", b"Origin"),
@@ -110,15 +170,20 @@ class WidgetCORSMiddleware:
                 (b"access-control-max-age", b"86400"),
                 (b"access-control-allow-credentials", b"true"),
             ]
-            await send({"type": "http.response.start", "status": 200, "headers": response_headers})
+            # 204 per the S0 preflight contract (a body-less answer; browsers
+            # accept 200 or 204, the contract pins the canonical one).
+            await send({"type": "http.response.start", "status": 204, "headers": response_headers})
             await send({"type": "http.response.body", "body": b""})
             return
 
-        # For actual requests, inject CORS headers only for allowed origins.
-        # Strip any CORS headers an upstream middleware (e.g. FastAPI's
-        # CORSMiddleware) already added — duplicate Access-Control-Allow-*
-        # headers cause Chrome to reject the response with "Failed to fetch".
-        allowed = _origin_allowed(origin) if origin else False
+        # For actual requests, inject CORS headers only for allowed origins —
+        # the SAME combined decision as the preflight (S0 contract point 2: a
+        # green preflight alone doesn't let the browser read the SSE stream;
+        # the POST response must carry ACAO too). Strip any CORS headers an
+        # upstream middleware (e.g. FastAPI's CORSMiddleware) already added —
+        # duplicate Access-Control-Allow-* headers cause Chrome to reject the
+        # response with "Failed to fetch".
+        allowed = await _origin_allowed_dynamic(origin) if origin else False
 
         _CORS_HEADERS_TO_OVERRIDE = (
             b"access-control-allow-origin",

--- a/orchestrator/core/services/api_key_service.py
+++ b/orchestrator/core/services/api_key_service.py
@@ -227,6 +227,36 @@ class ApiKeyService:
 
         return False
 
+    @staticmethod
+    def origin_allowed_by_any_key(db: Session, origin: str) -> bool:
+        """True when *origin* matches the ``allowed_domains`` of ANY active
+        public key (widget CORS preflight fallback, PRD-TUTOR-LIVE S0).
+
+        A preflight carries no Authorization header, so the CORS middleware
+        cannot resolve which key the actual request will present — it can
+        only ask whether the origin is explicitly allowlisted by *some*
+        active public key, via the same :meth:`check_domain` matcher the
+        request-time check uses. Keys with an EMPTY ``allowed_domains`` (the
+        "any origin" opt-in honoured by :meth:`check_domain`) are
+        deliberately excluded here: counting them would reflect CORS headers
+        for every origin on earth the moment one unrestricted key exists.
+        A green preflight grants nothing by itself — ``widget_auth`` still
+        enforces the presented key's own allowlist on the request proper.
+        """
+        keys = (
+            db.query(SdkApiKey)
+            .filter(
+                SdkApiKey.is_active.is_(True),
+                SdkApiKey.key_type == "public",
+                SdkApiKey.allowed_domains.isnot(None),
+            )
+            .all()
+        )
+        return any(
+            key.allowed_domains and ApiKeyService.check_domain(key, origin)
+            for key in keys
+        )
+
     # ------------------------------------------------------------------
     # Permission check
     # ------------------------------------------------------------------

--- a/orchestrator/tests/test_prd008a_cors_coverage.py
+++ b/orchestrator/tests/test_prd008a_cors_coverage.py
@@ -93,5 +93,114 @@ def test_origin_allowed_with_explicit_allowlist():
         cors_mod.WIDGET_ORIGIN_ALLOWLIST = original
 
 
+# ---------------------------------------------------------------------------
+# PRD-TUTOR-LIVE S0 — key-allowlist preflight fallback
+# ---------------------------------------------------------------------------
+
+import asyncio  # noqa: E402
+from types import SimpleNamespace  # noqa: E402
+
+
+def _isolated_dynamic(monkeypatch):
+    """Fresh cache + saas edition + an env allowlist that misses the origin,
+    so every test exercises the fallback path deliberately."""
+    import api.widgets.cors as cors_mod
+
+    monkeypatch.setattr(cors_mod, "_dynamic_origin_cache", {})
+    monkeypatch.setattr(cors_mod, "WIDGET_ORIGIN_ALLOWLIST", {"https://app.automatos.app"})
+    monkeypatch.setattr(cors_mod.config, "AUTH_EDITION", "saas")
+    return cors_mod
+
+
+def test_preflight_falls_back_to_key_allowlist(monkeypatch):
+    """An origin absent from the env allowlist but named on an active public
+    key's allowed_domains passes the dynamic check (the academy case)."""
+    cors_mod = _isolated_dynamic(monkeypatch)
+    monkeypatch.setattr(cors_mod, "_origin_allowed_by_key_sync", lambda origin: True)
+
+    assert asyncio.run(cors_mod._origin_allowed_dynamic("https://academy.automatos.app")) is True
+
+
+def test_key_fallback_denies_unknown_origin(monkeypatch):
+    cors_mod = _isolated_dynamic(monkeypatch)
+    monkeypatch.setattr(cors_mod, "_origin_allowed_by_key_sync", lambda origin: False)
+
+    assert asyncio.run(cors_mod._origin_allowed_dynamic("https://malicious.example.com")) is False
+
+
+def test_env_fast_path_skips_the_db(monkeypatch):
+    cors_mod = _isolated_dynamic(monkeypatch)
+
+    def _boom(origin):
+        raise AssertionError("DB lookup must not run for env-allowlisted origins")
+
+    monkeypatch.setattr(cors_mod, "_origin_allowed_by_key_sync", _boom)
+    assert asyncio.run(cors_mod._origin_allowed_dynamic("https://app.automatos.app")) is True
+
+
+def test_key_fallback_verdict_is_cached(monkeypatch):
+    """Second ask within the TTL answers from cache — no second DB scan."""
+    cors_mod = _isolated_dynamic(monkeypatch)
+    calls = []
+
+    def _count(origin):
+        calls.append(origin)
+        return True
+
+    monkeypatch.setattr(cors_mod, "_origin_allowed_by_key_sync", _count)
+    assert asyncio.run(cors_mod._origin_allowed_dynamic("https://academy.automatos.app")) is True
+    assert asyncio.run(cors_mod._origin_allowed_dynamic("https://academy.automatos.app")) is True
+    assert len(calls) == 1
+
+
+def test_key_fallback_fails_closed_and_does_not_cache_failures(monkeypatch):
+    """A lookup ERROR denies now but is retried next time (only verdicts
+    cache); a scanning client cannot poison the cache with an outage."""
+    cors_mod = _isolated_dynamic(monkeypatch)
+
+    def _down(origin):
+        raise RuntimeError("db unavailable")
+
+    monkeypatch.setattr(cors_mod, "_origin_allowed_by_key_sync", _down)
+    assert asyncio.run(cors_mod._origin_allowed_dynamic("https://academy.automatos.app")) is False
+
+    monkeypatch.setattr(cors_mod, "_origin_allowed_by_key_sync", lambda origin: True)
+    assert asyncio.run(cors_mod._origin_allowed_dynamic("https://academy.automatos.app")) is True
+
+
+def test_origin_allowed_by_any_key_uses_check_domain_matcher():
+    """Service-level: the fallback consults the same matcher widget_auth
+    uses (host-only, fnmatch wildcards); empty-allowlist keys never count."""
+    from core.services.api_key_service import ApiKeyService
+
+    class _StubQuery:
+        def __init__(self, rows):
+            self._rows = rows
+
+        def filter(self, *_args):
+            return self
+
+        def all(self):
+            return self._rows
+
+    class _StubDb:
+        def __init__(self, rows):
+            self._rows = rows
+
+        def query(self, _model):
+            return _StubQuery(self._rows)
+
+    keyed = SimpleNamespace(allowed_domains=["academy.automatos.app", "*.up.railway.app"])
+    unrestricted = SimpleNamespace(allowed_domains=[])  # "any origin" opt-in — must NOT count
+
+    db = _StubDb([keyed])
+    assert ApiKeyService.origin_allowed_by_any_key(db, "https://academy.automatos.app") is True
+    assert ApiKeyService.origin_allowed_by_any_key(db, "https://automatos-academy-production.up.railway.app") is True
+    assert ApiKeyService.origin_allowed_by_any_key(db, "https://malicious.example.com") is False
+
+    assert ApiKeyService.origin_allowed_by_any_key(_StubDb([unrestricted]), "https://anything.example.com") is False
+    assert ApiKeyService.origin_allowed_by_any_key(_StubDb([]), "https://academy.automatos.app") is False
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Problem — the Academy tutor dies at preflight (PRD-TUTOR-LIVE S0)

Reproduced 2026-07-16 (full repro in `automatos-academy` → `docs/prds/PRD-TUTOR-LIVE.md` §4.1):

```bash
# The agent is alive — a direct POST (no preflight) streams a reply:
curl -sN -X POST https://api.automatos.app/api/widgets/chat \
  -H "Origin: https://academy.automatos.app" \
  -H "Authorization: Bearer $ACADEMY_CHAT_PUBLIC_KEY" ... # → 200 + SSE

# What every browser sends first — and where it dies:
curl -si -X OPTIONS https://api.automatos.app/api/widgets/chat \
  -H "Origin: https://academy.automatos.app" \
  -H "Access-Control-Request-Method: POST" ...            # → 403, zero ACAO headers
```

`WidgetCORSMiddleware` answers preflights **only** from the `WIDGET_ORIGIN_ALLOWLIST` env var. The academy origin lives on its `ak_pub_` key's `allowed_domains` — which `widget_auth` checks on the POST… that the browser never sends. Any key-scoped origin not duplicated into the env var has the same failure — this likely affects provisioned storefront embeds too, not just the Academy.

## Fix

Preflights carry no Authorization, so the middleware can't know *which* key will arrive — but it can ask whether the origin is **explicitly named on ANY active public key's `allowed_domains`**. New `ApiKeyService.origin_allowed_by_any_key(db, origin)` reuses the exact request-time matcher (`check_domain` — host-only compare, fnmatch wildcards), so preflight and request decisions can never drift. The combined decision also applies to the actual response: a green preflight alone doesn't let the browser read the SSE stream (S0 contract point 2).

Guard rails:

- **Origin policy is not loosened.** Empty-`allowed_domains` keys (the "any origin" POST-side opt-in) never count toward preflight reflection — an origin must be explicitly named somewhere (env var or a key). Unknown origins keep getting 403-with-no-ACAO.
- Per-origin **60s TTL cache** (bounded, 512 entries): one DB scan per origin per minute, negative verdicts cached, lookup **failures fail closed and are not cached** (deny now, retry next preflight).
- Env allowlist remains the DB-free fast path; `local`-edition permissiveness unchanged.
- Preflight status 200 → **204** per the S0 contract.

## S0 acceptance (PRD-TUTOR-LIVE §4.1)

1. ✅ `OPTIONS /api/widgets/chat` from an allowlisted origin → 204 + ACAO/methods/headers/max-age, answered from `Origin` alone
2. ✅ The actual POST (200, SSE) carries ACAO for the requesting origin
3. ✅ Non-allowlisted origins keep failing with no ACAO
4. ⬜ Browser verify on academy.automatos.app after deploy (devtools: preflight 204 → POST 200 → stream renders)

## Immediate unblock, no deploy needed

The tutor can come alive **today** by adding the academy origins to the existing env var on Railway:

```
WIDGET_ORIGIN_ALLOWLIST=...existing...,https://academy.automatos.app,https://automatos-academy-production.up.railway.app
```

(Entries must be full origins including `https://` — the env matcher compares whole origin strings.) This PR makes that duplication unnecessary going forward.

## Tests

7 new tests in `test_prd008a_cors_coverage.py`: fallback allows key-named origin / denies unknown / env fast-path skips DB / verdict caching / fail-closed-without-caching-failures / service matcher parity incl. wildcard + empty-list exclusion. No migration; no route changes.
