### PR TITLE
🚨 hotfix(chat): WSOD on every authed load — TDZ in Chat render

### DIFF
--- a/frontend/components/chatbot/chat.tsx
+++ b/frontend/components/chatbot/chat.tsx
@@ -207,40 +207,6 @@ export function Chat({
 
   // PRD-207 S5: live voice mode — the orb mounts, content drops lower.
   const [isLiveMode, setIsLiveMode] = useState(false)
-  // PRD-207 (Gerard: "same as old, she just talks it"): spoken words are
-  // upserted as REAL entries in the messages array — the identical render
-  // path as typed streaming. When chat_changed lands the persisted copies,
-  // the ephemeral voice-live entries are dropped and the server rows follow.
-  const handleLiveTurn = useCallback(
-    (turn: { userText: string; agentText: string }) => {
-      setMessages((prev) => {
-        const next = [...prev]
-        const upsert = (mid: string, role: 'user' | 'assistant', text: string) => {
-          if (!text) return
-          const idx = next.findIndex((m) => m.id === mid)
-          const entry = {
-            id: mid,
-            role,
-            content: text,
-            parts: [{ type: 'text', text }],
-          } as ChatMessage
-          if (idx >= 0) next[idx] = { ...next[idx], ...entry }
-          else next.push(entry)
-        }
-        upsert('voice-live-user', 'user', turn.userText)
-        upsert('voice-live-assistant', 'assistant', turn.agentText)
-        return next
-      })
-    },
-    [setMessages]
-  )
-  useEffect(() => {
-    if (typeof window === 'undefined') return
-    const onPersisted = () =>
-      setMessages((prev) => prev.filter((m) => !String(m.id).startsWith('voice-live-')))
-    window.addEventListener('automatos:chat-changed', onPersisted)
-    return () => window.removeEventListener('automatos:chat-changed', onPersisted)
-  }, [setMessages])
   // PRD-207: presence feed from the call → the ambient background wave.
   const [voicePresence, setVoicePresence] = useState<OrbState>('idle')
   const [voiceLevels, setVoiceLevels] = useState<MutableRefObject<VoiceLevels> | null>(null)
@@ -588,6 +554,44 @@ export function Chat({
       }
     },
   })
+
+  // PRD-207 (Gerard: "same as old, she just talks it"): spoken words are
+  // upserted as REAL entries in the messages array — the identical render
+  // path as typed streaming. When chat_changed lands the persisted copies,
+  // the ephemeral voice-live entries are dropped and the server rows follow.
+  // MUST live below the useChat call: the dependency arrays read setMessages
+  // during render, so hoisting this above useChat is a first-render
+  // ReferenceError (TDZ) that takes down the whole chat page.
+  const handleLiveTurn = useCallback(
+    (turn: { userText: string; agentText: string }) => {
+      setMessages((prev) => {
+        const next = [...prev]
+        const upsert = (mid: string, role: 'user' | 'assistant', text: string) => {
+          if (!text) return
+          const idx = next.findIndex((m) => m.id === mid)
+          const entry = {
+            id: mid,
+            role,
+            content: text,
+            parts: [{ type: 'text', text }],
+          } as ChatMessage
+          if (idx >= 0) next[idx] = { ...next[idx], ...entry }
+          else next.push(entry)
+        }
+        upsert('voice-live-user', 'user', turn.userText)
+        upsert('voice-live-assistant', 'assistant', turn.agentText)
+        return next
+      })
+    },
+    [setMessages]
+  )
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const onPersisted = () =>
+      setMessages((prev) => prev.filter((m) => !String(m.id).startsWith('voice-live-')))
+    window.addEventListener('automatos:chat-changed', onPersisted)
+    return () => window.removeEventListener('automatos:chat-changed', onPersisted)
+  }, [setMessages])
 
   const regenerate = () => reload()
 


### PR DESCRIPTION
## Outage

ui.automatos.app white-screens ("Application error: a client-side exception has occurred") on every **authenticated** page load. Unauthed → /sign-in renders fine, so it looked auth-related — it isn't.

## Root cause

Railway logs for `automotas-ai-frontend` show the same throw on every request:

```
⨯ ReferenceError: Cannot access 'aS' before initialization
    at db (.next/server/chunks/7746.js:10:81865)
```

Reading the deployed chunk at that offset: `db` is `Chat`, `aS` is `setMessages`. PRD-207 live-typing (#579, reshuffled in #580) inserted `handleLiveTurn` (useCallback) and the voice-live cleanup effect **above** the `useChat()` call that declares `setMessages`. The closures alone would have been legal, but their **dependency arrays** (`[setMessages]`) evaluate during render → temporal-dead-zone ReferenceError on Chat's first render. Chat is the home surface, so every authed load dies during SSR and again on the client.

## Fix

Move the block below the `useChat` destructuring — behaviour identical, hook order still unconditional — with a comment pinning why it must not be hoisted back.

## Why CI let it through

Frontend CI (tsc baselined, vitest) is **non-required**, and the vitest suite never renders `Chat`. tsc flags use-before-declaration (TS2448), but a baselined+non-required lane can't stop a merge. Worth considering: make Frontend CI required, and/or a render smoke test for `Chat`.

## Deploy

- [ ] Merge → Railway auto-deploys main
- [ ] Confirm `/` renders for a signed-in user + Railway logs stop throwing the ReferenceError
- Interim option while CI runs: Railway dashboard → automotas-ai-frontend → redeploy the last deployment **before** #579's merge