### PR TITLE
fix(prd-207): Retell custom-LLM is WebSocket-only — replace the uncallable HTTP bridge

### DIFF
--- a/orchestrator/api/voice_retell.py
+++ b/orchestrator/api/voice_retell.py
@@ -1,33 +1,41 @@
 """
-Retell streaming-voice webhook (PRD-203 V·S4)
-=============================================
+Retell voice lane (PRD-203 V·S4 seam · PRD-207 Auto Live)
+==========================================================
 
-POST /api/voice/retell/llm — Retell's custom-LLM webhook.
+* ``WS /api/voice/retell/llm-websocket/{call_id}`` — Retell's custom-LLM
+  transport (WebSocket-ONLY per their integration contract; the HTTP variant
+  PRD-203 merged was uncallable by Retell and is deleted). Retell runs
+  STT/TTS/turn-taking/barge-in vendor-side and drives Auto's OWN agent loop
+  (the same ``StreamingChatService`` text chat uses) through this socket,
+  streaming each reply chunk the moment it exists.
+* ``POST /api/voice/web-call`` — the S1 session mint (hybrid auth, four
+  ordered fail-closed gates); the ``voice_calls`` row born here is BOTH the
+  webhook trust boundary and the WS credential.
+* ``POST /api/voice/retell/events`` — call-lifecycle webhook (HMAC
+  fail-closed), the minute meter's write path.
+* ``GET /api/voice/live-status`` — the S7 settings read.
 
-Retell (§8-Qa) runs STT/TTS/turn-taking/barge-in vendor-side and calls THIS
-endpoint for the words. We front Auto's own agent loop (the same
-``StreamingChatService`` text chat uses) and **stream** the reply back as Retell
-custom-LLM frames, so Retell starts speaking (first audio) before the full
-generation completes — the streaming posture the blocking self-hosted path
-(``chat_voice._collect_streaming_response``) never had.
-
-Auth: the webhook carries no user JWT — it is authenticated by an HMAC signature
-(``config.RETELL_WEBHOOK_SECRET``) and fails closed. Per-call workspace/agent
-context rides in Retell dynamic variables (set when the call is created).
-
-The self-hosted pod path stays as the fallback; retiring the Pipecat/GPU pod is a
-cross-repo automatos-voice coordination (§8-Qa), NOT done here.
+The self-hosted pod path stays as the fallback; retiring the Pipecat/GPU pod
+is a cross-repo automatos-voice coordination (§8-Qd/Qe), NOT done here.
 """
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import uuid
 from typing import Any, AsyncIterator, Optional
 
-from fastapi import APIRouter, Body, Depends, HTTPException, Request
-from fastapi.responses import StreamingResponse
+from fastapi import (
+    APIRouter,
+    Body,
+    Depends,
+    HTTPException,
+    Request,
+    WebSocket,
+    WebSocketDisconnect,
+)
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
@@ -37,17 +45,19 @@ from core.auth.hybrid import get_request_context_hybrid
 from core.database.database import get_db, get_db_session
 from modules.voice import live_settings, retell_api, voice_meter
 from modules.voice.providers.retell import (
+    INTERACTION_CALL_DETAILS,
+    INTERACTION_PING_PONG,
+    INTERACTION_REMINDER,
     INTERACTION_RESPONSE_REQUIRED,
     RetellLLMRequest,
     parse_llm_request,
     retell_response_frames,
     verify_webhook_signature,
+    wrap_ws_response,
 )
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["voice"])
-
-_NDJSON = "application/x-ndjson"
 
 
 # ---------------------------------------------------------------------------
@@ -333,13 +343,6 @@ async def voice_live_status(
     }
 
 
