### PR TITLE
feat(prd-207): Auto's words type out in the thread AS he speaks

### DIFF
--- a/frontend/components/chatbot/chat.tsx
+++ b/frontend/components/chatbot/chat.tsx
@@ -190,6 +190,20 @@ export function Chat({
 
   // PRD-207 S5: live voice mode — the orb mounts, content drops lower.
   const [isLiveMode, setIsLiveMode] = useState(false)
+  // PRD-207: the current spoken exchange, streamed from Retell — rendered as
+  // live-typing bubbles so Auto's words print in the thread AS he reads them.
+  // Cleared when chat_changed lands the persisted (badged) versions.
+  const [liveVoiceTurn, setLiveVoiceTurn] = useState<{ userText: string; agentText: string }>({
+    userText: '',
+    agentText: '',
+  })
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const clearDrafts = () => setLiveVoiceTurn({ userText: '', agentText: '' })
+    window.addEventListener('automatos:chat-changed', clearDrafts)
+    return () => window.removeEventListener('automatos:chat-changed', clearDrafts)
+  }, [])
+  const liveDraftActive = isLiveMode && Boolean(liveVoiceTurn.userText || liveVoiceTurn.agentText)
   // PRD-207 S6 (closing a PRD-205 gap): the chat page subscribes to the SSE
   // lane so chat_changed reaches the useChat merge listener HERE — not only
   // while Command Center happens to be open.
