### PR TITLE
fix(prd-207): voice silence root cause (su capture at mint) + the reference canvas

### DIFF
--- a/frontend/components/voice/PresenceOrb.tsx
+++ b/frontend/components/voice/PresenceOrb.tsx
@@ -1,21 +1,21 @@
 'use client'
 
 /**
- * PresenceOrb v3 — the voice-wave band (PRD-207 S5, to Gerard's waveform brief).
+ * PresenceOrb v4 — two renderers, one component.
  *
- * The reference set is HORIZONTAL: a bright beam across the screen, dense
- * mirrored vertical bars breathing out of it, smooth ribbon waves flowing
- * through, a hot core flare at centre, drifting particles. Voice history
- * enters at the centre and travels outward to both edges, so speech
- * literally radiates from the middle of the beam.
+ * `fullBleed` (the chat's living background) draws GERARD'S REFERENCE — the
+ * image sent twelve times: thick WOVEN RIBBON BUNDLES (gold / magenta /
+ * blue, seven offset strands each, a bright leading strand), TALL luminous
+ * bars across the FULL width, a soft floor glow, particles — no dominant
+ * beam. Alive with the voices: bar energy radiates outward from centre,
+ * ribbon amplitude swells as either of you speaks, the core flares on
+ * Auto's voice.
  *
- * Canvas-2D, one rAF, zero React re-renders per audio frame (levels arrive
- * through a mutable ref). `prefers-reduced-motion` renders the full
- * composition once, static. All per-element "randomness" is a
- * deterministic index hash — stable frame to frame.
+ * The compact band (VoiceCallPanel) keeps the original beam-and-bars look.
  *
- * `size` is the band HEIGHT; the band spans the container width (canvas
- * has a fixed internal resolution and stretches via CSS).
+ * Canvas-2D, one rAF, zero React re-renders per audio frame (levels via a
+ * mutable ref). `prefers-reduced-motion` renders one static frame. All
+ * per-element randomness is a deterministic index hash.
  */
 
 import { useEffect, useRef, type MutableRefObject } from 'react'
@@ -27,8 +27,7 @@ interface PresenceOrbProps {
   levelsRef: MutableRefObject<VoiceLevels>
   /** Band height in px; the band fills its container's width. */
   size?: number
-  /** Ambient-background mode: no width cap, wider internal resolution —
-   * the beam spans the whole container edge-to-edge with no canvas seam. */
+  /** Ambient-background mode: reference composition, no width cap. */
   fullBleed?: boolean
 }
 
