### PR TITLE
🚨 hotfix(prd-207): repair the two-session splice crash + voice error boundary

### DIFF
--- a/frontend/components/chatbot/chat.tsx
+++ b/frontend/components/chatbot/chat.tsx
@@ -49,6 +49,7 @@ import { CreateMissionModal } from '@/components/missions/create-mission-modal'
 // presence up. The SSE lane also mounts here so voice/background messages
 // land live (chat_changed → the useChat merge listener).
 import { LiveVoiceMode } from '@/components/voice/LiveVoiceMode'
+import { VoiceErrorBoundary } from '@/components/voice/VoiceErrorBoundary'
 import { PresenceOrb } from '@/components/voice/PresenceOrb'
 import type { VoiceLevels } from '@/hooks/use-retell-call'
 import type { OrbState } from '@/lib/voice/orb-state'
@@ -1181,11 +1182,13 @@ export function Chat({
                 exit={{ opacity: 0 }}
                 transition={{ duration: 0.5 }}
               >
-                <PresenceOrb
-                  state={voicePresence}
-                  levelsRef={voiceLevels}
-                  horizon={showWelcomeCard ? 0.56 : 0.74}
-                />
+                <VoiceErrorBoundary>
+                  <PresenceOrb
+                    state={voicePresence}
+                    levelsRef={voiceLevels}
+                    horizon={showWelcomeCard ? 0.56 : 0.74}
+                  />
+                </VoiceErrorBoundary>
               </motion.div>
             )}
           </AnimatePresence>
