### PR TITLE
feat(prd-207): one-click arming — paste the Retell key on the Auto Live card, server does the rest

### DIFF
--- a/frontend/components/settings/VoiceProfilesSettingsTab.tsx
+++ b/frontend/components/settings/VoiceProfilesSettingsTab.tsx
@@ -134,6 +134,7 @@ interface VoiceLiveStatus {
   cap_minutes: number
   active_calls: number
   max_call_minutes: number
+  viewer_is_admin: boolean
 }
 
 /**
@@ -148,6 +149,8 @@ function AutoLiveCard() {
   const [savingToggle, setSavingToggle] = useState(false)
   const [voiceId, setVoiceId] = useState('')
   const [savingVoice, setSavingVoice] = useState(false)
+  const [armKey, setArmKey] = useState('')
+  const [arming, setArming] = useState(false)
 
   const loadStatus = useCallback(async () => {
     try {
@@ -186,14 +189,59 @@ function AutoLiveCard() {
   }
 
   const handleSaveVoice = async () => {
+    const vid = voiceId.trim()
+    if (vid.toLowerCase().startsWith('key_')) {
+      toast.error("That's your Retell API key — it goes in the Arm box above, not the voice field")
+      return
+    }
     setSavingVoice(true)
     try {
-      await saveVoiceLive({ retell_voice_id: voiceId.trim() })
+      await saveVoiceLive({ retell_voice_id: vid })
       toast.success('Auto Live voice saved')
     } catch (err: any) {
       toast.error(err?.message || 'Failed to save the voice')
     } finally {
       setSavingVoice(false)
+    }
+  }
+
+  // One-click arm: the server creates the Retell agent (right URLs, no
+  // copy-paste) and files the key into the masked platform slots.
+  const handleArm = async () => {
+    const key = armKey.trim()
+    if (!key) {
+      toast.error('Paste your Retell API key first')
+      return
+    }
+    setArming(true)
+    try {
+      const out = await apiClient.request<{ armed: boolean; agent_id?: string }>(
+        '/api/voice/arm',
+        { method: 'POST', body: { enabled: true, api_key: key } as any }
+      )
+      toast.success(`Auto Live armed — agent ${out.agent_id || 'ready'}`)
+      setArmKey('')
+      await loadStatus()
+    } catch (err: any) {
+      toast.error(err?.message || 'Arming failed')
+    } finally {
+      setArming(false)
+    }
+  }
+
+  const handlePlatformToggle = async (enabled: boolean) => {
+    setArming(true)
+    try {
+      await apiClient.request('/api/voice/arm', {
+        method: 'POST',
+        body: { enabled } as any,
+      })
+      toast.success(enabled ? 'Platform voice ON' : 'Platform voice OFF — all calls killed')
+      await loadStatus()
+    } catch (err: any) {
+      toast.error(err?.message || 'Failed to switch platform voice')
+    } finally {
+      setArming(false)
     }
   }
 
@@ -232,7 +280,7 @@ function AutoLiveCard() {
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-5">
-        {/* Read-only platform truth from the super-admin gate */}
+        {/* Platform truth + the controls that act on it, in one place */}
         <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
           <span>
             Platform voice:{' '}
