### PR TITLE
fix(memory): make Memory Explorer visible to workspace members

### DIFF
--- a/orchestrator/api/memory_stats.py
+++ b/orchestrator/api/memory_stats.py
@@ -23,10 +23,23 @@ from core.auth.super_admin import require_super_admin
 
 logger = logging.getLogger(__name__)
 
-# PRD-143 S7: observability tier — router-wide super-admin lock (fail-closed).
+# PRD-77 Memory Explorer is a per-workspace USER feature. Every read below
+# (/browse, /health, /stats/*, /layers) filters strictly on ctx.workspace_id and
+# rides the shared hybrid dependency, so an authenticated member sees ONLY their
+# own workspace's memory — full tenant isolation without a super-admin gate.
+# (PRD-143 S7 had locked the WHOLE router to the observability super-admin tier,
+# which 403'd the user-facing explorer and left the Memory tab blank.)
 router = APIRouter(
     prefix="/api/v1/memory",
-    tags=["Real Memory Stats"],
+    tags=["Memory Explorer"],
+)
+
+# The destructive / LLM-spending verbs (delete, consolidate) stay on the PRD-143
+# observability super-admin lock — admin-only, never relaxed. Same prefix, so the
+# route paths are unchanged; only their auth tier differs from the reads.
+admin_router = APIRouter(
+    prefix="/api/v1/memory",
+    tags=["Memory Admin"],
     dependencies=[Depends(require_super_admin)],
 )
 
