### PR TITLE
fix(tests): heal main — repoint two guards (PRD-206 thread_checkpoint substring + #566 memory_stats router split)

### DIFF
--- a/orchestrator/tests/test_p2w3_checkpoints_deleted.py
+++ b/orchestrator/tests/test_p2w3_checkpoints_deleted.py
@@ -25,6 +25,7 @@ config, which must survive.)
 from __future__ import annotations
 
 import pathlib
+import re
 import sys
 
 _ORCH = pathlib.Path(__file__).resolve().parents[1]
@@ -34,7 +35,10 @@ if str(_ORCH) not in sys.path:
 _SOURCE_DIRS = ("modules", "services", "core", "api", "consumers", "evals")
 
 # Specific deleted symbols only — NOT the bare word "checkpoint" (PRD-164's
-# joiner "checkpoint" and seed_skills "checkpoint_enabled" are unrelated live code).
+# joiner "checkpoint" and seed_skills "checkpoint_enabled" are unrelated live
+# code). Matched on WORD BOUNDARIES, not substrings — PRD-206's
+# ``thread_checkpoint`` (an unrelated live module) contains the letters
+# "read_checkpoint", which a substring scan false-positives on.
 _GONE_TOKENS = (
     "checkpoint_service",
     "SessionCheckpoint",
@@ -42,6 +46,9 @@ _GONE_TOKENS = (
     "list_checkpoints",
     "read_checkpoint",
     "checkpoint_count",
+)
+_GONE_TOKEN_PATTERNS = tuple(
+    (token, re.compile(rf"\b{re.escape(token)}\b")) for token in _GONE_TOKENS
 )
 
 
@@ -62,13 +69,13 @@ def test_no_dangling_checkpoint_imports():
             continue
         for path in root.rglob("*.py"):
             text = path.read_text(errors="ignore")
-            for token in _GONE_TOKENS:
-                if token in text:
+            for token, pattern in _GONE_TOKEN_PATTERNS:
+                if pattern.search(text):
                     offenders.append(f"{path.relative_to(_ORCH)}: {token}")
     for extra in ("main.py", "config.py"):
         text = (_ORCH / extra).read_text(errors="ignore")
-        for token in _GONE_TOKENS:
-            if token in text:
+        for token, pattern in _GONE_TOKEN_PATTERNS:
+            if pattern.search(text):
                 offenders.append(f"{extra}: {token}")
     assert not offenders, f"dangling checkpoint references: {offenders}"
 

--- a/orchestrator/tests/test_prd143_boundary_sweep.py
+++ b/orchestrator/tests/test_prd143_boundary_sweep.py
@@ -520,15 +520,27 @@ def _fill_path_params(path: str) -> str:
     return re.sub(r"\{[^}]+\}", "1", path)
 
 
+# The deliberate member-tier exceptions inside otherwise-locked modules —
+# named (module, router-attr) pairs, never a pattern. PRD-206/#566 split
+# ``api/memory_stats.py``: the Memory Explorer's GET reads moved to a
+# member-visible hybrid ``router`` (the router-wide su lock over the PRD-77
+# explorer's own reads was a prod outage — members saw a blank Memory tab);
+# the mutations stayed su-locked on ``admin_router``, which this sweep still
+# covers structurally AND behaviourally. Adding to this set is a consent
+# decision, not a convenience.
+_MEMBER_VISIBLE_ROUTERS = {("memory_stats", "router")}
+
+
 def _module_routers(module_name: str) -> List[Tuple[str, APIRouter]]:
     """Every super-admin-locked APIRouter in the module.
 
     PRD-185 S12 added a sibling ``require_workspace_admin`` router in
     ``analytics_real`` for own-workspace health tiles — a deliberately narrower
     tier, gated and swept separately (``test_p2w0_cockpit_reach``). It is excluded
-    here. An accidentally *ungated* router (neither gate) still surfaces and trips
-    the structural ``require_super_admin`` assertion below, so the guard keeps its
-    teeth against a new endpoint added without any lock.
+    here, as are the named ``_MEMBER_VISIBLE_ROUTERS`` exceptions (#566). An
+    accidentally *ungated* router (neither gate, not named) still surfaces and
+    trips the structural ``require_super_admin`` assertion below, so the guard
+    keeps its teeth against a new endpoint added without any lock.
     """
     from core.auth.workspace_admin import require_workspace_admin
 
@@ -537,6 +549,8 @@ def _module_routers(module_name: str) -> List[Tuple[str, APIRouter]]:
     for attr, obj in vars(module).items():
         if not isinstance(obj, APIRouter):
             continue
+        if (module_name, attr) in _MEMBER_VISIBLE_ROUTERS:
+            continue  # #566 member-tier read half — deliberately not su-locked
         dep_fns = [getattr(d, "dependency", None) for d in (obj.dependencies or [])]
         if require_workspace_admin in dep_fns:
             continue  # S12 own-workspace tier — not part of the super-admin sweep


### PR DESCRIPTION
**Main's test.yml has been red since #566** (four merges: #566/#568/#569 failure, #567 cancelled). Two test-only fixes, both were built on PR #567's branch as `91f2d898d` but Gerard merged at the gitleaks-green moment just before that push — so the fix got stranded on the closed branch. Cherry-picked here onto main.

1. **`test_p2w3_checkpoints_deleted`** — the PRD-200 gone-token scan matches substrings, so PRD-206's live `thread_checkpoint` module (merged in #567) trips `read_checkpoint` via `th·read_checkpoint`. Repointed to word-boundary regex — the guard's own 'deliberately specific' intent; genuine dangling refs still trip it.
2. **`test_prd143_boundary_sweep[memory_stats]`** — red since #566 split `api/memory_stats` (reads member-visible, mutations su-locked on `admin_router`) but this sweep still asserted router-wide su on every router in the module. The member-visible read router is now a NAMED `(module, attr)` exception; `admin_router` stays fully swept structurally + behaviourally; an ungated new router still trips the assert.

**Merge-first** — every PR branched from current main inherits these two failures via CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved detection of lingering references to removed checkpoint functionality by preventing substring false positives.
  * Updated perimeter validation to recognize the intentionally member-visible memory statistics route while continuing to enforce restricted access for other routes.
  * Clarified test documentation for deleted functionality and approved route exceptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->