### PR TITLE
fix(prd-207): brain turns starved the socket (every 1006) + silent-mic banner & device picker

### DIFF
--- a/frontend/components/__tests__/prd207-live-voice.test.tsx
+++ b/frontend/components/__tests__/prd207-live-voice.test.tsx
@@ -13,6 +13,12 @@ import {
   rmsLevel,
   type OrbSnapshot,
 } from '@/lib/voice/orb-state'
+import {
+  MIC_SILENT_AFTER_MS,
+  MIC_SILENT_PEAK,
+  feedMicLevel,
+  initialMicHealth,
+} from '@/lib/voice/mic-health'
 
 afterEach(() => {
   cleanup()
@@ -81,6 +87,43 @@ describe('PRD-207 — orbReducer', () => {
 })
 
 // ---------------------------------------------------------------------------
+// mic-health — the silent-capture detector (pure, the orb-state discipline)
+// ---------------------------------------------------------------------------
+
+describe('PRD-207 — feedMicLevel', () => {
+  it('a full window of digital silence raises silent', () => {
+    let h = initialMicHealth(1_000)
+    h = feedMicLevel(h, 0, 1_060)
+    expect(h.silent).toBe(false) // not yet — the window must fill
+    h = feedMicLevel(h, 0.0001, 1_000 + MIC_SILENT_AFTER_MS)
+    expect(h.silent).toBe(true)
+  })
+
+  it('any real signal clears silent instantly and restarts the window', () => {
+    let h = initialMicHealth(0)
+    h = feedMicLevel(h, 0, MIC_SILENT_AFTER_MS) // silent
+    expect(h.silent).toBe(true)
+    h = feedMicLevel(h, MIC_SILENT_PEAK * 3, MIC_SILENT_AFTER_MS + 60)
+    expect(h.silent).toBe(false)
+    expect(h.windowStartAt).toBe(MIC_SILENT_AFTER_MS + 60)
+  })
+
+  it('a quiet-but-live mic (noise floor above the threshold) never trips it', () => {
+    let h = initialMicHealth(0)
+    for (let t = 60; t <= MIC_SILENT_AFTER_MS * 2; t += 60) {
+      h = feedMicLevel(h, MIC_SILENT_PEAK * 1.5, t)
+    }
+    expect(h.silent).toBe(false)
+  })
+
+  it('is immutable — feeding never mutates the previous snapshot', () => {
+    const first = initialMicHealth(0)
+    feedMicLevel(first, 0, 2_000)
+    expect(first).toEqual(initialMicHealth(0))
+  })
+})
+
+// ---------------------------------------------------------------------------
 // LiveVoiceMode — every failure state has designed copy; controls are named
 // ---------------------------------------------------------------------------
 
@@ -94,6 +137,8 @@ const hookState = {
   refusal: null as string | null,
   error: null as string | null,
   isLive: true,
+  micSilent: false,
+  inputDevices: [] as Array<{ deviceId: string; label: string }>,
   start: vi.fn(async () => {}),
   stop: vi.fn(),
   toggleMute: vi.fn(),
@@ -147,5 +192,47 @@ describe('PRD-207 — LiveVoiceMode', () => {
     // caption strip under the wave (Gerard: "why am I seeing two sources")
     expect(screen.queryByText(/where did we leave off/)).toBeNull()
     expect(screen.queryByText(/mid-way through the social pack/)).toBeNull()
+  })
+
+  it('a silent capture raises the honest banner with a way to pick another mic', () => {
+    Object.assign(hookState, {
+      refusal: null, error: null, isLive: true, muted: false,
+      orbState: 'listening', stateLabel: 'Auto is listening', captions: [],
+      micSilent: true,
+      inputDevices: [
+        { deviceId: 'default', label: 'MacBook Pro Microphone' },
+        { deviceId: 'iphone-1', label: "Gerard's iPhone" },
+      ],
+    })
+    render(<LiveVoiceMode onExit={() => {}} />)
+    expect(screen.getByTestId('mic-silent-banner')).toBeTruthy()
+    expect(screen.getByText(/microphone is silent/i)).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Pick another mic' })).toBeTruthy()
+  })
+
+  it('a healthy capture shows no banner; the strip offers the device picker', () => {
+    Object.assign(hookState, {
+      refusal: null, error: null, isLive: true, muted: false,
+      orbState: 'listening', stateLabel: 'Auto is listening', captions: [],
+      micSilent: false,
+      inputDevices: [
+        { deviceId: 'default', label: 'MacBook Pro Microphone' },
+        { deviceId: 'usb-1', label: 'USB Interface' },
+      ],
+    })
+    render(<LiveVoiceMode onExit={() => {}} />)
+    expect(screen.queryByTestId('mic-silent-banner')).toBeNull()
+    expect(screen.getByRole('button', { name: 'Choose microphone' })).toBeTruthy()
+  })
+
+  it('one input device = nothing to choose, no picker chrome', () => {
+    Object.assign(hookState, {
+      refusal: null, error: null, isLive: true, muted: false,
+      orbState: 'listening', stateLabel: 'Auto is listening', captions: [],
+      micSilent: false,
+      inputDevices: [{ deviceId: 'default', label: 'MacBook Pro Microphone' }],
+    })
+    render(<LiveVoiceMode onExit={() => {}} />)
+    expect(screen.queryByRole('button', { name: 'Choose microphone' })).toBeNull()
   })
 })

--- a/frontend/components/voice/LiveVoiceMode.tsx
+++ b/frontend/components/voice/LiveVoiceMode.tsx
@@ -12,13 +12,26 @@
  * state · timer · mic · mute · end — plus honest failure copy.
  */
 
-import { useEffect } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { motion } from 'framer-motion'
 import { Mic, MicOff, PhoneOff, X } from 'lucide-react'
 import type { MutableRefObject } from 'react'
 import { Button } from '@/components/ui/button'
+import { MicDevicePicker, MicSilentBanner } from '@/components/voice/MicHealthControl'
 import { useRetellCall, type VoiceLevels } from '@/hooks/use-retell-call'
 import type { OrbState } from '@/lib/voice/orb-state'
+
+/** The capture device survives page loads — a mic that worked stays picked. */
+const CAPTURE_DEVICE_STORAGE_KEY = 'automatos.voice.capture-device'
+
+function readStoredCaptureDevice(): string | null {
+  if (typeof window === 'undefined') return null
+  try {
+    return window.localStorage.getItem(CAPTURE_DEVICE_STORAGE_KEY)
+  } catch {
+    return null
+  }
+}
 
 interface LiveVoiceModeProps {
   /** The on-screen thread to bind — omit when the chat has no server row yet. */
@@ -50,6 +63,8 @@ export function LiveVoiceMode({
   onLevelsRef,
   onExit,
 }: LiveVoiceModeProps) {
+  const [captureDeviceId, setCaptureDeviceId] = useState<string | null>(readStoredCaptureDevice)
+
   const {
     orbState,
     stateLabel,
@@ -59,10 +74,12 @@ export function LiveVoiceMode({
     refusal,
     error,
     isLive,
+    micSilent = false,
+    inputDevices = [],
     start,
     stop,
     toggleMute,
-  } = useRetellCall({ chatId, agentId, onChatId, onLiveTurn })
+  } = useRetellCall({ chatId, agentId, captureDeviceId, onChatId, onLiveTurn })
 
   // Live mode IS the call: mounting connects, one gesture from the Live pill.
   useEffect(() => {
@@ -74,6 +91,41 @@ export function LiveVoiceMode({
   useEffect(() => {
     onPresence?.(orbState)
   }, [orbState, onPresence])
+
+  // A stored device that no longer exists must not pin the call to nothing.
+  useEffect(() => {
+    if (!captureDeviceId || inputDevices.length === 0) return
+    if (inputDevices.some((d) => d.deviceId === captureDeviceId)) return
+    try {
+      window.localStorage.removeItem(CAPTURE_DEVICE_STORAGE_KEY)
+    } catch {
+      // storage is a nicety
+    }
+    setCaptureDeviceId(null)
+  }, [captureDeviceId, inputDevices])
+
+  const pickDevice = (deviceId: string) => {
+    try {
+      window.localStorage.setItem(CAPTURE_DEVICE_STORAGE_KEY, deviceId)
+    } catch {
+      // storage is a nicety
+    }
+    setCaptureDeviceId(deviceId)
+  }
+
+  // Rebinding the SDK's capture needs a fresh call — restart on device change
+  // (skipping mount, where the stored device rides the initial start()).
+  const deviceRunRef = useRef(true)
+  useEffect(() => {
+    if (deviceRunRef.current) {
+      deviceRunRef.current = false
+      return
+    }
+    stop()
+    const timer = setTimeout(() => void start(), 200)
+    return () => clearTimeout(timer)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [captureDeviceId])
 
   const handleExit = () => {
     stop()
@@ -130,6 +182,13 @@ export function LiveVoiceMode({
               )}
             </Button>
           )}
+          {isLive && (
+            <MicDevicePicker
+              devices={inputDevices}
+              activeDeviceId={captureDeviceId}
+              onPickDevice={pickDevice}
+            />
+          )}
           {isLive || orbState === 'connecting' ? (
             <Button
               variant="ghost"
@@ -152,6 +211,16 @@ export function LiveVoiceMode({
             </Button>
           )}
         </div>
+      )}
+
+      {/* The mic is bound to a device delivering silence — name it, fix it
+          here. The #1 cause of "recording forever, Auto never answers". */}
+      {!failure && isLive && micSilent && !muted && (
+        <MicSilentBanner
+          devices={inputDevices}
+          activeDeviceId={captureDeviceId}
+          onPickDevice={pickDevice}
+        />
       )}
 
       {/* Failure states — honest copy, always a way out. */}

--- a/frontend/components/voice/MicHealthControl.tsx
+++ b/frontend/components/voice/MicHealthControl.tsx
@@ -1,0 +1,111 @@
+'use client'
+
+/**
+ * MicHealthControl — the microphone picker + the silent-capture banner
+ * (PRD-207).
+ *
+ * The invisible failure class this kills: the SDK binds a capture device
+ * that delivers flat silence (a continuity iPhone, a recorder extension's
+ * virtual input, an unplugged USB mic) while the strip says "Mic live" —
+ * the caller talks into a dead channel and Auto never hears a word. The
+ * hook's analyser measures the user's RMS; when a full window stays at
+ * digital silence the banner names the fault and offers the fix — pick
+ * another device — right where the eye already is.
+ */
+
+import type { ReactNode } from 'react'
+import { ChevronDown, MicOff } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import type { MicInputDevice } from '@/hooks/use-retell-call'
+
+interface DevicePickProps {
+  devices: MicInputDevice[]
+  /** null = the browser default device. */
+  activeDeviceId: string | null
+  onPickDevice: (deviceId: string) => void
+}
+
+function DeviceMenu({
+  devices,
+  activeDeviceId,
+  onPickDevice,
+  trigger,
+}: DevicePickProps & { trigger: ReactNode }) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>{trigger}</DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="max-w-[300px]">
+        <DropdownMenuLabel className="text-xs">Microphone</DropdownMenuLabel>
+        {devices.map((device) => (
+          <DropdownMenuCheckboxItem
+            key={device.deviceId}
+            className="text-xs"
+            checked={
+              device.deviceId === activeDeviceId ||
+              (!activeDeviceId && device.deviceId === 'default')
+            }
+            onCheckedChange={() => onPickDevice(device.deviceId)}
+          >
+            <span className="truncate">{device.label}</span>
+          </DropdownMenuCheckboxItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+/** The whisper-strip device chooser — present whenever there is a choice. */
+export function MicDevicePicker(props: DevicePickProps) {
+  if (props.devices.length < 2) return null
+  return (
+    <DeviceMenu
+      {...props}
+      trigger={
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7 rounded-full"
+          aria-label="Choose microphone"
+        >
+          <ChevronDown className="h-3.5 w-3.5" />
+        </Button>
+      }
+    />
+  )
+}
+
+/** Shown only when the capture has delivered a full window of silence. */
+export function MicSilentBanner(props: DevicePickProps) {
+  return (
+    <div
+      data-testid="mic-silent-banner"
+      className="mx-auto mt-1 flex w-fit max-w-full items-center gap-2 rounded-lg border border-warning/40 bg-warning/10 px-3 py-1.5"
+    >
+      <MicOff className="h-3.5 w-3.5 shrink-0 text-warning" />
+      <p className="text-xs text-warning">
+        Your microphone is silent — Auto can&apos;t hear you.
+      </p>
+      {props.devices.length > 1 && (
+        <DeviceMenu
+          {...props}
+          trigger={
+            <Button
+              size="sm"
+              variant="outline"
+              className="h-6 border-warning/40 px-2 text-[11px]"
+            >
+              Pick another mic
+            </Button>
+          }
+        />
+      )}
+    </div>
+  )
+}

--- a/frontend/hooks/use-retell-call.ts
+++ b/frontend/hooks/use-retell-call.ts
@@ -14,6 +14,7 @@
 
 import { useCallback, useEffect, useRef, useState, type MutableRefObject } from 'react'
 import { apiClient } from '@/lib/api-client'
+import { feedMicLevel, initialMicHealth } from '@/lib/voice/mic-health'
 import {
   ORB_STATE_LABELS,
   OrbSnapshot,
@@ -34,6 +35,11 @@ export interface CaptionLine {
   text: string
 }
 
+export interface MicInputDevice {
+  deviceId: string
+  label: string
+}
+
 export interface UseRetellCallReturn {
   orbState: OrbState
   stateLabel: string
@@ -46,6 +52,11 @@ export interface UseRetellCallReturn {
   refusal: string | null
   error: string | null
   isLive: boolean
+  /** True once the capture has delivered a full window of digital silence
+   * while unmuted — the mic is bound to a device that hears nothing. */
+  micSilent: boolean
+  /** Audio inputs the browser offers (labelled once permission exists). */
+  inputDevices: MicInputDevice[]
   start: () => Promise<void>
   stop: () => void
   toggleMute: () => void
@@ -55,6 +66,10 @@ interface UseRetellCallOptions {
   /** Bind the call to this on-screen thread (omit when the chat has no server row yet). */
   chatId?: string | null
   agentId?: number | null
+  /** Send the call's uplink from this capture device (default mic when null).
+   * The classic silent-call cause is the default binding to a continuity
+   * iPhone or a virtual/recorder device that delivers flat zeros. */
+  captureDeviceId?: string | null
   /** Fires with the call's thread id (server-created when none was bound) —
    * the chat screen points itself at it so voice and text are ONE
    * conversation, visible while speaking. */
@@ -68,6 +83,7 @@ interface UseRetellCallOptions {
 export function useRetellCall({
   chatId,
   agentId,
+  captureDeviceId,
   onChatId,
   onLiveTurn,
 }: UseRetellCallOptions): UseRetellCallReturn {
@@ -80,6 +96,8 @@ export function useRetellCall({
   const [muted, setMuted] = useState(false)
   const [refusal, setRefusal] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const [micSilent, setMicSilentState] = useState(false)
+  const [inputDevices, setInputDevices] = useState<MicInputDevice[]>([])
 
   const levelsRef = useRef<VoiceLevels>({ agent: 0, user: 0 })
   const clientRef = useRef<any>(null)
@@ -89,6 +107,21 @@ export function useRetellCall({
   const durationTimerRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const tickTimerRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const startedAtRef = useRef(0)
+  const micHealthRef = useRef(initialMicHealth(0))
+  const micSilentRef = useRef(false)
+  const mutedRef = useRef(false)
+
+  // The 60ms analyser tick may not re-render per sample — flip state only on
+  // actual transitions.
+  const setMicSilent = useCallback((value: boolean) => {
+    if (micSilentRef.current === value) return
+    micSilentRef.current = value
+    setMicSilentState(value)
+  }, [])
+
+  useEffect(() => {
+    mutedRef.current = muted
+  }, [muted])
 
   const dispatch = useCallback((event: Parameters<typeof orbReducer>[1]) => {
     setSnap((prev) => orbReducer(prev, event))
@@ -114,7 +147,33 @@ export function useRetellCall({
     }
     clientRef.current = null
     levelsRef.current = { agent: 0, user: 0 }
+    micHealthRef.current = initialMicHealth(0)
+    setMicSilent(false)
+  }, [setMicSilent])
+
+  /** Audio inputs, labelled once a permission grant exists. Listing is a
+   * nicety — the call works without it, so failures stay quiet. */
+  const refreshDevices = useCallback(async () => {
+    if (typeof navigator === 'undefined' || !navigator.mediaDevices?.enumerateDevices) return
+    try {
+      const all = await navigator.mediaDevices.enumerateDevices()
+      setInputDevices(
+        all
+          .filter((d) => d.kind === 'audioinput' && d.deviceId)
+          .map((d, i) => ({ deviceId: d.deviceId, label: d.label || `Microphone ${i + 1}` }))
+      )
+    } catch {
+      // keep whatever list we had
+    }
   }, [])
+
+  useEffect(() => {
+    const media = typeof navigator !== 'undefined' ? navigator.mediaDevices : undefined
+    if (!media?.addEventListener) return
+    const onChange = () => void refreshDevices()
+    media.addEventListener('devicechange', onChange)
+    return () => media.removeEventListener('devicechange', onChange)
+  }, [refreshDevices])
 
   const stop = useCallback(() => {
     teardown()
@@ -232,6 +291,9 @@ export function useRetellCall({
       await client.startCall({
         accessToken: minted.access_token,
         emitRawAudioSamples: true,
+        // Explicit capture binding: the default device is exactly what fails
+        // silently (continuity iPhone, virtual/recorder inputs).
+        ...(captureDeviceId ? { captureDeviceId } : {}),
       })
     } catch (err: any) {
       const message = String(err?.message || err || '')
@@ -245,10 +307,21 @@ export function useRetellCall({
       return
     }
 
-    // 3 — the user's side of the orb: a local analyser tap (viz only; the SDK
-    // owns the mic track it sends).
+    // 3 — the user's side of the orb + the mic-health meter: a local analyser
+    // tap on the SAME device the SDK captures (viz + honesty; the SDK owns
+    // the track it actually sends).
     try {
-      const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
+      let stream: MediaStream
+      try {
+        stream = await navigator.mediaDevices.getUserMedia(
+          captureDeviceId
+            ? { audio: { deviceId: { exact: captureDeviceId } } }
+            : { audio: true }
+        )
+      } catch {
+        // The picked device vanished — meter the default rather than nothing.
+        stream = await navigator.mediaDevices.getUserMedia({ audio: true })
+      }
       micStreamRef.current = stream
       const ctx = new AudioContext()
       audioCtxRef.current = ctx
@@ -256,6 +329,7 @@ export function useRetellCall({
       analyser.fftSize = 512
       ctx.createMediaStreamSource(stream).connect(analyser)
       const buf = new Float32Array(analyser.fftSize)
+      micHealthRef.current = initialMicHealth(Date.now())
       analyserTimerRef.current = setInterval(() => {
         analyser.getFloatTimeDomainData(buf)
         const level = rmsLevel(buf)
@@ -263,12 +337,25 @@ export function useRetellCall({
         if (level >= USER_SPEECH_THRESHOLD) {
           dispatch({ type: 'user_voice', now: Date.now() })
         }
+        // Mic health: muted silence is intentional — keep the window fresh;
+        // unmuted digital silence for a full window raises the banner.
+        if (mutedRef.current) {
+          micHealthRef.current = initialMicHealth(Date.now())
+          setMicSilent(false)
+        } else {
+          const next = feedMicLevel(micHealthRef.current, level, Date.now())
+          micHealthRef.current = next
+          setMicSilent(next.silent)
+        }
       }, 60)
     } catch {
       // No analyser is cosmetic-only: the call still works, the orb just
-      // won't react to the user's voice.
+      // won't react to the user's voice (and mic health stays unknown).
     }
-  }, [agentId, chatId, onChatId, dispatch, stop, teardown])
+
+    // Permission now exists → device labels are real.
+    void refreshDevices()
+  }, [agentId, chatId, captureDeviceId, onChatId, dispatch, stop, teardown, setMicSilent, refreshDevices])
 
   useEffect(() => () => teardown(), [teardown])
 
@@ -282,6 +369,8 @@ export function useRetellCall({
     refusal,
     error,
     isLive: snap.state === 'listening' || snap.state === 'thinking' || snap.state === 'speaking',
+    micSilent,
+    inputDevices,
     start,
     stop,
     toggleMute,

--- a/frontend/lib/voice/mic-health.ts
+++ b/frontend/lib/voice/mic-health.ts
@@ -1,0 +1,47 @@
+/**
+ * PRD-207 — mic-health: is the capture actually delivering signal?
+ *
+ * A live microphone always shows a noise floor comfortably above digital
+ * silence; a capture bound to a dead or virtual device (a continuity iPhone
+ * that never picked up, a recorder extension's loopback, an unplugged USB
+ * mic) delivers flat zeros while the UI says "Mic live". First armed
+ * morning three of five calls streamed exactly that — Retell's ASR received
+ * no audio and the call sat "recording" with nothing to transcribe.
+ *
+ * Pure + immutable (explicit `now`, no Date.now inside) so the detector is
+ * unit-testable, the orb-state discipline.
+ */
+
+export interface MicHealth {
+  /** Start of the current observation window (ms). */
+  windowStartAt: number
+  /** Loudest RMS level seen inside the current window. */
+  peak: number
+  /** True once a full window stayed at digital silence. */
+  silent: boolean
+}
+
+/** Peak RMS below this across a full window = the capture is delivering silence. */
+export const MIC_SILENT_PEAK = 0.004
+/** How long the capture must stay flat before we call it silent. */
+export const MIC_SILENT_AFTER_MS = 3000
+
+export function initialMicHealth(now: number): MicHealth {
+  return { windowStartAt: now, peak: 0, silent: false }
+}
+
+/**
+ * Fold one analyser reading in. Any real signal clears `silent` instantly
+ * (a recovering mic must never keep wearing the banner); a full window of
+ * near-zero peaks raises it and keeps it raised window over window.
+ */
+export function feedMicLevel(prev: MicHealth, level: number, now: number): MicHealth {
+  if (level >= MIC_SILENT_PEAK) {
+    return { windowStartAt: now, peak: level, silent: false }
+  }
+  const peak = Math.max(prev.peak, level)
+  if (now - prev.windowStartAt >= MIC_SILENT_AFTER_MS) {
+    return { windowStartAt: now, peak: 0, silent: true }
+  }
+  return { windowStartAt: prev.windowStartAt, peak, silent: prev.silent }
+}

--- a/orchestrator/api/voice_retell.py
+++ b/orchestrator/api/voice_retell.py
@@ -178,12 +178,32 @@ async def mint_web_call(
             raise HTTPException(status_code=403, detail="You can only bind a live call to your own chat")
         bound_chat_id = str(chat_uuid)
     else:
+        # Welcome-screen mint (no thread on screen): CONTINUE the caller's one
+        # voice conversation — reuse their existing voice thread if it exists,
+        # else create it. Without the find, every welcome-screen call spun up a
+        # brand-new "Voice call —" thread, fragmenting the conversation (#585 —
+        # the ONE-voice-thread contract; unique_user_title made a fixed title
+        # 500 on the second call, so the thread is timestamped and found by
+        # prefix rather than by a colliding constant title).
         from modules.voice.call_binding import create_voice_chat
 
-        chat = create_voice_chat(
-            db, user_id=int(user_int_id), workspace_id=ctx.workspace_id
+        existing = (
+            db.query(Chat)
+            .filter(
+                Chat.user_id == int(user_int_id),
+                Chat.workspace_id == ctx.workspace_id,
+                Chat.title.like("Voice call%"),
+            )
+            .order_by(Chat.created_at.desc())
+            .first()
         )
-        bound_chat_id = str(chat.id)
+        if existing is not None:
+            bound_chat_id = str(existing.id)
+        else:
+            chat = create_voice_chat(
+                db, user_id=int(user_int_id), workspace_id=ctx.workspace_id
+            )
+            bound_chat_id = str(chat.id)
 
     dynamic_vars = {
         "workspace_id": str(ctx.workspace_id),

--- a/orchestrator/api/voice_retell.py
+++ b/orchestrator/api/voice_retell.py
@@ -22,8 +22,10 @@ is a cross-repo automatos-voice coordination (§8-Qd/Qe), NOT done here.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
+import threading
 import uuid
 from typing import Any, AsyncIterator, Optional
 
@@ -463,7 +465,99 @@ async def arm_voice_live(
     return {"armed": True, "platform_enabled": True, "agent_id": agent_id}
 
 
+# The worker loop gets this long after a turn settles to run its finallys
+# (closing the inner generator, its sessions) before the loop is stopped.
+_WORKER_STOP_GRACE_SECONDS = 2.0
+# On socket exit, an in-flight turn gets this long to finish in the
+# foreground; past it the turn keeps running detached (shielded) so the
+# reply still persists to the thread.
+_TURN_EXIT_GRACE_SECONDS = 3.0
+# A cross-thread frame hand-off that cannot land this long means the caller
+# stopped draining (dead socket, cancelled turn) — the pump gives up.
+_BRIDGE_PUT_TIMEOUT_SECONDS = 10.0
+_STREAM_DONE = object()
+_STREAM_ERROR = object()
+
+
 async def _agent_retell_stream(req: RetellLLMRequest) -> AsyncIterator[dict[str, Any]]:
+    """Frames for one turn, generated on a DEDICATED thread + event loop.
+
+    The agent loop inside ``_agent_retell_stream_inner`` performs synchronous
+    I/O (ORM reads, memory retrieval, embedding and model-gateway calls). Run
+    on the WS event loop those blocks freeze it — and a frozen loop stops
+    echoing Retell's 2s ``ping_pong``, which severs the socket after ~5s of
+    pong silence (their keepalive contract, up to 2 auto-reconnects). First
+    armed morning: every brained turn died code=1006 ~8s after
+    ``response_required`` with frames=0 — the reply was killed mid-generation
+    by our own starved loop. Isolating the brain on a worker loop keeps THIS
+    loop answering pings no matter what the turn is doing.
+
+    Frames hop back through a bounded queue; closing this generator cancels
+    the worker task, whose own ``finally`` closes the inner generator
+    (sessions and all). The worker thread is daemonic and bounded by the put
+    timeout, so an abandoned turn can never pin the process.
+    """
+    caller_loop = asyncio.get_running_loop()
+    frames: asyncio.Queue = asyncio.Queue(maxsize=8)
+    worker_loop = asyncio.new_event_loop()
+
+    def _worker_main() -> None:
+        try:
+            worker_loop.run_forever()
+        finally:
+            with contextlib.suppress(Exception):
+                worker_loop.close()
+
+    worker = threading.Thread(
+        target=_worker_main,
+        name=f"voice-turn-{(req.call_id or 'call')[-8:]}-{req.response_id}",
+        daemon=True,
+    )
+    worker.start()
+
+    async def pump() -> None:
+        inner = _agent_retell_stream_inner(req)
+        try:
+            async for frame in inner:
+                asyncio.run_coroutine_threadsafe(frames.put(frame), caller_loop).result(
+                    timeout=_BRIDGE_PUT_TIMEOUT_SECONDS
+                )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # noqa: BLE001 — re-raised on the caller loop
+            with contextlib.suppress(Exception):
+                asyncio.run_coroutine_threadsafe(
+                    frames.put((_STREAM_ERROR, exc)), caller_loop
+                ).result(timeout=_BRIDGE_PUT_TIMEOUT_SECONDS)
+            return
+        finally:
+            with contextlib.suppress(BaseException):
+                await inner.aclose()
+        with contextlib.suppress(Exception):
+            asyncio.run_coroutine_threadsafe(frames.put(_STREAM_DONE), caller_loop).result(
+                timeout=_BRIDGE_PUT_TIMEOUT_SECONDS
+            )
+
+    turn = asyncio.run_coroutine_threadsafe(pump(), worker_loop)
+    try:
+        while True:
+            item = await frames.get()
+            if item is _STREAM_DONE:
+                break
+            if isinstance(item, tuple) and len(item) == 2 and item[0] is _STREAM_ERROR:
+                raise item[1]
+            yield item
+    finally:
+        # Normal end, aclose() or caller cancellation all land here: cancel
+        # the worker task (propagates into the inner generator's finally) and
+        # stop the worker loop once those finallys have had their grace.
+        turn.cancel()
+        worker_loop.call_soon_threadsafe(
+            worker_loop.call_later, _WORKER_STOP_GRACE_SECONDS, worker_loop.stop
+        )
+
+
+async def _agent_retell_stream_inner(req: RetellLLMRequest) -> AsyncIterator[dict[str, Any]]:
     """Drive Auto's agent loop for one Retell turn and yield Retell frames.
 
     PRD-207 S2 rewired this onto the mint-row trust boundary
@@ -657,11 +751,55 @@ async def retell_llm_websocket(websocket: WebSocket, call_id: str) -> None:
             return False
 
     async def respond(req: RetellLLMRequest) -> None:
+        from time import monotonic
+
+        started = monotonic()
+        first_frame_at: Optional[float] = None
+        sendable = True
+
+        # Slow-turn honesty: if the brain has said NOTHING by the deadline,
+        # speak a short acknowledgment — the caller hears life (and the log
+        # gains the smoking gun) instead of dead air while tools run.
+        ack_task: asyncio.Task | None = None
+        ack_seconds = float(config.VOICE_LIVE_FIRST_FRAME_ACK_SECONDS or 0)
+        ack_text = str(config.VOICE_LIVE_FIRST_FRAME_ACK_TEXT or "").strip()
+        if ack_seconds > 0:
+            async def _slow_turn_ack() -> None:
+                await asyncio.sleep(ack_seconds)
+                logger.warning(
+                    "voice_live_ws_turn_slow call=%s rid=%s waited_ms=%d",
+                    call_id, req.response_id, int((monotonic() - started) * 1000),
+                )
+                if ack_text:
+                    await safe_send(
+                        wrap_ws_response(
+                            {
+                                "response_id": req.response_id,
+                                "content": ack_text + " ",
+                                "content_complete": False,
+                            }
+                        )
+                    )
+
+            ack_task = asyncio.create_task(_slow_turn_ack())
+
         try:
             async for frame in _agent_retell_stream(req):
+                if first_frame_at is None:
+                    first_frame_at = monotonic()
+                    if ack_task is not None:
+                        ack_task.cancel()
+                    logger.info(
+                        "voice_live_ws_first_frame call=%s rid=%s ms=%d",
+                        call_id, req.response_id, int((first_frame_at - started) * 1000),
+                    )
                 stats["frames"] += 1
-                if not await safe_send(wrap_ws_response(frame)):
-                    return
+                if sendable and not await safe_send(wrap_ws_response(frame)):
+                    # The socket died mid-reply (Retell reconnects live calls).
+                    # Keep DRAINING: the streaming service persists the reply at
+                    # stream end, so the words still land in the thread and the
+                    # open chat hears them over SSE — only the TTS leg is lost.
+                    sendable = False
         except asyncio.CancelledError:
             # Superseded turn (barge-in): Retell has moved on — stop quietly.
             raise
@@ -672,6 +810,9 @@ async def retell_llm_websocket(websocket: WebSocket, call_id: str) -> None:
                     {"response_id": req.response_id, "content": "", "content_complete": True}
                 )
             )
+        finally:
+            if ack_task is not None and not ack_task.done():
+                ack_task.cancel()
 
     try:
         # Handshake per Retell's own demo: config first (asks for
@@ -732,8 +873,14 @@ async def retell_llm_websocket(websocket: WebSocket, call_id: str) -> None:
             "voice_live_ws_died call=%s err=%s", call_id, type(exc).__name__, exc_info=True
         )
     finally:
+        # The socket is gone but the brain may be mid-reply. Do NOT cancel it:
+        # give it a bounded grace to finish (the reply persists to the thread
+        # and reaches the open chat over SSE); past the grace the shield lets
+        # it run detached to the same end. Killing it here was how a severed
+        # socket turned a healthy generation into silence.
         if speaking is not None and not speaking.done():
-            speaking.cancel()
+            with contextlib.suppress(Exception):
+                await asyncio.wait_for(asyncio.shield(speaking), _TURN_EXIT_GRACE_SECONDS)
         logger.info(
             "voice_live_ws_summary call=%s turns=%s frames=%s pings=%s updates=%s begun=%s",
             call_id, stats["turns"], stats["frames"], stats["pings"], stats["updates"], begun,

--- a/orchestrator/config.py
+++ b/orchestrator/config.py
@@ -1296,9 +1296,10 @@ class Config:
     # The public host Retell must reach for the custom-LLM socket + events
     # webhook (one-click arming builds the URLs from it). Railway injects
     # RAILWAY_PUBLIC_DOMAIN; override with PUBLIC_API_HOST where that's absent.
-    PUBLIC_API_HOST: str = os.getenv(
-        "PUBLIC_API_HOST", os.getenv("RAILWAY_PUBLIC_DOMAIN", "api.automatos.app")
-    )
+    PUBLIC_API_HOST: str = (
+        os.getenv("PUBLIC_API_HOST", os.getenv("RAILWAY_PUBLIC_DOMAIN", "api.automatos.app"))
+        or "api.automatos.app"
+    ).strip().rstrip("/")
 
     def validate_security(self) -> None:
         """PRD-172: fail-closed validation of tenant-isolation secrets.

--- a/orchestrator/config.py
+++ b/orchestrator/config.py
@@ -1282,6 +1282,17 @@ class Config:
     VOICE_LIVE_TURN_HISTORY_MESSAGES: int = int(
         os.getenv("VOICE_LIVE_TURN_HISTORY_MESSAGES", "12")
     )
+    # If the brain has produced NO first frame this many seconds into a turn,
+    # speak a short honest acknowledgment so the caller hears life instead of
+    # dead air (0 disables the watchdog; empty text keeps the log but says
+    # nothing). Retell severs a socket after ~5s without its ping_pong echoed,
+    # so silence here used to read as a hang even when the turn was healthy.
+    VOICE_LIVE_FIRST_FRAME_ACK_SECONDS: float = float(
+        os.getenv("VOICE_LIVE_FIRST_FRAME_ACK_SECONDS", "2.5")
+    )
+    VOICE_LIVE_FIRST_FRAME_ACK_TEXT: str = os.getenv(
+        "VOICE_LIVE_FIRST_FRAME_ACK_TEXT", "One moment."
+    )
     # The public host Retell must reach for the custom-LLM socket + events
     # webhook (one-click arming builds the URLs from it). Railway injects
     # RAILWAY_PUBLIC_DOMAIN; override with PUBLIC_API_HOST where that's absent.

--- a/orchestrator/modules/voice/call_binding.py
+++ b/orchestrator/modules/voice/call_binding.py
@@ -52,6 +52,17 @@ def voice_source(role: str) -> Dict[str, Any]:
     }
 
 
+# Trailing characters Retell's interim transcripts churn as a sentence grows —
+# stripped before the grow-aware prefix compare so "…chat?" still matches
+# "…chat, or is it mixed?".
+_UTTERANCE_TRAILING = " \t\r\n.?!,;:…—–-"
+
+
+def _utterance_stem(s: str) -> str:
+    """One utterance's comparable stem: trailing punctuation/whitespace off."""
+    return (s or "").rstrip(_UTTERANCE_TRAILING)
+
+
 @dataclass(frozen=True)
 class CallBinding:
     chat_id: str  # the thread this turn writes into
@@ -299,7 +310,13 @@ def upsert_voice_user_message(db: Session, *, chat_id: str, workspace_id: str, t
             if isinstance(part, dict) and part.get("type") == "text":
                 old = str(part.get("text") or "")
                 break
-        if old and (text.startswith(old) or old.startswith(text)):
+        # Retell's interim transcripts drift in TRAILING punctuation as the
+        # sentence continues ("…voice chat?" → "…voice chat, or is it mixed?"),
+        # so the strict prefix check missed every punctuation-terminated
+        # interim and stacked it as a new message. Compare on the stem (trailing
+        # punctuation/whitespace stripped); keep the longer ORIGINAL text.
+        stem_old, stem_new = _utterance_stem(old), _utterance_stem(text)
+        if stem_old and (stem_new.startswith(stem_old) or stem_old.startswith(stem_new)):
             longer = text if len(text) >= len(old) else old
             last.parts = [{"type": "text", "text": longer}]  # rebuild, never mutate
             db.commit()

--- a/orchestrator/tests/authz_sweep_probe.py
+++ b/orchestrator/tests/authz_sweep_probe.py
@@ -86,9 +86,13 @@ def main() -> None:
                         # api/gdpr.py's hand-rolled gate — PRD-196 S7 owns its
                         # consolidation; classified, not touched (PRD-195).
                         or "_require_workspace_admin(ctx)" in src
+                        # PRD-207 voice/arm: platform-admin gate in the handler.
+                        or "_is_platform_admin(ctx)" in src
                     ),
                     "own_gate_in_handler": (
                         "Admin access required to resolve credentials" in src
+                        # PRD-207 voice/web-call: the mint's own signed-in-user gate.
+                        or "Live voice requires a signed-in user" in src
                     ),
                 }
             )

--- a/orchestrator/tests/test_p2w2_authz_boundary_sweep.py
+++ b/orchestrator/tests/test_p2w2_authz_boundary_sweep.py
@@ -140,6 +140,9 @@ ADMIN_GATED_IN_HANDLER = {
     # admin-in-handler) — removed from this set so they classify exactly once.
     ("PUT", "/api/widget-marketplace/widgets/{widget_id}/approve"),
     ("PUT", "/api/widget-marketplace/widgets/{widget_id}/suspend"),
+    # PRD-207 S7: one-click arming — platform-admin gate in the handler body
+    # (`_is_platform_admin(ctx)` → 403), not a shared dependency.
+    ("POST", "/api/voice/arm"),
 }
 
 # (g) Own explicit in-handler gate.
@@ -147,6 +150,10 @@ OWN_GATE_IN_HANDLER = {
     # Returns DECRYPTED secrets: admin / env-API-key only, gated in the
     # handler; the NULL-workspace BOLA on its lookups is S7's fix.
     ("POST", "/api/credentials/resolve"),
+    # PRD-207 S1: the voice mint gates in the handler body — platform toggle,
+    # armed creds, workspace toggle, cap, and a strict signed-in-user resolve
+    # (403 "Live voice requires a signed-in user"); not a shared dependency.
+    ("POST", "/api/voice/web-call"),
 }
 
 # The agent-tool RBAC fossil (api/permissions.py, vocabulary #5) — unmounted

--- a/orchestrator/tests/test_prd207_voice_live.py
+++ b/orchestrator/tests/test_prd207_voice_live.py
@@ -1556,3 +1556,228 @@ def test_assistant_stamp_bounded_to_turn_window(voice_workspace, new_session):
     }
     assert rows[old] is None  # the pre-turn text reply keeps no voice badge
     assert rows[fresh] == {"origin": "voice", "label": "Auto · voice"}
+
+
+# ---------------------------------------------------------------------------
+# S2 · WS liveness — the brain must never starve the socket's event loop
+# (first armed morning: sync I/O inside the turn froze the loop, Retell's 2s
+# ping_pong went unanswered ~5s, the socket died 1006 mid-generation with
+# frames=0 — every brained turn was killed by our own starved loop).
+# ---------------------------------------------------------------------------
+
+class _TailWaitWebSocket(_FakeWebSocket):
+    """Keeps the socket open briefly after the script drains so in-flight
+    respond()/watchdog tasks land their sends before the disconnect."""
+
+    def __init__(self, incoming, tail_wait: float):
+        super().__init__(incoming)
+        self.tail_wait = tail_wait
+
+    async def receive_json(self):
+        from fastapi import WebSocketDisconnect
+
+        await asyncio.sleep(0)
+        if not self.incoming:
+            await asyncio.sleep(self.tail_wait)
+            raise WebSocketDisconnect(1000)
+        return self.incoming.pop(0)
+
+
+class _DyingWebSocket(_FakeWebSocket):
+    """send_json severs once the turn has sent `fail_after` response frames."""
+
+    def __init__(self, incoming, fail_after: int):
+        super().__init__(incoming)
+        self.fail_after = fail_after
+        self._turn_sends = 0
+
+    async def send_json(self, data):
+        if data.get("response_type") == "response" and data.get("response_id") == 1:
+            self._turn_sends += 1
+            if self._turn_sends > self.fail_after:
+                raise RuntimeError("socket severed")
+        self.sent.append(data)
+
+
+def _turn_msg(rid: int, text: str = "hey auto") -> dict:
+    return {
+        "interaction_type": "response_required",
+        "response_id": rid,
+        "transcript": [{"role": "user", "content": text}],
+    }
+
+
+_CALL_DETAILS_MSG = {
+    "interaction_type": "call_details",
+    "call": {"retell_llm_dynamic_variables": {"workspace_id": "ws-9"}},
+}
+
+
+def test_stream_bridge_isolates_the_brain_on_a_worker_thread(monkeypatch):
+    """The REAL _agent_retell_stream runs the turn on a dedicated thread —
+    the WS loop stays free to echo Retell's pings while tools grind."""
+    import threading as _threading
+
+    import api.voice_retell as vr
+    from modules.voice.providers.retell import RetellLLMRequest
+
+    seen = {}
+
+    async def fake_inner(req):
+        seen["thread"] = _threading.get_ident()
+        yield {"response_id": req.response_id, "content": "hi", "content_complete": False}
+        yield {"response_id": req.response_id, "content": "", "content_complete": True}
+
+    monkeypatch.setattr(vr, "_agent_retell_stream_inner", fake_inner)
+    req = RetellLLMRequest(
+        response_id=1, user_text="hey", interaction_type="response_required",
+        workspace_id="ws-9", agent_id=None, call_id="call_bridge1",
+    )
+
+    async def run():
+        return [f async for f in vr._agent_retell_stream(req)]
+
+    frames = asyncio.run(run())
+    assert [f["content"] for f in frames] == ["hi", ""]
+    assert seen["thread"] != _threading.get_ident()  # off the caller's thread
+
+
+def test_stream_bridge_propagates_inner_errors(monkeypatch):
+    import api.voice_retell as vr
+    from modules.voice.providers.retell import RetellLLMRequest
+
+    async def fake_inner(req):
+        yield {"response_id": 1, "content": "a", "content_complete": False}
+        raise RuntimeError("brain fault")
+
+    monkeypatch.setattr(vr, "_agent_retell_stream_inner", fake_inner)
+    req = RetellLLMRequest(
+        response_id=1, user_text="hey", interaction_type="response_required",
+        workspace_id="ws-9", agent_id=None, call_id="call_bridge2",
+    )
+
+    async def run():
+        return [f async for f in vr._agent_retell_stream(req)]
+
+    with pytest.raises(RuntimeError, match="brain fault"):
+        asyncio.run(run())
+
+
+def test_stream_bridge_close_cancels_the_inner_turn(monkeypatch):
+    """Closing the bridge (barge-in cancel) reaches the worker: the inner
+    generator's finally runs, so sessions and telemetry never leak."""
+    import threading as _threading
+
+    import api.voice_retell as vr
+    from modules.voice.providers.retell import RetellLLMRequest
+
+    inner_finally = _threading.Event()
+
+    async def fake_inner(req):
+        try:
+            yield {"response_id": 1, "content": "first", "content_complete": False}
+            await asyncio.Event().wait()  # parks until cancelled
+        finally:
+            inner_finally.set()
+
+    monkeypatch.setattr(vr, "_agent_retell_stream_inner", fake_inner)
+    req = RetellLLMRequest(
+        response_id=1, user_text="hey", interaction_type="response_required",
+        workspace_id="ws-9", agent_id=None, call_id="call_bridge3",
+    )
+
+    async def run():
+        agen = vr._agent_retell_stream(req)
+        first = await agen.__anext__()
+        await agen.aclose()
+        return first
+
+    first = asyncio.run(run())
+    assert first["content"] == "first"
+    assert inner_finally.wait(timeout=3.0)
+
+
+def test_ws_slow_first_frame_speaks_an_honest_ack(monkeypatch):
+    """No first frame by the deadline → ONE short spoken acknowledgment
+    (content_complete=False, same rid) — then the real answer streams."""
+    import api.voice_retell as vr
+    from config import config as app_config
+
+    monkeypatch.setattr(vr.live_settings, "voice_live_enabled", lambda: True)
+    monkeypatch.setattr(vr, "get_db_session", _ws_db(minted=True))
+    monkeypatch.setattr(app_config, "VOICE_LIVE_FIRST_FRAME_ACK_SECONDS", 0.05)
+    monkeypatch.setattr(app_config, "VOICE_LIVE_FIRST_FRAME_ACK_TEXT", "One moment.")
+
+    async def slow_stream(req):
+        await asyncio.sleep(0.25)
+        yield {"response_id": req.response_id, "content": "the answer", "content_complete": True}
+
+    monkeypatch.setattr(vr, "_agent_retell_stream", slow_stream)
+
+    ws = _TailWaitWebSocket([_CALL_DETAILS_MSG, _turn_msg(1)], tail_wait=0.6)
+    asyncio.run(vr.retell_llm_websocket(ws, "call_slow"))
+
+    turn_frames = [
+        m for m in ws.sent
+        if m.get("response_type") == "response" and m.get("response_id") == 1
+    ]
+    assert turn_frames, "the turn sent nothing at all"
+    assert turn_frames[0]["content"].startswith("One moment.")
+    assert turn_frames[0]["content_complete"] is False
+    assert any(m.get("content") == "the answer" for m in turn_frames)
+    acks = [m for m in turn_frames if "One moment." in str(m.get("content"))]
+    assert len(acks) == 1  # the watchdog speaks once, never nags
+
+
+def test_ws_fast_turn_sends_no_ack(monkeypatch):
+    import api.voice_retell as vr
+    from config import config as app_config
+
+    monkeypatch.setattr(vr.live_settings, "voice_live_enabled", lambda: True)
+    monkeypatch.setattr(vr, "get_db_session", _ws_db(minted=True))
+    monkeypatch.setattr(app_config, "VOICE_LIVE_FIRST_FRAME_ACK_SECONDS", 0.3)
+    monkeypatch.setattr(app_config, "VOICE_LIVE_FIRST_FRAME_ACK_TEXT", "One moment.")
+
+    async def fast_stream(req):
+        yield {"response_id": req.response_id, "content": "instant", "content_complete": True}
+
+    monkeypatch.setattr(vr, "_agent_retell_stream", fast_stream)
+
+    ws = _TailWaitWebSocket([_CALL_DETAILS_MSG, _turn_msg(1)], tail_wait=0.05)
+    asyncio.run(vr.retell_llm_websocket(ws, "call_fast_noack"))
+
+    assert not any("One moment." in str(m.get("content")) for m in ws.sent)
+    assert any(m.get("content") == "instant" for m in ws.sent)
+
+
+def test_ws_dead_socket_mid_turn_still_drains_the_brain(monkeypatch):
+    """A severed socket mid-reply must NOT kill the generation: the turn
+    drains to its natural end (the streaming service persists the reply into
+    the thread; only the TTS leg is lost) and later frames are simply not
+    sent."""
+    import api.voice_retell as vr
+    from config import config as app_config
+
+    monkeypatch.setattr(vr.live_settings, "voice_live_enabled", lambda: True)
+    monkeypatch.setattr(vr, "get_db_session", _ws_db(minted=True))
+    monkeypatch.setattr(app_config, "VOICE_LIVE_FIRST_FRAME_ACK_SECONDS", 0)
+
+    drained = []
+
+    async def stream(req):
+        yield {"response_id": 1, "content": "a", "content_complete": False}
+        yield {"response_id": 1, "content": "b", "content_complete": False}
+        yield {"response_id": 1, "content": "", "content_complete": True}
+        drained.append(True)  # reached ONLY if the async-for pulled past every frame
+
+    monkeypatch.setattr(vr, "_agent_retell_stream", stream)
+
+    ws = _DyingWebSocket([_CALL_DETAILS_MSG, _turn_msg(1)], fail_after=1)
+    asyncio.run(vr.retell_llm_websocket(ws, "call_severed"))
+
+    assert drained == [True]
+    turn_frames = [
+        m for m in ws.sent
+        if m.get("response_type") == "response" and m.get("response_id") == 1
+    ]
+    assert [m["content"] for m in turn_frames] == ["a"]  # sends stopped, drain did not

--- a/orchestrator/tests/test_prd207_voice_live.py
+++ b/orchestrator/tests/test_prd207_voice_live.py
@@ -281,7 +281,10 @@ def _mint_db(workspace=None, chat="unqueried"):
         if model_arg is WorkspaceModel:
             q.filter.return_value.first.return_value = workspace
         elif model_arg is ChatModel:
-            q.filter.return_value.first.return_value = None if chat == "unqueried" else chat
+            result = None if chat == "unqueried" else chat
+            q.filter.return_value.first.return_value = result
+            # The welcome-path find-or-create queries .filter(...).order_by(...).first()
+            q.filter.return_value.order_by.return_value.first.return_value = result
         else:
             q.filter.return_value.first.return_value = None
         return q
@@ -749,10 +752,12 @@ def voice_workspace(engine, new_session):
         {"ws": ws_id, "u": uids[0]},
     )
     chat_id = str(uuid.uuid4())
+    # chats.visibility is NOT NULL with a Python-side default only (no
+    # server_default, unlike chats.kind) — a raw INSERT must set it explicitly.
     s.execute(
         text(
-            "INSERT INTO chats (id, user_id, workspace_id, title) "
-            "VALUES (CAST(:id AS uuid), :u, CAST(:ws AS uuid), 'my thread')"
+            "INSERT INTO chats (id, user_id, workspace_id, title, visibility) "
+            "VALUES (CAST(:id AS uuid), :u, CAST(:ws AS uuid), 'my thread', 'private')"
         ),
         {"id": chat_id, "u": uids[0], "ws": ws_id},
     )
@@ -936,6 +941,11 @@ def _admin_ctx():
 def _arm_env(monkeypatch, *, creds, workspace=None):
     """Wire the arm endpoint's collaborators to recorders."""
     import api.voice_retell as vr
+
+    # The endpoint calls SQLAlchemy's flag_modified to track the in-place JSONB
+    # settings mutation; the fake workspace is a SimpleNamespace (no ORM state),
+    # so neutralise that plumbing call — the test asserts the settings dict.
+    monkeypatch.setattr("sqlalchemy.orm.attributes.flag_modified", lambda *a, **k: None)
 
     written = {}
     monkeypatch.setattr(
@@ -1440,8 +1450,13 @@ def test_voice_live_put_refuses_malformed_with_honest_reason():
     assert ws.settings["voice_live"]["enabled"] is False  # nothing written
 
 
-def test_voice_live_put_merges_not_replaces():
+def test_voice_live_put_merges_not_replaces(monkeypatch):
     from api.workspaces import save_voice_live_settings
+
+    # flag_modified is SQLAlchemy plumbing for the in-place JSONB mutation;
+    # the fake workspace has no ORM state, so neutralise it — the test asserts
+    # the merged settings dict, not the change-tracking call.
+    monkeypatch.setattr("sqlalchemy.orm.attributes.flag_modified", lambda *a, **k: None)
 
     ws = SimpleNamespace(
         id=uuid.uuid4(), settings={"voice_live": {"enabled": True, "retell_voice_id": "keep"}}


### PR DESCRIPTION
## The morning's two faults, from telemetry (10:44–11:08 UTC)

**Fault B — Auto never answers even when the mic works (server, fixed here).**
Retell's keepalive contract: ping every 2s, **5s without an echo → they sever + reconnect (≤2×)**. Our brain turn runs synchronous I/O (ORM, memory retrieval, embeddings, model gateways) on the WS event loop — the loop froze the moment a turn started, pongs stopped, and Retell killed the socket. The logs show it twice on one call, surgically:

```
10:58:55 voice_live_ws_turn  call=…306ea…34f rid=1        ← you spoke, ASR heard you
10:59:03 voice_live_ws_closed code=1006                    ← +7.9s, frames=0
11:01:04 voice_live_ws_turn  call=…306ea…34f rid=2        ← reconnect, you spoke again
11:01:12 voice_live_ws_closed code=1006                    ← +7.9s, frames=0 again
```

Pings flowed perfectly (63 ≈ every 2s) **until** each turn began. The handler then cancelled the in-flight brain on socket exit — so the reply was lost even though generation was healthy. This is why the 01:30 banter call worked (fast path era) and nothing has answered since the full brain returned in #581.

**Fault A — the mic is intermittently silent (client, surfaced here).**
3 of 5 calls had `updates=0`: Retell's ASR received digital silence (capture bound to a continuity-iPhone/virtual/recorder device). 2 of 5 carried audio fine — same browser, minutes apart. Invisible until now: the strip said "Mic live" while streaming zeros.

## What changed

**Backend — `api/voice_retell.py`**
- `_agent_retell_stream` is now a **bridging generator**: the real turn (`_agent_retell_stream_inner`, body unchanged) runs on a dedicated worker thread + event loop; frames hop back over a bounded queue. The WS loop stays free to echo pings no matter what the brain does — the 1006 class dies.
- **First-frame watchdog**: no first frame by 2.5s → log `voice_live_ws_turn_slow` and speak an honest `"One moment."` (dials: `VOICE_LIVE_FIRST_FRAME_ACK_SECONDS` / `_TEXT`; 0/empty disables).
- **First-frame telemetry**: `voice_live_ws_first_frame call= rid= ms=` — the next call tells us exactly how slow the full brain is.
- **Severed socket ≠ lost reply**: sends stop, the turn drains to completion, the reply persists into the thread and reaches the open chat over SSE. Handler exit gives an in-flight turn a bounded grace (then it finishes detached). Barge-in supersede still cancels, unchanged.

**Frontend — mic health**
- `lib/voice/mic-health.ts`: pure detector (orb-state discipline) — a full 3s window at digital silence = the capture is dead.
- `use-retell-call`: analyser feeds the detector on the SAME device the SDK captures; exposes `micSilent` + `inputDevices`; passes `captureDeviceId` to `startCall`.
- `MicHealthControl.tsx`: whisper-strip device picker (≥2 devices) + amber banner **"Your microphone is silent — Auto can't hear you" → Pick another mic**. Choice persists (`localStorage`); picking restarts the call bound to the new device; a vanished stored device falls back to default.

## Tests
- Bridge: frames cross threads in order; inner errors re-raise; closing the bridge cancels the inner turn (its `finally` runs).
- Watchdog: slow turn → exactly ONE spoken ack before content; fast turn → none.
- Dead socket mid-turn: sends stop, the generator still drains (persistence path).
- All existing WS tests (handshake, supersede-cancel, 4401/4403) untouched and passing semantics preserved — the fakes monkeypatch above the bridge.
- mic-health: window flip, instant recovery, quiet-but-live mic never trips, immutability. LiveVoiceMode: banner + picker rendering states.

## Your 60-second check after deploy
1. Press **Live**, say something. If the banner appears — the mic feed is dead: pick **MacBook Pro Microphone** from the new picker and speak again.
2. When a turn lands you'll hear **"One moment."** within ~2.5s if the brain is slow — that's the watchdog being honest, and `voice_live_ws_first_frame ms=` in the logs then tells us if we need the faster-model-tier lever for spoken turns (§8 note).
3. Even if you hang up mid-think, the reply should appear in the thread.

## Flags (separate issues, not touched here)
- `ERROR main: Platform OpenRouter fallback MISSING — OPENROUTER_API_KEY not set` on every boot (BYOK users unaffected).
- `api.widgets.cors` ERROR spam: `WIDGET_ORIGIN_ALLOWLIST empty in saas edition — denying https://automatos.app`.
- `entity_extractor` LLM 400 `invalid model ID` during calls (memory/KG side-path).
- `platform_get_blog_post failed: badly formed hexadecimal UUID` from the tool executor at 11:00:14.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added microphone selection during live voice calls, with the chosen device remembered for future sessions.
  * Added silent-microphone detection with an in-call warning and guidance to choose another microphone.
  * Added a brief spoken acknowledgment when responses take longer to begin.
* **Bug Fixes**
  * Improved voice streaming reliability during slow responses, connection drops, and shutdowns.
  * Prevented event-loop freezes while processing voice responses.
* **Tests**
  * Expanded coverage for microphone health, device selection, delayed responses, and disconnected calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->