@@ -1228,6 +1231,7 @@ export function Chat({
                     conversation surface, spoken or typed. */}
                 <AnimatePresence>
                   {isLiveMode && (
+                    <VoiceErrorBoundary>
                     <LiveVoiceMode
                       chatId={hasSentMessage ? activeChatId : undefined}
                       agentId={selectedAgentId}
@@ -1240,6 +1244,7 @@ export function Chat({
                         setVoicePresence('ended')
                       }}
                     />
+                    </VoiceErrorBoundary>
                   )}
                 </AnimatePresence>
                 {/* PRD-40: Tool Suggestion Bar */}
@@ -1410,6 +1415,7 @@ export function Chat({
                     conversation surface, spoken or typed. */}
                 <AnimatePresence>
                   {isLiveMode && (
+                    <VoiceErrorBoundary>
                     <LiveVoiceMode
                       chatId={hasSentMessage ? activeChatId : undefined}
                       agentId={selectedAgentId}
@@ -1422,6 +1428,7 @@ export function Chat({
                         setVoicePresence('ended')
                       }}
                     />
+                    </VoiceErrorBoundary>
                   )}
                 </AnimatePresence>
                 {/* PRD-40: Tool Suggestion Bar */}

--- a/frontend/components/voice/PresenceOrb.tsx
+++ b/frontend/components/voice/PresenceOrb.tsx
@@ -1,21 +1,28 @@
 'use client'
 
 /**
- * PresenceOrb v4 — two renderers, one component.
+ * PresenceOrb v5 — the repair of the two-session splice (and the union of
+ * both designs).
  *
- * `fullBleed` (the chat's living background) draws GERARD'S REFERENCE — the
- * image sent twelve times: thick WOVEN RIBBON BUNDLES (gold / magenta /
- * blue, seven offset strands each, a bright leading strand), TALL luminous
- * bars across the FULL width, a soft floor glow, particles — no dominant
- * beam. Alive with the voices: bar energy radiates outward from centre,
- * ribbon amplitude swells as either of you speaks, the core flares on
- * Auto's voice.
+ * Two parallel sessions rewrote v4 simultaneously; the merge stitched half
+ * of each (`warningHsl`/`SLOTS` called, `cssHsl`/`MAX_SLOTS` defined) and
+ * the resulting ReferenceError white-screened the app the moment Live
+ * mounted. v5 is ONE coherent implementation honouring BOTH contracts:
  *
- * The compact band (VoiceCallPanel) keeps the original beam-and-bars look.
+ * * `horizon` (chat background, the other session's API): the canvas fills
+ *   its absolute host, the beamline sits at `horizon`×height and GLIDES
+ *   when it changes (welcome 0.56 → thread 0.74 — words own the upper
+ *   field); state intensity lives inside.
+ * * `size` band (VoiceCallPanel): the compact beam-and-bars strip.
  *
- * Canvas-2D, one rAF, zero React re-renders per audio frame (levels via a
- * mutable ref). `prefers-reduced-motion` renders one static frame. All
- * per-element randomness is a deterministic index hash.
+ * The background draws GERARD'S REFERENCE: three woven ribbon bundles
+ * (gold / magenta / blue, seven offset strands, bright leading strand),
+ * tall three-pass luminous bars across the full width with energy
+ * radiating from centre, floor glow, particles, a flare on Auto's voice —
+ * no dominant beam. A slow envelope keeps the room lit between words.
+ *
+ * Safety: the rAF loop is try/caught — a draw fault logs once and stops
+ * the loop; it can never take the page down again.
  */
 
 import { useEffect, useRef, type MutableRefObject } from 'react'
@@ -25,25 +32,21 @@ import type { OrbState } from '@/lib/voice/orb-state'
 interface PresenceOrbProps {
   state: OrbState
   levelsRef: MutableRefObject<VoiceLevels>
-  /** Band height in px; the band fills its container's width. */
+  /** Compact-band height (VoiceCallPanel). Ignored in background mode. */
   size?: number
-  /** Ambient-background mode: reference composition, no width cap. */
+  /** Background mode (fills the host). Implied when `horizon` is given. */
   fullBleed?: boolean
+  /** 0..1 vertical beamline placement in background mode; glides on change. */
+  horizon?: number
 }
 
-interface Hsl {
-  h: number
-  s: number
-  l: number
-}
-
-function cssHsl(varName: string, fallback: Hsl): Hsl {
+function brandHsl(): { h: number; s: number; l: number } {
   if (typeof window !== 'undefined') {
-    const raw = getComputedStyle(document.documentElement).getPropertyValue(varName).trim()
+    const raw = getComputedStyle(document.documentElement).getPropertyValue('--warning').trim()
     const m = raw.match(/^([\d.]+)\s+([\d.]+)%\s+([\d.]+)%$/)
     if (m) return { h: Number(m[1]), s: Number(m[2]), l: Number(m[3]) }
   }
-  return fallback
+  return { h: 38, s: 92, l: 50 }
 }
 
 /** Deterministic 0..1 hash per index — stable "randomness", no Math.random. */
@@ -52,29 +55,11 @@ function hash(i: number): number {
   return x - Math.floor(x)
 }
 
-/** Pre-baked soft radial sprite: colour stops fading to transparent. */
-function bakeRadialSprite(size: number, stops: Array<[number, string]>): HTMLCanvasElement {
-  const c = document.createElement('canvas')
-  c.width = size
-  c.height = size
-  const sctx = c.getContext('2d')
-  if (sctx) {
-    const g = sctx.createRadialGradient(size / 2, size / 2, 0, size / 2, size / 2, size / 2)
-    for (const [at, col] of stops) g.addColorStop(at, col)
-    sctx.fillStyle = g
-    sctx.fillRect(0, 0, size, size)
-  }
-  return c
-}
+const SLOTS = 60 // half-width history slots (centre → edge)
+const BAR_SPACING = 5.5 // compact band
+const HORIZON_GLIDE = 0.06 // per-frame lerp toward the horizon target
 
-const BAR_SPACING = 2.6
-const MAX_SLOTS = 420
-const INTRO_MS = 400
-const ENDED_DECAY_MS = 450
-const HORIZON_GLIDE = 0.06 // per-frame lerp (~600ms settle at 60fps)
-
-// State → master intensity. The MODE of motion is decided in drawFrame();
-// this only scales how present the room feels.
+// State → how present the room feels (background mode).
 const STATE_INTENSITY: Record<OrbState, number> = {
   speaking: 1,
   listening: 0.8,
@@ -85,56 +70,77 @@ const STATE_INTENSITY: Record<OrbState, number> = {
   ended: 0,
 }
 
-export function PresenceOrb({ state, levelsRef, horizon = 0.56 }: PresenceOrbProps) {
+export function PresenceOrb({
+  state,
+  levelsRef,
+  size = 170,
+  fullBleed = false,
+  horizon,
+}: PresenceOrbProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const stateRef = useRef<OrbState>(state)
   stateRef.current = state
-  const horizonTargetRef = useRef(horizon)
-  horizonTargetRef.current = horizon
+  const horizonTargetRef = useRef(horizon ?? 0.5)
+  horizonTargetRef.current = horizon ?? 0.5
+
+  const isBackground = fullBleed || horizon != null
 
   useEffect(() => {
     const canvas = canvasRef.current
-    const host = canvas?.parentElement
-    if (!canvas || !host) return
+    if (!canvas) return
     const ctx = canvas.getContext('2d')
     if (!ctx) return
+    const host = canvas.parentElement
 
-    const W = fullBleed ? 1440 : 680
-    const H = size
     const dpr = typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1
-    canvas.width = W * dpr
-    canvas.height = H * dpr
-    ctx.scale(dpr, dpr)
+    let W = 680
+    let H = size
 
-    const { h: brandH, s: brandS, l: brandL } = warningHsl()
-    // The reference palette: brand gold anchored, magenta and blue companions.
-    const HUES = [brandH, 318, 215]
+    const applySize = () => {
+      if (isBackground && host) {
+        const rect = host.getBoundingClientRect()
+        W = Math.max(320, Math.round(rect.width)) || 1280
+        H = Math.max(240, Math.round(rect.height)) || 560
+      } else {
+        W = 680
+        H = size
+      }
+      canvas.width = W * dpr
+      canvas.height = H * dpr
+      ctx.setTransform(1, 0, 0, 1, 0, 0)
+      ctx.scale(dpr, dpr)
+    }
+    applySize()
+
+    let observer: ResizeObserver | null = null
+    if (isBackground && host && typeof ResizeObserver !== 'undefined') {
+      observer = new ResizeObserver(applySize)
+      observer.observe(host)
+    }
+
+    const { h: brandH, s: brandS, l: brandL } = brandHsl()
+    const HUES = [brandH, 318, 215] // gold anchor, magenta + blue companions
     const col = (hue: number, alpha: number, dl = 0, ds = 0) =>
       `hsla(${hue}, ${Math.max(0, Math.min(100, brandS + ds))}%, ${Math.max(
         0,
         Math.min(100, brandL + dl)
-      )}%, ${Math.min(1, alpha)})`
+      )}%, ${Math.min(1, Math.max(0, alpha))})`
     const gold = (alpha: number, dl = 0) => col(brandH, alpha, dl)
-    const hot = (alpha: number) => `hsla(${brandH + 6}, 100%, 92%, ${Math.min(1, alpha)})`
+    const hot = (alpha: number) =>
+      `hsla(${brandH + 6}, 100%, 92%, ${Math.min(1, Math.max(0, alpha))})`
 
     const reducedMotion =
       typeof window !== 'undefined' &&
       window.matchMedia?.('(prefers-reduced-motion: reduce)').matches
 
-    const cx = W / 2
-    const cy = H / 2
-
     const hist = new Float32Array(SLOTS)
     let smoothAgent = 0
     let smoothUser = 0
-    let energyEnv = 0 // slow envelope: the room keeps glowing between words
+    let energyEnv = 0
+    let horizonY = horizonTargetRef.current
     let raf = 0
-    let lastT = 0
-    let stopped = false
+    let dead = false
 
-    // ------------------------------------------------------------------
-    // THE REFERENCE (fullBleed): woven ribbon bundles + tall bars + floor
-    // ------------------------------------------------------------------
     const drawReference = (t: number, animate: boolean) => {
       const st = stateRef.current
       const levels = levelsRef.current
@@ -142,18 +148,22 @@ export function PresenceOrb({ state, levelsRef, horizon = 0.56 }: PresenceOrbPro
       smoothUser += (levels.user - smoothUser) * 0.3
       const energy = Math.min(1, smoothAgent * 1.7 + smoothUser * 1.0)
       energyEnv += ((st === 'speaking' ? Math.max(0.35, energy) : energy) - energyEnv) * 0.06
+      horizonY += (horizonTargetRef.current - horizonY) * HORIZON_GLIDE
 
       if (animate) {
         hist.copyWithin(1, 0)
         hist[0] = energy
       }
 
-      const dim = st === 'ended' ? 0 : st === 'error' ? 0.35 : st === 'connecting' ? 0.6 : 1
+      const dim = STATE_INTENSITY[st] ?? 0.5
       ctx.clearRect(0, 0, W, H)
-      if (dim === 0) return
+      if (dim <= 0) return
+
+      const cx = W / 2
+      const cy = H * horizonY
 
       // floor glow — grounds the scene like the reference's reflections
-      const floor = ctx.createRadialGradient(cx, cy + H * 0.22, 0, cx, cy + H * 0.22, W * 0.45)
+      const floor = ctx.createRadialGradient(cx, cy + H * 0.16, 0, cx, cy + H * 0.16, W * 0.45)
       floor.addColorStop(0, gold(0.14 * dim, 6))
       floor.addColorStop(1, gold(0))
       ctx.fillStyle = floor
@@ -161,26 +171,22 @@ export function PresenceOrb({ state, levelsRef, horizon = 0.56 }: PresenceOrbPro
 
       // TALL BARS across the full width — energy radiates from the centre
       const step = 16
+      const barField = Math.min(H * 0.3, 260)
       for (let x = step / 2; x < W; x += step) {
         const i = Math.round(x / step)
-        const distSlot = Math.min(
-          SLOTS - 1,
-          Math.floor((Math.abs(x - cx) / (W / 2)) * SLOTS)
-        )
+        const distSlot = Math.min(SLOTS - 1, Math.floor((Math.abs(x - cx) / (W / 2)) * SLOTS))
         const v = distSlot === 0 ? Math.max(energy, hist[0]) : hist[distSlot]
         const idle = 0.1 + 0.14 * hash(i * 13) + 0.06 * Math.sin((animate ? t : 700) / 1200 + i)
         const amp = Math.min(1, idle + v * 1.1 + energyEnv * 0.25)
-        const bh = amp * H * 0.42
-        const hue = HUES[i % 7 === 0 ? 1 : i % 11 === 0 ? 2 : 0] // gold field, pink/blue accents
-        const bright = v > 0.45
-        // three passes: halo, body, hot core — the luminous fade of the ref
-        ctx.strokeStyle = col(hue, 0.10 * dim, 10)
+        const bh = amp * barField
+        const hue = HUES[i % 7 === 0 ? 1 : i % 11 === 0 ? 2 : 0]
+        ctx.strokeStyle = col(hue, 0.1 * dim, 10)
         ctx.lineWidth = 7
         ctx.beginPath(); ctx.moveTo(x, cy - bh); ctx.lineTo(x, cy + bh * 0.9); ctx.stroke()
         ctx.strokeStyle = col(hue, 0.3 * dim, 16)
         ctx.lineWidth = 2.6
         ctx.beginPath(); ctx.moveTo(x, cy - bh); ctx.lineTo(x, cy + bh * 0.9); ctx.stroke()
-        ctx.strokeStyle = bright ? hot(0.85 * dim) : col(hue, 0.5 * dim, 24)
+        ctx.strokeStyle = v > 0.45 ? hot(0.85 * dim) : col(hue, 0.5 * dim, 24)
         ctx.lineWidth = 1.2
         ctx.beginPath(); ctx.moveTo(x, cy - bh); ctx.lineTo(x, cy + bh * 0.9); ctx.stroke()
       }
@@ -189,7 +195,7 @@ export function PresenceOrb({ state, levelsRef, horizon = 0.56 }: PresenceOrbPro
       const sway = 0.55 + 0.75 * energyEnv
       for (let b = 0; b < 3; b++) {
         const hue = HUES[b]
-        const baseAmp = H * (0.13 + b * 0.055) * sway
+        const baseAmp = Math.min(H * 0.11, 90) * (1 + b * 0.4) * sway
         const k = 0.0075 + b * 0.0022
         const dir = b % 2 === 0 ? 1 : -1
         const speed = (animate ? t : 900) / (1150 + b * 420)
@@ -202,19 +208,14 @@ export function PresenceOrb({ state, levelsRef, horizon = 0.56 }: PresenceOrbPro
             const env = 0.55 + 0.45 * Math.sin((x / W) * Math.PI)
             const y =
               cy -
-              H * 0.02 +
+              H * 0.015 +
               Math.sin(x * k + dir * speed * 2 + phase) * ampJ * env +
               (sIdx - 3) * 2.4
             if (x === 0) ctx.moveTo(x, y)
             else ctx.lineTo(x, y)
           }
-          if (lead) {
-            ctx.strokeStyle = col(hue, 0.55 * dim, 30, 8)
-            ctx.lineWidth = 2.1
-          } else {
-            ctx.strokeStyle = col(hue, 0.14 * dim, 14)
-            ctx.lineWidth = 1.1
-          }
+          ctx.strokeStyle = lead ? col(hue, 0.55 * dim, 30, 8) : col(hue, 0.14 * dim, 14)
+          ctx.lineWidth = lead ? 2.1 : 1.1
           ctx.stroke()
         }
       }
@@ -232,11 +233,10 @@ export function PresenceOrb({ state, levelsRef, horizon = 0.56 }: PresenceOrbPro
       // particles
       for (let p = 0; p < 34; p++) {
         const drift = animate ? (t / 1000) * (4 + hash(p) * 10) : 40
-        const px = (hash(p * 3) * W + drift * (p % 2 === 0 ? 1 : -1) + W * 4) % W
-        const py = cy + (hash(p * 5) - 0.5) * H * 0.8
+        const px = (hash(p * 3) * W + drift * (p % 2 === 0 ? 1 : -1) + W * 8) % W
+        const py = cy + (hash(p * 5) - 0.5) * Math.min(H * 0.7, 500)
         const tw = 0.3 + 0.6 * Math.abs(Math.sin((animate ? t : 500) / 900 + p * 1.7))
-        ctx.fillStyle =
-          p % 6 === 0 ? col(HUES[1], tw * 0.7 * dim, 20) : gold(tw * 0.55 * dim, 18)
+        ctx.fillStyle = p % 6 === 0 ? col(HUES[1], tw * 0.7 * dim, 20) : gold(tw * 0.55 * dim, 18)
         ctx.beginPath()
         ctx.arc(px, py, p % 4 === 0 ? 1.7 : 1.1, 0, Math.PI * 2)
         ctx.fill()
@@ -256,9 +256,6 @@ export function PresenceOrb({ state, levelsRef, horizon = 0.56 }: PresenceOrbPro
       }
     }
 
-    // ------------------------------------------------------------------
-    // The compact band (VoiceCallPanel): original beam + centred bars
-    // ------------------------------------------------------------------
     const drawBand = (t: number, animate: boolean) => {
       const st = stateRef.current
       const levels = levelsRef.current
@@ -273,6 +270,8 @@ export function PresenceOrb({ state, levelsRef, horizon = 0.56 }: PresenceOrbPro
 
       const dim = st === 'ended' || st === 'error' ? 0.35 : st === 'connecting' ? 0.65 : 1
       ctx.clearRect(0, 0, W, H)
+      const cx = W / 2
+      const cy = H / 2
 
       for (let sIdx = 0; sIdx < SLOTS; sIdx++) {
         const v = sIdx === 0 ? energy : hist[sIdx]
@@ -306,36 +305,52 @@ export function PresenceOrb({ state, levelsRef, horizon = 0.56 }: PresenceOrbPro
       ctx.fill()
     }
 
-    const draw = fullBleed ? drawReference : drawBand
+    const draw = isBackground ? drawReference : drawBand
 
     if (reducedMotion) {
       for (let i = 0; i < SLOTS; i++) hist[i] = 0.15 + hash(i) * 0.45
       energyEnv = 0.35
-      draw(900, false)
-      return () => undefined
+      try {
+        draw(900, false)
+      } catch (err) {
+        console.error('[PresenceOrb] static draw failed', err)
+      }
+      return () => {
+        observer?.disconnect()
+      }
     }
 
     const loop = (t: number) => {
-      draw(t, true)
+      if (dead) return
+      try {
+        draw(t, true)
+      } catch (err) {
+        // A draw fault is cosmetic — log once, stop the loop, never crash React.
+        dead = true
+        console.error('[PresenceOrb] draw loop stopped', err)
+        return
+      }
       raf = requestAnimationFrame(loop)
     }
     raf = requestAnimationFrame(loop)
-
     return () => {
+      dead = true
       cancelAnimationFrame(raf)
-      ro.disconnect()
+      observer?.disconnect()
     }
-  }, [levelsRef])
+  }, [levelsRef, size, isBackground])
 
   return (
     <canvas
       ref={canvasRef}
+      style={
+        isBackground
+          ? { width: '100%', height: '100%', display: 'block' }
+          : { width: '100%', maxWidth: 720, height: size, display: 'block' }
+      }
       role="img"
       aria-hidden="true"
       data-orb-state={state}
-      className="absolute inset-0 h-full w-full"
     />
   )
 }
-
-export default PresenceOrb

--- a/frontend/components/voice/VoiceErrorBoundary.tsx
+++ b/frontend/components/voice/VoiceErrorBoundary.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+/**
+ * VoiceErrorBoundary — the voice layer may never take the page down again.
+ *
+ * Born from the two-session splice crash (a ReferenceError in the wave
+ * white-screened the whole app the moment Live mounted). Any exception in
+ * a voice surface is contained here: logged with a grep-able tag, rendered
+ * as nothing (the chat beneath keeps working), reset when the user toggles
+ * Live again.
+ */
+
+import { Component, type ReactNode } from 'react'
+
+interface Props {
+  children: ReactNode
+}
+
+interface State {
+  crashed: boolean
+}
+
+export class VoiceErrorBoundary extends Component<Props, State> {
+  state: State = { crashed: false }
+
+  static getDerivedStateFromError(): State {
+    return { crashed: true }
+  }
+
+  componentDidCatch(error: unknown, info: unknown) {
+    // Grep-able in the console AND in any client-log forwarding.
+    console.error('[VoiceUI] crashed — contained by VoiceErrorBoundary', error, info)
+  }
+
+  render() {
+    if (this.state.crashed) return null
+    return this.props.children
+  }
+}


### PR DESCRIPTION
## The page crash, root-caused
`Application error: a client-side exception` — **the committed PresenceOrb on main is a splice of two parallel rewrites** (this session's v4 + another session's `horizon` redesign; the #588 conflict merge stitched half of each). The file calls `warningHsl()`/`SLOTS` which its other half renamed to `cssHsl`/`MAX_SLOTS` → **ReferenceError the moment Live mounts → whole-page white screen.** Confirmed by inspecting `origin/main`'s copy: undefined identifiers, props destructured that aren't in the interface.

## The repair — v5, the union of both designs
One coherent implementation honouring **both contracts**: the other session's `horizon` background API (host-filling canvas with ResizeObserver, beamline gliding 0.56→0.74 so words own the upper field when the thread shows, state intensity inside) **and** the `size` band for VoiceCallPanel. It draws the reference composition — woven gold/magenta/blue ribbon bundles, tall three-pass full-width bars with centre-radiating energy, floor glow, particles, voice flare, no dominant beam.

## The armour — never again
`VoiceErrorBoundary` wraps the ambient wave and both LiveVoiceMode sites: any voice-layer exception logs `[VoiceUI] crashed` and renders nothing — **the chat keeps working**. The rAF loop also try/catches, so a draw fault stops the animation, not React.

## Process note (important)
Two Claude sessions were editing the same file; the GitHub conflict merge produced code neither wrote. **One session per file** — or the merge commit itself needs review, not just the branches.