-async def _single_complete(response_id: int) -> AsyncIterator[str]:
-    """A one-frame stream that closes the turn without words (non-answer events)."""
-    yield json.dumps(
-        {"response_id": response_id, "content": "", "content_complete": True}
-    ) + "\n"
-
-
 async def _agent_retell_stream(req: RetellLLMRequest) -> AsyncIterator[dict[str, Any]]:
     """Drive Auto's agent loop for one Retell turn and yield Retell frames.
 
@@ -461,47 +464,97 @@ async def _agent_retell_stream(req: RetellLLMRequest) -> AsyncIterator[dict[str,
     )
 
 
-@router.post("/api/voice/retell/llm")
-async def retell_llm_webhook(request: Request) -> StreamingResponse:
-    """Retell custom-LLM webhook — stream Auto's reply back as Retell frames."""
-    # PRD-207 S4: the settings toggle is the master switch for the WHOLE
-    # Retell lane — flipping it off in Settings kills in-flight speech too
-    # (the "instant platform-wide kill" promise), no redeploy.
+@router.websocket("/api/voice/retell/llm-websocket/{call_id}")
+async def retell_llm_websocket(websocket: WebSocket, call_id: str) -> None:
+    """Retell custom-LLM WebSocket — Auto's brain on Retell's actual transport.
+
+    Retell's dashboard takes a ``wss://…/api/voice/retell/llm-websocket`` URL
+    and appends ``/{call_id}``. Protocol: the server speaks FIRST with an
+    empty response (the human has the floor); ``call_details`` delivers the
+    dynamic variables once; ``ping_pong`` must be echoed; ``update_only``
+    owes nothing; ``response_required``/``reminder_required`` start a turn —
+    a newer ``response_required`` supersedes a still-streaming one (barge-in),
+    so the old stream task is cancelled.
+
+    Auth: a WS handshake carries no HMAC — the MINTED ``call_id`` is the
+    credential (born server-side at ``/api/voice/web-call``, unguessable,
+    dead in ~30s unused). No mint row → close 4401 before accept. The
+    steward/orphan fallback lane stays exclusive to the HMAC-verified events
+    webhook; an unauthenticated socket can never conjure attribution.
+
+    The settings toggle gates the socket too — disarming kills in-flight
+    speech (§7.5-3), no redeploy.
+    """
     if not live_settings.voice_live_enabled():
-        raise HTTPException(status_code=503, detail="Auto Live is switched off platform-wide")
+        await websocket.close(code=4403)
+        return
 
-    body = await request.body()
-    signature = request.headers.get("x-retell-signature")
-    secret = live_settings.retell_credentials().webhook_secret
-    if not verify_webhook_signature(secret, signature, body):
-        # Fail-closed: unsigned/unconfigured/mismatched → never drive the agent.
-        raise HTTPException(status_code=401, detail="Invalid Retell webhook signature")
+    from core.models.voice_calls import VoiceCall
 
-    try:
-        payload = json.loads(body)
-    except ValueError:
-        raise HTTPException(status_code=400, detail="Invalid JSON body")
+    with get_db_session() as db:
+        minted = db.query(VoiceCall.id).filter(VoiceCall.call_id == str(call_id)).first()
+    if minted is None:
+        logger.warning("voice_live_ws_rejected reason=unminted_call call=%s", call_id)
+        await websocket.close(code=4401)
+        return
 
-    req = parse_llm_request(payload)
+    await websocket.accept()
 
-    # Non-answer interactions (pings/updates) just close the turn.
-    if req.interaction_type != INTERACTION_RESPONSE_REQUIRED:
-        return StreamingResponse(_single_complete(req.response_id), media_type=_NDJSON)
+    dynamic_vars: dict[str, Any] = {}
+    speaking: asyncio.Task | None = None
 
-    if not req.workspace_id:
-        raise HTTPException(
-            status_code=422,
-            detail="Retell call is missing the workspace_id dynamic variable",
-        )
-
-    async def stream() -> AsyncIterator[str]:
+    async def respond(req: RetellLLMRequest) -> None:
         try:
             async for frame in _agent_retell_stream(req):
-                yield json.dumps(frame) + "\n"
-        except Exception:  # noqa: BLE001 — a mid-stream fault closes the turn cleanly
-            logger.exception("retell_llm_stream_failed call=%s", req.call_id)
-            yield json.dumps(
-                {"response_id": req.response_id, "content": "", "content_complete": True}
-            ) + "\n"
+                await websocket.send_json(wrap_ws_response(frame))
+        except asyncio.CancelledError:
+            # Superseded turn (barge-in): Retell has moved on — stop quietly.
+            raise
+        except Exception:  # noqa: BLE001 — a mid-turn fault closes the turn cleanly
+            logger.exception("retell_ws_stream_failed call=%s", call_id)
+            try:
+                await websocket.send_json(
+                    wrap_ws_response(
+                        {"response_id": req.response_id, "content": "", "content_complete": True}
+                    )
+                )
+            except Exception:  # noqa: BLE001 — socket already gone
+                pass
 
