### PR TITLE
fix(prd-207): 'Failed to fetch' root cause + the bold reference-grade background

### DIFF
--- a/frontend/components/chatbot/chat.tsx
+++ b/frontend/components/chatbot/chat.tsx
@@ -58,13 +58,13 @@ import { useBoardEventStream } from '@/hooks/use-board-event-stream'
 // How present the room feels per call state — the background wave breathes
 // up when Auto (or you) speaks and nearly vanishes at rest.
 const AMBIENT_OPACITY: Record<string, number> = {
-  speaking: 0.34,
-  listening: 0.2,
-  thinking: 0.24,
-  connecting: 0.14,
-  idle: 0.1,
+  speaking: 0.85,
+  listening: 0.6,
+  thinking: 0.68,
+  connecting: 0.4,
+  idle: 0.4,
   ended: 0,
-  error: 0.1,
+  error: 0.25,
 }
 
 export interface ChatProps {
@@ -1194,7 +1194,7 @@ export function Chat({
                   'radial-gradient(ellipse 90% 70% at 50% 52%, black 45%, transparent 82%)',
               }}
             >
-              <PresenceOrb state={voicePresence} levelsRef={voiceLevels} size={440} fullBleed />
+              <PresenceOrb state={voicePresence} levelsRef={voiceLevels} size={560} fullBleed />
             </div>
           )}
 

