### PR TITLE
feat(voice): the living background — full-bleed brand-gold presence (PresenceOrb v4)

### DIFF
--- a/frontend/components/chatbot/chat.tsx
+++ b/frontend/components/chatbot/chat.tsx
@@ -55,18 +55,6 @@ import type { OrbState } from '@/lib/voice/orb-state'
 import type { MutableRefObject } from 'react'
 import { useBoardEventStream } from '@/hooks/use-board-event-stream'
 
-// How present the room feels per call state — the background wave breathes
-// up when Auto (or you) speaks and nearly vanishes at rest.
-const AMBIENT_OPACITY: Record<string, number> = {
-  speaking: 0.34,
-  listening: 0.2,
-  thinking: 0.24,
-  connecting: 0.14,
-  idle: 0.1,
-  ended: 0,
-  error: 0.1,
-}
-
 export interface ChatProps {
   id: string
   initialMessages?: ChatMessage[]
@@ -1178,25 +1166,29 @@ export function Chat({
       {/* Normal chat view - NO widgets */}
       {!hasWidgets && !isArtifactViewerVisible && (
         <div className="relative flex flex-col bg-transparent" style={{ height: '100%', width: '100%', minHeight: 0 }}>
-          {/* PRD-207: the room itself — the wave lives BEHIND the chat as an
-              ambient background, waking only while someone speaks. Not a
-              widget, not a screen: the same chat window, alive. */}
-          {isLiveMode && voiceLevels && (
-            <div
-              aria-hidden="true"
-              className="pointer-events-none absolute inset-0 z-0 flex items-center overflow-hidden"
-              style={{
-                opacity: AMBIENT_OPACITY[voicePresence] ?? 0.12,
-                transition: 'opacity 900ms ease',
-                maskImage:
-                  'radial-gradient(ellipse 75% 65% at 50% 55%, black 35%, transparent 78%)',
-                WebkitMaskImage:
-                  'radial-gradient(ellipse 75% 65% at 50% 55%, black 35%, transparent 78%)',
-              }}
-            >
-              <PresenceOrb state={voicePresence} levelsRef={voiceLevels} size={440} />
-            </div>
-          )}
+          {/* PRD-207/208: the room itself — the wave is the chat's living
+              full-bleed background (Gerard's reference set, brand gold).
+              State intensity, envelopes, and the text-protecting vignette
+              live INSIDE PresenceOrb; the wave sinks lower when the thread
+              is on screen so words own the upper field. */}
+          <AnimatePresence>
+            {isLiveMode && voiceLevels && (
+              <motion.div
+                aria-hidden="true"
+                className="pointer-events-none absolute inset-0 z-0 overflow-hidden"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: 0.5 }}
+              >
+                <PresenceOrb
+                  state={voicePresence}
+                  levelsRef={voiceLevels}
+                  horizon={showWelcomeCard ? 0.56 : 0.74}
+                />
+              </motion.div>
+            )}
+          </AnimatePresence>
 
           {/* Clean welcome state — greeting + chat input */}
           {showWelcomeCard && (
@@ -1327,7 +1319,10 @@ export function Chat({
               className="relative z-10 flex-1 overflow-y-scroll overscroll-contain"
               style={{ overflowAnchor: 'none' }}
             >
-              <div className="mx-auto flex min-w-0 max-w-4xl flex-col gap-4 px-4 py-4 md:gap-6 md:px-8">
+              {/* min-h-full + justify-end: a young thread grows upward from
+                  the composer (no lone bubble stranded at the top of an
+                  empty viewport); once content overflows, normal scroll. */}
+              <div className="mx-auto flex min-h-full min-w-0 max-w-4xl flex-col justify-end gap-4 px-4 py-4 md:gap-6 md:px-8">
 
                 {/* Messages */}
                 <AnimatePresence>

--- a/frontend/components/voice/PresenceOrb.tsx
+++ b/frontend/components/voice/PresenceOrb.tsx
@@ -1,21 +1,35 @@
 'use client'
 
 /**
- * PresenceOrb v3 — the voice-wave band (PRD-207 S5, to Gerard's waveform brief).
+ * PresenceOrb v4 — the living background (PRD-207/PRD-208, Gerard's brief
+ * 2026-07-18: "voice is not another channel — a visual and audio extra;
+ * the BACKGROUND makes Auto feel alive").
  *
- * The reference set is HORIZONTAL: a bright beam across the screen, dense
- * mirrored vertical bars breathing out of it, smooth ribbon waves flowing
- * through, a hot core flare at centre, drifting particles. Voice history
- * enters at the centre and travels outward to both edges, so speech
- * literally radiates from the middle of the beam.
+ * Full-bleed canvas behind the chat thread. The composition follows Gerard's
+ * reference set — a luminous horizontal spectral wave: dense fine-grain
+ * mirrored bars radiating speech history from the centre, flowing ribbon
+ * waves, a hot horizon beam with a core flare, ember fog masses, drifting
+ * particles, floor reflections — rendered entirely in the brand palette
+ * (--warning gold + --primary orange), never the reference blues.
  *
- * Canvas-2D, one rAF, zero React re-renders per audio frame (levels arrive
- * through a mutable ref). `prefers-reduced-motion` renders the full
- * composition once, static. All per-element "randomness" is a
- * deterministic index hash — stable frame to frame.
+ * Discipline (from the voice-UI field study, 2026-07-18):
+ * - State and energy are separate axes: the OrbState picks the MODE of
+ *   motion (thinking shimmers with zero RMS coupling; idle only breathes);
+ *   RMS only modulates intensity within the mode.
+ * - User and Auto get disjoint geometry: Auto is the horizon; the user is a
+ *   top-edge rim light that answers the mic live — including while Auto
+ *   speaks (barge-in preview).
+ * - Text wins: a vignette keeps the top (thread) and bottom (composer)
+ *   zones dark; hot cores live only in the horizon band.
+ * - Envelopes are asymmetric (fast attack, slow release) and the agent
+ *   envelope is floored while speaking so speech never looks dead.
+ * - No per-frame gradient allocation: soft glows are pre-baked sprites and
+ *   static gradients are rebuilt only on resize (per-frame
+ *   createRadialGradient/shadowBlur/filter are the Safari killers).
  *
- * `size` is the band HEIGHT; the band spans the container width (canvas
- * has a fixed internal resolution and stretches via CSS).
+ * `prefers-reduced-motion` renders one static composed frame per state.
+ * All per-element "randomness" is a deterministic index hash — stable
+ * frame to frame.
  */
 
 import { useEffect, useRef, type MutableRefObject } from 'react'
@@ -25,17 +39,24 @@ import type { OrbState } from '@/lib/voice/orb-state'
 interface PresenceOrbProps {
   state: OrbState
   levelsRef: MutableRefObject<VoiceLevels>
-  /** Band height in px; the band fills its container's width. */
-  size?: number
+  /** Horizon line as a fraction of height (welcome ~0.56, thread ~0.74).
+   * Changes glide — the wave sinks or rises over ~600ms. */
+  horizon?: number
 }
 
-function warningHsl(): { h: number; s: number; l: number } {
+interface Hsl {
+  h: number
+  s: number
+  l: number
+}
+
+function cssHsl(varName: string, fallback: Hsl): Hsl {
   if (typeof window !== 'undefined') {
-    const raw = getComputedStyle(document.documentElement).getPropertyValue('--warning').trim()
+    const raw = getComputedStyle(document.documentElement).getPropertyValue(varName).trim()
     const m = raw.match(/^([\d.]+)\s+([\d.]+)%\s+([\d.]+)%$/)
     if (m) return { h: Number(m[1]), s: Number(m[2]), l: Number(m[3]) }
   }
-  return { h: 38, s: 92, l: 50 }
+  return fallback
 }
 
 /** Deterministic 0..1 hash per index — stable "randomness", no Math.random. */
@@ -44,184 +65,384 @@ function hash(i: number): number {
   return x - Math.floor(x)
 }
 
-const W = 680 // internal canvas width; CSS stretches to the container
-const SLOTS = 60 // half-width history slots (centre → edge)
-const BAR_SPACING = 5.5
+/** Pre-baked soft radial sprite: colour stops fading to transparent. */
+function bakeRadialSprite(size: number, stops: Array<[number, string]>): HTMLCanvasElement {
+  const c = document.createElement('canvas')
+  c.width = size
+  c.height = size
+  const sctx = c.getContext('2d')
+  if (sctx) {
+    const g = sctx.createRadialGradient(size / 2, size / 2, 0, size / 2, size / 2, size / 2)
+    for (const [at, col] of stops) g.addColorStop(at, col)
+    sctx.fillStyle = g
+    sctx.fillRect(0, 0, size, size)
+  }
+  return c
+}
 
-export function PresenceOrb({ state, levelsRef, size = 170 }: PresenceOrbProps) {
+const BAR_SPACING = 2.6
+const MAX_SLOTS = 420
+const INTRO_MS = 400
+const ENDED_DECAY_MS = 450
+const HORIZON_GLIDE = 0.06 // per-frame lerp (~600ms settle at 60fps)
+
+// State → master intensity. The MODE of motion is decided in drawFrame();
+// this only scales how present the room feels.
+const STATE_INTENSITY: Record<OrbState, number> = {
+  speaking: 1,
+  listening: 0.8,
+  thinking: 0.9,
+  connecting: 0.55,
+  idle: 0.5,
+  error: 0.32,
+  ended: 0,
+}
+
+export function PresenceOrb({ state, levelsRef, horizon = 0.56 }: PresenceOrbProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const stateRef = useRef<OrbState>(state)
   stateRef.current = state
+  const horizonTargetRef = useRef(horizon)
+  horizonTargetRef.current = horizon
 
   useEffect(() => {
     const canvas = canvasRef.current
-    if (!canvas) return
+    const host = canvas?.parentElement
+    if (!canvas || !host) return
     const ctx = canvas.getContext('2d')
     if (!ctx) return
 
-    const H = size
-    const dpr = typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1
-    canvas.width = W * dpr
-    canvas.height = H * dpr
-    ctx.scale(dpr, dpr)
+    const GOLD = cssHsl('--warning', { h: 43, s: 96, l: 56 })
+    const EMBER = cssHsl('--primary', { h: 16, s: 100, l: 60 })
+    const clampL = (l: number) => Math.max(0, Math.min(100, l))
+    const gold = (a: number, dl = 0) => `hsla(${GOLD.h},${GOLD.s}%,${clampL(GOLD.l + dl)}%,${a})`
+    const ember = (a: number, dl = 0) => `hsla(${EMBER.h},${EMBER.s}%,${clampL(EMBER.l + dl)}%,${a})`
+    const hot = (a: number) => `hsla(${GOLD.h + 6},100%,92%,${a})`
 
-    const { h, s, l } = warningHsl()
-    const gold = (alpha: number, dl = 0) =>
-      `hsla(${h}, ${s}%, ${Math.max(0, Math.min(100, l + dl))}%, ${alpha})`
-    const hot = (alpha: number) => `hsla(${h + 6}, 100%, 90%, ${alpha})`
+    // Pre-baked glow sprites — drawn scaled per frame, never re-created.
+    const fogEmber = bakeRadialSprite(256, [[0, ember(0.85, -16)], [1, 'hsla(0,0%,0%,0)']])
+    const fogGold = bakeRadialSprite(256, [[0, gold(0.85, -20)], [1, 'hsla(0,0%,0%,0)']])
+    const flare = bakeRadialSprite(256, [
+      [0, hot(0.85)],
+      [0.35, gold(0.4, 10)],
+      [1, 'hsla(0,0%,0%,0)'],
+    ])
 
-    const reducedMotion =
-      typeof window !== 'undefined' &&
-      window.matchMedia?.('(prefers-reduced-motion: reduce)').matches
+    let W = 0
+    let H = 0
+    let slots = 0
+    let hist = new Float32Array(0)
+    let haloGrad: CanvasGradient | null = null
+    let beamGrad: CanvasGradient | null = null
+    let horizonGrad: CanvasGradient | null = null
+    let vignetteGrad: CanvasGradient | null = null
+    let rimGrad: CanvasGradient | null = null
+    let horizonY = 0
 
-    const cx = W / 2
-    const cy = H / 2
-    const maxBar = H * 0.36
+    const rebuildStatics = () => {
+      haloGrad = ctx.createLinearGradient(0, -H * 0.26, 0, H * 0.26)
+      haloGrad.addColorStop(0, 'hsla(0,0%,0%,0)')
+      haloGrad.addColorStop(0.5, gold(0.12, -6))
+      haloGrad.addColorStop(1, 'hsla(0,0%,0%,0)')
+      beamGrad = ctx.createLinearGradient(0, -18, 0, 18)
+      beamGrad.addColorStop(0, 'hsla(0,0%,0%,0)')
+      beamGrad.addColorStop(0.5, gold(0.2, 8))
+      beamGrad.addColorStop(1, 'hsla(0,0%,0%,0)')
+      horizonGrad = ctx.createLinearGradient(0, 0, W, 0)
+      horizonGrad.addColorStop(0, 'hsla(0,0%,0%,0)')
+      horizonGrad.addColorStop(0.5, hot(0.55))
+      horizonGrad.addColorStop(1, 'hsla(0,0%,0%,0)')
+      vignetteGrad = ctx.createLinearGradient(0, 0, 0, H)
+      vignetteGrad.addColorStop(0, 'rgba(7,6,6,0.55)')
+      vignetteGrad.addColorStop(0.3, 'rgba(7,6,6,0)')
+      vignetteGrad.addColorStop(0.76, 'rgba(7,6,6,0)')
+      vignetteGrad.addColorStop(1, 'rgba(7,6,6,0.62)')
+      rimGrad = ctx.createLinearGradient(0, 0, 0, 110)
+      rimGrad.addColorStop(0, gold(0.5, 22))
+      rimGrad.addColorStop(1, 'hsla(0,0%,0%,0)')
+    }
 
-    // Voice history: slot 0 = centre (now), travelling outward each frame.
-    const hist = new Float32Array(SLOTS)
-    let smoothAgent = 0
-    let smoothUser = 0
+    const resize = () => {
+      const dpr = Math.min(window.devicePixelRatio || 1, 1.5)
+      W = host.clientWidth
+      H = host.clientHeight
+      if (W === 0 || H === 0) return
+      canvas.width = Math.round(W * dpr)
+      canvas.height = Math.round(H * dpr)
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
+      slots = Math.min(MAX_SLOTS, Math.ceil(W / 2 / BAR_SPACING) + 2)
+      const old = hist
+      hist = new Float32Array(slots)
+      hist.set(old.subarray(0, Math.min(old.length, slots)))
+      if (horizonY === 0) horizonY = H * horizonTargetRef.current
+      rebuildStatics()
+    }
+    resize()
+    const ro = new ResizeObserver(resize)
+    ro.observe(host)
+
+    // Asymmetric envelopes (fast attack, slow release) over the raw RMS refs.
+    let agentEnv = 0
+    let userEnv = 0
+    let masterAlpha = 0 // intro ramp / ended decay
+    let smoothIntensity = STATE_INTENSITY[stateRef.current] ?? 0.5
+    const envStep = (env: number, target: number, dt: number, attackMs: number, releaseMs: number) => {
+      const tau = target > env ? attackMs : releaseMs
+      return env + (target - env) * (1 - Math.exp(-dt / tau))
+    }
+
+    // Adaptive degrade: two slow frames inside a second halves the bar work.
+    let degraded = false
+    let slowFrames = 0
+    let slowWindowStart = 0
+
     let raf = 0
+    let lastT = 0
+    let stopped = false
 
     const drawFrame = (t: number, animate: boolean) => {
+      const dt = Math.min(50, lastT ? t - lastT : 16)
+      lastT = t
       const st = stateRef.current
-      const levels = levelsRef.current
-      smoothAgent += (levels.agent - smoothAgent) * 0.35
-      smoothUser += (levels.user - smoothUser) * 0.3
-      const energy = Math.min(1, smoothAgent * 1.7 + smoothUser * 1.0)
+      const I0 = STATE_INTENSITY[st] ?? 0.5
+      smoothIntensity += (I0 - smoothIntensity) * 0.08
+
+      if (st === 'ended') {
+        masterAlpha = Math.max(0, masterAlpha - dt / ENDED_DECAY_MS)
+        if (masterAlpha === 0) stopped = true
+      } else {
+        masterAlpha = Math.min(1, masterAlpha + dt / INTRO_MS)
+      }
+      const I = smoothIntensity * masterAlpha
+      horizonY += (H * horizonTargetRef.current - horizonY) * HORIZON_GLIDE
+
+      const { agent, user } = levelsRef.current
+      // The state picks the mode: idle/thinking/connecting ignore the mic
+      // for the horizon; the rim always answers the user.
+      const agentDrive =
+        st === 'speaking' ? Math.max(0.25, agent * 1.6) : st === 'listening' ? agent * 0.4 : 0
+      userEnv = envStep(userEnv, Math.min(1, user * 2.2), dt, 50, 200)
+      agentEnv = envStep(agentEnv, Math.min(1, agentDrive), dt, 70, 300)
+      const energy = Math.min(1, agentEnv + userEnv * 0.55)
 
       if (animate) {
         hist.copyWithin(1, 0) // history radiates outward from the centre
         hist[0] = energy
       }
 
-      const dim = st === 'ended' || st === 'error' ? 0.35 : st === 'connecting' ? 0.65 : 1
-
+      const cy = horizonY
+      const breathe = 0.5 + 0.5 * Math.sin((t / 4200) * 2 * Math.PI)
       ctx.clearRect(0, 0, W, H)
+      if (I <= 0.001) return
 
-      // 1 — ambient wash above/below the beam
-      const wash = ctx.createLinearGradient(0, 0, 0, H)
-      wash.addColorStop(0, gold(0))
-      wash.addColorStop(0.5, gold(0.10 * dim, 6))
-      wash.addColorStop(1, gold(0))
-      ctx.fillStyle = wash
-      ctx.fillRect(0, 0, W, H)
+      // L1 — ember fog masses drifting on slow sines.
+      const drawFog = (img: HTMLCanvasElement, x: number, y: number, r: number, a: number) => {
+        ctx.globalAlpha = a
+        ctx.drawImage(img, x - r, y - r, r * 2, r * 2)
+      }
+      drawFog(fogEmber, W * (0.3 + 0.1 * Math.sin(t / 17000)), cy - H * 0.16, W * 0.46, 0.2 * I)
+      drawFog(fogGold, W * (0.72 + 0.08 * Math.sin(t / 23000 + 2)), cy + H * 0.1, W * 0.42, 0.14 * I)
+      drawFog(fogEmber, W * (0.52 + 0.12 * Math.sin(t / 14000 + 4)), cy, W * 0.34, 0.12 * I)
+      ctx.globalAlpha = 1
 
-      // 2 — mirrored voice bars: history flows centre → edges (both sides)
-      for (let sIdx = 0; sIdx < SLOTS; sIdx++) {
-        const v = sIdx === 0 ? energy : hist[sIdx]
-        const fade = 1 - (sIdx / SLOTS) * 0.8
-        const jitter = hash(sIdx * 7) * 2
-        const bh = 3 + v * maxBar * (0.45 + fade * 0.55) + jitter
-        const hotBar = v > 0.45
+      ctx.globalCompositeOperation = 'lighter'
+
+      // Wide soft halo hugging the horizon.
+      if (haloGrad) {
+        ctx.save()
+        ctx.translate(0, cy)
+        ctx.globalAlpha = Math.min(1, (0.75 + energy * 0.6) * I)
+        ctx.fillStyle = haloGrad
+        ctx.fillRect(0, -H * 0.26, W, H * 0.52)
+        ctx.restore()
+        ctx.globalAlpha = 1
+      }
+
+      // L2 — dense fine spectrum: neighbour-smoothed history + shimmer floor.
+      const step = degraded ? 2 : 1
+      for (let s = 0; s < slots; s += step) {
+        const vRaw =
+          (hist[Math.max(0, s - 2)] +
+            hist[Math.max(0, s - 1)] * 2 +
+            hist[s] * 3 +
+            hist[Math.min(slots - 1, s + 1)] * 2 +
+            hist[Math.min(slots - 1, s + 2)]) / 9
+        const centerW = 1 - 0.5 * (s / slots)
+        const floorH = (2.5 + 5 * hash(s * 3)) * (0.7 + 0.6 * Math.sin(t / 700 + s * 0.35))
+        const hgt = (floorH + vRaw * H * 0.16 * centerW * (0.75 + 0.5 * hash(s))) * I
+        const a = (0.1 + vRaw * 0.3) * centerW * I
+        const colMain = vRaw > 0.65 ? hot(a) : gold(a * 1.3, 12)
+        const colSoft = vRaw > 0.65 ? hot(a * 0.75) : gold(a, 4)
         for (const dir of [-1, 1]) {
-          const x = cx + dir * (sIdx * BAR_SPACING + 2)
-          // soft wide pass + bright thin core = cheap glow
-          ctx.strokeStyle = gold(0.14 * fade * dim, 8)
-          ctx.lineWidth = 3.6
-          ctx.beginPath(); ctx.moveTo(x, cy - bh); ctx.lineTo(x, cy + bh); ctx.stroke()
-          ctx.strokeStyle = hotBar ? hot(0.9 * fade * dim) : gold(0.55 * fade * dim, 14)
-          ctx.lineWidth = 1.4
-          ctx.beginPath(); ctx.moveTo(x, cy - bh); ctx.lineTo(x, cy + bh); ctx.stroke()
+          const x = W / 2 + dir * s * BAR_SPACING
+          ctx.strokeStyle = colSoft
+          ctx.lineWidth = 2.2
+          ctx.beginPath()
+          ctx.moveTo(x, cy - hgt)
+          ctx.lineTo(x, cy + hgt * 0.7)
+          ctx.stroke()
+          ctx.strokeStyle = colMain
+          ctx.lineWidth = 0.9
+          ctx.beginPath()
+          ctx.moveTo(x, cy - hgt)
+          ctx.lineTo(x, cy + hgt * 0.7)
+          ctx.stroke()
+          if (!degraded && s % 2 === 0) {
+            // Floor reflection — the reference set's mirrored glow.
+            ctx.strokeStyle = gold(a * 0.36, -6)
+            ctx.lineWidth = 1.4
+            ctx.beginPath()
+            ctx.moveTo(x, cy + hgt * 0.7)
+            ctx.lineTo(x, cy + hgt * 0.7 + hgt * 0.48)
+            ctx.stroke()
+          }
         }
       }
 
-      // 3 — ribbon waves flowing through the bars (three phase-shifted layers)
-      const ribbonEnv = (x: number) => {
-        const d = Math.abs(x - cx) / cx
-        return (1 - d * d) * (0.35 + energy * 0.65)
-      }
-      for (let rIdx = 0; rIdx < 3; rIdx++) {
-        const amp = H * (0.10 + rIdx * 0.045)
-        const k = 0.012 + rIdx * 0.004
-        const speed = (animate ? t : 900) / (900 + rIdx * 380)
-        ctx.beginPath()
-        for (let x = 0; x <= W; x += 6) {
-          const y =
-            cy +
-            Math.sin(x * k + speed * (rIdx % 2 === 0 ? 1 : -1) * 2 + rIdx * 2.1) *
-              amp * ribbonEnv(x)
-          if (x === 0) ctx.moveTo(x, y)
-          else ctx.lineTo(x, y)
+      // L3 — ribbon waves flowing the full width (soft pass + bright core).
+      const ribbonSpeed = st === 'thinking' ? 0.72 : 1
+      const ribbons = [
+        { wl: W / 2.1, sp: 2600, amp: 22, lw: 1.9, col: (a: number) => gold(a, 10) },
+        { wl: W / 3.3, sp: 1900, amp: 15, lw: 1.3, col: (a: number) => ember(a, 8) },
+        { wl: W / 5.2, sp: 1450, amp: 9, lw: 0.9, col: (a: number) => hot(a * 0.8) },
+      ]
+      for (let r = 0; r < ribbons.length; r++) {
+        const rb = ribbons[r]
+        const baseA = (0.16 + energy * 0.3) * I
+        for (const pass of [
+          { lw: rb.lw * 3.4, a: baseA * 0.35 },
+          { lw: rb.lw, a: baseA },
+        ]) {
+          ctx.strokeStyle = rb.col(pass.a)
+          ctx.lineWidth = pass.lw
+          ctx.beginPath()
+          for (let x = 0; x <= W; x += 4) {
+            const cw = 1 - Math.min(1, Math.abs(x - W / 2) / (W / 2)) * 0.45
+            const y =
+              cy +
+              Math.sin((x / rb.wl) * 2 * Math.PI + t / (rb.sp * ribbonSpeed) + r * 2.1) *
+                (rb.amp + energy * 52 * cw) *
+                cw *
+                (0.6 + 0.4 * Math.sin(t / 3400 + r))
+            if (x === 0) ctx.moveTo(x, y)
+            else ctx.lineTo(x, y)
+          }
+          ctx.stroke()
         }
-        ctx.strokeStyle = rIdx === 0 ? hot(0.35 * dim) : gold(0.22 * dim, 12 - rIdx * 6)
-        ctx.lineWidth = rIdx === 0 ? 1.6 : 1.1
-        ctx.stroke()
       }
 
-      // 4 — the beam: a bright horizon line with a soft vertical glow
-      const beamGlow = ctx.createLinearGradient(0, cy - 14, 0, cy + 14)
-      beamGlow.addColorStop(0, gold(0))
-      beamGlow.addColorStop(0.5, gold(0.5 * dim, 18))
-      beamGlow.addColorStop(1, gold(0))
-      ctx.fillStyle = beamGlow
-      ctx.fillRect(0, cy - 14, W, 28)
-      const beam = ctx.createLinearGradient(0, 0, W, 0)
-      beam.addColorStop(0, gold(0.05 * dim))
-      beam.addColorStop(0.5, hot(0.95 * dim))
-      beam.addColorStop(1, gold(0.05 * dim))
-      ctx.fillStyle = beam
-      ctx.fillRect(0, cy - 0.8, W, 1.6)
+      // L4 — horizon beam + core flare blooming with Auto's voice.
+      if (beamGrad) {
+        ctx.save()
+        ctx.translate(0, cy)
+        ctx.globalAlpha = I
+        ctx.fillStyle = beamGrad
+        ctx.fillRect(0, -18, W, 36)
+        ctx.restore()
+      }
+      if (horizonGrad) {
+        ctx.globalAlpha = I
+        ctx.fillStyle = horizonGrad
+        ctx.fillRect(0, cy - 0.8, W, 1.6)
+        ctx.globalAlpha = 1
+      }
+      const flareR = (36 + agentEnv * 150 + 8 * breathe) * (0.6 + 0.4 * I)
+      ctx.globalAlpha = 0.9 * I
+      ctx.drawImage(flare, W / 2 - flareR, cy - flareR, flareR * 2, flareR * 2)
+      ctx.globalAlpha = 1
 
-      // 5 — core flare at centre: blooms with Auto's voice
-      const flareR = 26 + smoothAgent * 95 + 6 * Math.sin((animate ? t : 600) / 700)
-      const flare = ctx.createRadialGradient(cx, cy, 0, cx, cy, flareR)
-      flare.addColorStop(0, hot(0.95 * dim))
-      flare.addColorStop(0.3, gold(0.55 * dim, 20))
-      flare.addColorStop(1, gold(0))
-      ctx.fillStyle = flare
-      ctx.beginPath()
-      ctx.arc(cx, cy, flareR, 0, Math.PI * 2)
-      ctx.fill()
-
-      // 6 — drifting particles (the dust in the references)
-      for (let p = 0; p < 26; p++) {
-        const drift = animate ? (t / 1000) * (4 + hash(p) * 10) : 40
-        const px = (hash(p * 3) * W + drift * (p % 2 === 0 ? 1 : -1) + W * 4) % W
-        const py = cy + (hash(p * 5) - 0.5) * H * 0.75
-        const tw = 0.25 + 0.6 * Math.abs(Math.sin((animate ? t : 500) / 900 + p * 1.7))
-        ctx.fillStyle = p % 5 === 0 ? hot(tw * 0.8 * dim) : gold(tw * 0.5 * dim, 15)
+      // L6 — drifting particles.
+      const particleCount = degraded ? 14 : 30
+      for (let i = 0; i < particleCount; i++) {
+        const px = (((hash(i) * 1.3 + t / (30000 + 20000 * hash(i + 40))) % 1.1) - 0.05) * W
+        const py = cy + (hash(i + 80) - 0.5) * H * 0.5
+        const pa = (0.04 + 0.12 * hash(i + 21)) * I * (0.5 + 0.5 * Math.sin(t / 2400 + i))
+        ctx.fillStyle = i % 3 ? gold(pa, 12) : ember(pa, 8)
         ctx.beginPath()
-        ctx.arc(px, py, p % 4 === 0 ? 1.6 : 1, 0, Math.PI * 2)
+        ctx.arc(px, py, 0.8 + 1.4 * hash(i + 55), 0, 7)
         ctx.fill()
       }
 
-      // 7 — thinking/connecting: a bright pulse travelling the beam
+      // L7 — thinking / connecting travelling pulse (volume-independent).
       if (st === 'thinking' || st === 'connecting') {
-        const cycle = animate ? (t / 1600) % 1 : 0.35
-        const xp = cycle * W
-        const pg = ctx.createRadialGradient(xp, cy, 0, xp, cy, 22)
-        pg.addColorStop(0, hot(0.9 * dim))
-        pg.addColorStop(1, gold(0))
-        ctx.fillStyle = pg
-        ctx.beginPath()
-        ctx.arc(xp, cy, 22, 0, Math.PI * 2)
-        ctx.fill()
+        const tx = W / 2 + Math.sin(t / 900) * W * 0.28
+        ctx.globalAlpha = 0.55 * I
+        ctx.drawImage(flare, tx - 26, cy - 26, 52, 52)
+        ctx.globalAlpha = 1
+      }
+
+      ctx.globalCompositeOperation = 'source-over'
+
+      // User rim — the top edge answers the mic (disjoint geometry from
+      // Auto's horizon; lights while Auto speaks = barge-in preview).
+      if (rimGrad && userEnv > 0.02 && st !== 'idle' && st !== 'ended' && st !== 'error') {
+        ctx.globalAlpha = Math.min(0.5, userEnv * 0.45) * masterAlpha
+        ctx.fillStyle = rimGrad
+        ctx.fillRect(0, 0, W, 110)
+        ctx.globalAlpha = 1
+      }
+
+      // Vignette — the thread (top) and composer (bottom) stay readable.
+      if (vignetteGrad) {
+        ctx.fillStyle = vignetteGrad
+        ctx.fillRect(0, 0, W, H)
       }
     }
 
-    if (reducedMotion) {
-      for (let i = 0; i < SLOTS; i++) hist[i] = 0.15 + hash(i) * 0.45
-      drawFrame(900, false)
-      return () => undefined
+    const reduced = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches
+    if (reduced) {
+      // One static composed frame per state (and layout), no rAF loop.
+      const staticDraw = () => {
+        masterAlpha = 1
+        lastT = 0
+        agentEnv = stateRef.current === 'speaking' ? 0.45 : 0
+        userEnv = stateRef.current === 'listening' ? 0.3 : 0
+        for (let s = 0; s < slots; s++) {
+          hist[s] = Math.max(0, 0.4 - s / slots) * (0.6 + 0.4 * hash(s))
+        }
+        horizonY = H * horizonTargetRef.current
+        drawFrame(900, false)
+      }
+      staticDraw()
+      const interval = window.setInterval(staticDraw, 1200)
+      return () => {
+        window.clearInterval(interval)
+        ro.disconnect()
+      }
     }
 
     const loop = (t: number) => {
+      if (stopped) return
+      const frameStart = performance.now()
       drawFrame(t, true)
+      const frameMs = performance.now() - frameStart
+      if (frameMs > 12) {
+        if (t - slowWindowStart > 1000) {
+          slowWindowStart = t
+          slowFrames = 0
+        }
+        slowFrames += 1
+        if (slowFrames >= 2) degraded = true
+      }
       raf = requestAnimationFrame(loop)
     }
     raf = requestAnimationFrame(loop)
-    return () => cancelAnimationFrame(raf)
-  }, [levelsRef, size])
+
+    return () => {
+      cancelAnimationFrame(raf)
+      ro.disconnect()
+    }
+  }, [levelsRef])
 
   return (
     <canvas
       ref={canvasRef}
-      style={{ width: '100%', maxWidth: 720, height: size, display: 'block' }}
       role="img"
       aria-hidden="true"
       data-orb-state={state}
+      className="absolute inset-0 h-full w-full"
     />
   )
 }
+
+export default PresenceOrb


### PR DESCRIPTION
## What

The voice surface's visual layer, rebuilt to the reference brief: a **full-viewport living background** — luminous horizontal spectral wave, atmospheric ember depth, floor reflections — in the **brand palette** (`--warning` gold + `--primary` ember), behind the same single thread where spoken words type out. Voice stays what it is: not another channel, a visual and audio extra on the one Auto.

Prototyped standalone and screenshot-iterated against the reference images before porting; built with the craft rules from a field study of ChatGPT Advanced Voice, Siri's edge glow, Gemini Live, Perplexity, Hume, ElevenLabs, and the Codrops ambient-canvas playbook.

## Why the old one looked broken

- Canvas was 680px internal with `maxWidth: 720` — the wave **cut off mid-screen**.
- Wrapper opacity capped at 0.34 behind an aggressive radial mask — a faint wisp, not a presence.
- First spoken word unmounted the welcome screen into a top-anchored empty thread — one stranded bubble in a void.

## PresenceOrb v4 (rewrite)

- **Full-bleed** via ResizeObserver, dpr ≤ 1.5, dynamic bar count; layers: ember fog, horizon halo, dense neighbour-smoothed spectrum with an ever-alive shimmer floor, reflections, three glow-pass ribbons, beam + core flare, particles, thinking/connecting pulse.
- **State ≠ energy**: OrbState picks the motion mode (thinking shimmers with zero RMS coupling; idle only breathes); RMS scales intensity inside the mode. Asymmetric envelopes (50–70ms attack, 200–300ms release); agent envelope floored at 0.25 while speaking.
- **User gets disjoint geometry**: top-edge rim light answers the mic live — including during Auto's turn (barge-in preview).
- **Text wins**: vignette inside the canvas keeps thread + composer zones readable at every state; hot cores only in the horizon band.
- **Perf**: zero per-frame gradient allocation (pre-baked sprites, statics rebuilt on resize), adaptive degrade after two slow frames, `ended` decays and parks the rAF loop; `prefers-reduced-motion` = one static frame per state.
- New `horizon` prop glides the wave between welcome (0.56) and thread (0.74) layouts.

## chat.tsx

- Background mount is a plain full-bleed `z-0` div in `AnimatePresence` (graceful 500ms exit). `AMBIENT_OPACITY`, the radial mask, and the 440px band are deleted — the canvas owns state intensity now.
- Thread column: `min-h-full justify-end` — a young conversation grows upward from the composer.

## Contracts kept

LiveVoiceMode untouched (pinned aria-labels, refusal copy, no captions in the strip). `data-orb-state` preserved. Reducer/state machine untouched. Voice messages stay ordinary thread messages.

## Test plan

- [ ] CI green
- [ ] Live call from welcome screen: full-width wave, breathes at idle intensity while listening, blooms while Auto speaks, shimmer travels while thinking
- [ ] Speak over Auto → top-edge rim lights immediately
- [ ] First spoken words land just above the composer (no stranded bubble), wave sinks lower as the thread fills
- [ ] Hang up → 450ms exhale, thread + 'Call ended' strip remain
- [ ] macOS reduce-motion → static composed frame, states still legible via the status line