### PR TITLE
fix(prd-207): ONE Auto — restore the full brain to spoken turns

### DIFF
--- a/orchestrator/api/voice_retell.py
+++ b/orchestrator/api/voice_retell.py
@@ -529,15 +529,21 @@ async def _agent_retell_stream(req: RetellLLMRequest) -> AsyncIterator[dict[str,
         if agent_id is None:
             agent_id = get_default_agent_id(db, binding.workspace_id)
 
-        # VOICE FAST PATH (first live calls measured MINUTES per turn — the
-        # full chat pipeline is built for screens, not speech):
-        # * history is the recent conversation, not the archive — Retell holds
-        #   the floor open while we re-read old messages;
-        # * force_text_only: widget/tool-data payload assembly is meaningless
-        #   to a voice — words only;
-        # * skip_composio: external tool loops are tens of seconds of dead
-        #   air mid-call. Auto says what it knows; deep work belongs to text
-        #   turns or background missions.
+        # ONE AUTO (Gerard, first live night: "voice auto and text auto are
+        # not the same… my auto and voice auto need to be the same"). The
+        # spoken turn gets the SAME brain as the typed turn: full tool
+        # router, memory retrieval, composio actions, and the caller's real
+        # privilege tier. An earlier latency pass set force_text_only here —
+        # which forces the tool-less ATOM path AND skips memory entirely —
+        # a lobotomy, reverted. The one voice-specific trim that stays:
+        # history is the recent conversation, not the archive (rhythm, not
+        # brain — memory injection is retrieval, not history replay). Tool
+        # work mid-call reads as the honest THINKING state, never silence.
+        from core.models.core import User
+
+        role_row = db.query(User.system_role).filter(User.id == binding.user_id).first()
+        is_super_admin = bool(role_row and role_row[0] == "super_admin")
+
         messages = chat_service.get_messages_by_chat_id(conversation_id)
         recent = messages[-int(config.VOICE_LIVE_TURN_HISTORY_MESSAGES):]
         message_history = [{"role": m.role, "parts": m.parts} for m in recent]
@@ -548,8 +554,7 @@ async def _agent_retell_stream(req: RetellLLMRequest) -> AsyncIterator[dict[str,
             agent_id=agent_id,
             user_id=binding.user_id,
             use_orchestrator_llm=True,
-            force_text_only=True,
-            skip_composio=True,
+            is_super_admin=is_super_admin,
         )
 
         response_chars = 0

--- a/orchestrator/tests/test_prd207_voice_live.py
+++ b/orchestrator/tests/test_prd207_voice_live.py
@@ -471,9 +471,11 @@ def test_mint_without_chat_creates_and_binds_thread(monkeypatch):
     assert rows[0].chat_id == str(created_chat_id)  # mint-proven binding → webhook writes HERE
 
 
-def test_voice_turn_rides_the_fast_path(monkeypatch):
-    """First live calls measured MINUTES per turn: the spoken lane must trim
-    history and skip widget payloads + external tool loops."""
+def test_voice_turn_has_the_full_brain(monkeypatch):
+    """ONE Auto: the spoken turn gets the SAME brain as the typed turn —
+    full tools + memory (no force_text_only lobotomy, no composio skip) and
+    the caller's REAL privilege tier — with only the history trimmed (rhythm,
+    not brain)."""
     import consumers.chatbot as chatbot_pkg
 
     import api.voice_retell as vr
@@ -534,9 +536,14 @@ def test_voice_turn_rides_the_fast_path(monkeypatch):
 
     from contextlib import contextmanager
 
+    fake_db = MagicMock()
+    # the bound user's REAL privilege tier flows into the turn (PRD-143: su
+    # derives from system_role only)
+    fake_db.query.return_value.filter.return_value.first.return_value = ("super_admin",)
+
     @contextmanager
     def fake_session():
-        yield MagicMock()
+        yield fake_db
 
     monkeypatch.setattr(vr, "get_db_session", fake_session)
 
@@ -553,8 +560,11 @@ def test_voice_turn_rides_the_fast_path(monkeypatch):
     frames = asyncio.run(run())
     assert any(f.get("content") for f in frames)  # the turn streamed
 
-    assert captured["force_text_only"] is True   # words only — no widget payloads
-    assert captured["skip_composio"] is True     # no external tool loops mid-call
+    # the lobotomy flags are GONE — same brain as text chat
+    assert captured.get("force_text_only", False) is False  # tools + memory live
+    assert captured.get("skip_composio", False) is False    # full action surface
+    assert captured["is_super_admin"] is True               # the caller's real tier
+    # the one voice-specific trim: recent conversation, not the archive
     assert len(captured["messages"]) <= int(app_config.VOICE_LIVE_TURN_HISTORY_MESSAGES)
 
 


### PR DESCRIPTION
Gerard's report from the first live night, verbatim: *'voice auto and text auto are not the same… voice auto can't read memory, can't access any platform tools… not the same persona. New voice is Auto's voice NOT a NEW Auto.'*

**Root cause: the 01:00 latency fast-path.** `force_text_only=True` forces the tool-less ATOM path **and** (per its own docstring) *skips memory retrieval entirely* — that one flag was the lobotomy. `skip_composio` additionally cut the action surface. And a third parity gap: text chat passes the caller's real privilege tier (`is_super_admin` from `system_role`); voice passed nothing, so elevated tools never existed on calls.

**All three reverted/closed:** spoken turns now run the identical pipeline as typed turns — full tool router, memory retrieval, composio actions, the bound user's real privilege tier. The ONE voice-specific trim that stays: history is the recent conversation, not the archive (rhythm, not brain — memory is retrieval, not replay). Tool work mid-call shows as the honest THINKING state, never silence.

**Honest latency note:** giving her the brain back returns *some* thinking-time when tools actually fire — that's Auto genuinely working, visible in the state. If it feels heavy, the tuning levers (which tools, model tier for voice) are a knobs conversation, not silent flags.

Same agent, same tools, same memory, same powers. Her voice — not a new Auto.

(Cherry-picked; #580 merged while this was in flight.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Voice interactions now support the agent’s full capabilities, including tool execution, when appropriate.
  * Super-admin callers receive behavior tailored to their elevated permissions.

* **Bug Fixes**
  * Removed previous voice-specific restrictions that limited responses to text-only processing and disabled tools.
  * Updated voice interaction coverage to verify permission-aware behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->