@@ -61,20 +60,23 @@ export function PresenceOrb({ state, levelsRef, size = 170, fullBleed = false }:
     const ctx = canvas.getContext('2d')
     if (!ctx) return
 
-    // Internal resolution; CSS stretches to the container. Full-bleed uses a
-    // wider raster so the beam/ribbons stay crisp across the whole window
-    // while the voice bars keep their centred concentration.
-    const W = fullBleed ? 1280 : 680
+    const W = fullBleed ? 1440 : 680
     const H = size
     const dpr = typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1
     canvas.width = W * dpr
     canvas.height = H * dpr
     ctx.scale(dpr, dpr)
 
-    const { h, s, l } = warningHsl()
-    const gold = (alpha: number, dl = 0) =>
-      `hsla(${h}, ${s}%, ${Math.max(0, Math.min(100, l + dl))}%, ${alpha})`
-    const hot = (alpha: number) => `hsla(${h + 6}, 100%, 90%, ${alpha})`
+    const { h: brandH, s: brandS, l: brandL } = warningHsl()
+    // The reference palette: brand gold anchored, magenta and blue companions.
+    const HUES = [brandH, 318, 215]
+    const col = (hue: number, alpha: number, dl = 0, ds = 0) =>
+      `hsla(${hue}, ${Math.max(0, Math.min(100, brandS + ds))}%, ${Math.max(
+        0,
+        Math.min(100, brandL + dl)
+      )}%, ${Math.min(1, alpha)})`
+    const gold = (alpha: number, dl = 0) => col(brandH, alpha, dl)
+    const hot = (alpha: number) => `hsla(${brandH + 6}, 100%, 92%, ${Math.min(1, alpha)})`
 
     const reducedMotion =
       typeof window !== 'undefined' &&
@@ -82,15 +84,141 @@ export function PresenceOrb({ state, levelsRef, size = 170, fullBleed = false }:
 
     const cx = W / 2
     const cy = H / 2
-    const maxBar = H * 0.36
 
-    // Voice history: slot 0 = centre (now), travelling outward each frame.
     const hist = new Float32Array(SLOTS)
     let smoothAgent = 0
     let smoothUser = 0
+    let energyEnv = 0 // slow envelope: the room keeps glowing between words
     let raf = 0
 
-    const drawFrame = (t: number, animate: boolean) => {
+    // ------------------------------------------------------------------
+    // THE REFERENCE (fullBleed): woven ribbon bundles + tall bars + floor
+    // ------------------------------------------------------------------
+    const drawReference = (t: number, animate: boolean) => {
+      const st = stateRef.current
+      const levels = levelsRef.current
+      smoothAgent += (levels.agent - smoothAgent) * 0.35
+      smoothUser += (levels.user - smoothUser) * 0.3
+      const energy = Math.min(1, smoothAgent * 1.7 + smoothUser * 1.0)
+      energyEnv += ((st === 'speaking' ? Math.max(0.35, energy) : energy) - energyEnv) * 0.06
+
+      if (animate) {
+        hist.copyWithin(1, 0)
+        hist[0] = energy
+      }
+
+      const dim = st === 'ended' ? 0 : st === 'error' ? 0.35 : st === 'connecting' ? 0.6 : 1
+      ctx.clearRect(0, 0, W, H)
+      if (dim === 0) return
+
+      // floor glow — grounds the scene like the reference's reflections
+      const floor = ctx.createRadialGradient(cx, cy + H * 0.22, 0, cx, cy + H * 0.22, W * 0.45)
+      floor.addColorStop(0, gold(0.14 * dim, 6))
+      floor.addColorStop(1, gold(0))
+      ctx.fillStyle = floor
+      ctx.fillRect(0, 0, W, H)
+
+      // TALL BARS across the full width — energy radiates from the centre
+      const step = 16
+      for (let x = step / 2; x < W; x += step) {
+        const i = Math.round(x / step)
+        const distSlot = Math.min(
+          SLOTS - 1,
+          Math.floor((Math.abs(x - cx) / (W / 2)) * SLOTS)
+        )
+        const v = distSlot === 0 ? Math.max(energy, hist[0]) : hist[distSlot]
+        const idle = 0.1 + 0.14 * hash(i * 13) + 0.06 * Math.sin((animate ? t : 700) / 1200 + i)
+        const amp = Math.min(1, idle + v * 1.1 + energyEnv * 0.25)
+        const bh = amp * H * 0.42
+        const hue = HUES[i % 7 === 0 ? 1 : i % 11 === 0 ? 2 : 0] // gold field, pink/blue accents
+        const bright = v > 0.45
+        // three passes: halo, body, hot core — the luminous fade of the ref
+        ctx.strokeStyle = col(hue, 0.10 * dim, 10)
+        ctx.lineWidth = 7
+        ctx.beginPath(); ctx.moveTo(x, cy - bh); ctx.lineTo(x, cy + bh * 0.9); ctx.stroke()
+        ctx.strokeStyle = col(hue, 0.3 * dim, 16)
+        ctx.lineWidth = 2.6
+        ctx.beginPath(); ctx.moveTo(x, cy - bh); ctx.lineTo(x, cy + bh * 0.9); ctx.stroke()
+        ctx.strokeStyle = bright ? hot(0.85 * dim) : col(hue, 0.5 * dim, 24)
+        ctx.lineWidth = 1.2
+        ctx.beginPath(); ctx.moveTo(x, cy - bh); ctx.lineTo(x, cy + bh * 0.9); ctx.stroke()
+      }
+
+      // WOVEN RIBBON BUNDLES — the hero of the reference
+      const sway = 0.55 + 0.75 * energyEnv
+      for (let b = 0; b < 3; b++) {
+        const hue = HUES[b]
+        const baseAmp = H * (0.13 + b * 0.055) * sway
+        const k = 0.0075 + b * 0.0022
+        const dir = b % 2 === 0 ? 1 : -1
+        const speed = (animate ? t : 900) / (1150 + b * 420)
+        for (let sIdx = 0; sIdx < 7; sIdx++) {
+          const ampJ = baseAmp * (0.8 + 0.4 * hash(b * 31 + sIdx))
+          const phase = sIdx * 0.33 + hash(b * 7 + sIdx) * 2.2
+          const lead = sIdx === 3
+          ctx.beginPath()
+          for (let x = 0; x <= W; x += 8) {
+            const env = 0.55 + 0.45 * Math.sin((x / W) * Math.PI)
+            const y =
+              cy -
+              H * 0.02 +
+              Math.sin(x * k + dir * speed * 2 + phase) * ampJ * env +
+              (sIdx - 3) * 2.4
+            if (x === 0) ctx.moveTo(x, y)
+            else ctx.lineTo(x, y)
+          }
+          if (lead) {
+            ctx.strokeStyle = col(hue, 0.55 * dim, 30, 8)
+            ctx.lineWidth = 2.1
+          } else {
+            ctx.strokeStyle = col(hue, 0.14 * dim, 14)
+            ctx.lineWidth = 1.1
+          }
+          ctx.stroke()
+        }
+      }
+
+      // centre flare on Auto's voice
+      const flareR = 20 + smoothAgent * 120
+      const flare = ctx.createRadialGradient(cx, cy, 0, cx, cy, flareR)
+      flare.addColorStop(0, hot(0.9 * dim * (0.25 + smoothAgent)))
+      flare.addColorStop(1, gold(0))
+      ctx.fillStyle = flare
+      ctx.beginPath()
+      ctx.arc(cx, cy, flareR, 0, Math.PI * 2)
+      ctx.fill()
+
+      // particles
+      for (let p = 0; p < 34; p++) {
+        const drift = animate ? (t / 1000) * (4 + hash(p) * 10) : 40
+        const px = (hash(p * 3) * W + drift * (p % 2 === 0 ? 1 : -1) + W * 4) % W
+        const py = cy + (hash(p * 5) - 0.5) * H * 0.8
+        const tw = 0.3 + 0.6 * Math.abs(Math.sin((animate ? t : 500) / 900 + p * 1.7))
+        ctx.fillStyle =
+          p % 6 === 0 ? col(HUES[1], tw * 0.7 * dim, 20) : gold(tw * 0.55 * dim, 18)
+        ctx.beginPath()
+        ctx.arc(px, py, p % 4 === 0 ? 1.7 : 1.1, 0, Math.PI * 2)
+        ctx.fill()
+      }
+
+      // thinking / connecting: a bright pulse crossing the scene
+      if (st === 'thinking' || st === 'connecting') {
+        const cycle = animate ? (t / 1600) % 1 : 0.35
+        const xp = cycle * W
+        const pg = ctx.createRadialGradient(xp, cy, 0, xp, cy, 26)
+        pg.addColorStop(0, hot(0.9 * dim))
+        pg.addColorStop(1, gold(0))
+        ctx.fillStyle = pg
+        ctx.beginPath()
+        ctx.arc(xp, cy, 26, 0, Math.PI * 2)
+        ctx.fill()
+      }
+    }
+
+    // ------------------------------------------------------------------
+    // The compact band (VoiceCallPanel): original beam + centred bars
+    // ------------------------------------------------------------------
+    const drawBand = (t: number, animate: boolean) => {
       const st = stateRef.current
       const levels = levelsRef.current
       smoothAgent += (levels.agent - smoothAgent) * 0.35
@@ -98,71 +226,28 @@ export function PresenceOrb({ state, levelsRef, size = 170, fullBleed = false }:
       const energy = Math.min(1, smoothAgent * 1.7 + smoothUser * 1.0)
 
       if (animate) {
-        hist.copyWithin(1, 0) // history radiates outward from the centre
+        hist.copyWithin(1, 0)
         hist[0] = energy
       }
 
       const dim = st === 'ended' || st === 'error' ? 0.35 : st === 'connecting' ? 0.65 : 1
-
       ctx.clearRect(0, 0, W, H)
 
-      // 1 — ambient wash above/below the beam
-      const wash = ctx.createLinearGradient(0, 0, 0, H)
-      wash.addColorStop(0, gold(0))
-      wash.addColorStop(0.5, gold(0.10 * dim, 6))
-      wash.addColorStop(1, gold(0))
-      ctx.fillStyle = wash
-      ctx.fillRect(0, 0, W, H)
-
-      // 2 — mirrored voice bars: history flows centre → edges (both sides)
       for (let sIdx = 0; sIdx < SLOTS; sIdx++) {
         const v = sIdx === 0 ? energy : hist[sIdx]
         const fade = 1 - (sIdx / SLOTS) * 0.8
-        const jitter = hash(sIdx * 7) * 2
-        const bh = 3 + v * maxBar * (0.45 + fade * 0.55) + jitter
-        const hotBar = v > 0.45
+        const bh = 3 + v * H * 0.36 * (0.45 + fade * 0.55) + hash(sIdx * 7) * 2
         for (const dir of [-1, 1]) {
           const x = cx + dir * (sIdx * BAR_SPACING + 2)
-          // soft wide pass + bright thin core = cheap glow
           ctx.strokeStyle = gold(0.14 * fade * dim, 8)
           ctx.lineWidth = 3.6
           ctx.beginPath(); ctx.moveTo(x, cy - bh); ctx.lineTo(x, cy + bh); ctx.stroke()
-          ctx.strokeStyle = hotBar ? hot(0.9 * fade * dim) : gold(0.55 * fade * dim, 14)
+          ctx.strokeStyle = v > 0.45 ? hot(0.9 * fade * dim) : gold(0.55 * fade * dim, 14)
           ctx.lineWidth = 1.4
           ctx.beginPath(); ctx.moveTo(x, cy - bh); ctx.lineTo(x, cy + bh); ctx.stroke()
         }
       }
 
-      // 3 — ribbon waves flowing through the bars (three phase-shifted layers)
-      const ribbonEnv = (x: number) => {
-        const d = Math.abs(x - cx) / cx
-        return (1 - d * d) * (0.35 + energy * 0.65)
-      }
-      for (let rIdx = 0; rIdx < 3; rIdx++) {
-        const amp = H * (0.10 + rIdx * 0.045)
-        const k = 0.012 + rIdx * 0.004
-        const speed = (animate ? t : 900) / (900 + rIdx * 380)
-        ctx.beginPath()
-        for (let x = 0; x <= W; x += 6) {
-          const y =
-            cy +
-            Math.sin(x * k + speed * (rIdx % 2 === 0 ? 1 : -1) * 2 + rIdx * 2.1) *
-              amp * ribbonEnv(x)
-          if (x === 0) ctx.moveTo(x, y)
-          else ctx.lineTo(x, y)
-        }
-        ctx.strokeStyle = rIdx === 0 ? hot(0.35 * dim) : gold(0.22 * dim, 12 - rIdx * 6)
-        ctx.lineWidth = rIdx === 0 ? 1.6 : 1.1
-        ctx.stroke()
-      }
-
-      // 4 — the beam: a bright horizon line with a soft vertical glow
-      const beamGlow = ctx.createLinearGradient(0, cy - 14, 0, cy + 14)
-      beamGlow.addColorStop(0, gold(0))
-      beamGlow.addColorStop(0.5, gold(0.5 * dim, 18))
-      beamGlow.addColorStop(1, gold(0))
-      ctx.fillStyle = beamGlow
-      ctx.fillRect(0, cy - 14, W, 28)
       const beam = ctx.createLinearGradient(0, 0, W, 0)
       beam.addColorStop(0, gold(0.05 * dim))
       beam.addColorStop(0.5, hot(0.95 * dim))
@@ -170,51 +255,27 @@ export function PresenceOrb({ state, levelsRef, size = 170, fullBleed = false }:
       ctx.fillStyle = beam
       ctx.fillRect(0, cy - 0.8, W, 1.6)
 
-      // 5 — core flare at centre: blooms with Auto's voice
-      const flareR = 26 + smoothAgent * 95 + 6 * Math.sin((animate ? t : 600) / 700)
+      const flareR = 26 + smoothAgent * 60
       const flare = ctx.createRadialGradient(cx, cy, 0, cx, cy, flareR)
-      flare.addColorStop(0, hot(0.95 * dim))
-      flare.addColorStop(0.3, gold(0.55 * dim, 20))
+      flare.addColorStop(0, hot(0.9 * dim))
       flare.addColorStop(1, gold(0))
       ctx.fillStyle = flare
       ctx.beginPath()
       ctx.arc(cx, cy, flareR, 0, Math.PI * 2)
       ctx.fill()
-
-      // 6 — drifting particles (the dust in the references)
-      for (let p = 0; p < 26; p++) {
-        const drift = animate ? (t / 1000) * (4 + hash(p) * 10) : 40
-        const px = (hash(p * 3) * W + drift * (p % 2 === 0 ? 1 : -1) + W * 4) % W
-        const py = cy + (hash(p * 5) - 0.5) * H * 0.75
-        const tw = 0.25 + 0.6 * Math.abs(Math.sin((animate ? t : 500) / 900 + p * 1.7))
-        ctx.fillStyle = p % 5 === 0 ? hot(tw * 0.8 * dim) : gold(tw * 0.5 * dim, 15)
-        ctx.beginPath()
-        ctx.arc(px, py, p % 4 === 0 ? 1.6 : 1, 0, Math.PI * 2)
-        ctx.fill()
-      }
-
-      // 7 — thinking/connecting: a bright pulse travelling the beam
-      if (st === 'thinking' || st === 'connecting') {
-        const cycle = animate ? (t / 1600) % 1 : 0.35
-        const xp = cycle * W
-        const pg = ctx.createRadialGradient(xp, cy, 0, xp, cy, 22)
-        pg.addColorStop(0, hot(0.9 * dim))
-        pg.addColorStop(1, gold(0))
-        ctx.fillStyle = pg
-        ctx.beginPath()
-        ctx.arc(xp, cy, 22, 0, Math.PI * 2)
-        ctx.fill()
-      }
     }
+
+    const draw = fullBleed ? drawReference : drawBand
 
     if (reducedMotion) {
       for (let i = 0; i < SLOTS; i++) hist[i] = 0.15 + hash(i) * 0.45
-      drawFrame(900, false)
+      energyEnv = 0.35
+      draw(900, false)
       return () => undefined
     }
 
     const loop = (t: number) => {
-      drawFrame(t, true)
+      draw(t, true)
       raf = requestAnimationFrame(loop)
     }
     raf = requestAnimationFrame(loop)

--- a/orchestrator/alembic/versions/prd207_su_capture.py
+++ b/orchestrator/alembic/versions/prd207_su_capture.py
@@ -1,0 +1,36 @@
+"""PRD-207: capture the caller's privilege tier on the mint row
+
+``system_role`` lives ONLY in Clerk token claims (no users column) — the
+custom-LLM webhook has no auth context, so a runtime lookup is impossible
+(the #581 attempt crashed every spoken turn: silence). The mint, which DOES
+hold the caller's session, now stamps ``is_super_admin`` onto the
+``voice_calls`` row; the webhook reads row-truth like everything else on it.
+
+Chains single-parent on prd207_voice_live (the current single head).
+
+Revision ID: prd207_su_capture
+Revises: prd207_voice_live
+Create Date: 2026-07-18
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "prd207_su_capture"
+down_revision = "prd207_voice_live"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "voice_calls",
+        sa.Column(
+            "is_super_admin", sa.Boolean, nullable=False, server_default=sa.text("false")
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("voice_calls", "is_super_admin")

--- a/orchestrator/api/voice_retell.py
+++ b/orchestrator/api/voice_retell.py
@@ -208,6 +208,11 @@ async def mint_web_call(
         raise HTTPException(status_code=502, detail=f"Could not start the call: {exc}")
 
     # The row is BORN at mint — the webhook validates against it (S2/S3).
+    # PRD-143 discipline: su derives from Clerk-claims system_role ONLY —
+    # captured HERE (the one place the session exists) for the webhook.
+    caller_is_su = (
+        getattr(getattr(ctx, "user", None), "system_role", "user") == "super_admin"
+    )
     db.add(
         VoiceCall(
             call_id=web_call.call_id,
@@ -216,6 +221,7 @@ async def mint_web_call(
             user_id=user_int_id,
             chat_id=bound_chat_id,
             status="minted",
+            is_super_admin=caller_is_su,
         )
     )
     db.commit()
@@ -539,11 +545,6 @@ async def _agent_retell_stream(req: RetellLLMRequest) -> AsyncIterator[dict[str,
         # history is the recent conversation, not the archive (rhythm, not
         # brain — memory injection is retrieval, not history replay). Tool
         # work mid-call reads as the honest THINKING state, never silence.
-        from core.models.core import User
-
-        role_row = db.query(User.system_role).filter(User.id == binding.user_id).first()
-        is_super_admin = bool(role_row and role_row[0] == "super_admin")
-
         messages = chat_service.get_messages_by_chat_id(conversation_id)
         recent = messages[-int(config.VOICE_LIVE_TURN_HISTORY_MESSAGES):]
         message_history = [{"role": m.role, "parts": m.parts} for m in recent]
@@ -554,7 +555,10 @@ async def _agent_retell_stream(req: RetellLLMRequest) -> AsyncIterator[dict[str,
             agent_id=agent_id,
             user_id=binding.user_id,
             use_orchestrator_llm=True,
-            is_super_admin=is_super_admin,
+            # captured at mint (Clerk claims live only there); False for the
+            # steward/orphan lanes — fail-closed. The #581 runtime lookup
+            # crashed every turn: User has no system_role attribute.
+            is_super_admin=binding.is_super_admin,
         )
 
         response_chars = 0

--- a/orchestrator/core/models/voice_calls.py
+++ b/orchestrator/core/models/voice_calls.py
@@ -27,7 +27,7 @@ silently dropped.
 
 from __future__ import annotations
 
-from sqlalchemy import BigInteger, Column, DateTime, Index, Integer, String
+from sqlalchemy import BigInteger, Boolean, Column, DateTime, Index, Integer, String
 from sqlalchemy.dialects.postgresql import UUID as PGUUID
 from sqlalchemy.sql import func
 
@@ -64,6 +64,11 @@ class VoiceCall(Base):
     fallback_chat_id = Column(String(64), nullable=True)
 
     status = Column(String(16), nullable=False, server_default="minted")
+
+    # The caller's privilege tier, captured at mint — system_role lives only
+    # in Clerk claims (no users column), so the webhook reads it from HERE
+    # (row-truth), never a runtime lookup. False for steward/orphan lanes.
+    is_super_admin = Column(Boolean, nullable=False, server_default="false")
 
     minted_at = Column(DateTime, nullable=False, server_default=func.now())
     started_at = Column(DateTime, nullable=True)

--- a/orchestrator/modules/voice/call_binding.py
+++ b/orchestrator/modules/voice/call_binding.py
@@ -58,6 +58,9 @@ class CallBinding:
     user_id: int  # INTEGER users.id driving attribution (memory owner, Q7)
     workspace_id: str  # str(uuid) — always the PROVEN workspace
     bound: bool  # True = the mint-proven on-screen thread
+    # Captured at mint from Clerk claims (no DB column exists); the spoken
+    # turn's tool tier. False on steward/orphan lanes — fail-closed.
+    is_super_admin: bool = False
 
 
 def _workspace_steward(db: Session, ws_uuid: uuid.UUID) -> Optional[int]:
@@ -169,6 +172,7 @@ def resolve_call_binding(
                         user_id=int(row.user_id),
                         workspace_id=str(ws_uuid),
                         bound=True,
+                        is_super_admin=bool(row.is_super_admin),
                     )
                 logger.warning(
                     "voice_live_webhook_rejected reason=chat_gone_or_reowned call=%s chat=%s",
@@ -183,7 +187,11 @@ def resolve_call_binding(
         if row.user_id is not None:
             chat_id = _fallback_chat(db, row, ws_uuid, int(row.user_id), first_text)
             return CallBinding(
-                chat_id=chat_id, user_id=int(row.user_id), workspace_id=str(ws_uuid), bound=False
+                chat_id=chat_id,
+                user_id=int(row.user_id),
+                workspace_id=str(ws_uuid),
+                bound=False,
+                is_super_admin=bool(row.is_super_admin),
             )
         # A minted row with no user should not exist (mint requires one) —
         # treat like the unminted lane below.

--- a/orchestrator/tests/test_prd207_voice_live.py
+++ b/orchestrator/tests/test_prd207_voice_live.py
@@ -518,7 +518,9 @@ def test_voice_turn_has_the_full_brain(monkeypatch):
 
     monkeypatch.setattr(
         cb, "resolve_call_binding",
-        lambda db, **k: CallBinding(chat_id=chat_id, user_id=7, workspace_id=ws_id, bound=True),
+        lambda db, **k: CallBinding(
+            chat_id=chat_id, user_id=7, workspace_id=ws_id, bound=True, is_super_admin=True
+        ),
     )
     monkeypatch.setattr(cb, "stamp_assistant_voice_source", lambda db, **k: 0)
 
@@ -536,14 +538,9 @@ def test_voice_turn_has_the_full_brain(monkeypatch):
 
     from contextlib import contextmanager
 
-    fake_db = MagicMock()
-    # the bound user's REAL privilege tier flows into the turn (PRD-143: su
-    # derives from system_role only)
-    fake_db.query.return_value.filter.return_value.first.return_value = ("super_admin",)
-
     @contextmanager
     def fake_session():
-        yield fake_db
+        yield MagicMock()
 
     monkeypatch.setattr(vr, "get_db_session", fake_session)
 
@@ -563,7 +560,7 @@ def test_voice_turn_has_the_full_brain(monkeypatch):
     # the lobotomy flags are GONE — same brain as text chat
     assert captured.get("force_text_only", False) is False  # tools + memory live
     assert captured.get("skip_composio", False) is False    # full action surface
-    assert captured["is_super_admin"] is True               # the caller's real tier
+    assert captured["is_super_admin"] is True  # mint-captured tier rides the binding
     # the one voice-specific trim: recent conversation, not the archive
     assert len(captured["messages"]) <= int(app_config.VOICE_LIVE_TURN_HISTORY_MESSAGES)
 


### PR DESCRIPTION
## /goal fix auto, make it work, amazing voice and graphics

### Voice — the silence since #581, root-caused in prod logs
`type object 'User' has no attribute 'system_role'` → `retell_ws_stream_failed` on **every spoken turn**. The privilege tier lives ONLY in Clerk token claims — there is no users column — and the webhook has no auth context. The #581 runtime lookup could never work.

**Truth-shaped fix:** the **mint** (where the caller's session exists) stamps `is_super_admin` onto the `voice_calls` row (migration `prd207_su_capture`, single-parent chain); the trust-boundary binding carries row-truth into the turn; steward/orphan lanes stay False, fail-closed. The crashing lookup is deleted. Full brain + real tier + no crash.

### Graphics — the composition from the reference, not another opacity tweak
Full-bleed renderer rebuilt: **three woven ribbon bundles** (gold/magenta/blue, seven offset strands each, bright leading strand, amplitude swelling with the voices) · **tall three-pass luminous bars across the entire width** with energy radiating from the centre and pink/blue accents · floor glow · particles · centre flare on Auto's voice · **no dominant beam** · a slow envelope keeps the room lit between words. The docked panel keeps the compact band.

After merge + deploy: **call connects (thread reuse, #585), Auto answers (this), and the background is the picture.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated the voice presence visualization with full-bleed and compact modes, including audio-responsive ribbons, bars, glow, particles, and pulses.
  - Voice calls now capture and persist the caller’s super-admin privilege tier at creation time for consistent downstream behavior.

- **Bug Fixes**
  - Reduced-motion mode now produces a stable, correctly initialized visualization.
  - Voice-turn super-admin attribution no longer depends on a later role lookup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->