### PR TITLE
fix(prd-207): Auto speaks + the JARVIS orb — first-live-contact fixes

### DIFF
--- a/frontend/components/voice/LiveVoiceMode.tsx
+++ b/frontend/components/voice/LiveVoiceMode.tsx
@@ -65,13 +65,25 @@ export function LiveVoiceMode({ chatId, agentId, onExit }: LiveVoiceModeProps) {
       animate={{ opacity: 1, y: 0 }}
       exit={{ opacity: 0, y: -16 }}
       transition={{ duration: 0.35 }}
-      className="flex w-full flex-col items-center gap-2 pt-6 pb-2"
+      className="relative flex w-full flex-col items-center gap-1 pt-4 pb-2"
       data-testid="live-voice-mode"
     >
-      <PresenceOrb state={orbState} levelsRef={levelsRef} size={120} />
+      {/* The room: a soft gold field behind the ring so Auto has a stage,
+          not a black void. Pure CSS, pointer-transparent. */}
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute left-1/2 top-0 h-[340px] w-[560px] -translate-x-1/2 opacity-70"
+        style={{
+          background:
+            'radial-gradient(ellipse at center, hsl(var(--warning) / 0.14) 0%, hsl(var(--warning) / 0.05) 45%, transparent 70%)',
+          filter: 'blur(2px)',
+        }}
+      />
+
+      <PresenceOrb state={orbState} levelsRef={levelsRef} size={260} />
 
       {/* State for ears and eyes — the a11y surface for the canvas. */}
-      <p aria-live="polite" className="text-sm text-muted-foreground">
+      <p aria-live="polite" className="relative -mt-3 text-sm font-medium text-warning/90 tracking-wide">
         {stateLabel}
         {isLive && (
           <span className="ml-2 font-mono text-xs text-muted-foreground/70">
@@ -82,12 +94,12 @@ export function LiveVoiceMode({ chatId, agentId, onExit }: LiveVoiceModeProps) {
 
       {/* Live captions (accessibility + trust) */}
       {isLive && captions.length > 0 && (
-        <div className="max-w-md space-y-0.5 text-center">
+        <div className="relative max-w-md space-y-0.5 text-center">
           {captions.map((line, i) => (
             <p
               key={`${line.role}-${i}`}
               className={`truncate text-xs ${
-                line.role === 'agent' ? 'text-warning' : 'text-muted-foreground'
+                line.role === 'agent' ? 'text-warning/90' : 'text-muted-foreground/70'
               }`}
             >
               <span className="font-medium">{line.role === 'agent' ? 'Auto' : 'You'}:</span>{' '}

--- a/frontend/components/voice/PresenceOrb.tsx
+++ b/frontend/components/voice/PresenceOrb.tsx
@@ -1,14 +1,17 @@
 'use client'
 
 /**
- * PresenceOrb — Auto in the room (PRD-207 S5).
+ * PresenceOrb v2 — the JARVIS ring (PRD-207 S5, rebuilt to Gerard's brief).
  *
- * Canvas-rendered brand-orange presence: idle breathing, a user-reactive
- * listening ring, a thinking shimmer arc, and voice-reactive speaking
- * pulses. Levels arrive through a mutable ref read inside the rAF loop —
- * zero React re-renders per audio frame. `prefers-reduced-motion` collapses
- * everything to a static glow (state is still announced textually by the
- * parent's aria-live label).
+ * Reference direction: Iron-Man-style circular interface — fragmented gold
+ * arc rings rotating at different speeds, a radial audio waveform bent
+ * around the core, particle blips, a white-hot turbulent centre, glow
+ * everywhere. Canvas-2D, one rAF, zero React re-renders per audio frame
+ * (levels arrive through a mutable ref). `prefers-reduced-motion` renders
+ * the full composition once, static.
+ *
+ * All per-segment "randomness" is a deterministic index hash so the ring is
+ * stable frame-to-frame and identical across mounts.
  */
 
 import { useEffect, useRef, type MutableRefObject } from 'react'
@@ -21,9 +24,7 @@ interface PresenceOrbProps {
   size?: number
 }
 
-function warningColor(): { h: number; s: number; l: number } {
-  // The brand `warning` token (the orange→warning codemod rule). Fallback
-  // matches the design system's amber if the var is unreadable (tests/SSR).
+function warningHsl(): { h: number; s: number; l: number } {
   if (typeof window !== 'undefined') {
     const raw = getComputedStyle(document.documentElement).getPropertyValue('--warning').trim()
     const m = raw.match(/^([\d.]+)\s+([\d.]+)%\s+([\d.]+)%$/)
@@ -32,7 +33,16 @@ function warningColor(): { h: number; s: number; l: number } {
   return { h: 38, s: 92, l: 50 }
 }
 
-export function PresenceOrb({ state, levelsRef, size = 120 }: PresenceOrbProps) {
+/** Deterministic 0..1 hash per index — stable "randomness", no Math.random. */
+function hash(i: number): number {
+  const x = Math.sin(i * 127.1 + 311.7) * 43758.5453
+  return x - Math.floor(x)
+}
+
+const WAVE_BARS = 72
+const RING_SEGMENTS = [26, 34, 18] // fragments per arc ring, inner→outer
+
+export function PresenceOrb({ state, levelsRef, size = 260 }: PresenceOrbProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const stateRef = useRef<OrbState>(state)
   stateRef.current = state
@@ -48,9 +58,10 @@ export function PresenceOrb({ state, levelsRef, size = 120 }: PresenceOrbProps) 
     canvas.height = size * dpr
     ctx.scale(dpr, dpr)
 
-    const { h, s, l } = warningColor()
-    const hsl = (alpha: number, dl = 0) => `hsla(${h}, ${s}%, ${l + dl}%, ${alpha}`
-    const color = (alpha: number, dl = 0) => `${hsl(alpha, dl)})`
+    const { h, s, l } = warningHsl()
+    const gold = (alpha: number, dl = 0, ds = 0) =>
+      `hsla(${h}, ${Math.max(0, Math.min(100, s + ds))}%, ${Math.max(0, Math.min(100, l + dl))}%, ${alpha})`
+    const hot = (alpha: number) => `hsla(${h + 6}, 100%, 88%, ${alpha})`
 
     const reducedMotion =
       typeof window !== 'undefined' &&
@@ -58,99 +69,146 @@ export function PresenceOrb({ state, levelsRef, size = 120 }: PresenceOrbProps) 
 
     const cx = size / 2
     const cy = size / 2
-    const baseR = size * 0.3
-    let raf = 0
+    const R = size * 0.46 // outermost reach
+    const coreR = size * 0.16
+    const waveInner = size * 0.24
+    const waveMax = size * 0.115
+
+    // Rotating radial-waveform history: each frame writes the current energy
+    // at the write head, so the bars carry a spinning trace of the last
+    // seconds of BOTH voices (the audio-waveform references, bent circular).
+    const waveHist = new Float32Array(WAVE_BARS)
+    let waveHead = 0
     let smoothAgent = 0
     let smoothUser = 0
+    let raf = 0
 
-    const drawStatic = () => {
+    const drawFrame = (t: number, animate: boolean) => {
+      const st = stateRef.current
+      const levels = levelsRef.current
+      smoothAgent += (levels.agent - smoothAgent) * 0.3
+      smoothUser += (levels.user - smoothUser) * 0.25
+      const energy = Math.min(1, smoothAgent * 1.6 + smoothUser * 0.9)
+
+      if (animate) {
+        waveHist[waveHead] = energy
+        waveHead = (waveHead + 1) % WAVE_BARS
+      }
+
+      const dim = st === 'ended' || st === 'error' ? 0.35 : st === 'connecting' ? 0.6 : 1
+      const spin = st === 'speaking' ? 1.6 : st === 'thinking' ? 0.5 : 1
+
       ctx.clearRect(0, 0, size, size)
-      const glow = ctx.createRadialGradient(cx, cy, baseR * 0.2, cx, cy, baseR * 1.6)
-      glow.addColorStop(0, color(0.9, 8))
-      glow.addColorStop(0.65, color(0.35))
-      glow.addColorStop(1, color(0))
-      ctx.fillStyle = glow
+
+      // 1 — ambient halo, breathing with the room's energy
+      const breath = 1 + 0.05 * Math.sin(t / 1100) + energy * 0.25
+      const halo = ctx.createRadialGradient(cx, cy, coreR * 0.4, cx, cy, R * breath)
+      halo.addColorStop(0, gold(0.16 * dim, 10))
+      halo.addColorStop(0.5, gold(0.07 * dim))
+      halo.addColorStop(1, gold(0))
+      ctx.fillStyle = halo
+      ctx.fillRect(0, 0, size, size)
+
+      // 2 — fragmented arc rings (the JARVIS signature), counter-rotating
+      RING_SEGMENTS.forEach((count, ringIdx) => {
+        const rr = R * (0.78 + ringIdx * 0.09)
+        const dir = ringIdx % 2 === 0 ? 1 : -1
+        const rot = animate ? dir * (t / (9000 - ringIdx * 2600)) * spin : dir * 0.6
+        const width = ringIdx === 1 ? 2.5 : 1.25
+        for (let i = 0; i < count; i++) {
+          const g0 = hash(i * 7 + ringIdx * 101)
+          const g1 = hash(i * 13 + ringIdx * 211)
+          const a0 = (i / count) * Math.PI * 2 + rot + g0 * 0.18
+          const span = (Math.PI * 2 / count) * (0.25 + g1 * 0.55)
+          // occasional bright "data blip" segments that flicker over time
+          const blip = animate
+            ? Math.max(0, Math.sin(t / 700 + i * 2.3 + ringIdx * 5)) ** 6
+            : g1 * 0.4
+          const alpha = (0.22 + g0 * 0.3 + blip * 0.5 + energy * 0.25) * dim
+          ctx.strokeStyle = blip > 0.6 ? hot(Math.min(1, alpha)) : gold(Math.min(1, alpha), 8)
+          ctx.lineWidth = width + blip * 1.5
+          ctx.beginPath()
+          ctx.arc(cx, cy, rr, a0, a0 + span)
+          ctx.stroke()
+        }
+      })
+
+      // 3 — radial waveform: the last seconds of voice, spun around the core.
+      //     Agent speech renders hot gold; user presence warm amber.
+      const userTint = st === 'listening' || st === 'thinking'
+      for (let i = 0; i < WAVE_BARS; i++) {
+        const slot = (waveHead - 1 - i + WAVE_BARS * 2) % WAVE_BARS
+        const v = waveHist[slot]
+        const live = i === 0 ? energy : v
+        const len = 2 + live * waveMax + hash(i * 3) * 1.5
+        const ang = (i / WAVE_BARS) * Math.PI * 2 + (animate ? t / 14000 : 0)
+        const x0 = cx + Math.cos(ang) * waveInner
+        const y0 = cy + Math.sin(ang) * waveInner
+        const x1 = cx + Math.cos(ang) * (waveInner + len)
+        const y1 = cy + Math.sin(ang) * (waveInner + len)
+        const fade = 1 - (i / WAVE_BARS) * 0.75
+        // wide soft pass + thin bright core = cheap glow
+        ctx.strokeStyle = gold(0.12 * fade * dim, userTint ? 2 : 10)
+        ctx.lineWidth = 3.4
+        ctx.beginPath(); ctx.moveTo(x0, y0); ctx.lineTo(x1, y1); ctx.stroke()
+        ctx.strokeStyle =
+          live > 0.5 ? hot(0.85 * fade * dim) : gold(0.6 * fade * dim, userTint ? 6 : 16)
+        ctx.lineWidth = 1.3
+        ctx.beginPath(); ctx.moveTo(x0, y0); ctx.lineTo(x1, y1); ctx.stroke()
+      }
+
+      // 4 — turbulent core: white-hot centre, gold body, wobbled rim
+      const pulse = coreR * (1 + 0.06 * Math.sin(t / 800) + smoothAgent * 0.5)
       ctx.beginPath()
-      ctx.arc(cx, cy, baseR * 1.6, 0, Math.PI * 2)
+      const pts = 48
+      for (let i = 0; i <= pts; i++) {
+        const a = (i / pts) * Math.PI * 2
+        const wob = animate
+          ? 0.05 * Math.sin(3 * a + t / 500) +
+            0.035 * Math.sin(5 * a - t / 380) +
+            smoothAgent * 0.12 * Math.sin(8 * a + t / 210)
+          : 0.04 * Math.sin(3 * a)
+        const r = pulse * (1 + wob)
+        const x = cx + Math.cos(a) * r
+        const y = cy + Math.sin(a) * r
+        if (i === 0) ctx.moveTo(x, y)
+        else ctx.lineTo(x, y)
+      }
+      ctx.closePath()
+      const core = ctx.createRadialGradient(cx, cy, 0, cx, cy, pulse * 1.15)
+      core.addColorStop(0, hot(0.95 * dim))
+      core.addColorStop(0.35, gold(0.9 * dim, 18))
+      core.addColorStop(0.8, gold(0.5 * dim, 4))
+      core.addColorStop(1, gold(0))
+      ctx.fillStyle = core
       ctx.fill()
-      ctx.fillStyle = color(0.95, 5)
-      ctx.beginPath()
-      ctx.arc(cx, cy, baseR * 0.9, 0, Math.PI * 2)
-      ctx.fill()
+
+      // 5 — thinking / connecting: a comet orbiting the waveform ring
+      if (st === 'thinking' || st === 'connecting') {
+        const base = animate ? t / 650 : 0.8
+        const cometR = waveInner + waveMax * 0.5
+        for (let i = 0; i < 10; i++) {
+          const a = base - i * 0.09
+          ctx.fillStyle = i === 0 ? hot(0.95 * dim) : gold((0.5 - i * 0.05) * dim, 12)
+          ctx.beginPath()
+          ctx.arc(cx + Math.cos(a) * cometR, cy + Math.sin(a) * cometR, i === 0 ? 3 : 2, 0, Math.PI * 2)
+          ctx.fill()
+        }
+      }
     }
 
     if (reducedMotion) {
-      drawStatic()
+      // full composition, one static frame — designed, not a dot
+      waveHist.forEach((_, i) => { waveHist[i] = hash(i) * 0.5 })
+      drawFrame(1200, false)
       return () => undefined
     }
 
-    const frame = (t: number) => {
-      const st = stateRef.current
-      const levels = levelsRef.current
-      // Smooth the raw RMS so the orb feels alive, not jittery.
-      smoothAgent += (levels.agent - smoothAgent) * 0.25
-      smoothUser += (levels.user - smoothUser) * 0.25
-
-      ctx.clearRect(0, 0, size, size)
-
-      const breath = 1 + 0.04 * Math.sin(t / 900)
-      let r = baseR * breath
-      let coreAlpha = 0.85
-      let glowReach = 1.55
-
-      if (st === 'speaking') {
-        r = baseR * (1 + Math.min(0.45, smoothAgent * 2.2))
-        coreAlpha = 0.95
-        glowReach = 1.8
-      } else if (st === 'listening') {
-        r = baseR * breath
-        glowReach = 1.6
-      } else if (st === 'connecting' || st === 'ended') {
-        coreAlpha = 0.5
-      } else if (st === 'error') {
-        coreAlpha = 0.35
-      }
-
-      const glow = ctx.createRadialGradient(cx, cy, r * 0.2, cx, cy, r * glowReach)
-      glow.addColorStop(0, color(coreAlpha, 8))
-      glow.addColorStop(0.65, color(coreAlpha * 0.4))
-      glow.addColorStop(1, color(0))
-      ctx.fillStyle = glow
-      ctx.beginPath()
-      ctx.arc(cx, cy, r * glowReach, 0, Math.PI * 2)
-      ctx.fill()
-
-      ctx.fillStyle = color(coreAlpha, 5)
-      ctx.beginPath()
-      ctx.arc(cx, cy, r * 0.82, 0, Math.PI * 2)
-      ctx.fill()
-
-      // Listening: a ring that swells with the USER's voice — both voices live
-      // in the one presence.
-      if (st === 'listening' || st === 'thinking') {
-        const ringR = r * (1.02 + Math.min(0.5, smoothUser * 3))
-        ctx.strokeStyle = color(0.5 + Math.min(0.4, smoothUser * 2.5), 12)
-        ctx.lineWidth = 2
-        ctx.beginPath()
-        ctx.arc(cx, cy, ringR, 0, Math.PI * 2)
-        ctx.stroke()
-      }
-
-      // Thinking: a slow shimmer arc orbiting the core — visible work, not limbo.
-      if (st === 'thinking' || st === 'connecting') {
-        const a0 = (t / 700) % (Math.PI * 2)
-        ctx.strokeStyle = color(0.9, 15)
-        ctx.lineWidth = 3
-        ctx.lineCap = 'round'
-        ctx.beginPath()
-        ctx.arc(cx, cy, r * 1.12, a0, a0 + Math.PI * 0.6)
-        ctx.stroke()
-      }
-
-      raf = requestAnimationFrame(frame)
+    const loop = (t: number) => {
+      drawFrame(t, true)
+      raf = requestAnimationFrame(loop)
     }
-
-    raf = requestAnimationFrame(frame)
+    raf = requestAnimationFrame(loop)
     return () => cancelAnimationFrame(raf)
   }, [levelsRef, size])
 

--- a/orchestrator/api/voice_retell.py
+++ b/orchestrator/api/voice_retell.py
@@ -619,6 +619,13 @@ async def retell_llm_websocket(websocket: WebSocket, call_id: str) -> None:
                 pass
 
     try:
+        # Protocol handshake: ASK for call_details — Retell only echoes the
+        # call object (and our dynamic variables) when the server requests it.
+        # First live contact: without this config frame the vars never arrived,
+        # every turn failed binding, and Auto sat silent through whole calls.
+        await websocket.send_json(
+            {"response_type": "config", "config": {"auto_reconnect": True, "call_details": True}}
+        )
         # Server speaks first with an EMPTY response — the human opens.
         await websocket.send_json(
             wrap_ws_response({"response_id": 0, "content": "", "content_complete": True})

--- a/orchestrator/modules/voice/call_binding.py
+++ b/orchestrator/modules/voice/call_binding.py
@@ -131,32 +131,30 @@ def resolve_call_binding(
         logger.warning("voice_live_webhook_rejected reason=missing_call_id workspace=%s", workspace_id)
         return None
 
-    try:
-        ws_uuid = uuid.UUID(str(workspace_id))
-    except ValueError:
-        logger.warning("voice_live_webhook_rejected reason=bad_workspace_var call=%s", call_id)
-        return None
-
     row = db.query(VoiceCall).filter(VoiceCall.call_id == str(call_id)).first()
 
-    if row is not None:
-        # The row is OUR truth. A workspace var that contradicts it is a
-        # misroute/tamper — refuse outright (§7.5-2).
-        if str(row.workspace_id) != str(workspace_id):
+    if row is not None and row.workspace_id is not None:
+        # The mint row is SERVER-BORN truth — the vars were only ever our own
+        # values echoed back through Retell. The row alone authorises; vars,
+        # WHEN PRESENT, must not contradict it (a contradiction is tamper and
+        # refuses outright, §7.5-2). Absent vars are fine — first live
+        # contact showed Retell omits them unless the config frame asks.
+        ws_uuid = row.workspace_id
+        if workspace_id and str(workspace_id) != str(row.workspace_id):
             logger.warning(
                 "voice_live_webhook_rejected reason=workspace_mismatch call=%s var=%s row=%s",
                 call_id, workspace_id, row.workspace_id,
             )
             return None
 
-        # Mint-proven thread binding: every var matches the row AND the chat
-        # still exists here, owned by the minted user.
+        # Mint-proven thread binding: the chat still exists here, owned by the
+        # minted user; any PRESENT var must agree with the row.
         if row.chat_id and row.user_id is not None:
-            vars_match = (
-                str(chat_id_var or "") == str(row.chat_id)
-                and str(user_id_var or "") == str(row.user_id)
+            vars_agree = (
+                (chat_id_var is None or str(chat_id_var) == str(row.chat_id))
+                and (user_id_var is None or str(user_id_var) == str(row.user_id))
             )
-            if vars_match:
+            if vars_agree:
                 try:
                     chat = (
                         db.query(Chat)
@@ -190,8 +188,15 @@ def resolve_call_binding(
         # A minted row with no user should not exist (mint requires one) —
         # treat like the unminted lane below.
 
-    # Unminted call (phone lane, or a row missing its user): attribute to the
-    # workspace steward, register/reuse the orphan row LOUD.
+    # Unminted call (phone lane, or a row missing its user): the workspace can
+    # only come from the var here — absent/garbage refuses the turn.
+    try:
+        ws_uuid = uuid.UUID(str(workspace_id))
+    except (TypeError, ValueError):
+        logger.warning("voice_live_webhook_rejected reason=bad_workspace_var call=%s", call_id)
+        return None
+
+    # Attribute to the workspace steward, register/reuse the orphan row LOUD.
     steward = _workspace_steward(db, ws_uuid)
     if steward is None:
         logger.warning(

--- a/orchestrator/tests/test_prd207_voice_live.py
+++ b/orchestrator/tests/test_prd207_voice_live.py
@@ -663,6 +663,31 @@ def test_webhook_rejects_workspace_mismatch_outright(voice_workspace, new_sessio
     assert b is None  # no proven workspace → refuse the turn entirely
 
 
+def test_webhook_binds_from_mint_row_when_vars_absent(voice_workspace, new_session):
+    """First-live-contact regression: Retell omits dynamic vars unless the
+    config frame asks — the mint row ALONE must authorise binding (it is the
+    server-born source the vars merely echoed)."""
+    from modules.voice.call_binding import resolve_call_binding
+
+    s = new_session()
+    _mint_row(
+        s, call_id="call_novars", ws_id=voice_workspace.ws_id,
+        user_id=voice_workspace.owner, chat_id=voice_workspace.chat_id,
+    )
+    b = resolve_call_binding(
+        s,
+        call_id="call_novars",
+        workspace_id=None,  # no vars arrived at all
+        user_id_var=None,
+        chat_id_var=None,
+        first_text="hello",
+    )
+    assert b is not None and b.bound is True
+    assert b.chat_id == voice_workspace.chat_id
+    assert b.user_id == voice_workspace.owner
+    assert b.workspace_id == voice_workspace.ws_id  # row truth, not var
+
+
 def test_webhook_fallback_chat_is_stable_across_turns(voice_workspace, new_session):
     """The per-turn-chat bug is dead: two turns of one call share ONE thread."""
     from modules.voice.call_binding import resolve_call_binding
@@ -951,8 +976,12 @@ def test_ws_user_speaks_first_then_answers_with_call_details_vars(monkeypatch):
     )
     asyncio.run(vr.retell_llm_websocket(ws, "call_ws1"))
 
-    # server spoke first with the empty floor-yielding response
+    # handshake order: config FIRST (ask for call_details — without it Retell
+    # never sends the vars), then the empty floor-yielding response
     assert ws.sent[0] == {
+        "response_type": "config", "config": {"auto_reconnect": True, "call_details": True},
+    }
+    assert ws.sent[1] == {
         "response_type": "response", "response_id": 0, "content": "", "content_complete": True,
     }
     # ping echoed


### PR DESCRIPTION
Two fixes from tonight's first real calls, one merge.

## 1. Auto now speaks (the silence bug)
The logs from the 23:00/23:01 calls showed the full story: Retell connected, streamed the words, and **every turn died at our trust boundary** (`voice_live_webhook_rejected reason=bad_workspace_var`). Two causes:
- Retell only echoes the call object + dynamic variables **when the server asks** — the WS handshake now sends `{response_type: config, config: {auto_reconnect, call_details}}` first.
- The binding demanded vars that are only ever our own minted values echoed back. **The mint row now authorises alone** (server-born truth); vars, when present, must not contradict it — contradiction still refuses outright, and the phone lane still requires the workspace var.

Regression test: binding succeeds with NO vars at all against a minted row; handshake test asserts the config frame precedes the floor-yielding empty response.

## 2. The orb is now the one from the reference images
Three counter-rotating fragmented gold arc rings (deterministic segment hash, flickering data-blips), a 72-bar radial waveform spinning a live history of both voices around the core (agent hot-gold, user amber), a white-hot turbulent core that pulses with Auto's speech, comet orbit while thinking, 260px with a soft gold field behind it. One rAF, zero React re-renders per audio frame, full static composition under reduced-motion.

## Note on #575
Hold it — production logs show the deployed (plain-HMAC) verifier now PASSING genuine Retell events, contradicting the SDK-derived scheme #575 encodes. I'm updating #575 to accept both formats before it should merge.

**After merging this: refresh /chat, click Live, say hello — then tap mute (the TV counts as you talking and keeps interrupting Auto).**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Refreshed the live voice experience with a larger, more dynamic presence orb and enhanced visual effects.
  * Added a decorative background treatment and improved live status and caption presentation.

* **Bug Fixes**
  * Improved voice call connection reliability by retrieving call details earlier during connection setup.
  * Voice calls can now bind successfully when optional call variables are unavailable, while still rejecting mismatched details.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->