### PR TITLE
fix(graph): cluster drill clears stale focus + explanatory empty state

### DIFF
--- a/frontend/components/knowledge/BusinessGraphPanel.tsx
+++ b/frontend/components/knowledge/BusinessGraphPanel.tsx
@@ -337,6 +337,17 @@ export function BusinessGraphPanel() {
     return new Set(relationChips.filter((c) => !hiddenRelSet.has(c.relation)).map((c) => c.relation))
   }, [hiddenRelSet, relationChips])
 
+  // Hidden types actually present in this graph — named in the viz empty
+  // state so an empty filter intersection is explainable.
+  const hiddenTypeCount = useMemo(
+    () => typeChips.filter((c) => hiddenTypeSet.has(c.type)).length,
+    [typeChips, hiddenTypeSet],
+  )
+
+  const handleClearTypeFilters = useCallback(() => {
+    updatePrefs({ hiddenTypes: [] })
+  }, [updatePrefs])
+
   // Cap chips per section: a general knowledge graph carries hundreds of
   // free-text edge relations (each count 1) that flood the legend and bury the
   // canvas. Chips are pre-sorted (curated order, then count desc), so the slice
@@ -394,6 +405,14 @@ export function BusinessGraphPanel() {
 
   const handleNodeSelect = useCallback((node: GraphNode | null) => {
     setSelectedNode(node)
+  }, [])
+
+  // Cluster drill and neighbourhood focus are different drill modes — a stale
+  // focus must not silently AND with the new cluster (often an empty
+  // intersection). Clear it through the viz's one focus-clear path.
+  const handleCommunitySelect = useCallback((id: number | null) => {
+    vizRef.current?.resetFocus()
+    setSelectedCommunity(id)
   }, [])
 
   // ── Empty state — drag-and-drop import zone (bespoke, kept off the shell) ──
@@ -614,7 +633,7 @@ export function BusinessGraphPanel() {
       }
       sidebar={
         graphData ? (
-          <ClusterSidebar communities={communities} selectedCommunity={selectedCommunity} onSelect={setSelectedCommunity} />
+          <ClusterSidebar communities={communities} selectedCommunity={selectedCommunity} onSelect={handleCommunitySelect} />
         ) : undefined
       }
       sidePanel={nodeDetailPanel}
@@ -628,6 +647,8 @@ export function BusinessGraphPanel() {
         visibleTypes={visibleTypes}
         visibleRelations={visibleRelations}
         colorMode={prefs.colorMode}
+        hiddenTypeCount={hiddenTypeCount}
+        onClearFilters={handleClearTypeFilters}
       />
     </GraphView>
   )

--- a/frontend/components/knowledge/BusinessGraphVisualization.tsx
+++ b/frontend/components/knowledge/BusinessGraphVisualization.tsx
@@ -70,6 +70,12 @@ export interface BusinessGraphVisualizationProps {
   visibleRelations?: Set<string>;
   /** Coloring strategy. */
   colorMode?: ColorMode;
+  /** How many node types the panel legend currently hides — named in the
+   *  empty state so an empty filter intersection is explainable. */
+  hiddenTypeCount?: number;
+  /** Panel-side filter reset (hidden node types) for the empty state's
+   *  "Clear filters" button. Focus is cleared viz-side by the same button. */
+  onClearFilters?: () => void;
 }
 
 export interface BusinessGraphHandle {
@@ -128,6 +134,8 @@ const BusinessGraphVisualization = forwardRef<
     visibleTypes,
     visibleRelations,
     colorMode = "community",
+    hiddenTypeCount = 0,
+    onClearFilters,
   },
   ref,
 ) {
@@ -149,15 +157,20 @@ const BusinessGraphVisualization = forwardRef<
     return () => ro.disconnect();
   }, []);
 
-  // ── ESC clears focus ───────────────────────────────────────────────────
+  // ── Clearing focus ─────────────────────────────────────────────────────
+  // The one focus-clear implementation — ESC, background click, the
+  // imperative resetFocus() (cluster drill), and the empty-state
+  // "Clear filters" button all funnel through here.
+
+  const clearFocus = useCallback(() => setFocusNodeId(null), []);
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setFocusNodeId(null);
+      if (e.key === "Escape") clearFocus();
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, []);
+  }, [clearFocus]);
 
   // ── Filter + augment ───────────────────────────────────────────────────
 
