### PR TITLE
fix(graph): stop the Knowledge Graph legend from covering the canvas

### DIFF
--- a/frontend/components/graph/GraphLegend.tsx
+++ b/frontend/components/graph/GraphLegend.tsx
@@ -66,13 +66,18 @@ export function GraphLegend({
   }
 
   return (
+    // Height-bounded so a chip-heavy graph never eats the canvas: the collapse
+    // control is a fixed header (shrink-0) and the chip rows scroll beneath it,
+    // so "Hide legend" stays reachable even with hundreds of edge types. The
+    // parent graph area is `relative overflow-hidden`, which used to clip the
+    // bottom-anchored panel's top (and its close button) right off the canvas.
     <div
-      className={`${position} flex flex-col items-end gap-1.5 max-w-[65%] rounded-lg border border-white/10 bg-black/50 backdrop-blur-sm p-2`}
+      className={`${position} flex flex-col items-end gap-1.5 max-w-[40%] sm:max-w-[320px] max-h-[380px] rounded-lg border border-white/10 bg-black/50 backdrop-blur-sm p-2`}
     >
       <button
         type="button"
         onClick={() => onCollapsedChange(true)}
-        className="flex items-center gap-1 self-end text-[10px] uppercase tracking-wider text-muted-foreground/70 hover:text-foreground transition"
+        className="flex items-center gap-1 self-end shrink-0 text-[10px] uppercase tracking-wider text-muted-foreground/70 hover:text-foreground transition"
         title="Hide legend"
         aria-expanded={true}
       >
@@ -80,6 +85,7 @@ export function GraphLegend({
         <ChevronDown className="w-3 h-3" />
       </button>
 
+      <div className="flex flex-col items-end gap-1.5 overflow-y-auto min-h-0 w-full">
       {sections.map((section) =>
         section.chips.length === 0 ? null : (
           <div key={section.title} className="flex flex-wrap gap-1.5 justify-end">
@@ -129,6 +135,7 @@ export function GraphLegend({
           </div>
         ),
       )}
+      </div>
     </div>
   )
 }

--- a/frontend/components/knowledge/BusinessGraphPanel.tsx
+++ b/frontend/components/knowledge/BusinessGraphPanel.tsx
@@ -58,6 +58,11 @@ const graphQueryKeys = {
   meta: (wsId: string) => ['business-graph', 'meta', wsId] as const,
 }
 
+/** Max legend chips rendered per section before the title switches to a
+ *  "top N/total" summary — keeps a free-text-heavy graph from flooding the
+ *  legend over the canvas (paired with the height-bounded GraphLegend). */
+const MAX_LEGEND_CHIPS = 12
+
 // ─── Component ──────────────────────────────────────────
 
 export function BusinessGraphPanel() {
@@ -332,24 +337,33 @@ export function BusinessGraphPanel() {
     return new Set(relationChips.filter((c) => !hiddenRelSet.has(c.relation)).map((c) => c.relation))
   }, [hiddenRelSet, relationChips])
 
-  const legendSections: LegendSection[] = useMemo(() => [
-    {
-      title: 'Nodes',
-      onToggle: toggleType,
-      chips: typeChips.map((c) => ({
-        key: c.type, label: c.label, color: c.color, count: c.count,
-        hidden: hiddenTypeSet.has(c.type),
-      })),
-    },
-    {
-      title: 'Edges',
-      onToggle: toggleRelation,
-      chips: relationChips.map((c) => ({
-        key: c.relation, label: c.label, color: c.color, count: c.count,
-        hidden: hiddenRelSet.has(c.relation),
-      })),
-    },
-  ], [typeChips, relationChips, hiddenTypeSet, hiddenRelSet, toggleType, toggleRelation])
+  // Cap chips per section: a general knowledge graph carries hundreds of
+  // free-text edge relations (each count 1) that flood the legend and bury the
+  // canvas. Chips are pre-sorted (curated order, then count desc), so the slice
+  // keeps the most meaningful ones and the title shows "top N/total" when
+  // truncated. The legend itself is height-bounded + scrollable for any residual.
+  const legendSections: LegendSection[] = useMemo(() => {
+    const cap = (title: string, total: number) =>
+      total > MAX_LEGEND_CHIPS ? `${title} · top ${MAX_LEGEND_CHIPS}/${total}` : title
+    return [
+      {
+        title: cap('Nodes', typeChips.length),
+        onToggle: toggleType,
+        chips: typeChips.slice(0, MAX_LEGEND_CHIPS).map((c) => ({
+          key: c.type, label: c.label, color: c.color, count: c.count,
+          hidden: hiddenTypeSet.has(c.type),
+        })),
+      },
+      {
+        title: cap('Edges', relationChips.length),
+        onToggle: toggleRelation,
+        chips: relationChips.slice(0, MAX_LEGEND_CHIPS).map((c) => ({
+          key: c.relation, label: c.label, color: c.color, count: c.count,
+          hidden: hiddenRelSet.has(c.relation),
+        })),
+      },
+    ]
+  }, [typeChips, relationChips, hiddenTypeSet, hiddenRelSet, toggleType, toggleRelation])
 
   const filteredData = useMemo((): GraphData | null => {
     if (!graphData) return null


### PR DESCRIPTION
## Problem

On `/documents` → **Knowledge Graph**, opening the legend covered the whole graph and **couldn't be closed**.

Two compounding causes:
1. **Unbounded chips.** The "Edges" section rendered a chip for *every distinct edge relation*. A general KG (vs. a curated Shopify graph) has hundreds of free-text relations — each `count 1` (`used as`, `has not produced`, `is unavailable`, …) — so the panel flooded.
2. **No height bound + clipped close button.** Expanded, the panel had no `max-height` and grew upward from its `bottom-3` anchor. The parent graph area is `relative overflow-hidden` ([GraphView.tsx:105](frontend/components/graph/GraphView.tsx#L105)), so the panel's top — including the **"Hide legend"** button — was clipped off the canvas. The `legendCollapsed:false` state persists in localStorage, so a reload didn't help either.

## Fix

**[GraphLegend.tsx](frontend/components/graph/GraphLegend.tsx)** (benefits every graph surface — KG, codegraph, mission, field):
- `max-h-[380px]` on the expanded panel + the chip rows scroll in an inner container.
- The collapse button is a `shrink-0` fixed header above the scroll area → **always reachable** regardless of chip count.
- Width cap `65%` → `320px` (desktop) so it no longer spans the canvas.

**[BusinessGraphPanel.tsx](frontend/components/knowledge/BusinessGraphPanel.tsx)**:
- Cap chips at **12 per section** (chips are pre-sorted by curated order, then count desc, so the slice keeps the most meaningful). Section title shows `top 12/N` when truncated.
- Curated Shopify graphs (≤5 relations) render unchanged.

No API/route/pref-schema changes. `legendCollapsed` already defaults collapsed (PRD-165 S1 Q25); this makes the *expanded* state survivable instead of a trap.

## Immediate workaround (before deploy)
Browser console on the page, then reload:
```js
Object.keys(localStorage).filter(k=>k.startsWith('automatos:graph-prefs')).forEach(k=>localStorage.removeItem(k)); location.reload()
```

## Test plan
- [ ] CI green (frontend build/lint; existing `useGraphPrefs`/`graph-viz-utils` tests untouched)
- [ ] KG tab: legend opens as a small bounded box, chips scroll, "Hide legend" closes it
- [ ] Shopify business graph: legend unchanged (few relations, no "top N/N")

🤖 Generated with [Claude Code](https://claude.com/claude-code)