@@ -247,12 +295,59 @@ function AutoLiveCard() {
               {status.armed ? 'armed' : 'not configured'}
             </span>
           </span>
-          {!platformReady && (
+          {!platformReady && !status.viewer_is_admin && (
             <span className="basis-full text-muted-foreground/80">
-              A super-admin arms voice platform-wide in System Settings → Voice.
+              An admin arms voice platform-wide right here.
             </span>
           )}
         </div>
+
+        {/* One-click arming — paste the key, the server does the rest */}
+        {status.viewer_is_admin && !status.armed && (
+          <div className="rounded-xl border border-warning/30 bg-warning/5 px-4 py-3 space-y-2">
+            <Label htmlFor="arm-key" className="font-medium">
+              Arm Auto Live — paste your Retell API key
+            </Label>
+            <p className="text-xs text-muted-foreground">
+              We create the &quot;Auto Live&quot; agent in your Retell account and wire
+              every URL for you. No dashboard visit needed.
+            </p>
+            <div className="flex gap-2">
+              <Input
+                id="arm-key"
+                type="password"
+                value={armKey}
+                onChange={(e) => setArmKey(e.target.value)}
+                placeholder="key_…"
+                className="font-mono"
+                autoComplete="off"
+              />
+              <Button onClick={handleArm} disabled={arming}>
+                {arming ? <Loader2 className="w-4 h-4 animate-spin" /> : 'Arm'}
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {/* Armed: the master switch lives here too */}
+        {status.viewer_is_admin && status.armed && (
+          <div className="flex items-center justify-between rounded-xl border border-border/50 px-4 py-3">
+            <div>
+              <Label htmlFor="platform-voice" className="font-medium">
+                Platform voice (master switch)
+              </Label>
+              <p className="text-xs text-muted-foreground mt-0.5">
+                OFF refuses new calls and kills in-flight speech, platform-wide.
+              </p>
+            </div>
+            <Switch
+              id="platform-voice"
+              checked={status.platform_enabled}
+              onCheckedChange={handlePlatformToggle}
+              disabled={arming}
+            />
+          </div>
+        )}
 
         {/* The workspace gate */}
         <div className="flex items-center justify-between rounded-xl border border-border/50 px-4 py-3">

--- a/orchestrator/api/voice_retell.py
+++ b/orchestrator/api/voice_retell.py
@@ -314,6 +314,14 @@ async def retell_events_webhook(request: Request) -> dict:
     return {"ok": True}
 
 
+def _is_platform_admin(ctx: RequestContext) -> bool:
+    """The system-settings admin posture (api-key lane or admin/super_admin)."""
+    if getattr(ctx, "auth_type", "") == "api_key":
+        return True
+    user = getattr(ctx, "user", None)
+    return bool(user and getattr(user, "system_role", "user") in ("admin", "super_admin"))
+
+
 @router.get("/api/voice/live-status")
 async def voice_live_status(
     ctx: RequestContext = Depends(get_request_context_hybrid),
@@ -322,6 +330,8 @@ async def voice_live_status(
     """The S7 settings card's one read: both gates + the meter, honestly.
 
     Never returns credential VALUES — only whether they are present.
+    ``viewer_is_admin`` lets the card show the one-click Arm box to the
+    people who can actually use it.
     """
     from core.models.workspaces import Workspace
 
@@ -340,7 +350,94 @@ async def voice_live_status(
         "cap_minutes": ws_voice.monthly_cap_minutes,
         "active_calls": reading.active_calls,
         "max_call_minutes": int(config.VOICE_LIVE_MAX_CALL_MINUTES),
+        "viewer_is_admin": _is_platform_admin(ctx),
     }
+
+
+class ArmVoiceRequest(BaseModel):
+    """One-click arming from the Auto Live card (S7)."""
+
+    enabled: bool = True
+    api_key: Optional[str] = Field(default=None, description="Retell API key (first arm)")
+    voice_id: Optional[str] = Field(default=None, description="Voice for the created agent")
+
+
+@router.post("/api/voice/arm")
+async def arm_voice_live(
+    body: ArmVoiceRequest,
+    ctx: RequestContext = Depends(get_request_context_hybrid),
+    db: Session = Depends(get_db),
+) -> dict:
+    """Arm (or disarm) Auto Live platform-wide from ONE box on the card.
+
+    Paste the Retell API key, click Arm: the server creates the custom-LLM
+    agent in the customer's Retell account (correct wss + webhook URLs —
+    nobody hand-copies transport strings), files key/signing-key/agent-id
+    into the masked settings slots and flips ``voice.live_enabled`` ON.
+    Idempotent: an existing agent id is kept; re-arming just updates the key
+    or re-enables. ``enabled=false`` flips the master toggle only (creds
+    stay, instant kill preserved). Admin-gated; refusals are honest.
+
+    Also sweeps the caller-workspace's ``retell_voice_id`` if an API key was
+    mis-filed there (the field now refuses key-shaped strings, but stored
+    mistakes get cleaned rather than lectured about).
+    """
+    if not _is_platform_admin(ctx):
+        raise HTTPException(status_code=403, detail="Admin access required to arm voice")
+
+    if not body.enabled:
+        live_settings.set_voice_setting(db, live_settings.KEY_LIVE_ENABLED, "false")
+        db.commit()
+        logger.warning("voice_live_disarmed by=%s", getattr(getattr(ctx, "user", None), "id", "?"))
+        return {"armed": live_settings.retell_credentials().armed, "platform_enabled": False}
+
+    creds = live_settings.retell_credentials()
+    api_key = (body.api_key or creds.api_key or "").strip()
+    if not api_key:
+        raise HTTPException(status_code=400, detail="Paste your Retell API key to arm Auto Live")
+
+    agent_id = creds.agent_id
+    if not agent_id:
+        host = str(config.PUBLIC_API_HOST).strip().rstrip("/")
+        try:
+            agent_id = await retell_api.create_custom_llm_agent(
+                api_key,
+                agent_name="Auto Live",
+                llm_websocket_url=f"wss://{host}/api/voice/retell/llm-websocket",
+                webhook_url=f"https://{host}/api/voice/retell/events",
+                voice_id=(body.voice_id or "").strip() or "retell-Cimo",
+            )
+        except retell_api.RetellApiError as exc:
+            raise HTTPException(status_code=502, detail=str(exc))
+
+    live_settings.set_voice_setting(db, live_settings.KEY_RETELL_API_KEY, api_key)
+    # Retell signs webhooks with the API key unless a distinct secret is
+    # configured — only fill the slot when it is empty, never overwrite one.
+    if not creds.webhook_secret:
+        live_settings.set_voice_setting(db, live_settings.KEY_RETELL_WEBHOOK_SECRET, api_key)
+    live_settings.set_voice_setting(db, live_settings.KEY_RETELL_AGENT_ID, agent_id)
+    live_settings.set_voice_setting(db, live_settings.KEY_LIVE_ENABLED, "true")
+
+    # Hygiene sweep: a key mis-filed into the caller-workspace's voice field.
+    from core.models.workspaces import Workspace
+
+    workspace = db.query(Workspace).filter(Workspace.id == ctx.workspace_id).first()
+    if workspace is not None:
+        settings = dict(workspace.settings or {})
+        vl = dict(settings.get("voice_live") or {})
+        stray = str(vl.get("retell_voice_id") or "")
+        if stray.lower().startswith("key_"):
+            vl.pop("retell_voice_id", None)
+            settings["voice_live"] = vl
+            workspace.settings = settings
+            from sqlalchemy.orm.attributes import flag_modified
+
+            flag_modified(workspace, "settings")
+            logger.info("voice_live_arm swept a mis-filed API key out of workspace %s", workspace.id)
+
+    db.commit()
+    logger.info("voice_live_armed agent=%s by=%s", agent_id, getattr(getattr(ctx, "user", None), "id", "?"))
+    return {"armed": True, "platform_enabled": True, "agent_id": agent_id}
 
 
 async def _agent_retell_stream(req: RetellLLMRequest) -> AsyncIterator[dict[str, Any]]:

--- a/orchestrator/config.py
+++ b/orchestrator/config.py
@@ -1276,6 +1276,12 @@ class Config:
         os.getenv("VOICE_LIVE_ACTIVE_CALL_RESERVE_MINUTES", "10")
     )
     VOICE_LIVE_MAX_CALL_MINUTES: int = int(os.getenv("VOICE_LIVE_MAX_CALL_MINUTES", "30"))
+    # The public host Retell must reach for the custom-LLM socket + events
+    # webhook (one-click arming builds the URLs from it). Railway injects
+    # RAILWAY_PUBLIC_DOMAIN; override with PUBLIC_API_HOST where that's absent.
+    PUBLIC_API_HOST: str = os.getenv(
+        "PUBLIC_API_HOST", os.getenv("RAILWAY_PUBLIC_DOMAIN", "api.automatos.app")
+    )
 
     def validate_security(self) -> None:
         """PRD-172: fail-closed validation of tenant-isolation secrets.

--- a/orchestrator/modules/voice/live_settings.py
+++ b/orchestrator/modules/voice/live_settings.py
@@ -68,6 +68,33 @@ def retell_credentials() -> RetellCredentials:
     )
 
 
+def set_voice_setting(db, key: str, value: str) -> None:
+    """Write one ``voice.*`` system-settings row (the arm endpoint's pen).
+
+    Rows are migration-seeded; if one is missing (fresh env), it is created
+    with the safe shape rather than silently skipped.
+    """
+    from core.models.system_settings import SystemSetting
+
+    row = (
+        db.query(SystemSetting)
+        .filter(SystemSetting.category == VOICE_SETTINGS_CATEGORY, SystemSetting.key == key)
+        .first()
+    )
+    if row is None:
+        row = SystemSetting(
+            category=VOICE_SETTINGS_CATEGORY,
+            key=key,
+            value=value,
+            value_type="boolean" if key == KEY_LIVE_ENABLED else "string",
+            is_sensitive=key in (KEY_RETELL_API_KEY, KEY_RETELL_WEBHOOK_SECRET),
+            created_by="prd207",
+        )
+        db.add(row)
+    else:
+        row.value = value
+
+
 @dataclass(frozen=True)
 class WorkspaceVoiceLive:
     enabled: bool
@@ -137,6 +164,12 @@ def validate_voice_live_update(value: Any) -> Dict[str, Any]:
         vid = value["retell_voice_id"]
         if not isinstance(vid, str) or len(vid) > 64:
             raise ValueError("voice_live.retell_voice_id must be a string of at most 64 characters")
-        normalized["retell_voice_id"] = vid.strip()
+        vid = vid.strip()
+        # The field that ate Gerard's API key: a Retell key is NEVER a voice id.
+        if vid.lower().startswith("key_"):
+            raise ValueError(
+                "that looks like a Retell API key — it belongs in the Arm box, not the voice field"
+            )
+        normalized["retell_voice_id"] = vid
 
     return normalized

--- a/orchestrator/modules/voice/retell_api.py
+++ b/orchestrator/modules/voice/retell_api.py
@@ -22,7 +22,9 @@ import httpx
 logger = logging.getLogger(__name__)
 
 RETELL_CREATE_WEB_CALL_URL = "https://api.retellai.com/v2/create-web-call"
+RETELL_CREATE_AGENT_URL = "https://api.retellai.com/create-agent"
 _TIMEOUT_SECONDS = 10.0
+_AGENT_TIMEOUT_SECONDS = 25.0
 
 
 class RetellApiError(Exception):
@@ -66,6 +68,54 @@ def build_web_call_payload(
         payload["agent_override"] = {"agent": override}
 
     return payload
+
+
+async def create_custom_llm_agent(
+    api_key: str,
+    *,
+    agent_name: str,
+    llm_websocket_url: str,
+    webhook_url: str,
+    voice_id: str,
+) -> str:
+    """Create the Retell agent that fronts Auto Live (one-click arming, S7).
+
+    Verified request shape: ``response_engine {type: custom-llm,
+    llm_websocket_url}``, ``voice_id``, ``agent_name``, ``webhook_url``;
+    the response carries ``agent_id``. Raises ``RetellApiError`` with the
+    vendor's own words (never the key) so the settings card can show an
+    honest reason.
+    """
+    payload = {
+        "agent_name": agent_name,
+        "voice_id": voice_id,
+        "response_engine": {"type": "custom-llm", "llm_websocket_url": llm_websocket_url},
+        "webhook_url": webhook_url,
+    }
+    try:
+        async with httpx.AsyncClient(timeout=_AGENT_TIMEOUT_SECONDS) as client:
+            resp = await client.post(
+                RETELL_CREATE_AGENT_URL,
+                json=payload,
+                headers={"Authorization": f"Bearer {api_key}"},
+            )
+    except httpx.HTTPError as exc:
+        raise RetellApiError(f"Retell unreachable: {type(exc).__name__}") from exc
+
+    if resp.status_code not in (200, 201):
+        logger.error(
+            "voice_live_create_agent_failed status=%s body=%s",
+            resp.status_code,
+            resp.text[:300],
+        )
+        raise RetellApiError(
+            f"Retell refused the API key or agent creation (HTTP {resp.status_code}): {resp.text[:200]}"
+        )
+
+    agent_id = resp.json().get("agent_id")
+    if not agent_id:
+        raise RetellApiError("Retell response missing agent_id")
+    return str(agent_id)
 
 
 async def create_web_call(api_key: str, payload: Dict[str, Any]) -> RetellWebCall:

--- a/orchestrator/reports/route-manifest.json
+++ b/orchestrator/reports/route-manifest.json
@@ -1,5 +1,5 @@
 {
-  "route_count": 775,
+  "route_count": 776,
   "routes": [
     {
       "method": "GET",
@@ -2436,6 +2436,10 @@
     {
       "method": "POST",
       "path": "/api/verticals/{vertical}/provision"
+    },
+    {
+      "method": "POST",
+      "path": "/api/voice/arm"
     },
     {
       "method": "GET",

--- a/orchestrator/tests/test_prd207_voice_live.py
+++ b/orchestrator/tests/test_prd207_voice_live.py
@@ -106,6 +106,7 @@ def test_validate_voice_live_update_matrix():
         {"monthly_cap_minutes": 0},             # zero cap
         {"monthly_cap_minutes": 200_000},       # absurd cap
         {"retell_voice_id": "x" * 65},          # oversized voice id
+        {"retell_voice_id": "key_" + "a1b2"},   # an API key is never a voice id
         {"surprise": 1},                        # unknown key fail-closed
     ):
         with pytest.raises(ValueError):
@@ -708,6 +709,131 @@ def test_phone_lane_attributes_to_workspace_steward(voice_workspace, new_session
         text("SELECT status, fallback_chat_id FROM voice_calls WHERE call_id = 'call_phone1'")
     ).fetchone()
     assert row is not None and row[1] == b.chat_id  # orphan registered for reuse
+
+
+# ---------------------------------------------------------------------------
+# S7 · one-click arming — the card does the whole job
+# ---------------------------------------------------------------------------
+
+def _admin_ctx():
+    return SimpleNamespace(
+        workspace_id=uuid.uuid4(),
+        user=SimpleNamespace(id=7, system_role="admin"),
+        auth_type="clerk",
+    )
+
+
+def _arm_env(monkeypatch, *, creds, workspace=None):
+    """Wire the arm endpoint's collaborators to recorders."""
+    import api.voice_retell as vr
+
+    written = {}
+    monkeypatch.setattr(
+        vr.live_settings, "set_voice_setting", lambda db, k, v: written.__setitem__(k, v)
+    )
+    monkeypatch.setattr(vr.live_settings, "retell_credentials", lambda: creds)
+
+    created = {}
+
+    async def fake_create(api_key, **kwargs):
+        created.update(kwargs, api_key=api_key)
+        return "agent_new_1"
+
+    monkeypatch.setattr(vr.retell_api, "create_custom_llm_agent", fake_create)
+
+    db = _mint_db(workspace=workspace)
+    return vr, written, created, db
+
+
+def test_arm_requires_admin(monkeypatch):
+    from fastapi import HTTPException
+
+    import api.voice_retell as vr
+    from api.voice_retell import ArmVoiceRequest
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(
+            vr.arm_voice_live(ArmVoiceRequest(api_key="key_x"), ctx=_mint_ctx(), db=MagicMock())
+        )
+    assert exc.value.status_code == 403
+
+
+def test_arm_without_key_is_an_honest_400(monkeypatch):
+    from fastapi import HTTPException
+
+    from api.voice_retell import ArmVoiceRequest
+    from modules.voice.live_settings import RetellCredentials
+
+    vr, written, created, db = _arm_env(monkeypatch, creds=RetellCredentials("", "", ""))
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(vr.arm_voice_live(ArmVoiceRequest(), ctx=_admin_ctx(), db=db))
+    assert exc.value.status_code == 400
+    assert "API key" in exc.value.detail
+    assert written == {} and created == {}
+
+
+def test_arm_creates_agent_stores_all_and_sweeps_misfiled_key(monkeypatch):
+    from api.voice_retell import ArmVoiceRequest
+    from modules.voice.live_settings import RetellCredentials
+
+    stray_key = "key_" + "misfiled"
+    ws = SimpleNamespace(
+        id=uuid.uuid4(),
+        settings={"voice_live": {"enabled": True, "retell_voice_id": stray_key}},
+    )
+    vr, written, created, db = _arm_env(
+        monkeypatch, creds=RetellCredentials("", "", ""), workspace=ws
+    )
+
+    out = asyncio.run(
+        vr.arm_voice_live(ArmVoiceRequest(api_key="key_real"), ctx=_admin_ctx(), db=db)
+    )
+
+    assert out == {"armed": True, "platform_enabled": True, "agent_id": "agent_new_1"}
+    # the server built the transport URLs — nobody hand-copies wss strings
+    assert created["llm_websocket_url"].startswith("wss://")
+    assert created["llm_websocket_url"].endswith("/api/voice/retell/llm-websocket")
+    assert created["webhook_url"].endswith("/api/voice/retell/events")
+    # all four slots written; signing key defaults to the API key
+    assert written["retell_api_key"] == "key_real"
+    assert written["retell_webhook_secret"] == "key_real"
+    assert written["retell_agent_id"] == "agent_new_1"
+    assert written["live_enabled"] == "true"
+    # the mis-filed key is swept out of the workspace voice field
+    assert "retell_voice_id" not in ws.settings["voice_live"]
+    assert db.commit.called
+
+
+def test_arm_is_idempotent_when_agent_exists(monkeypatch):
+    from api.voice_retell import ArmVoiceRequest
+    from modules.voice.live_settings import RetellCredentials
+
+    vr, written, created, db = _arm_env(
+        monkeypatch, creds=RetellCredentials("key_old", "sec_old", "agent_existing")
+    )
+    out = asyncio.run(
+        vr.arm_voice_live(ArmVoiceRequest(api_key="key_rotated"), ctx=_admin_ctx(), db=db)
+    )
+    assert created == {}  # no second agent — the existing one is kept
+    assert out["agent_id"] == "agent_existing"
+    assert written["retell_api_key"] == "key_rotated"
+    # an explicitly-configured distinct signing secret is never overwritten
+    assert "retell_webhook_secret" not in written
+
+
+def test_disarm_flips_toggle_only(monkeypatch):
+    from api.voice_retell import ArmVoiceRequest
+    from modules.voice.live_settings import RetellCredentials
+
+    vr, written, created, db = _arm_env(
+        monkeypatch, creds=RetellCredentials("key_k", "key_k", "agent_1")
+    )
+    out = asyncio.run(
+        vr.arm_voice_live(ArmVoiceRequest(enabled=False), ctx=_admin_ctx(), db=db)
+    )
+    assert written == {"live_enabled": "false"}  # creds untouched — instant re-arm
+    assert created == {}
+    assert out["platform_enabled"] is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## The fix for tonight's arming failure

Gerard did everything right: found the Auto Live card on the **Voices** tab, toggled it ON, pasted his API key into the only field there. The product failed him twice: the actual arming fields were buried on a tab-inside-a-tab (System Settings → Voice), and the card's voice-id field silently swallowed a `key_…` string.

### Now the card does the whole job
- **POST /api/voice/arm** (admin-gated): paste the Retell API key → the server creates the **Auto Live** custom-LLM agent in your Retell account via their API (verified shape: `response_engine.custom-llm` + `llm_websocket_url`), with the correct `wss://` + webhook URLs built from `config.PUBLIC_API_HOST` — no dashboard visit, no URL copy-paste. Files key + signing key + agent id into the masked slots, flips the master toggle ON. Idempotent (existing agent kept; re-arm rotates the key). `enabled:false` = disarm: toggle only, creds kept, instant re-arm.
- **Auto Live card**: Arm box (admins, when unarmed) + platform master switch (admins, when armed) + honest status line. The buried System Settings → Voice tab remains as the manual/advanced surface.
- **The field that ate the key** now rejects `key_…` strings client- AND server-side with a pointing message; arming sweeps any previously mis-filed key out of workspace settings automatically.
- `live-status` gains `viewer_is_admin`. Manifest 775→776.

### After merge + deploy
Refresh the Voices settings page → paste the key in the **Arm** box → click **Arm** → toggle stays ON → refresh /chat → **Live**.

### Tests
Arm matrix: admin gate, honest no-key 400, agent creation with server-built URLs, all-slots write + mis-filed-key sweep, idempotent re-arm (no duplicate agent, distinct signing secret never clobbered), disarm-flips-toggle-only. Voice-id key-rejection in the shared validator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an admin-only “Arm Auto Live” flow using a Retell API key.
  - Added controls to enable or disable the platform voice setting.
  - Updated Auto Live status display based on viewer permissions and current platform state.

- **Bug Fixes**
  - Prevented API keys from being mistakenly saved as voice IDs.
  - Improved handling of voice configuration and status updates, with success and error notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->