@@ -449,9 +462,9 @@ const BusinessGraphVisualization = forwardRef<
   );
 
   const handleBgClick = useCallback(() => {
-    setFocusNodeId(null);
+    clearFocus();
     onNodeSelect?.(null);
-  }, [onNodeSelect]);
+  }, [clearFocus, onNodeSelect]);
 
   // ── Pre-filtered render data ───────────────────────────────────────────
   // At 24k nodes, the per-tick nodeVisibility/linkVisibility callback path
@@ -482,10 +495,30 @@ const BusinessGraphVisualization = forwardRef<
     ref,
     () => ({
       zoomToFit: () => fgRef.current?.zoomToFit?.(500, 40),
-      resetFocus: () => setFocusNodeId(null),
+      resetFocus: clearFocus,
     }),
-    [],
+    [clearFocus],
   );
+
+  // ── Empty-state explanation ────────────────────────────────────────────
+  // Cluster selection, neighbourhood focus, and hidden node types AND
+  // together — the intersection can be empty. Name the active filters and
+  // offer a one-click reset (focus + hidden types; the cluster is kept).
+
+  const activeFilterSummary = useMemo(() => {
+    const parts: string[] = [];
+    if (selectedCommunity != null) parts.push(`Cluster ${selectedCommunity}`);
+    if (focusNodeId) parts.push("neighbourhood focus");
+    if (hiddenTypeCount > 0) {
+      parts.push(`${hiddenTypeCount} node type${hiddenTypeCount === 1 ? "" : "s"} hidden`);
+    }
+    return parts.join(" + ");
+  }, [selectedCommunity, focusNodeId, hiddenTypeCount]);
+
+  const handleClearFilters = useCallback(() => {
+    clearFocus();
+    onClearFilters?.();
+  }, [clearFocus, onClearFilters]);
 
   // ── Auto zoom-to-fit on data change ────────────────────────────────────
 
