### PR TITLE
fix(voice): web-call 500 — unique_user_title collision kills every welcome-screen call

### DIFF
--- a/orchestrator/api/voice_retell.py
+++ b/orchestrator/api/voice_retell.py
@@ -175,12 +175,10 @@ async def mint_web_call(
             raise HTTPException(status_code=403, detail="You can only bind a live call to your own chat")
         bound_chat_id = str(chat_uuid)
     else:
-        from consumers.chatbot.service import ChatService
+        from modules.voice.call_binding import create_voice_chat
 
-        chat = ChatService(db).create_chat(
-            user_id=int(user_int_id),
-            title="Voice call",
-            workspace_id=ctx.workspace_id,
+        chat = create_voice_chat(
+            db, user_id=int(user_int_id), workspace_id=ctx.workspace_id
         )
         bound_chat_id = str(chat.id)
 

--- a/orchestrator/modules/voice/call_binding.py
+++ b/orchestrator/modules/voice/call_binding.py
@@ -81,10 +81,43 @@ def _workspace_steward(db: Session, ws_uuid: uuid.UUID) -> Optional[int]:
     return int(row[0]) if row else None
 
 
+def _voice_chat_title(first_text: str, attempt: int) -> str:
+    """chats carries UNIQUE (user_id, title): a fixed 'Voice call' title
+    500s the SECOND call a user ever makes. Stamp the start time so every
+    call is its own thread; a same-minute repeat gets a numbered suffix."""
+    base = (first_text or "").strip()[:50] or f"Voice call — {datetime.utcnow():%b %d, %H:%M}"
+    return base if attempt == 0 else f"{base[:44]} ({attempt + 1})"
+
+
+def create_voice_chat(db: Session, *, user_id: int, workspace_id, first_text: str = ""):
+    """Create the thread a live call lands in, immune to unique_user_title.
+
+    No pre-SELECT (test doubles stub the session); collisions surface as
+    IntegrityError on commit and retry with a suffixed title."""
+    from sqlalchemy.exc import IntegrityError
+
+    from consumers.chatbot.service import ChatService
+
+    last_err: Optional[IntegrityError] = None
+    for attempt in range(3):
+        try:
+            return ChatService(db).create_chat(
+                user_id=int(user_id),
+                title=_voice_chat_title(first_text, attempt),
+                workspace_id=workspace_id,
+            )
+        except IntegrityError as err:
+            db.rollback()
+            last_err = err
+            logger.warning(
+                "voice_chat_title_collision user=%s attempt=%s", user_id, attempt
+            )
+    raise last_err  # three suffixed collisions in one minute — genuinely stuck
+
+
 def _fallback_chat(db: Session, row, ws_uuid: uuid.UUID, user_id: int, first_text: str) -> str:
     """Find-or-create the per-call fallback chat, remembered on the row so
     every later turn of this call lands in the SAME thread."""
-    from consumers.chatbot.service import ChatService
     from core.models.core import Chat
 
     if row.fallback_chat_id:
@@ -99,11 +132,7 @@ def _fallback_chat(db: Session, row, ws_uuid: uuid.UUID, user_id: int, first_tex
         except ValueError:
             pass
 
-    chat = ChatService(db).create_chat(
-        user_id=int(user_id),
-        title=(first_text or "Voice call")[:50],
-        workspace_id=ws_uuid,
-    )
+    chat = create_voice_chat(db, user_id=int(user_id), workspace_id=ws_uuid, first_text=first_text)
     row.fallback_chat_id = str(chat.id)
     db.commit()
     return str(chat.id)

--- a/orchestrator/tests/test_prd207_voice_live.py
+++ b/orchestrator/tests/test_prd207_voice_live.py
@@ -466,7 +466,9 @@ def test_mint_without_chat_creates_and_binds_thread(monkeypatch):
     out = _run_mint(ctx=_mint_ctx(ws_id=ws_id, user_int=7), db=db)
 
     assert out["chat_id"] == str(created_chat_id)  # the screen can follow it
-    assert created["user_id"] == 7 and created["title"] == "Voice call"
+    # Title is time-stamped (unique_user_title makes fixed titles a 500
+    # on the second call — 2026-07-18 incident).
+    assert created["user_id"] == 7 and created["title"].startswith("Voice call — ")
     rows = [a.args[0] for a in db.add.call_args_list if isinstance(a.args[0], VoiceCall)]
     assert rows[0].chat_id == str(created_chat_id)  # mint-proven binding → webhook writes HERE
 


### PR DESCRIPTION
Every welcome-screen live call after a user's first 500s: the mint creates the call's thread titled literally `Voice call`, and `chats` has UNIQUE `(user_id, title)`. Live in prod now (user 2, repeating in API logs). The webhook fallback path shares the landmine via repeated first utterances.

**Fix:** `create_voice_chat()` in `call_binding.py` — titles carry the call's start time (`Voice call — Jul 18, 00:41`); a same-minute collision retries with a numbered suffix (IntegrityError + rollback, no pre-SELECT so the stubbed-session mint tests keep working). Both creation sites (mint + webhook fallback) route through it. Title test pins the prefix instead of the exact string.

Merge → voice starts working from the welcome screen again.

Part of the PRD-207 stabilisation; front-end presence rebuild lands separately.