--- a/frontend/components/voice/PresenceOrb.tsx
+++ b/frontend/components/voice/PresenceOrb.tsx
@@ -72,9 +72,12 @@ export function PresenceOrb({ state, levelsRef, size = 170, fullBleed = false }:
     ctx.scale(dpr, dpr)
 
     const { h, s, l } = warningHsl()
+    // Full-bleed = the reference look: luminous, clearly THERE. The gain
+    // lifts every stroke; the layer's opacity map still does the breathing.
+    const gain = fullBleed ? 1.5 : 1
     const gold = (alpha: number, dl = 0) =>
-      `hsla(${h}, ${s}%, ${Math.max(0, Math.min(100, l + dl))}%, ${alpha})`
-    const hot = (alpha: number) => `hsla(${h + 6}, 100%, 90%, ${alpha})`
+      `hsla(${h}, ${s}%, ${Math.max(0, Math.min(100, l + dl))}%, ${Math.min(1, alpha * gain)})`
+    const hot = (alpha: number) => `hsla(${h + 6}, 100%, 90%, ${Math.min(1, alpha * gain)})`
 
     const reducedMotion =
       typeof window !== 'undefined' &&
@@ -82,7 +85,7 @@ export function PresenceOrb({ state, levelsRef, size = 170, fullBleed = false }:
 
     const cx = W / 2
     const cy = H / 2
-    const maxBar = H * 0.36
+    const maxBar = H * (fullBleed ? 0.44 : 0.36)
 
     // Voice history: slot 0 = centre (now), travelling outward each frame.
     const hist = new Float32Array(SLOTS)

--- a/orchestrator/api/voice_retell.py
+++ b/orchestrator/api/voice_retell.py
@@ -175,13 +175,40 @@ async def mint_web_call(
             raise HTTPException(status_code=403, detail="You can only bind a live call to your own chat")
         bound_chat_id = str(chat_uuid)
     else:
+        # Find-or-create the caller's ONE voice thread (the Auto-thread
+        # pattern): the chats table enforces unique_user_title, so a second
+        # "Voice call" insert 500'd EVERY welcome-screen call after the first
+        # (surfacing as "Failed to fetch"). Reuse is also the better product —
+        # welcome-screen calls CONTINUE the same conversation. Race-safe:
+        # the IntegrityError loser re-selects.
+        from sqlalchemy.exc import IntegrityError
+
         from consumers.chatbot.service import ChatService
 
-        chat = ChatService(db).create_chat(
-            user_id=int(user_int_id),
-            title="Voice call",
-            workspace_id=ctx.workspace_id,
-        )
+        def _find_voice_thread():
+            return (
+                db.query(Chat)
+                .filter(
+                    Chat.workspace_id == ctx.workspace_id,
+                    Chat.user_id == int(user_int_id),
+                    Chat.title == "Voice call",
+                )
+                .first()
+            )
+
+        chat = _find_voice_thread()
+        if chat is None:
+            try:
+                chat = ChatService(db).create_chat(
+                    user_id=int(user_int_id),
+                    title="Voice call",
+                    workspace_id=ctx.workspace_id,
+                )
+            except IntegrityError:
+                db.rollback()
+                chat = _find_voice_thread()
+        if chat is None:
+            raise HTTPException(status_code=500, detail="Could not open the voice thread")
         bound_chat_id = str(chat.id)
 
     dynamic_vars = {

--- a/orchestrator/tests/test_prd207_voice_live.py
+++ b/orchestrator/tests/test_prd207_voice_live.py
@@ -471,6 +471,48 @@ def test_mint_without_chat_creates_and_binds_thread(monkeypatch):
     assert rows[0].chat_id == str(created_chat_id)  # mint-proven binding → webhook writes HERE
 
 
+def test_mint_reuses_the_voice_thread(monkeypatch):
+    """chats enforces unique_user_title: the SECOND welcome-screen call must
+    REUSE the caller's 'Voice call' thread (the Auto-thread pattern), never
+    insert-and-500 — the 'Failed to fetch' every call after the first."""
+    import consumers.chatbot.service as chat_service_mod
+
+    import api.voice_retell as vr
+    from modules.voice.live_settings import RetellCredentials
+    from modules.voice.retell_api import RetellWebCall
+    from modules.voice.voice_meter import MeterReading
+
+    ws_id = uuid.uuid4()
+    existing_id = uuid.uuid4()
+    existing = SimpleNamespace(id=existing_id, user_id=7, workspace_id=ws_id, title="Voice call")
+
+    class NeverCreate:
+        def __init__(self, db):
+            pass
+
+        def create_chat(self, **kwargs):
+            raise AssertionError("must reuse the existing voice thread, not create")
+
+    monkeypatch.setattr(chat_service_mod, "ChatService", NeverCreate)
+    monkeypatch.setattr(vr.live_settings, "voice_live_enabled", lambda: True)
+    monkeypatch.setattr(
+        vr.live_settings, "retell_credentials", lambda: RetellCredentials("k", "s", "a")
+    )
+    monkeypatch.setattr(vr.voice_meter, "monthly_meter", lambda db, w: MeterReading(0, 0, 10))
+
+    async def fake_vendor(api_key, payload):
+        return RetellWebCall(call_id="call_again", access_token="tok")
+
+    monkeypatch.setattr(vr.retell_api, "create_web_call", fake_vendor)
+
+    ws = SimpleNamespace(settings={"voice_live": {"enabled": True}})
+    out = _run_mint(
+        ctx=_mint_ctx(ws_id=ws_id, user_int=7),
+        db=_mint_db(workspace=ws, chat=existing),
+    )
+    assert out["chat_id"] == str(existing_id)  # same thread, conversation continues
+
+
 def test_voice_turn_has_the_full_brain(monkeypatch):
     """ONE Auto: the spoken turn gets the SAME brain as the typed turn —
     full tools + memory (no force_text_only lobotomy, no composio skip) and


### PR DESCRIPTION
## The reproducible 'Failed to fetch' — root cause found in prod logs
`psycopg2.UniqueViolation: unique_user_title → POST /api/voice/web-call 500`

The welcome-screen mint creates a thread titled **'Voice call'** — the chats table enforces unique titles per user, so the first call worked and **every call since collided and 500'd** (the browser renders that as 'Failed to fetch'; CORS verified healthy today). Fix: **find-or-create the caller's one voice thread**, race-safe via the Auto-thread pattern — which is also better product: welcome-screen calls **continue the same conversation** across sessions. Regression test: a second mint reuses, never creates.

## The bold background (the reference images, finally at reference intensity)
The ambience had been dialled toward invisible. Now: opacity map speaking **0.85** / listening 0.6 / idle 0.4, band height 560px, full-bleed stroke luminance ×1.5, taller bars. Edge-to-edge (per #584), behind everything, chat flow untouched.

One merge: calls stop failing, the room finally looks like the pictures.