### PR TITLE
feat(prd-207): voice fast path, one visible conversation, and the waveform that stranded

### DIFF
--- a/frontend/components/chatbot/chat.tsx
+++ b/frontend/components/chatbot/chat.tsx
@@ -1129,6 +1129,7 @@ export function Chat({
               <LiveVoiceMode
                 chatId={hasSentMessage ? activeChatId : undefined}
                 agentId={selectedAgentId}
+                onChatId={(cid) => setActiveChatId(cid)}
                 onExit={() => setIsLiveMode(false)}
               />
             )}

--- a/frontend/components/voice/LiveVoiceMode.tsx
+++ b/frontend/components/voice/LiveVoiceMode.tsx
@@ -68,19 +68,21 @@ export function LiveVoiceMode({ chatId, agentId, onExit }: LiveVoiceModeProps) {
       className="relative flex w-full flex-col items-center gap-1 pt-4 pb-2"
       data-testid="live-voice-mode"
     >
-      {/* The room: a soft gold field behind the ring so Auto has a stage,
+      {/* The room: a soft gold field behind the wave so Auto has a stage,
           not a black void. Pure CSS, pointer-transparent. */}
       <div
         aria-hidden="true"
-        className="pointer-events-none absolute left-1/2 top-0 h-[340px] w-[560px] -translate-x-1/2 opacity-70"
+        className="pointer-events-none absolute left-1/2 top-0 h-[260px] w-[720px] max-w-full -translate-x-1/2 opacity-80"
         style={{
           background:
-            'radial-gradient(ellipse at center, hsl(var(--warning) / 0.14) 0%, hsl(var(--warning) / 0.05) 45%, transparent 70%)',
+            'radial-gradient(ellipse at center, hsl(var(--warning) / 0.14) 0%, hsl(var(--warning) / 0.05) 45%, transparent 72%)',
           filter: 'blur(2px)',
         }}
       />
 
-      <PresenceOrb state={orbState} levelsRef={levelsRef} size={260} />
+      <div className="w-full max-w-[720px] px-4">
+        <PresenceOrb state={orbState} levelsRef={levelsRef} size={170} />
+      </div>
 
       {/* State for ears and eyes — the a11y surface for the canvas. */}
       <p aria-live="polite" className="relative -mt-3 text-sm font-medium text-warning/90 tracking-wide">

--- a/frontend/components/voice/LiveVoiceMode.tsx
+++ b/frontend/components/voice/LiveVoiceMode.tsx
@@ -21,6 +21,9 @@ interface LiveVoiceModeProps {
   /** The on-screen thread to bind — omit when the chat has no server row yet. */
   chatId?: string | null
   agentId?: number | null
+  /** The call's thread id (created server-side when none was bound) — the
+   * chat screen points at it so the spoken conversation is the visible one. */
+  onChatId?: (chatId: string) => void
   onExit: () => void
 }
 
@@ -30,7 +33,7 @@ function formatDuration(seconds: number): string {
   return `${m}:${s.toString().padStart(2, '0')}`
 }
 
-export function LiveVoiceMode({ chatId, agentId, onExit }: LiveVoiceModeProps) {
+export function LiveVoiceMode({ chatId, agentId, onChatId, onExit }: LiveVoiceModeProps) {
   const {
     orbState,
     stateLabel,
@@ -44,7 +47,7 @@ export function LiveVoiceMode({ chatId, agentId, onExit }: LiveVoiceModeProps) {
     start,
     stop,
     toggleMute,
-  } = useRetellCall({ chatId, agentId })
+  } = useRetellCall({ chatId, agentId, onChatId })
 
   // Live mode IS the call: mounting connects, one gesture from the Live pill.
   useEffect(() => {

--- a/frontend/components/voice/PresenceOrb.tsx
+++ b/frontend/components/voice/PresenceOrb.tsx
@@ -1,17 +1,21 @@
 'use client'
 
 /**
- * PresenceOrb v2 — the JARVIS ring (PRD-207 S5, rebuilt to Gerard's brief).
+ * PresenceOrb v3 — the voice-wave band (PRD-207 S5, to Gerard's waveform brief).
  *
- * Reference direction: Iron-Man-style circular interface — fragmented gold
- * arc rings rotating at different speeds, a radial audio waveform bent
- * around the core, particle blips, a white-hot turbulent centre, glow
- * everywhere. Canvas-2D, one rAF, zero React re-renders per audio frame
- * (levels arrive through a mutable ref). `prefers-reduced-motion` renders
- * the full composition once, static.
+ * The reference set is HORIZONTAL: a bright beam across the screen, dense
+ * mirrored vertical bars breathing out of it, smooth ribbon waves flowing
+ * through, a hot core flare at centre, drifting particles. Voice history
+ * enters at the centre and travels outward to both edges, so speech
+ * literally radiates from the middle of the beam.
  *
- * All per-segment "randomness" is a deterministic index hash so the ring is
- * stable frame-to-frame and identical across mounts.
+ * Canvas-2D, one rAF, zero React re-renders per audio frame (levels arrive
+ * through a mutable ref). `prefers-reduced-motion` renders the full
+ * composition once, static. All per-element "randomness" is a
+ * deterministic index hash — stable frame to frame.
+ *
+ * `size` is the band HEIGHT; the band spans the container width (canvas
+ * has a fixed internal resolution and stretches via CSS).
  */
 
 import { useEffect, useRef, type MutableRefObject } from 'react'
@@ -21,6 +25,7 @@ import type { OrbState } from '@/lib/voice/orb-state'
 interface PresenceOrbProps {
   state: OrbState
   levelsRef: MutableRefObject<VoiceLevels>
+  /** Band height in px; the band fills its container's width. */
   size?: number
 }
 
@@ -39,10 +44,11 @@ function hash(i: number): number {
   return x - Math.floor(x)
 }
 
-const WAVE_BARS = 72
-const RING_SEGMENTS = [26, 34, 18] // fragments per arc ring, inner→outer
+const W = 680 // internal canvas width; CSS stretches to the container
+const SLOTS = 60 // half-width history slots (centre → edge)
+const BAR_SPACING = 5.5
 
-export function PresenceOrb({ state, levelsRef, size = 260 }: PresenceOrbProps) {
+export function PresenceOrb({ state, levelsRef, size = 170 }: PresenceOrbProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const stateRef = useRef<OrbState>(state)
   stateRef.current = state
@@ -53,32 +59,27 @@ export function PresenceOrb({ state, levelsRef, size = 260 }: PresenceOrbProps) 
     const ctx = canvas.getContext('2d')
     if (!ctx) return
 
+    const H = size
     const dpr = typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1
-    canvas.width = size * dpr
-    canvas.height = size * dpr
+    canvas.width = W * dpr
+    canvas.height = H * dpr
     ctx.scale(dpr, dpr)
 
     const { h, s, l } = warningHsl()
-    const gold = (alpha: number, dl = 0, ds = 0) =>
-      `hsla(${h}, ${Math.max(0, Math.min(100, s + ds))}%, ${Math.max(0, Math.min(100, l + dl))}%, ${alpha})`
-    const hot = (alpha: number) => `hsla(${h + 6}, 100%, 88%, ${alpha})`
+    const gold = (alpha: number, dl = 0) =>
+      `hsla(${h}, ${s}%, ${Math.max(0, Math.min(100, l + dl))}%, ${alpha})`
+    const hot = (alpha: number) => `hsla(${h + 6}, 100%, 90%, ${alpha})`
 
     const reducedMotion =
       typeof window !== 'undefined' &&
       window.matchMedia?.('(prefers-reduced-motion: reduce)').matches
 
-    const cx = size / 2
-    const cy = size / 2
-    const R = size * 0.46 // outermost reach
-    const coreR = size * 0.16
-    const waveInner = size * 0.24
-    const waveMax = size * 0.115
+    const cx = W / 2
+    const cy = H / 2
+    const maxBar = H * 0.36
 
-    // Rotating radial-waveform history: each frame writes the current energy
-    // at the write head, so the bars carry a spinning trace of the last
-    // seconds of BOTH voices (the audio-waveform references, bent circular).
-    const waveHist = new Float32Array(WAVE_BARS)
-    let waveHead = 0
+    // Voice history: slot 0 = centre (now), travelling outward each frame.
+    const hist = new Float32Array(SLOTS)
     let smoothAgent = 0
     let smoothUser = 0
     let raf = 0
@@ -86,121 +87,123 @@ export function PresenceOrb({ state, levelsRef, size = 260 }: PresenceOrbProps) 
     const drawFrame = (t: number, animate: boolean) => {
       const st = stateRef.current
       const levels = levelsRef.current
-      smoothAgent += (levels.agent - smoothAgent) * 0.3
-      smoothUser += (levels.user - smoothUser) * 0.25
-      const energy = Math.min(1, smoothAgent * 1.6 + smoothUser * 0.9)
+      smoothAgent += (levels.agent - smoothAgent) * 0.35
+      smoothUser += (levels.user - smoothUser) * 0.3
+      const energy = Math.min(1, smoothAgent * 1.7 + smoothUser * 1.0)
 
       if (animate) {
-        waveHist[waveHead] = energy
-        waveHead = (waveHead + 1) % WAVE_BARS
+        hist.copyWithin(1, 0) // history radiates outward from the centre
+        hist[0] = energy
       }
 
-      const dim = st === 'ended' || st === 'error' ? 0.35 : st === 'connecting' ? 0.6 : 1
-      const spin = st === 'speaking' ? 1.6 : st === 'thinking' ? 0.5 : 1
+      const dim = st === 'ended' || st === 'error' ? 0.35 : st === 'connecting' ? 0.65 : 1
 
-      ctx.clearRect(0, 0, size, size)
+      ctx.clearRect(0, 0, W, H)
 
-      // 1 — ambient halo, breathing with the room's energy
-      const breath = 1 + 0.05 * Math.sin(t / 1100) + energy * 0.25
-      const halo = ctx.createRadialGradient(cx, cy, coreR * 0.4, cx, cy, R * breath)
-      halo.addColorStop(0, gold(0.16 * dim, 10))
-      halo.addColorStop(0.5, gold(0.07 * dim))
-      halo.addColorStop(1, gold(0))
-      ctx.fillStyle = halo
-      ctx.fillRect(0, 0, size, size)
+      // 1 — ambient wash above/below the beam
+      const wash = ctx.createLinearGradient(0, 0, 0, H)
+      wash.addColorStop(0, gold(0))
+      wash.addColorStop(0.5, gold(0.10 * dim, 6))
+      wash.addColorStop(1, gold(0))
+      ctx.fillStyle = wash
+      ctx.fillRect(0, 0, W, H)
 
-      // 2 — fragmented arc rings (the JARVIS signature), counter-rotating
-      RING_SEGMENTS.forEach((count, ringIdx) => {
-        const rr = R * (0.78 + ringIdx * 0.09)
-        const dir = ringIdx % 2 === 0 ? 1 : -1
-        const rot = animate ? dir * (t / (9000 - ringIdx * 2600)) * spin : dir * 0.6
-        const width = ringIdx === 1 ? 2.5 : 1.25
-        for (let i = 0; i < count; i++) {
-          const g0 = hash(i * 7 + ringIdx * 101)
-          const g1 = hash(i * 13 + ringIdx * 211)
-          const a0 = (i / count) * Math.PI * 2 + rot + g0 * 0.18
-          const span = (Math.PI * 2 / count) * (0.25 + g1 * 0.55)
-          // occasional bright "data blip" segments that flicker over time
-          const blip = animate
-            ? Math.max(0, Math.sin(t / 700 + i * 2.3 + ringIdx * 5)) ** 6
-            : g1 * 0.4
-          const alpha = (0.22 + g0 * 0.3 + blip * 0.5 + energy * 0.25) * dim
-          ctx.strokeStyle = blip > 0.6 ? hot(Math.min(1, alpha)) : gold(Math.min(1, alpha), 8)
-          ctx.lineWidth = width + blip * 1.5
-          ctx.beginPath()
-          ctx.arc(cx, cy, rr, a0, a0 + span)
-          ctx.stroke()
+      // 2 — mirrored voice bars: history flows centre → edges (both sides)
+      for (let sIdx = 0; sIdx < SLOTS; sIdx++) {
+        const v = sIdx === 0 ? energy : hist[sIdx]
+        const fade = 1 - (sIdx / SLOTS) * 0.8
+        const jitter = hash(sIdx * 7) * 2
+        const bh = 3 + v * maxBar * (0.45 + fade * 0.55) + jitter
+        const hotBar = v > 0.45
+        for (const dir of [-1, 1]) {
+          const x = cx + dir * (sIdx * BAR_SPACING + 2)
+          // soft wide pass + bright thin core = cheap glow
+          ctx.strokeStyle = gold(0.14 * fade * dim, 8)
+          ctx.lineWidth = 3.6
+          ctx.beginPath(); ctx.moveTo(x, cy - bh); ctx.lineTo(x, cy + bh); ctx.stroke()
+          ctx.strokeStyle = hotBar ? hot(0.9 * fade * dim) : gold(0.55 * fade * dim, 14)
+          ctx.lineWidth = 1.4
+          ctx.beginPath(); ctx.moveTo(x, cy - bh); ctx.lineTo(x, cy + bh); ctx.stroke()
         }
-      })
-
-      // 3 — radial waveform: the last seconds of voice, spun around the core.
-      //     Agent speech renders hot gold; user presence warm amber.
-      const userTint = st === 'listening' || st === 'thinking'
-      for (let i = 0; i < WAVE_BARS; i++) {
-        const slot = (waveHead - 1 - i + WAVE_BARS * 2) % WAVE_BARS
-        const v = waveHist[slot]
-        const live = i === 0 ? energy : v
-        const len = 2 + live * waveMax + hash(i * 3) * 1.5
-        const ang = (i / WAVE_BARS) * Math.PI * 2 + (animate ? t / 14000 : 0)
-        const x0 = cx + Math.cos(ang) * waveInner
-        const y0 = cy + Math.sin(ang) * waveInner
-        const x1 = cx + Math.cos(ang) * (waveInner + len)
-        const y1 = cy + Math.sin(ang) * (waveInner + len)
-        const fade = 1 - (i / WAVE_BARS) * 0.75
-        // wide soft pass + thin bright core = cheap glow
-        ctx.strokeStyle = gold(0.12 * fade * dim, userTint ? 2 : 10)
-        ctx.lineWidth = 3.4
-        ctx.beginPath(); ctx.moveTo(x0, y0); ctx.lineTo(x1, y1); ctx.stroke()
-        ctx.strokeStyle =
-          live > 0.5 ? hot(0.85 * fade * dim) : gold(0.6 * fade * dim, userTint ? 6 : 16)
-        ctx.lineWidth = 1.3
-        ctx.beginPath(); ctx.moveTo(x0, y0); ctx.lineTo(x1, y1); ctx.stroke()
       }
 
-      // 4 — turbulent core: white-hot centre, gold body, wobbled rim
-      const pulse = coreR * (1 + 0.06 * Math.sin(t / 800) + smoothAgent * 0.5)
+      // 3 — ribbon waves flowing through the bars (three phase-shifted layers)
+      const ribbonEnv = (x: number) => {
+        const d = Math.abs(x - cx) / cx
+        return (1 - d * d) * (0.35 + energy * 0.65)
+      }
+      for (let rIdx = 0; rIdx < 3; rIdx++) {
+        const amp = H * (0.10 + rIdx * 0.045)
+        const k = 0.012 + rIdx * 0.004
+        const speed = (animate ? t : 900) / (900 + rIdx * 380)
+        ctx.beginPath()
+        for (let x = 0; x <= W; x += 6) {
+          const y =
+            cy +
+            Math.sin(x * k + speed * (rIdx % 2 === 0 ? 1 : -1) * 2 + rIdx * 2.1) *
+              amp * ribbonEnv(x)
+          if (x === 0) ctx.moveTo(x, y)
+          else ctx.lineTo(x, y)
+        }
+        ctx.strokeStyle = rIdx === 0 ? hot(0.35 * dim) : gold(0.22 * dim, 12 - rIdx * 6)
+        ctx.lineWidth = rIdx === 0 ? 1.6 : 1.1
+        ctx.stroke()
+      }
+
+      // 4 — the beam: a bright horizon line with a soft vertical glow
+      const beamGlow = ctx.createLinearGradient(0, cy - 14, 0, cy + 14)
+      beamGlow.addColorStop(0, gold(0))
+      beamGlow.addColorStop(0.5, gold(0.5 * dim, 18))
+      beamGlow.addColorStop(1, gold(0))
+      ctx.fillStyle = beamGlow
+      ctx.fillRect(0, cy - 14, W, 28)
+      const beam = ctx.createLinearGradient(0, 0, W, 0)
+      beam.addColorStop(0, gold(0.05 * dim))
+      beam.addColorStop(0.5, hot(0.95 * dim))
+      beam.addColorStop(1, gold(0.05 * dim))
+      ctx.fillStyle = beam
+      ctx.fillRect(0, cy - 0.8, W, 1.6)
+
+      // 5 — core flare at centre: blooms with Auto's voice
+      const flareR = 26 + smoothAgent * 95 + 6 * Math.sin((animate ? t : 600) / 700)
+      const flare = ctx.createRadialGradient(cx, cy, 0, cx, cy, flareR)
+      flare.addColorStop(0, hot(0.95 * dim))
+      flare.addColorStop(0.3, gold(0.55 * dim, 20))
+      flare.addColorStop(1, gold(0))
+      ctx.fillStyle = flare
       ctx.beginPath()
-      const pts = 48
-      for (let i = 0; i <= pts; i++) {
-        const a = (i / pts) * Math.PI * 2
-        const wob = animate
-          ? 0.05 * Math.sin(3 * a + t / 500) +
-            0.035 * Math.sin(5 * a - t / 380) +
-            smoothAgent * 0.12 * Math.sin(8 * a + t / 210)
-          : 0.04 * Math.sin(3 * a)
-        const r = pulse * (1 + wob)
-        const x = cx + Math.cos(a) * r
-        const y = cy + Math.sin(a) * r
-        if (i === 0) ctx.moveTo(x, y)
-        else ctx.lineTo(x, y)
-      }
-      ctx.closePath()
-      const core = ctx.createRadialGradient(cx, cy, 0, cx, cy, pulse * 1.15)
-      core.addColorStop(0, hot(0.95 * dim))
-      core.addColorStop(0.35, gold(0.9 * dim, 18))
-      core.addColorStop(0.8, gold(0.5 * dim, 4))
-      core.addColorStop(1, gold(0))
-      ctx.fillStyle = core
+      ctx.arc(cx, cy, flareR, 0, Math.PI * 2)
       ctx.fill()
 
-      // 5 — thinking / connecting: a comet orbiting the waveform ring
+      // 6 — drifting particles (the dust in the references)
+      for (let p = 0; p < 26; p++) {
+        const drift = animate ? (t / 1000) * (4 + hash(p) * 10) : 40
+        const px = (hash(p * 3) * W + drift * (p % 2 === 0 ? 1 : -1) + W * 4) % W
+        const py = cy + (hash(p * 5) - 0.5) * H * 0.75
+        const tw = 0.25 + 0.6 * Math.abs(Math.sin((animate ? t : 500) / 900 + p * 1.7))
+        ctx.fillStyle = p % 5 === 0 ? hot(tw * 0.8 * dim) : gold(tw * 0.5 * dim, 15)
+        ctx.beginPath()
+        ctx.arc(px, py, p % 4 === 0 ? 1.6 : 1, 0, Math.PI * 2)
+        ctx.fill()
+      }
+
+      // 7 — thinking/connecting: a bright pulse travelling the beam
       if (st === 'thinking' || st === 'connecting') {
-        const base = animate ? t / 650 : 0.8
-        const cometR = waveInner + waveMax * 0.5
-        for (let i = 0; i < 10; i++) {
-          const a = base - i * 0.09
-          ctx.fillStyle = i === 0 ? hot(0.95 * dim) : gold((0.5 - i * 0.05) * dim, 12)
-          ctx.beginPath()
-          ctx.arc(cx + Math.cos(a) * cometR, cy + Math.sin(a) * cometR, i === 0 ? 3 : 2, 0, Math.PI * 2)
-          ctx.fill()
-        }
+        const cycle = animate ? (t / 1600) % 1 : 0.35
+        const xp = cycle * W
+        const pg = ctx.createRadialGradient(xp, cy, 0, xp, cy, 22)
+        pg.addColorStop(0, hot(0.9 * dim))
+        pg.addColorStop(1, gold(0))
+        ctx.fillStyle = pg
+        ctx.beginPath()
+        ctx.arc(xp, cy, 22, 0, Math.PI * 2)
+        ctx.fill()
       }
     }
 
     if (reducedMotion) {
-      // full composition, one static frame — designed, not a dot
-      waveHist.forEach((_, i) => { waveHist[i] = hash(i) * 0.5 })
-      drawFrame(1200, false)
+      for (let i = 0; i < SLOTS; i++) hist[i] = 0.15 + hash(i) * 0.45
+      drawFrame(900, false)
       return () => undefined
     }
 
@@ -215,7 +218,7 @@ export function PresenceOrb({ state, levelsRef, size = 260 }: PresenceOrbProps) 
   return (
     <canvas
       ref={canvasRef}
-      style={{ width: size, height: size }}
+      style={{ width: '100%', maxWidth: 720, height: size, display: 'block' }}
       role="img"
       aria-hidden="true"
       data-orb-state={state}

--- a/frontend/hooks/use-retell-call.ts
+++ b/frontend/hooks/use-retell-call.ts
@@ -55,9 +55,13 @@ interface UseRetellCallOptions {
   /** Bind the call to this on-screen thread (omit when the chat has no server row yet). */
   chatId?: string | null
   agentId?: number | null
+  /** Fires with the call's thread id (server-created when none was bound) —
+   * the chat screen points itself at it so voice and text are ONE
+   * conversation, visible while speaking. */
+  onChatId?: (chatId: string) => void
 }
 
-export function useRetellCall({ chatId, agentId }: UseRetellCallOptions): UseRetellCallReturn {
+export function useRetellCall({ chatId, agentId, onChatId }: UseRetellCallOptions): UseRetellCallReturn {
   const [snap, setSnap] = useState<OrbSnapshot>(initialOrb)
   const [captions, setCaptions] = useState<CaptionLine[]>([])
   const [durationSec, setDurationSec] = useState(0)
@@ -135,22 +139,26 @@ export function useRetellCall({ chatId, agentId }: UseRetellCallOptions): UseRet
 
     // 1 — mint (every refusal reason here is user-facing truth: platform off,
     // not armed, workspace off, over budget).
-    let minted: { call_id: string; access_token: string }
+    let minted: { call_id: string; access_token: string; chat_id?: string | null }
     try {
-      minted = await apiClient.request<{ call_id: string; access_token: string }>(
-        '/api/voice/web-call',
-        {
-          method: 'POST',
-          body: {
-            ...(chatId ? { chat_id: chatId } : {}),
-            ...(agentId ? { agent_id: agentId } : {}),
-          } as any,
-        }
-      )
+      minted = await apiClient.request<{
+        call_id: string
+        access_token: string
+        chat_id?: string | null
+      }>('/api/voice/web-call', {
+        method: 'POST',
+        body: {
+          ...(chatId ? { chat_id: chatId } : {}),
+          ...(agentId ? { agent_id: agentId } : {}),
+        } as any,
+      })
     } catch (err: any) {
       setRefusal(err?.message || 'Live voice is unavailable right now')
       dispatch({ type: 'error' })
       return
+    }
+    if (minted.chat_id) {
+      onChatId?.(minted.chat_id)
     }
 
     // 2 — connect (the token dies in ~30s unused; go now).
@@ -235,7 +243,7 @@ export function useRetellCall({ chatId, agentId }: UseRetellCallOptions): UseRet
       // No analyser is cosmetic-only: the call still works, the orb just
       // won't react to the user's voice.
     }
-  }, [agentId, chatId, dispatch, stop, teardown])
+  }, [agentId, chatId, onChatId, dispatch, stop, teardown])
 
   useEffect(() => () => teardown(), [teardown])
 

--- a/frontend/lib/chat/hooks.ts
+++ b/frontend/lib/chat/hooks.ts
@@ -38,6 +38,13 @@ export function useChat({
   const [chatId, setChatId] = useState(id)
   const abortControllerRef = useRef<AbortController | null>(null)
 
+  // PRD-207: the id prop can move mid-mount (a live call binds the screen to
+  // its thread) — follow it so the chat_changed merge listener and sends
+  // target the conversation actually on screen.
+  useEffect(() => {
+    setChatId(id)
+  }, [id])
+
   const stop = useCallback(() => {
     if (abortControllerRef.current) {
       abortControllerRef.current.abort()

--- a/orchestrator/api/voice_retell.py
+++ b/orchestrator/api/voice_retell.py
@@ -154,7 +154,10 @@ async def mint_web_call(
 
     # Bind-target validation at mint: the chat must be the caller's own thread
     # in THIS workspace — refuse honestly rather than mint a lie the webhook
-    # would then reject (§7.5-1/2).
+    # would then reject (§7.5-1/2). No chat on screen yet? CREATE the thread
+    # here and hand its id back — voice and text are the SAME conversation,
+    # visible while you speak, typeable when you hang up (Gerard's first-call
+    # feedback: the transcript must never land in an invisible side thread).
     bound_chat_id: Optional[str] = None
     if body.chat_id:
         try:
@@ -171,6 +174,15 @@ async def mint_web_call(
         if int(chat.user_id) != int(user_int_id):
             raise HTTPException(status_code=403, detail="You can only bind a live call to your own chat")
         bound_chat_id = str(chat_uuid)
+    else:
+        from consumers.chatbot.service import ChatService
+
+        chat = ChatService(db).create_chat(
+            user_id=int(user_int_id),
+            title="Voice call",
+            workspace_id=ctx.workspace_id,
+        )
+        bound_chat_id = str(chat.id)
 
     dynamic_vars = {
         "workspace_id": str(ctx.workspace_id),
@@ -213,7 +225,13 @@ async def mint_web_call(
         web_call.call_id, ctx.workspace_id, user_int_id, bound_chat_id,
     )
     # The token dies in ~30s unused — the client connects immediately.
-    return {"call_id": web_call.call_id, "access_token": web_call.access_token}
+    # chat_id lets the screen point at the call's thread: one conversation,
+    # spoken and typed.
+    return {
+        "call_id": web_call.call_id,
+        "access_token": web_call.access_token,
+        "chat_id": bound_chat_id,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -509,8 +527,18 @@ async def _agent_retell_stream(req: RetellLLMRequest) -> AsyncIterator[dict[str,
         if agent_id is None:
             agent_id = get_default_agent_id(db, binding.workspace_id)
 
+        # VOICE FAST PATH (first live calls measured MINUTES per turn — the
+        # full chat pipeline is built for screens, not speech):
+        # * history is the recent conversation, not the archive — Retell holds
+        #   the floor open while we re-read old messages;
+        # * force_text_only: widget/tool-data payload assembly is meaningless
+        #   to a voice — words only;
+        # * skip_composio: external tool loops are tens of seconds of dead
+        #   air mid-call. Auto says what it knows; deep work belongs to text
+        #   turns or background missions.
         messages = chat_service.get_messages_by_chat_id(conversation_id)
-        message_history = [{"role": m.role, "parts": m.parts} for m in messages]
+        recent = messages[-int(config.VOICE_LIVE_TURN_HISTORY_MESSAGES):]
+        message_history = [{"role": m.role, "parts": m.parts} for m in recent]
 
         agent_chunks = streaming_service.stream_response_with_agent(
             chat_id=conversation_id,
@@ -518,6 +546,8 @@ async def _agent_retell_stream(req: RetellLLMRequest) -> AsyncIterator[dict[str,
             agent_id=agent_id,
             user_id=binding.user_id,
             use_orchestrator_llm=True,
+            force_text_only=True,
+            skip_composio=True,
         )
 
         response_chars = 0

--- a/orchestrator/config.py
+++ b/orchestrator/config.py
@@ -1276,6 +1276,12 @@ class Config:
         os.getenv("VOICE_LIVE_ACTIVE_CALL_RESERVE_MINUTES", "10")
     )
     VOICE_LIVE_MAX_CALL_MINUTES: int = int(os.getenv("VOICE_LIVE_MAX_CALL_MINUTES", "30"))
+    # Spoken turns ride a FAST PATH: only this many recent messages feed the
+    # prompt (a call is a conversation, not an archive replay) — first-token
+    # time is the product in voice.
+    VOICE_LIVE_TURN_HISTORY_MESSAGES: int = int(
+        os.getenv("VOICE_LIVE_TURN_HISTORY_MESSAGES", "12")
+    )
     # The public host Retell must reach for the custom-LLM socket + events
     # webhook (one-click arming builds the URLs from it). Railway injects
     # RAILWAY_PUBLIC_DOMAIN; override with PUBLIC_API_HOST where that's absent.

--- a/orchestrator/tests/test_prd207_voice_live.py
+++ b/orchestrator/tests/test_prd207_voice_live.py
@@ -404,7 +404,7 @@ def test_mint_passes_dynamic_vars_and_inserts_minted_row(monkeypatch):
         db=db,
     )
 
-    assert out == {"call_id": "call_abc", "access_token": "tok_xyz"}
+    assert out == {"call_id": "call_abc", "access_token": "tok_xyz", "chat_id": str(chat_id)}
     dv = seen["payload"]["retell_llm_dynamic_variables"]
     assert dv == {
         "workspace_id": str(ws_id),
@@ -422,6 +422,140 @@ def test_mint_passes_dynamic_vars_and_inserts_minted_row(monkeypatch):
     assert row.user_id == 7
     assert row.chat_id == str(chat_id)
     assert db.commit.called
+
+
+def test_mint_without_chat_creates_and_binds_thread(monkeypatch):
+    """Gerard's first-call feedback: the spoken conversation must be the
+    VISIBLE one. No chat on screen → mint creates the thread, binds it, and
+    hands its id back so the screen can point at it."""
+    import consumers.chatbot.service as chat_service_mod
+
+    import api.voice_retell as vr
+    from core.models.voice_calls import VoiceCall
+    from modules.voice.live_settings import RetellCredentials
+    from modules.voice.retell_api import RetellWebCall
+    from modules.voice.voice_meter import MeterReading
+
+    ws_id = uuid.uuid4()
+    created_chat_id = uuid.uuid4()
+    created = {}
+
+    class FakeChatService:
+        def __init__(self, db):
+            pass
+
+        def create_chat(self, *, user_id, title, workspace_id):
+            created.update(user_id=user_id, title=title, workspace_id=workspace_id)
+            return SimpleNamespace(id=created_chat_id)
+
+    monkeypatch.setattr(chat_service_mod, "ChatService", FakeChatService)
+    monkeypatch.setattr(vr.live_settings, "voice_live_enabled", lambda: True)
+    monkeypatch.setattr(
+        vr.live_settings, "retell_credentials", lambda: RetellCredentials("k", "s", "a")
+    )
+    monkeypatch.setattr(vr.voice_meter, "monthly_meter", lambda db, w: MeterReading(0, 0, 10))
+
+    async def fake_vendor(api_key, payload):
+        return RetellWebCall(call_id="call_fresh", access_token="tok")
+
+    monkeypatch.setattr(vr.retell_api, "create_web_call", fake_vendor)
+
+    ws = SimpleNamespace(settings={"voice_live": {"enabled": True}})
+    db = _mint_db(workspace=ws)
+
+    out = _run_mint(ctx=_mint_ctx(ws_id=ws_id, user_int=7), db=db)
+
+    assert out["chat_id"] == str(created_chat_id)  # the screen can follow it
+    assert created["user_id"] == 7 and created["title"] == "Voice call"
+    rows = [a.args[0] for a in db.add.call_args_list if isinstance(a.args[0], VoiceCall)]
+    assert rows[0].chat_id == str(created_chat_id)  # mint-proven binding → webhook writes HERE
+
+
+def test_voice_turn_rides_the_fast_path(monkeypatch):
+    """First live calls measured MINUTES per turn: the spoken lane must trim
+    history and skip widget payloads + external tool loops."""
+    import consumers.chatbot as chatbot_pkg
+
+    import api.voice_retell as vr
+    from config import config as app_config
+    from modules.voice.call_binding import CallBinding
+
+    captured = {}
+    ws_id = str(uuid.uuid4())
+    chat_id = str(uuid.uuid4())
+
+    class FakeChatService:
+        def __init__(self, db):
+            pass
+
+        def save_message(self, **kwargs):
+            return SimpleNamespace(id=uuid.uuid4())
+
+        def get_messages_by_chat_id(self, cid):
+            return [
+                SimpleNamespace(role="user", parts=[{"type": "text", "text": f"m{i}"}])
+                for i in range(40)  # a long archive — the call must not replay it
+            ]
+
+    class FakeStreaming:
+        def __init__(self, db, workspace_id=None):
+            pass
+
+        def stream_response_with_agent(self, **kwargs):
+            captured.update(kwargs)
+
+            async def gen():
+                yield '0:"hi"'
+
+            return gen()
+
+    monkeypatch.setattr(chatbot_pkg, "ChatService", FakeChatService)
+    monkeypatch.setattr(chatbot_pkg, "StreamingChatService", FakeStreaming)
+
+    import modules.voice.call_binding as cb
+
+    monkeypatch.setattr(
+        cb, "resolve_call_binding",
+        lambda db, **k: CallBinding(chat_id=chat_id, user_id=7, workspace_id=ws_id, bound=True),
+    )
+    monkeypatch.setattr(cb, "stamp_assistant_voice_source", lambda db, **k: 0)
+
+    import api.chat as chat_api
+
+    monkeypatch.setattr(chat_api, "get_default_agent_id", lambda db, w: 1)
+
+    import services.board_events as be
+
+    monkeypatch.setattr(be, "notify_chat_event", lambda db, **k: None)
+
+    import modules.voice.telemetry as tel
+
+    monkeypatch.setattr(tel, "record_voice_turn", lambda **k: None)
+
+    from contextlib import contextmanager
+
+    @contextmanager
+    def fake_session():
+        yield MagicMock()
+
+    monkeypatch.setattr(vr, "get_db_session", fake_session)
+
+    from modules.voice.providers.retell import RetellLLMRequest
+
+    req = RetellLLMRequest(
+        response_id=1, user_text="hey", interaction_type="response_required",
+        workspace_id=ws_id, agent_id=None, call_id="call_fast",
+    )
+
+    async def run():
+        return [f async for f in vr._agent_retell_stream(req)]
+
+    frames = asyncio.run(run())
+    assert any(f.get("content") for f in frames)  # the turn streamed
+
+    assert captured["force_text_only"] is True   # words only — no widget payloads
+    assert captured["skip_composio"] is True     # no external tool loops mid-call
+    assert len(captured["messages"]) <= int(app_config.VOICE_LIVE_TURN_HISTORY_MESSAGES)
 
 
 def test_mint_refuses_binding_to_someone_elses_chat(monkeypatch):


### PR DESCRIPTION
Three things from the first real conversations, one merge.

## 1. The minutes-of-delay bug → a voice fast path
Spoken turns were running Auto's FULL screen-built pipeline — archive-replay history, widget payload assembly, composio tool loops (tens of seconds of dead air each). The voice lane now: trims history to the recent conversation (`VOICE_LIVE_TURN_HISTORY_MESSAGES`, default 12), forces text-only assembly, skips composio mid-call. **Honest expectation:** this removes the minutes; the research target (≤1.5s) may additionally need a faster model tier for spoken turns — that's the next lever and a small follow-up if tonight's calls still feel slow.

## 2. Voice and text are the SAME conversation now
A welcome-screen call was writing its transcript into an invisible background thread. Now the mint **creates the conversation and returns its id**; the chat screen points itself at it (`useChat` follows its id prop). You SEE the transcript land while you talk, and typing afterwards continues the very same thread.

## 3. The waveform you actually asked for (stranded commit recovered)
#576 was merged before my waveform push landed, so production got the ring. Cherry-picked here: the **horizontal voice-wave band** — bright gold beam across the chat, mirrored bars radiating your voices outward from the centre, ribbon waves, a white-hot flare blooming with Auto's voice, drifting particles, a pulse walking the beam while he thinks.

## Tests
Fast-path kwargs asserted (history ≤ limit, text-only, no composio); mint-creates-thread + returns chat_id; existing binding/trust matrix untouched.

**After merge + ~15 min: refresh /chat → Live → talk. The transcript appears in the visible chat as you speak. Mute when you're done talking — the TV still counts as you holding the floor.**