### PR TITLE
chore: encode the 2026-07-17 decision-box answers (attribution hardening + Graphiti slice-gate + PRD-206 consent/scope)

### DIFF
--- a/docs/PRDS/PRD-206-MEMORY-CONTINUITY-PERSONAL-CONTEXT.md
+++ b/docs/PRDS/PRD-206-MEMORY-CONTINUITY-PERSONAL-CONTEXT.md
@@ -119,7 +119,7 @@ Workspace + user scoping on every read/write (the existing `knowledge:*` permiss
 
 ## 8. Open questions — Gerard's call (decide, don't let me defer — CLAUDE.md §12)
 
-The draft's ten, plus three of mine. Recommendations inline; build proceeds on the recommendation where unanswered, flagged per the house flip-and-recut pattern — EXCEPT Q3/Q7 (privacy-shaped), which block their stories until answered.
+The draft's ten, plus three of mine. **Q3 + Q7 ANSWERED by Gerard 2026-07-17: Q3 = SILENT everything (no confirmation prompts — the S1 exclusion validator carries the consent weight; transparency via the panel + "forget that"). Q7 = split default (user_fact/preference private-to-me; project/decision/open_loop workspace-shared; per-memory override).** Remaining boxes build to the recommendation, flip-and-recut.
 
 1. **Proactive cadence** — daily mentions vs context-triggered only? **Rec: context-triggered only** (the §13 trigger list); a daily digest is a later opt-in.
 2. **Project cards visible day one?** **Rec: yes** — cards are what make memory legible; ship with Phase 2.

--- a/orchestrator/evals/graphiti_vs_baseline.py
+++ b/orchestrator/evals/graphiti_vs_baseline.py
@@ -22,10 +22,11 @@ Verdict shape reuses the ``operating_graph_uplift`` honest gate:
 aliases, published, **exit 0 always** — a sub-margin uplift is a valid,
 honest outcome (the flag stays OFF and the trial is a documented no-op).
 
-Margin: ≥ +5.0 points recall@5 (§8-Q1 proposal — Gerard confirms; the
-capability-slice gates — dup-rate, contradiction, multi-hop — land with
-S3/S4 and are listed here as pending slices so the verdict never
-overstates what has been measured).
+Bar (§8-Q1 CONFIRMED by Gerard 2026-07-17): ≥ +5.0 points recall@5 mean
+across tenants **AND** the contradicted-fact slice resolves to one live
+fact. Margin alone never adopts — temporal invalidation is the capability
+with no in-house substitute. The other slices (dup-rate, multi-hop) are
+reported, not gating.
 """
 
 from __future__ import annotations
@@ -45,13 +46,16 @@ DEFAULT_RETRIEVAL_BASELINE = _HERE / "baseline" / "kg_retrieval_2026-07.json"
 DEFAULT_MEMORY_BASELINE = _HERE / "baseline" / "memory_recall_2026-07.json"
 DEFAULT_TREATMENT = _HERE / "results" / "graphiti_recall.json"
 
-# Slices the verdict must eventually include (S3/S4); listed as pending so
-# a bare recall win can never silently read as "all criteria met".
-PENDING_SLICES = (
+# Capability slices (measured by S3/S4 once the trial runs). The
+# contradiction slice GATES adoption (Gerard 2026-07-17); the others are
+# reported. Treatment artifacts carry them as
+# {"slices": {"contradicted_fact_resolution": {"passed": bool}, ...}}.
+GATING_SLICE = "contradicted_fact_resolution"
+REPORTED_SLICES = (
     "duplicate_node_rate",
-    "contradicted_fact_resolution",
     "multi_hop_answer_quality",
 )
+PENDING_SLICES = (GATING_SLICE,) + REPORTED_SLICES
 
 
 def load_artifact(path: Path) -> Optional[Dict[str, Any]]:
@@ -144,19 +148,44 @@ def compute_gate(
         )
 
     mean_uplift = round(sum(t["uplift_points"] for t in tenants) / len(tenants), 2)
-    beats = mean_uplift >= margin_points
+    beats_margin = mean_uplift >= margin_points
+
+    # §8-Q1 (CONFIRMED 2026-07-17): adoption requires the margin AND the
+    # contradiction slice. Margin met with the slice unmeasured is PENDING
+    # (the trial hasn't produced its gating evidence), never an adopt.
+    slices = (treatment or {}).get("slices") or {}
+    gating = slices.get(GATING_SLICE)
+
+    if beats_margin and gating is None:
+        verdict = "PENDING"
+        note = (
+            "recall margin met but the gating contradiction slice is "
+            "unmeasured (S3) — adoption cannot fire on the aggregate alone"
+        )
+    elif beats_margin and bool(gating.get("passed")):
+        verdict = "ADOPT_UNBLOCKED"
+        note = (
+            "margin AND contradiction slice met — the adopt follow-through "
+            "(retire the in-house merge path) is unblocked as a §8 decision"
+        )
+    elif beats_margin:
+        verdict = "DO_NOT_ADOPT"
+        note = (
+            "recall margin met but the contradiction slice FAILED — temporal "
+            "invalidation is the point; flag stays OFF"
+        )
+    else:
+        verdict = "DO_NOT_ADOPT"
+        note = "below margin — flag stays OFF; a documented no-op is a valid outcome"
+
     return {
-        "verdict": "ADOPT_UNBLOCKED" if beats else "DO_NOT_ADOPT",
+        "verdict": verdict,
         "mean_uplift_points": mean_uplift,
         "margin_points": margin_points,
+        "gating_slice": {GATING_SLICE: gating},
         "tenants": tenants,
-        "pending_slices": list(PENDING_SLICES),
-        "note": (
-            "recall margin met — the S3/S4 capability slices must also move "
-            "before the adopt follow-through (§8-Q1 slice-gate)"
-            if beats
-            else "below margin — flag stays OFF; a documented no-op is a valid outcome"
-        ),
+        "pending_slices": [name for name in PENDING_SLICES if name not in slices],
+        "note": note,
     }
 
 

--- a/orchestrator/modules/tools/discovery/platform_executor.py
+++ b/orchestrator/modules/tools/discovery/platform_executor.py
@@ -1000,8 +1000,15 @@ class PlatformActionExecutor:
             "platform_update_mission_plan",
         )
         if action_name in _MISSION_ATTRIBUTED:
+            # Hardened 2026-07-17 (Gerard's call, flagged in #563): STRIP any
+            # caller-supplied _created_by first, then inject from context --
+            # the original PRD-163 caller-preserving guard let a spoofed tool
+            # arg claim attribution on headless paths (board dispatcher,
+            # workflows) where caller_context carries no user_id. Grep-verified
+            # no legitimate params-side producer exists.
+            params = {k: v for k, v in params.items() if k != "_created_by"}
             _driver = (caller_context or {}).get("user_id")
-            if _driver and "_created_by" not in params:
+            if _driver:
                 params = {**params, "_created_by": str(_driver)}
 
         # PRD-205 S4: capture the originating conversation for watch-creating

--- a/orchestrator/tests/test_prd198_graphiti_gate.py
+++ b/orchestrator/tests/test_prd198_graphiti_gate.py
@@ -38,7 +38,7 @@ def test_graphiti_variant_registered():
         {"any": "memory-baseline"},
         _artifact("pilot-a", {"graphiti": 0.80}),
     )
-    assert gate["verdict"] in ("ADOPT_UNBLOCKED", "DO_NOT_ADOPT")
+    assert gate["verdict"] in ("ADOPT_UNBLOCKED", "DO_NOT_ADOPT", "PENDING")
     assert gate["tenants"][0]["graphiti_recall_at_5"] == 0.80
 
 
@@ -67,12 +67,26 @@ def test_uplift_points_treatment_minus_baseline():
     retrieval = _artifact("pilot-a", {"baseline": 0.65, "rerank": 0.769, "hybrid_rrf": 0.692})
     memory = {"frozen": True}
 
-    winning = compute_gate(retrieval, memory, _artifact("pilot-a", {"graphiti": 0.83}))
+    # Margin met, contradiction slice PASSED → adopt unblocked (the 2026-07-17
+    # confirmed bar: margin AND slice, never margin alone).
+    winning_artifact = _artifact("pilot-a", {"graphiti": 0.83})
+    winning_artifact["slices"] = {"contradicted_fact_resolution": {"passed": True}}
+    winning = compute_gate(retrieval, memory, winning_artifact)
     # best baseline is rerank (0.769), not the plain baseline — no strawman
     assert winning["tenants"][0]["best_baseline_recall_at_5"] == 0.769
     assert winning["tenants"][0]["uplift_points"] == pytest.approx(6.1)
     assert winning["verdict"] == "ADOPT_UNBLOCKED"
-    assert winning["pending_slices"]  # a recall win alone never claims the slices
+
+    # Margin met, slice unmeasured → PENDING, never an adopt on aggregate alone.
+    unmeasured = compute_gate(retrieval, memory, _artifact("pilot-a", {"graphiti": 0.83}))
+    assert unmeasured["verdict"] == "PENDING"
+    assert "contradicted_fact_resolution" in unmeasured["pending_slices"]
+
+    # Margin met, slice FAILED → do not adopt (temporal invalidation is the point).
+    failed_artifact = _artifact("pilot-a", {"graphiti": 0.83})
+    failed_artifact["slices"] = {"contradicted_fact_resolution": {"passed": False}}
+    failed = compute_gate(retrieval, memory, failed_artifact)
+    assert failed["verdict"] == "DO_NOT_ADOPT"
 
     losing = compute_gate(retrieval, memory, _artifact("pilot-a", {"graphiti": 0.78}))
     assert losing["verdict"] == "DO_NOT_ADOPT"

--- a/orchestrator/tests/test_prd205_auto_speaks.py
+++ b/orchestrator/tests/test_prd205_auto_speaks.py
@@ -224,8 +224,9 @@ def test_origin_chat_id_parser():
 
 def test_executor_injects_and_overwrites_origin():
     """Source-level pin: the origin comes from caller_context and OVERWRITES
-    any LLM-supplied param (no `not in params` guard — unlike _created_by,
-    which is deliberately caller-preserving)."""
+    any LLM-supplied param. Since 2026-07-17 _created_by is hardened the
+    same way (strip-then-inject — Gerard's call on the #563 flag), so BOTH
+    attribution keys are unspoofable via tool args."""
     src = (
         _orchestrator_root
         / "modules" / "tools" / "discovery" / "platform_executor.py"
@@ -247,6 +248,23 @@ def test_executor_injects_and_overwrites_origin():
         assert action in block.group("actions")
     assert 'caller_context or {}).get("conversation_id")' in block.group("body")
     assert '"_origin_chat_id" not in params' not in block.group("body")
+
+
+def test_executor_created_by_is_strip_then_inject():
+    """The 2026-07-17 hardening: _created_by is stripped from params before
+    context injection — the old caller-preserving guard is gone, so a
+    spoofed tool arg can never claim mission attribution on headless
+    paths."""
+    src = (
+        _orchestrator_root
+        / "modules" / "tools" / "discovery" / "platform_executor.py"
+    ).read_text()
+    block = re.search(
+        r"if action_name in _MISSION_ATTRIBUTED:(?P<body>.*?)\n\n", src, re.S
+    )
+    assert block, "mission attribution block missing"
+    assert '"_created_by" not in params' not in block.group("body")
+    assert 'k != "_created_by"' in block.group("body")
 
 
 def test_executor_strips_spoofed_origin_without_context(monkeypatch):


### PR DESCRIPTION
Encodes the five answers Gerard selected on 2026-07-17:

1. **`_created_by` hardened** (strip-then-inject, matching `_origin_chat_id`) — the caller-preserving guard #563 flagged let a spoofed tool arg claim mission attribution on headless paths. Pinning tests updated; grep-verified no legitimate params-side producer.
2. **Graphiti adoption bar = +5pts AND the contradicted-fact slice.** The gate now returns `PENDING` when margin is met but the gating slice is unmeasured (adoption can never fire on the aggregate alone), `DO_NOT_ADOPT` when the slice failed. Tests cover all three margin×slice states.
3. **PRD-206 Q3 = silent-everything consent + Q7 = split sharing default** — stamped into the merged spec's §8. (Build note this creates: the S1 exclusion validator now carries the full consent weight — it gets hardened accordingly in the memory build, starting next.)
4. PRD-221 digest spend: approved as built (no code).

Small, test-covered, no migrations, no routes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stronger safeguards for mission attribution, ensuring caller-supplied creator information cannot override verified attribution.
  * Updated evaluation gates to require contradiction-resolution evidence before adoption is approved.

* **Bug Fixes**
  * Prevented false-positive adoption decisions when required evaluation evidence is missing or fails.

* **Documentation**
  * Updated memory continuity guidance with decisions on silent operation, consent, transparency, and default memory visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->