### PR TITLE
fix(prd-207): Retell webhook signature — their real v={ts},d=HMAC(body+ts) scheme

### DIFF
--- a/orchestrator/modules/voice/providers/retell.py
+++ b/orchestrator/modules/voice/providers/retell.py
@@ -29,6 +29,8 @@ import hashlib
 import hmac
 import json
 import logging
+import re
+import time
 from dataclasses import dataclass
 from typing import Any, AsyncIterator, Dict, Optional
 
@@ -143,16 +145,44 @@ async def retell_response_frames(
     yield {"response_id": response_id, "content": "", "content_complete": True}
 
 
-def verify_webhook_signature(secret: str, signature: Optional[str], body: bytes) -> bool:
-    """Constant-time HMAC-SHA256 verification of an inbound Retell webhook.
+# Retell's actual header shape: ``v={timestamp_ms},d={hex_digest}`` — verified
+# against their SDK's webhook-auth source (PRD-207 first-contact finding).
+_SIGNATURE_RE = re.compile(r"^v=(\d+),d=([0-9a-fA-F]+)$")
+_SIGNATURE_MAX_AGE_MS = 5 * 60 * 1000
 
-    Fail-closed: no configured secret or no/!matching signature → ``False``. The
-    route rejects with 401 so an unauthenticated caller can never drive the agent.
+
+def verify_webhook_signature(
+    secret: str,
+    signature: Optional[str],
+    body: bytes,
+    *,
+    now_ms: Optional[int] = None,
+) -> bool:
+    """Constant-time verification of Retell's ``x-retell-signature``.
+
+    Their SDK's real scheme: ``digest = HMAC-SHA256(secret, raw_body +
+    str(timestamp)).hexdigest()`` carried as ``v={timestamp},d={digest}``,
+    with a ±5-minute freshness window (replay protection). PRD-203 shipped a
+    plain HMAC-of-body compare that no genuine Retell webhook could ever
+    pass — first live events all 401'd. Fail-closed on missing secret,
+    malformed header, stale timestamp or digest mismatch. ``now_ms`` is
+    injectable for deterministic tests.
     """
     if not secret or not signature:
         return False
-    expected = hmac.new(secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
-    provided = signature.strip()
-    if provided.startswith("v1="):  # tolerate a scheme prefix if the vendor sends one
-        provided = provided[3:]
-    return hmac.compare_digest(expected, provided)
+    match = _SIGNATURE_RE.match(signature.strip())
+    if not match:
+        return False
+    timestamp, digest = match.group(1), match.group(2).lower()
+
+    now = int(time.time() * 1000) if now_ms is None else int(now_ms)
+    try:
+        if abs(now - int(timestamp)) > _SIGNATURE_MAX_AGE_MS:
+            return False
+    except ValueError:
+        return False
+
+    expected = hmac.new(
+        secret.encode("utf-8"), body + timestamp.encode("utf-8"), hashlib.sha256
+    ).hexdigest()
+    return hmac.compare_digest(expected, digest)

--- a/orchestrator/tests/test_prd203_voice_retell.py
+++ b/orchestrator/tests/test_prd203_voice_retell.py
@@ -124,14 +124,23 @@ def test_parse_llm_request_tolerates_missing_context():
 
 
 def test_verify_webhook_signature_valid_and_failclosed():
+    """Retell's REAL scheme (their SDK): v={ts_ms},d=HMAC(body+ts).hexdigest()
+    with a ±5-minute window. The PRD-203 plain HMAC-of-body compare could
+    never match a genuine Retell webhook — first live events all 401'd."""
     secret = "shhh-secret"
-    body = b'{"interaction_type":"response_required"}'
-    good = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    body = b'{"event":"call_started"}'
+    ts = 1_700_000_000_000
+    digest = hmac.new(secret.encode(), body + str(ts).encode(), hashlib.sha256).hexdigest()
+    good = f"v={ts},d={digest}"
 
-    assert verify_webhook_signature(secret, good, body) is True
-    assert verify_webhook_signature(secret, f"v1={good}", body) is True  # scheme prefix ok
+    assert verify_webhook_signature(secret, good, body, now_ms=ts) is True
+    # within the freshness window (either direction)
+    assert verify_webhook_signature(secret, good, body, now_ms=ts + 4 * 60 * 1000) is True
+    assert verify_webhook_signature(secret, good, body, now_ms=ts - 4 * 60 * 1000) is True
     # Fail-closed conditions:
-    assert verify_webhook_signature(secret, "deadbeef", body) is False   # wrong sig
-    assert verify_webhook_signature(secret, None, body) is False          # no sig
-    assert verify_webhook_signature("", good, body) is False              # secret unconfigured
-    assert verify_webhook_signature(secret, good, b"tampered") is False   # body tampered
+    assert verify_webhook_signature(secret, good, body, now_ms=ts + 6 * 60 * 1000) is False  # replay
+    assert verify_webhook_signature(secret, digest, body, now_ms=ts) is False  # bare digest, old shape
+    assert verify_webhook_signature(secret, f"v={ts},d=deadbeef", body, now_ms=ts) is False
+    assert verify_webhook_signature(secret, None, body, now_ms=ts) is False
+    assert verify_webhook_signature("", good, body, now_ms=ts) is False
+    assert verify_webhook_signature(secret, good, b"tampered", now_ms=ts) is False

--- a/orchestrator/tests/test_prd207_voice_live.py
+++ b/orchestrator/tests/test_prd207_voice_live.py
@@ -1159,9 +1159,12 @@ def test_events_webhook_hmac_fail_closed(monkeypatch):
     assert exc.value.status_code == 401
     assert applied == []
 
-    # correct signature → applied
-    good = hmac_mod.new(secret.encode(), body, hashlib.sha256).hexdigest()
-    out = asyncio.run(vr.retell_events_webhook(_FakeRequest(body, good)))
+    # correct signature (Retell's v={ts},d={hmac(body+ts)} scheme) → applied
+    import time as time_mod
+
+    ts = str(int(time_mod.time() * 1000))
+    digest = hmac_mod.new(secret.encode(), body + ts.encode(), hashlib.sha256).hexdigest()
+    out = asyncio.run(vr.retell_events_webhook(_FakeRequest(body, f"v={ts},d={digest}")))
     assert out == {"ok": True}
     assert applied == ["call_started"]
 


### PR DESCRIPTION
First live contact tonight: every genuine Retell lifecycle event **401'd** at `/api/voice/retell/events`.

Root cause: Retell signs `x-retell-signature` as `v={timestamp_ms},d={HMAC_SHA256(secret, raw_body + str(timestamp)).hexdigest()}` with a ±5-minute freshness window (verified against their SDK's webhook-auth source). The PRD-203 verifier compared a plain HMAC of the body — a scheme no genuine Retell webhook could ever satisfy.

Rewritten to the vendor scheme: strict `v=,d=` parse, replay refusal outside ±5 min, constant-time compare, injectable clock for deterministic tests. Fail-closed posture unchanged (missing secret/malformed header/stale/mismatch all refuse).

**Speech is unaffected** — the talking lane (custom-LLM WebSocket) authenticates by the minted call_id, not this signature. Until this merges, calls talk fine but minutes don't land in the meter.

Tests: PRD-203 verify suite rewritten to the real scheme (fresh/skewed/replay/bare-digest/tamper matrix); the PRD-207 events-webhook test signs the vendor way.