-    return StreamingResponse(stream(), media_type=_NDJSON)
+    try:
+        # Server speaks first with an EMPTY response — the human opens.
+        await websocket.send_json(
+            wrap_ws_response({"response_id": 0, "content": "", "content_complete": True})
+        )
+        while True:
+            message = await websocket.receive_json()
+            itype = message.get("interaction_type")
+            if itype == INTERACTION_PING_PONG:
+                await websocket.send_json(
+                    {"response_type": "ping_pong", "timestamp": message.get("timestamp")}
+                )
+            elif itype == INTERACTION_CALL_DETAILS:
+                dynamic_vars = (message.get("call") or {}).get(
+                    "retell_llm_dynamic_variables"
+                ) or {}
+            elif itype in (INTERACTION_RESPONSE_REQUIRED, INTERACTION_REMINDER):
+                if speaking is not None and not speaking.done():
+                    speaking.cancel()
+                req = parse_llm_request(
+                    {
+                        "response_id": message.get("response_id"),
+                        "interaction_type": INTERACTION_RESPONSE_REQUIRED,
+                        "transcript": message.get("transcript") or [],
+                        "call": {
+                            "call_id": call_id,
+                            "retell_llm_dynamic_variables": dynamic_vars,
+                        },
+                    }
+                )
+                speaking = asyncio.create_task(respond(req))
+            # update_only / unknown types: no response owed.
+    except WebSocketDisconnect:
+        pass
+    finally:
+        if speaking is not None and not speaking.done():
+            speaking.cancel()

--- a/orchestrator/modules/voice/providers/retell.py
+++ b/orchestrator/modules/voice/providers/retell.py
@@ -37,6 +37,17 @@ logger = logging.getLogger(__name__)
 # Retell custom-LLM interaction types we act on.
 INTERACTION_RESPONSE_REQUIRED = "response_required"
 INTERACTION_REMINDER = "reminder_required"
+# WebSocket-lane interaction types (PRD-207: Retell's custom-LLM transport is
+# WebSocket-only — dynamic variables arrive once in call_details, pings must
+# be echoed, update_only owes no response).
+INTERACTION_CALL_DETAILS = "call_details"
+INTERACTION_UPDATE_ONLY = "update_only"
+INTERACTION_PING_PONG = "ping_pong"
+
+
+def wrap_ws_response(frame: Dict[str, Any]) -> Dict[str, Any]:
+    """Wrap one custom-LLM response frame in Retell's WebSocket envelope."""
+    return {"response_type": "response", **frame}
 
 
 @dataclass(frozen=True)

