### PR TITLE
fix(graph): keep node labels a constant screen size while zooming

### DIFF
--- a/frontend/components/knowledge/BusinessGraphVisualization.tsx
+++ b/frontend/components/knowledge/BusinessGraphVisualization.tsx
@@ -303,20 +303,23 @@ const BusinessGraphVisualization = forwardRef<
         (globalScale > 3.5 && godNodeIds.has(n.id)) ||
         (globalScale > 5 && n.degree > maxDegree * 0.3);
       if (showLabel && n.label) {
-        const fontSize = Math.max(10, 13 / globalScale);
+        // ctx is pre-scaled by globalScale, so size/globalScale renders at a
+        // constant screen size. No graph-unit floor here — a floor stops
+        // cancelling the zoom and labels balloon as you zoom in.
+        const fontSize = 13 / globalScale;
         ctx.font = `${fontSize}px Inter, ui-sans-serif`;
         ctx.fillStyle = "#f1f5f9";
         ctx.textBaseline = "middle";
         // Background pill so the label is readable over dense edges.
         const padding = 3 / globalScale;
         const metrics = ctx.measureText(n.label);
-        const pillX = node.x + baseR + 4;
+        const pillX = node.x + baseR + 4 / globalScale;
         const pillY = node.y - fontSize / 2 - padding / 2;
         ctx.fillStyle = "rgba(10,13,20,0.85)";
         ctx.fillRect(
-          pillX - 2,
+          pillX - padding,
           pillY,
-          metrics.width + 4,
+          metrics.width + padding * 2,
           fontSize + padding,
         );
         ctx.fillStyle = "#f1f5f9";


### PR DESCRIPTION
## What

Zooming into the Knowledge Graph (documents page → Knowledge Graph tab, and the graph panel) filled the viewport with giant overlapping text. Labels now hold a constant 13px on screen at every zoom level, so zooming in spreads nodes apart and *declutters* instead of exploding.

## Why

`react-force-graph-2d` pre-scales the canvas by the zoom factor, so `size / globalScale` is the idiom for a fixed on-screen size. The label font had a `Math.max(10, 13 / globalScale)` floor — but the floor is in **graph units**. Past ~1.3× zoom it stopped cancelling the zoom, so labels rendered at `10 × zoom` screen px (80px letters at 8×). The floor read as "never smaller than 10px" but on a pre-scaled canvas it inverts into "grow without bound as you zoom in".

## Changes

One block in `BusinessGraphVisualization.tsx` (`nodeCanvasObject`):
- `fontSize = 13 / globalScale` — drop the graph-unit floor; constant 13px on screen.
- Label pill offset + padding moved to the same screen-constant units (they mixed graph/screen units the same way, giving oversized pills and gaps at high zoom).

Single renderer — both `KnowledgeGraphExplorer` and `BusinessGraphPanel` mount this component, so one fix covers both surfaces.

## Test plan

- [ ] CI green
- [ ] On ui.automatos.app/documents → Knowledge Graph: zoom in on a focused neighbourhood — labels stay 13px while nodes spread apart
- [ ] Zoomed-out label policy unchanged (hover/focus/god-node thresholds untouched)