@@ -458,7 +471,7 @@ async def browse_memories(
         return {"success": False, "error": str(e)[:200], "memories": []}
 
 
-@router.delete("/{memory_id}")
+@admin_router.delete("/{memory_id}")
 async def delete_memory(
     memory_id: str,
     ctx: RequestContext = Depends(get_request_context_hybrid),
@@ -800,7 +813,7 @@ class ConsolidateRequest(BaseModel):
     strategy: str = "merge"  # "merge" | "summarise"
 
 
-@router.post("/consolidate")
+@admin_router.post("/consolidate")
 async def consolidate_memories(
     body: ConsolidateRequest,
     ctx: RequestContext = Depends(get_request_context_hybrid),

--- a/orchestrator/main.py
+++ b/orchestrator/main.py
@@ -48,6 +48,7 @@ from api.widget_memory import router as widget_memory_router  # US-013: Widget m
 from api.analytics import router as analytics_router
 from api.workflow_history import router as workflow_history_router
 from api.memory_stats import router as memory_stats_router
+from api.memory_stats import admin_router as memory_stats_admin_router  # PRD-77: delete/consolidate stay super-admin (PRD-143 S7)
 from api.context_policy import router as context_policy_router
 from api.codegraph import router as codegraph_router  # PRD-11: New CodeGraph implementation
 from api.github_webhooks import router as github_webhooks_router  # GitHub PR automation
@@ -971,7 +972,8 @@ app.include_router(teams_router)  # PRD-158: Teams entity (list/create)
 app.include_router(blog_router)  # Authenticated blog management (Deliverables → Blogs)
 app.include_router(cache_router)  # Cache management and monitoring
 app.include_router(system_router)
-app.include_router(memory_stats_router)  # PRD-77 memory stats (/browse, /health, /stats/real)
+app.include_router(memory_stats_router)  # PRD-77 memory explorer reads (/browse, /health, /stats/real) — workspace-scoped, member-visible
+app.include_router(memory_stats_admin_router)  # PRD-77 memory mutations (delete/consolidate) — super-admin only (PRD-143 S7 obs tier)
 app.include_router(widget_memory_router)  # US-013: Widget memory panel (/api/memory)
 app.include_router(analytics_router)
 app.include_router(workflow_history_router)

--- a/orchestrator/tests/test_prd143_obs_routers_batch2.py
+++ b/orchestrator/tests/test_prd143_obs_routers_batch2.py
@@ -1,9 +1,15 @@
 """PRD-143 S7 — obs routers batch 2 locked to the super admin.
 
 Router-wide ``require_super_admin`` (core/auth/super_admin.py, S5) on:
-api/llm_analytics.py (BOTH routers: router + admin_router), api/memory_stats.py,
+api/llm_analytics.py (BOTH routers: router + admin_router),
 api/statistics.py, api/composio_analytics.py, api/database_analytics.py,
 api/execution_history.py, api/kpi_api.py, api/reports.py.
+
+api/memory_stats.py is NO LONGER router-wide locked: PRD-77's Memory Explorer is
+a per-workspace USER feature, so its reads (/browse, /health, /stats/*, /layers)
+ride hybrid auth and are workspace-scoped. Only its mutating verbs
+(DELETE /{id}, POST /consolidate) keep the super-admin lock on ``admin_router`` —
+covered by ``test_p2w2_authz_boundary_sweep::test_obs_tier_mutating_routes_stay_super_admin_locked``.
 
 Every endpoint on these routers must 403 for any principal that is not
 literally ``system_role == 'super_admin'`` — member, workspace admin/owner,
@@ -51,7 +57,6 @@ SUPER_ADMIN = UserContext(id="u-gerard", role="admin", system_role="super_admin"
 ROUTERS = [
     pytest.param("api.llm_analytics", "router", "/api/analytics/llm/usage", id="llm_analytics"),
     pytest.param("api.llm_analytics", "admin_router", "/api/admin/analytics/costs", id="llm_admin_analytics"),
-    pytest.param("api.memory_stats", "router", "/api/v1/memory/stats/real", id="memory_stats"),
     pytest.param("api.statistics", "router", "/api/system/agents/statistics", id="statistics"),
     pytest.param("api.composio_analytics", "router", "/api/analytics/composio/apps", id="composio_analytics"),
     pytest.param("api.database_analytics", "router", "/api/database/analytics/stats", id="database_analytics"),


### PR DESCRIPTION
## Problem

The **Memory tab** on `ui.automatos.app/documents` was blank for everyone. Railway prod logs showed the tab's own reads returning **403 Forbidden**:

```
GET /api/v1/memory/browse?limit=50   → 403 Forbidden
GET /api/v1/memory/health            → 403 Forbidden
GET /api/v1/memory/browse?...&tier=l2 → 403 Forbidden
```

The memory **substrate was healthy the whole time** (field_memory Qdrant scrolls succeeding every 5s, durable-memory probe green). This was purely an **authorization mismatch on the UI read path**, not missing data.

**Root cause:** PRD-77 built the Memory Explorer as a user-facing feature (the "Memory" tab is shown to every user on `/documents`, not role-gated). PRD-143 S7 later classified the **entire** `/api/v1/memory` router as observability tier and applied a router-wide `require_super_admin` lock — which also locked out the user-facing explorer that shares the router. `useMemoryBrowse` swallows the error, so the 403 rendered as a **silent empty tab** rather than "Forbidden."

## Fix

Split the router in `api/memory_stats.py`:

| Endpoints | Router | Auth |
|---|---|---|
| `GET /browse`, `/health`, `/stats/real`, `/stats/agents`, `/stats/recent`, `/layers` | `router` | hybrid (any authenticated member) |
| `DELETE /{memory_id}`, `POST /consolidate` | `admin_router` | `require_super_admin` (unchanged) |

Every read already filters strictly on `ctx.workspace_id`, so a member sees **only their own workspace's memory** — full tenant isolation is preserved; the super-admin gate was redundant *and* wrong for a per-tenant user feature. The destructive / LLM-spending verbs stay super-admin-locked.

## Why this is safe / CI-green

- **Route paths unchanged** (same `/api/v1/memory` prefix) → route manifest and `test_manifest_and_app_agree` unaffected.
- **The two mutations keep `require_super_admin`** on `admin_router` → they stay classified `su-locked` in `test_p2w2_authz_boundary_sweep`, and `api.memory_stats` stays in `SU_LOCKED_ENDPOINT_MODULES` (the `checked >= 10` guard count is unchanged).
- Verified all 4 endpoints (`/browse`, `/health`, `/stats/*`, `/consolidate`, `DELETE`) scope by `ctx.workspace_id` before relaxing the gate.
- Dropped the `memory_stats` representative from `test_prd143_obs_routers_batch2` (its reads are no longer router-wide locked; the mutations' lock is covered by the boundary sweep).

## Test plan

- [ ] CI green (obs-router batch2, authz boundary sweep, durable-store, manifest contract)
- [ ] After deploy: `/documents` → Memory tab populates for a normal workspace member
- [ ] Cross-tenant check: member of workspace A sees only A's memories

## Open question for follow-up

`DELETE`/`consolidate` remain **super-admin only**, so those buttons will 403 for regular members. If memory management (not just viewing) should be available to workspace members/admins, that's a small follow-up (move them to `require_workspace_permission` / `require_workspace_admin`) — flagged rather than decided here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Memory Explorer read-only endpoints are now available with standard workspace-scoped authorization.
  * Added dedicated administrator controls for deleting and consolidating memories.

* **Security**
  * Memory deletion and consolidation now require super-admin access.
  * Improved separation between read and destructive memory operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->