@@ -506,8 +539,25 @@ const BusinessGraphVisualization = forwardRef<
   return (
     <div ref={containerRef} className="relative w-full h-full min-h-[500px]">
       {renderData.nodes.length === 0 ? (
-        <div className="flex items-center justify-center h-full text-sm text-muted-foreground">
-          No nodes match the current filters.
+        <div className="flex flex-col items-center justify-center h-full gap-3 px-6 text-center text-sm text-muted-foreground">
+          <div>
+            No nodes match the current filters.
+            {activeFilterSummary && (
+              <div className="mt-1 text-xs text-muted-foreground/70">
+                Active: {activeFilterSummary}
+              </div>
+            )}
+          </div>
+          {(focusNodeId != null || hiddenTypeCount > 0) && (
+            <button
+              type="button"
+              onClick={handleClearFilters}
+              className="rounded-md border border-white/10 bg-white/5 px-3 py-1.5 text-xs text-foreground hover:bg-white/10 transition-colors"
+              title="Clear neighbourhood focus and hidden node types (keeps the selected cluster)"
+            >
+              Clear filters
+            </button>
+          )}
         </div>
       ) : (
         <ForceGraph2D
@@ -552,8 +602,8 @@ const BusinessGraphVisualization = forwardRef<
         </div>
       )}
 
-      {/* Focus hint */}
-      {focusNodeId && (
+      {/* Focus hint — only over a live canvas; the empty state explains itself */}
+      {focusNodeId && renderData.nodes.length > 0 && (
         <div className="absolute bottom-3 left-3 rounded-md border border-white/10 bg-black/70 backdrop-blur-sm px-3 py-1.5 text-xs text-muted-foreground">
           Focused on neighbourhood — press <kbd className="px-1 rounded bg-white/10 text-white">Esc</kbd> or click background to clear
         </div>

--- a/frontend/components/knowledge/KnowledgeGraphExplorer.tsx
+++ b/frontend/components/knowledge/KnowledgeGraphExplorer.tsx
@@ -1,13 +1,15 @@
 'use client'
 
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useMemo, useRef, useState } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { apiClient } from '@/lib/api-client'
 import { useWorkspace } from '@/hooks/use-workspace'
 import { Input } from '@/components/ui/input'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
-import BusinessGraphVisualization from './BusinessGraphVisualization'
+import BusinessGraphVisualization, {
+  type BusinessGraphHandle,
+} from './BusinessGraphVisualization'
 import { GraphView, useGraphPrefs } from '../graph'
 import {
   Layers, Search, X, FileText, Loader2,
@@ -56,6 +58,7 @@ export function KnowledgeGraphExplorer() {
   const { workspaceId } = useWorkspace()
   const queryClient = useQueryClient()
   const [prefs] = useGraphPrefs(workspaceId, 'knowledge')
+  const vizRef = useRef<BusinessGraphHandle>(null)
 
   const [activeCommunity, setActiveCommunity] = useState<number | null>(null)
   const [subgraph, setSubgraph] = useState<SubgraphData | null>(null)
@@ -83,6 +86,9 @@ export function KnowledgeGraphExplorer() {
 
   const loadCommunity = useCallback(async (cid: number) => {
     setLoadingSub(true); setError(null); setSelectedNode(null)
+    // Same drill-mode rule as the in-browser panel: picking a cluster clears
+    // any stale neighbourhood focus so it can't AND the new subgraph to nothing.
+    vizRef.current?.resetFocus()
     try {
       const res: any = await apiClient.graphCommunitySubgraph(cid)
       setSubgraph({ nodes: res.nodes ?? [], links: res.links ?? [], truncated: res.truncated })
@@ -333,6 +339,7 @@ export function KnowledgeGraphExplorer() {
         minHeightClassName="min-h-[520px]"
       >
         <BusinessGraphVisualization
+          ref={vizRef}
           graphData={active as any}
           onNodeSelect={handleNodeSelect as any}
           colorMode={prefs.colorMode}


### PR DESCRIPTION
## Bug

Documents page → Knowledge Graph tab: with a node's neighbourhood focused (the "Focused on neighbourhood — press Esc or click background to clear" hint showing), clicking a cluster in the CLUSTERS sidebar (e.g. "Cluster 12, 94 nodes") rendered **"No nodes match the current filters."** — an empty canvas with no explanation and no recovery affordance.

## Cause — AND-composition of drill modes

The rendered node set is the intersection of independent filters:

- `selectedCommunity` (panel `filteredData` + viz `renderData`)
- `focusNeighbourhood` (viz-local `focusNodeId`, 1-hop set — viz `renderData`)
- hidden node types from the legend (`visibleTypes` — viz `data`)
- search / confidence (panel `filteredData`)

Cluster drill and neighbourhood focus are *different drill modes*, but selecting a cluster left the stale `focusNodeId` in place. If the focused node isn't in the new cluster, `cluster ∩ neighbourhood = ∅` — silently, with several legend types hidden compounding it. The empty state named none of this.

## Fix

1. **Cluster selection clears stale focus.** `BusinessGraphPanel.handleCommunitySelect` calls the viz's existing `resetFocus()` imperative handle (already exported, previously never called) before setting the community. Same rule wired into `KnowledgeGraphExplorer.loadCommunity` (the large-graph mode of the same tab, which swaps subgraphs under the same viz-local focus).
2. **One clear implementation.** `clearFocus()` in `BusinessGraphVisualization` is now the single `setFocusNodeId(null)` path — Esc, background click, `resetFocus()`, and the new empty-state button all call it.
3. **Explanatory empty state.** When `renderData` is empty, the canvas names the active filters (e.g. `Active: Cluster 12 + neighbourhood focus + 5 node types hidden`) and renders a **Clear filters** button that resets focus + hidden node types while **keeping the selected cluster**. Button hides itself when nothing it controls is active. The bottom focus hint is suppressed while the canvas is empty ("click background" has no canvas to click; the empty state explains itself).

Not touched: `nodeCanvasObject` label rendering (#577 owns that); nothing outside `frontend/components/knowledge/`.

## Test plan

- [ ] Focus a node (hint visible) → click a cluster in the sidebar → cluster renders, no empty canvas, hint gone
- [ ] Focus a node → hide its type in the legend → empty state lists "neighbourhood focus + 1 node type hidden" with Clear filters
- [ ] Clear filters → focus + hidden types reset, selected cluster still applied and highlighted in the sidebar
- [ ] Empty state from search/cluster alone (no focus, no hidden types) → no Clear filters button, no stray "Active:" row
- [ ] Esc still clears focus (canvas and empty state); background click still clears focus + node selection
- [ ] Large-graph explorer (>50k): focus a node, pick another cluster → subgraph renders un-dimmed
- [ ] Toggling the same cluster off / "All clusters" also drops any focus (drill-mode switch)