@@ -880,7 +894,9 @@ export function Chat({
   const isTyping = status === 'streaming'
   const hasSentMessage = messages.length > 0
 
-  const showWelcomeCard = !hasSentMessage && !isTyping
+  // A live spoken exchange IS the conversation — leave the welcome screen the
+  // moment words start flowing, don't wait for a persisted message.
+  const showWelcomeCard = !hasSentMessage && !isTyping && !liveDraftActive
 
   return (
     <>
@@ -1130,7 +1146,11 @@ export function Chat({
                 chatId={hasSentMessage ? activeChatId : undefined}
                 agentId={selectedAgentId}
                 onChatId={(cid) => setActiveChatId(cid)}
-                onExit={() => setIsLiveMode(false)}
+                onLiveTurn={setLiveVoiceTurn}
+                onExit={() => {
+                  setIsLiveMode(false)
+                  setLiveVoiceTurn({ userText: '', agentText: '' })
+                }}
               />
             )}
           </AnimatePresence>
@@ -1266,6 +1286,42 @@ export function Chat({
                     />
                   ))}
                 </AnimatePresence>
+
+                {/* PRD-207: the spoken exchange typing out live — replaced by
+                    the persisted (voice-badged) messages when chat_changed
+                    lands them. Read-only bubbles; Auto's grows as he speaks. */}
+                {liveDraftActive && liveVoiceTurn.userText && (
+                  <Message
+                    key="voice-draft-user"
+                    chatId={id}
+                    message={{
+                      id: 'voice-draft-user',
+                      role: 'user',
+                      content: liveVoiceTurn.userText,
+                      parts: [{ type: 'text', text: liveVoiceTurn.userText }],
+                    } as any}
+                    isLoading={false}
+                    setMessages={setMessages}
+                    regenerate={regenerate}
+                    isReadonly
+                  />
+                )}
+                {liveDraftActive && liveVoiceTurn.agentText && (
+                  <Message
+                    key="voice-draft-assistant"
+                    chatId={id}
+                    message={{
+                      id: 'voice-draft-assistant',
+                      role: 'assistant',
+                      content: liveVoiceTurn.agentText,
+                      parts: [{ type: 'text', text: liveVoiceTurn.agentText }],
+                    } as any}
+                    isLoading={false}
+                    setMessages={setMessages}
+                    regenerate={regenerate}
+                    isReadonly
+                  />
+                )}
 
                 {/* Typing indicator removed: we show "Thinking…" on the streaming message */}
 

--- a/frontend/components/voice/LiveVoiceMode.tsx
+++ b/frontend/components/voice/LiveVoiceMode.tsx
@@ -24,6 +24,8 @@ interface LiveVoiceModeProps {
   /** The call's thread id (created server-side when none was bound) — the
    * chat screen points at it so the spoken conversation is the visible one. */
   onChatId?: (chatId: string) => void
+  /** The current exchange as it streams — the chat types it out live. */
+  onLiveTurn?: (turn: { userText: string; agentText: string }) => void
   onExit: () => void
 }
 
@@ -33,7 +35,7 @@ function formatDuration(seconds: number): string {
   return `${m}:${s.toString().padStart(2, '0')}`
 }
 
-export function LiveVoiceMode({ chatId, agentId, onChatId, onExit }: LiveVoiceModeProps) {
+export function LiveVoiceMode({ chatId, agentId, onChatId, onLiveTurn, onExit }: LiveVoiceModeProps) {
   const {
     orbState,
     stateLabel,
@@ -47,7 +49,7 @@ export function LiveVoiceMode({ chatId, agentId, onChatId, onExit }: LiveVoiceMo
     start,
     stop,
     toggleMute,
-  } = useRetellCall({ chatId, agentId, onChatId })
+  } = useRetellCall({ chatId, agentId, onChatId, onLiveTurn })
 
   // Live mode IS the call: mounting connects, one gesture from the Live pill.
   useEffect(() => {

--- a/frontend/hooks/use-retell-call.ts
+++ b/frontend/hooks/use-retell-call.ts
@@ -59,9 +59,21 @@ interface UseRetellCallOptions {
    * the chat screen points itself at it so voice and text are ONE
    * conversation, visible while speaking. */
   onChatId?: (chatId: string) => void
+  /** Fires on every Retell transcript update with the CURRENT exchange —
+   * the chat renders these as live-typing bubbles, so Auto's words print
+   * in the thread as he reads them (and yours as you speak). */
+  onLiveTurn?: (turn: { userText: string; agentText: string }) => void
 }
 
-export function useRetellCall({ chatId, agentId, onChatId }: UseRetellCallOptions): UseRetellCallReturn {
+export function useRetellCall({
+  chatId,
+  agentId,
+  onChatId,
+  onLiveTurn,
+}: UseRetellCallOptions): UseRetellCallReturn {
+  // Ref'd so transcript-update wiring never re-creates start() per render.
+  const onLiveTurnRef = useRef(onLiveTurn)
+  onLiveTurnRef.current = onLiveTurn
   const [snap, setSnap] = useState<OrbSnapshot>(initialOrb)
   const [captions, setCaptions] = useState<CaptionLine[]>([])
   const [durationSec, setDurationSec] = useState(0)
@@ -193,7 +205,7 @@ export function useRetellCall({ chatId, agentId, onChatId }: UseRetellCallOption
       client.on('audio', (samples: Float32Array) => {
         levelsRef.current.agent = rmsLevel(samples)
       })
-      // Live captions from Retell's running transcript.
+      // Live captions + live-typing bubbles from Retell's running transcript.
       client.on('update', (update: any) => {
         const transcript = update?.transcript
         if (!Array.isArray(transcript) || transcript.length === 0) return
@@ -202,6 +214,19 @@ export function useRetellCall({ chatId, agentId, onChatId }: UseRetellCallOption
           text: String(t?.content ?? ''),
         }))
         setCaptions(lines)
+        // The current exchange, growing word by word: the LAST utterance of
+        // each speaker — Auto's grows while he talks, so the thread can type
+        // it out in real time.
+        let userText = ''
+        let agentText = ''
+        for (let i = transcript.length - 1; i >= 0; i--) {
+          const t = transcript[i]
+          const isAgent = t?.role === 'agent'
+          if (isAgent && !agentText) agentText = String(t?.content ?? '')
+          if (!isAgent && !userText) userText = String(t?.content ?? '')
+          if (userText && agentText) break
+        }
+        onLiveTurnRef.current?.({ userText, agentText })
       })
 
       await client.startCall({


### PR DESCRIPTION
The last piece of Gerard's spec, verbatim: *'when Auto talks he also prints the text as he reads it.'*

Retell already streams the running transcript to the browser — this routes it into the **visible thread as live-typing bubbles**: your utterance and Auto's reply grow word-by-word inside the conversation itself (not just captions under the wave). The welcome screen yields the moment words start flowing; when the turn persists, the voice-badged server messages replace the drafts via the existing `chat_changed` merge. Hang up, type — same thread, same history.

(Cherry-picked from the #578 branch — that PR merged while this commit was in flight.)

**After merge: one conversation, spoken words typing out live, fast turns, your waveform. The full spec.**