--- a/orchestrator/reports/route-manifest.json
+++ b/orchestrator/reports/route-manifest.json
@@ -1,5 +1,5 @@
 {
-  "route_count": 776,
+  "route_count": 775,
   "routes": [
     {
       "method": "GET",
@@ -2476,10 +2476,6 @@
     {
       "method": "POST",
       "path": "/api/voice/retell/events"
-    },
-    {
-      "method": "POST",
-      "path": "/api/voice/retell/llm"
     },
     {
       "method": "POST",

--- a/orchestrator/tests/test_p2w2_authz_boundary_sweep.py
+++ b/orchestrator/tests/test_p2w2_authz_boundary_sweep.py
@@ -79,13 +79,11 @@ OWN_AUTH_ROUTES = {
     ("POST", "/api/github/webhook"),
     ("POST", "/api/webhooks/recipe/{webhook_id}"),
     ("POST", "/api/webhooks/ws/{workspace_key}"),
-    # Retell streaming-voice custom-LLM webhook (PRD-203 V·S4) — authenticated by
-    # RETELL_WEBHOOK_SECRET HMAC (verify_webhook_signature, fail-closed), NOT the
-    # shared hybrid dependency; per-call workspace rides Retell dynamic variables.
-    ("POST", "/api/voice/retell/llm"),
-    # Retell call-lifecycle events webhook (PRD-207 S3) — same HMAC fail-closed
-    # posture (secret from DB system_settings); binding trust is the mint-row
-    # cross-validation, never the vars.
+    # Retell call-lifecycle events webhook (PRD-207 S3) — HMAC fail-closed
+    # (verify_webhook_signature; secret from DB system_settings), NOT the shared
+    # hybrid dependency. The custom-LLM lane is a WebSocket route (Retell's
+    # transport contract) authenticated by the minted call_id — WS routes never
+    # appear in this HTTP manifest.
     ("POST", "/api/voice/retell/events"),
     # Shopify machine lane — _verify_internal_key shared-secret auth
     # (api/verticals.py provisioning + GDPR forwarding rides the same key).

--- a/orchestrator/tests/test_prd207_voice_live.py
+++ b/orchestrator/tests/test_prd207_voice_live.py
@@ -711,6 +711,179 @@ def test_phone_lane_attributes_to_workspace_steward(voice_workspace, new_session
 
 
 # ---------------------------------------------------------------------------
+# S2 · the custom-LLM WebSocket (Retell's actual transport)
+# ---------------------------------------------------------------------------
+
+class _FakeWebSocket:
+    """Scripted Retell-side socket. receive_json yields a loop tick first so
+    a just-created respond() task gets to start before the next message."""
+
+    def __init__(self, incoming):
+        self.incoming = list(incoming)
+        self.sent = []
+        self.accepted = False
+        self.close_code = None
+
+    async def accept(self):
+        self.accepted = True
+
+    async def close(self, code=1000):
+        self.close_code = code
+
+    async def send_json(self, data):
+        self.sent.append(data)
+
+    async def receive_json(self):
+        from fastapi import WebSocketDisconnect
+
+        await asyncio.sleep(0)
+        if not self.incoming:
+            raise WebSocketDisconnect(1000)
+        return self.incoming.pop(0)
+
+
+def _ws_db(minted: bool):
+    from contextlib import contextmanager
+
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = (
+        (1,) if minted else None
+    )
+
+    @contextmanager
+    def fake_session():
+        yield db
+
+    return fake_session
+
+
+def test_ws_wrap_shape():
+    from modules.voice.providers.retell import wrap_ws_response
+
+    assert wrap_ws_response({"response_id": 3, "content": "hi", "content_complete": False}) == {
+        "response_type": "response",
+        "response_id": 3,
+        "content": "hi",
+        "content_complete": False,
+    }
+
+
+def test_ws_closes_4403_when_platform_off(monkeypatch):
+    import api.voice_retell as vr
+
+    monkeypatch.setattr(vr.live_settings, "voice_live_enabled", lambda: False)
+    ws = _FakeWebSocket([])
+    asyncio.run(vr.retell_llm_websocket(ws, "call_x"))
+    assert ws.close_code == 4403
+    assert ws.accepted is False  # the kill-switch refuses before accept
+
+
+def test_ws_closes_4401_for_unminted_call(monkeypatch):
+    import api.voice_retell as vr
+
+    monkeypatch.setattr(vr.live_settings, "voice_live_enabled", lambda: True)
+    monkeypatch.setattr(vr, "get_db_session", _ws_db(minted=False))
+    ws = _FakeWebSocket([])
+    asyncio.run(vr.retell_llm_websocket(ws, "call_forged"))
+    assert ws.close_code == 4401  # the minted call_id IS the credential
+    assert ws.accepted is False
+
+
+def test_ws_user_speaks_first_then_answers_with_call_details_vars(monkeypatch):
+    import api.voice_retell as vr
+
+    monkeypatch.setattr(vr.live_settings, "voice_live_enabled", lambda: True)
+    monkeypatch.setattr(vr, "get_db_session", _ws_db(minted=True))
+
+    seen_reqs = []
+
+    async def fake_stream(req):
+        seen_reqs.append(req)
+        yield {"response_id": req.response_id, "content": "hello there", "content_complete": False}
+        yield {"response_id": req.response_id, "content": "", "content_complete": True}
+
+    monkeypatch.setattr(vr, "_agent_retell_stream", fake_stream)
+
+    ws = _FakeWebSocket(
+        [
+            {"interaction_type": "ping_pong", "timestamp": 123},
+            {
+                "interaction_type": "call_details",
+                "call": {
+                    "call_id": "call_ws1",
+                    "retell_llm_dynamic_variables": {
+                        "workspace_id": "ws-9", "user_id": "7", "chat_id": "c-1",
+                    },
+                },
+            },
+            {
+                "interaction_type": "response_required",
+                "response_id": 1,
+                "transcript": [{"role": "user", "content": "hey auto"}],
+            },
+        ]
+    )
+    asyncio.run(vr.retell_llm_websocket(ws, "call_ws1"))
+
+    # server spoke first with the empty floor-yielding response
+    assert ws.sent[0] == {
+        "response_type": "response", "response_id": 0, "content": "", "content_complete": True,
+    }
+    # ping echoed
+    assert {"response_type": "ping_pong", "timestamp": 123} in ws.sent
+    # the turn used the call_details vars + path call_id, and frames are wrapped
+    assert len(seen_reqs) == 1
+    req = seen_reqs[0]
+    assert (req.workspace_id, req.user_id, req.chat_id, req.call_id) == ("ws-9", "7", "c-1", "call_ws1")
+    assert req.user_text == "hey auto"
+    assert {"response_type": "response", "response_id": 1, "content": "hello there",
+            "content_complete": False} in ws.sent
+
+
+def test_ws_new_turn_supersedes_streaming_one(monkeypatch):
+    import api.voice_retell as vr
+
+    monkeypatch.setattr(vr.live_settings, "voice_live_enabled", lambda: True)
+    monkeypatch.setattr(vr, "get_db_session", _ws_db(minted=True))
+
+    events = []
+
+    async def fake_stream(req):
+        events.append(f"start:{req.response_id}")
+        try:
+            if req.response_id == 1:
+                yield {"response_id": 1, "content": "long answer…", "content_complete": False}
+                await asyncio.Event().wait()  # streams forever until cancelled
+            else:
+                yield {"response_id": 2, "content": "fresh", "content_complete": True}
+        finally:
+            if req.response_id == 1:
+                events.append("cancelled:1")
+
+    monkeypatch.setattr(vr, "_agent_retell_stream", fake_stream)
+
+    turn = lambda rid: {
+        "interaction_type": "response_required",
+        "response_id": rid,
+        "transcript": [{"role": "user", "content": f"turn {rid}"}],
+    }
+    ws = _FakeWebSocket(
+        [
+            {"interaction_type": "call_details",
+             "call": {"retell_llm_dynamic_variables": {"workspace_id": "ws-9"}}},
+            turn(1),
+            turn(2),
+        ]
+    )
+    asyncio.run(vr.retell_llm_websocket(ws, "call_ws2"))
+
+    assert "start:1" in events and "start:2" in events
+    assert "cancelled:1" in events  # barge-in: the superseded stream was stopped
+    assert {"response_type": "response", "response_id": 2, "content": "fresh",
+            "content_complete": True} in ws.sent
+
+
+# ---------------------------------------------------------------------------
 # Guard · the live path never touches the 120s-TTS pod client
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Fix: the Retell brain-bridge was on the wrong transport

While walking the arming runbook I verified [Retell's custom-LLM integration docs](https://docs.retellai.com/integrate-llm/setup-websocket-server): the vendor is **WebSocket-only** — their dashboard accepts a `wss://…` LLM URL and appends `/{call_id}`. The `POST /api/voice/retell/llm` endpoint (merged in PRD-203, activated by #572) **could never have been called by Retell** — the first live call would have connected and heard silence.

### What this does
- **New**: `WS /api/voice/retell/llm-websocket/{call_id}` implementing Retell's protocol — server speaks first with an empty response (the human opens), `call_details` delivers the dynamic variables once, `ping_pong` echoed, `update_only` ignored, `response_required`/`reminder_required` stream Auto's reply as `{"response_type":"response", …}` frames, and a newer turn **cancels** a still-streaming one (barge-in).
- Everything under it is unchanged and reused: the mint-row trust boundary, real-user attribution, voice source stamps, `chat_changed` live receive, `voice_turns` telemetry.
- **Auth for the socket**: a WS handshake carries no HMAC, so the **minted `call_id` is the credential** — born server-side at `/api/voice/web-call`, unguessable, dead in ~30s unused. No mint row → close `4401` before accept. The steward/orphan fallback stays exclusive to the HMAC-verified events webhook, so an unauthenticated socket can never conjure attribution.
- The settings kill-switch gates the socket too (`4403`) — disarming still kills in-flight speech.
- **Deleted**: the uncallable HTTP route (manifest 776→775; authz-sweep allowlist entry removed — WS routes aren't in the HTTP manifest).

### Dashboard values (updates the #572 runbook)
- Agent LLM URL: `wss://<your-api-host>/api/voice/retell/llm-websocket`
- Webhook URL: `https://<your-api-host>/api/voice/retell/events`

### Tests
WS protocol suite with a scripted fake socket: kill-switch 4403 before accept, forged/unminted call_id 4401, user-speaks-first empty frame, ping echo, call_details→vars→turn binding, frame wrapping, and barge-in cancellation of a superseded stream. PRD-203's pure tests (parse/frames/HMAC) untouched and still passing.
