### PR TITLE
fix(prd-207): full-bleed centred ambience — the wave IS the background, the chat flow untouched

### DIFF
--- a/frontend/components/chatbot/chat.tsx
+++ b/frontend/components/chatbot/chat.tsx
@@ -1184,17 +1184,17 @@ export function Chat({
           {isLiveMode && voiceLevels && (
             <div
               aria-hidden="true"
-              className="pointer-events-none absolute inset-0 z-0 flex items-center overflow-hidden"
+              className="pointer-events-none absolute inset-0 z-0 flex items-center justify-center overflow-hidden"
               style={{
                 opacity: AMBIENT_OPACITY[voicePresence] ?? 0.12,
                 transition: 'opacity 900ms ease',
                 maskImage:
-                  'radial-gradient(ellipse 75% 65% at 50% 55%, black 35%, transparent 78%)',
+                  'radial-gradient(ellipse 90% 70% at 50% 52%, black 45%, transparent 82%)',
                 WebkitMaskImage:
-                  'radial-gradient(ellipse 75% 65% at 50% 55%, black 35%, transparent 78%)',
+                  'radial-gradient(ellipse 90% 70% at 50% 52%, black 45%, transparent 82%)',
               }}
             >
-              <PresenceOrb state={voicePresence} levelsRef={voiceLevels} size={440} />
+              <PresenceOrb state={voicePresence} levelsRef={voiceLevels} size={440} fullBleed />
             </div>
           )}
 

--- a/frontend/components/voice/PresenceOrb.tsx
+++ b/frontend/components/voice/PresenceOrb.tsx
@@ -27,6 +27,9 @@ interface PresenceOrbProps {
   levelsRef: MutableRefObject<VoiceLevels>
   /** Band height in px; the band fills its container's width. */
   size?: number
+  /** Ambient-background mode: no width cap, wider internal resolution —
+   * the beam spans the whole container edge-to-edge with no canvas seam. */
+  fullBleed?: boolean
 }
 
 function warningHsl(): { h: number; s: number; l: number } {
@@ -44,11 +47,10 @@ function hash(i: number): number {
   return x - Math.floor(x)
 }
 
-const W = 680 // internal canvas width; CSS stretches to the container
 const SLOTS = 60 // half-width history slots (centre → edge)
 const BAR_SPACING = 5.5
 
-export function PresenceOrb({ state, levelsRef, size = 170 }: PresenceOrbProps) {
+export function PresenceOrb({ state, levelsRef, size = 170, fullBleed = false }: PresenceOrbProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const stateRef = useRef<OrbState>(state)
   stateRef.current = state
@@ -59,6 +61,10 @@ export function PresenceOrb({ state, levelsRef, size = 170 }: PresenceOrbProps) 
     const ctx = canvas.getContext('2d')
     if (!ctx) return
 
+    // Internal resolution; CSS stretches to the container. Full-bleed uses a
+    // wider raster so the beam/ribbons stay crisp across the whole window
+    // while the voice bars keep their centred concentration.
+    const W = fullBleed ? 1280 : 680
     const H = size
     const dpr = typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1
     canvas.width = W * dpr
@@ -213,12 +219,12 @@ export function PresenceOrb({ state, levelsRef, size = 170 }: PresenceOrbProps) 
     }
     raf = requestAnimationFrame(loop)
     return () => cancelAnimationFrame(raf)
-  }, [levelsRef, size])
+  }, [levelsRef, size, fullBleed])
 
   return (
     <canvas
       ref={canvasRef}
-      style={{ width: '100%', maxWidth: 720, height: size, display: 'block' }}
+      style={{ width: '100%', maxWidth: fullBleed ? undefined : 720, height: size, display: 'block' }}
       role="img"
       aria-hidden="true"
       data-orb-state={state}


### PR DESCRIPTION
Gerard's screenshots showed the background wave as a left-stuck 720px slab with a visible canvas seam — a broken widget, not a background. Two geometry faults fixed: the layer centred vertically but never horizontally, and the canvas self-capped at 720px. New `fullBleed` mode: no width cap, wider internal raster (1280) — the beam and ribbons run edge-to-edge with no seam, voice bars keep their centred concentration, feather mask widened.

**BACKGROUND**: behind everything, whisper opacity, alive only while someone speaks.
**SAME AGENT FLOW**: zero changes to the thread, bubbles, or composer in this PR — and #581 (merged) already gave spoken turns the identical brain: tools, memory, privileges.