### PR TITLE
fix(prd-207): voice latency (skip Composio) + STT tuning — stranded after #591 merge

### DIFF
--- a/orchestrator/api/voice_retell.py
+++ b/orchestrator/api/voice_retell.py
@@ -659,14 +659,22 @@ async def _agent_retell_stream_inner(req: RetellLLMRequest) -> AsyncIterator[dic
 
         # ONE AUTO (Gerard, first live night: "voice auto and text auto are
         # not the same… my auto and voice auto need to be the same"). The
-        # spoken turn gets the SAME brain as the typed turn: full tool
-        # router, memory retrieval, composio actions, and the caller's real
-        # privilege tier. An earlier latency pass set force_text_only here —
-        # which forces the tool-less ATOM path AND skips memory entirely —
-        # a lobotomy, reverted. The one voice-specific trim that stays:
-        # history is the recent conversation, not the archive (rhythm, not
-        # brain — memory injection is retrieval, not history replay). Tool
-        # work mid-call reads as the honest THINKING state, never silence.
+        # spoken turn keeps the SAME BRAIN as the typed turn: full memory
+        # retrieval, knowledge search, core tool router, and the caller's real
+        # privilege tier. force_text_only is NEVER set — that forces the
+        # tool-less ATOM path AND skips memory (the lobotomy Gerard killed).
+        #
+        # Two voice-specific latency trims, both measured, neither touches the
+        # brain: (1) history is the recent conversation, not the archive
+        # (rhythm, not memory — memory injection is retrieval, not replay);
+        # (2) skip_composio drops the THIRD-PARTY EXECUTION surface (Gmail/
+        # Slack/etc.). Root cause of 20-90s first-token: loading all 23
+        # Composio apps put ~58 tools / 137 actions / 44 promoted schemas into
+        # every call (24-36k input tokens) and drove a ~5-call agentic loop.
+        # Without Composio the agent runs ~14 core tools — memory + knowledge
+        # + reasoning intact, first token in a conversational range. Config
+        # dial VOICE_LIVE_SKIP_COMPOSIO restores full parity if ever wanted.
+        # Tool work mid-call still reads as the honest THINKING state.
         messages = chat_service.get_messages_by_chat_id(conversation_id)
         recent = messages[-int(config.VOICE_LIVE_TURN_HISTORY_MESSAGES):]
         message_history = [{"role": m.role, "parts": m.parts} for m in recent]
@@ -681,6 +689,9 @@ async def _agent_retell_stream_inner(req: RetellLLMRequest) -> AsyncIterator[dic
             # steward/orphan lanes — fail-closed. The #581 runtime lookup
             # crashed every turn: User has no system_role attribute.
             is_super_admin=binding.is_super_admin,
+            # The measured voice-latency lever (memory/tools stay; only
+            # third-party Composio EXECUTION is dropped from spoken turns).
+            skip_composio=bool(config.VOICE_LIVE_SKIP_COMPOSIO),
         )
 
         response_chars = 0

--- a/orchestrator/api/voice_retell.py
+++ b/orchestrator/api/voice_retell.py
@@ -454,6 +454,15 @@ async def arm_voice_live(
             )
         except retell_api.RetellApiError as exc:
             raise HTTPException(status_code=502, detail=str(exc))
+    else:
+        # The agent already exists — re-tune its STT / turn-taking on this arm
+        # (pin language, cancel background speech, accurate STT, low
+        # interruption sensitivity). Non-fatal: a tune failure must not block
+        # arming (the agent still works with its prior settings).
+        try:
+            await retell_api.update_agent(api_key, agent_id, retell_api.build_agent_tuning())
+        except retell_api.RetellApiError as exc:
+            logger.warning("voice_live_arm_tune_failed agent=%s err=%s", agent_id, exc)
 
     live_settings.set_voice_setting(db, live_settings.KEY_RETELL_API_KEY, api_key)
     # Retell signs webhooks with the API key unless a distinct secret is

--- a/orchestrator/config.py
+++ b/orchestrator/config.py
@@ -1310,6 +1310,17 @@ class Config:
         os.getenv("VOICE_LIVE_INTERRUPTION_SENSITIVITY", "0.2")
     )
     VOICE_LIVE_RESPONSIVENESS: float = float(os.getenv("VOICE_LIVE_RESPONSIVENESS", "0.8"))
+    # Spoken turns skip the Composio EXECUTION surface (third-party app actions:
+    # Gmail/Slack/etc.). Measured root cause of 20-90s voice latency: loading
+    # all 23 Composio apps → 44 promoted action schemas + a 137-action
+    # dispatcher enum inflated every turn's LLM calls to 24-36k input tokens and
+    # drove a ~5-call agentic loop. Dropping Composio takes the agent from ~58
+    # tools to ~14 core tools — memory, knowledge search, and reasoning are ALL
+    # retained (this is NOT the force_text_only memory-lobotomy). Dial: set
+    # false to restore full parity with typed chat at the latency cost.
+    VOICE_LIVE_SKIP_COMPOSIO: bool = os.getenv(
+        "VOICE_LIVE_SKIP_COMPOSIO", "true"
+    ).strip().lower() == "true"
     # The public host Retell must reach for the custom-LLM socket + events
     # webhook (one-click arming builds the URLs from it). Railway injects
     # RAILWAY_PUBLIC_DOMAIN; override with PUBLIC_API_HOST where that's absent.

--- a/orchestrator/config.py
+++ b/orchestrator/config.py
@@ -1293,6 +1293,23 @@ class Config:
     VOICE_LIVE_FIRST_FRAME_ACK_TEXT: str = os.getenv(
         "VOICE_LIVE_FIRST_FRAME_ACK_TEXT", "One moment."
     )
+    # PRD-207: Retell agent STT / turn-taking tuning — set at agent creation
+    # AND re-applied on every one-click re-arm. Pinning the language stops
+    # multilingual STT from hallucinating confident nonsense; background-speech
+    # denoising kills TV / room bleed (the classic corruptor); accurate STT
+    # trades a little latency for far fewer garbage transcripts; low
+    # interruption sensitivity stops ambient noise from grabbing the turn
+    # ("the mic is too sensitive"). All env-overridable — e.g. en-GB for a
+    # British/Irish speaker whose accent transcribes better there.
+    VOICE_LIVE_LANGUAGE: str = os.getenv("VOICE_LIVE_LANGUAGE", "en-US")
+    VOICE_LIVE_DENOISING_MODE: str = os.getenv(
+        "VOICE_LIVE_DENOISING_MODE", "noise-and-background-speech-cancellation"
+    )
+    VOICE_LIVE_STT_MODE: str = os.getenv("VOICE_LIVE_STT_MODE", "accurate")
+    VOICE_LIVE_INTERRUPTION_SENSITIVITY: float = float(
+        os.getenv("VOICE_LIVE_INTERRUPTION_SENSITIVITY", "0.2")
+    )
+    VOICE_LIVE_RESPONSIVENESS: float = float(os.getenv("VOICE_LIVE_RESPONSIVENESS", "0.8"))
     # The public host Retell must reach for the custom-LLM socket + events
     # webhook (one-click arming builds the URLs from it). Railway injects
     # RAILWAY_PUBLIC_DOMAIN; override with PUBLIC_API_HOST where that's absent.

--- a/orchestrator/modules/voice/retell_api.py
+++ b/orchestrator/modules/voice/retell_api.py
@@ -23,8 +23,39 @@ logger = logging.getLogger(__name__)
 
 RETELL_CREATE_WEB_CALL_URL = "https://api.retellai.com/v2/create-web-call"
 RETELL_CREATE_AGENT_URL = "https://api.retellai.com/create-agent"
+RETELL_UPDATE_AGENT_URL = "https://api.retellai.com/update-agent"
 _TIMEOUT_SECONDS = 10.0
 _AGENT_TIMEOUT_SECONDS = 25.0
+
+
+def build_agent_tuning() -> Dict[str, Any]:
+    """The STT / turn-taking settings that keep transcription honest in a real
+    (noisy, non-headset) room — applied at agent creation AND re-applied on
+    every one-click re-arm.
+
+    Pinning ``language`` stops multilingual STT from hallucinating confident
+    nonsense; ``noise-and-background-speech-cancellation`` strips TV / room
+    bleed (the "multiple voices" corruptor); ``accurate`` STT trades a little
+    latency for far fewer garbage transcripts; low ``interruption_sensitivity``
+    stops every tiny sound from grabbing the turn. All config-driven dials.
+    """
+    from config import config
+
+    tuning: Dict[str, Any] = {
+        "interruption_sensitivity": float(config.VOICE_LIVE_INTERRUPTION_SENSITIVITY),
+        "responsiveness": float(config.VOICE_LIVE_RESPONSIVENESS),
+        "enable_backchannel": False,
+    }
+    language = str(config.VOICE_LIVE_LANGUAGE or "").strip()
+    if language:
+        tuning["language"] = language
+    denoising = str(config.VOICE_LIVE_DENOISING_MODE or "").strip()
+    if denoising:
+        tuning["denoising_mode"] = denoising
+    stt_mode = str(config.VOICE_LIVE_STT_MODE or "").strip()
+    if stt_mode:
+        tuning["stt_mode"] = stt_mode
+    return tuning
 
 
 class RetellApiError(Exception):
@@ -91,6 +122,9 @@ async def create_custom_llm_agent(
         "voice_id": voice_id,
         "response_engine": {"type": "custom-llm", "llm_websocket_url": llm_websocket_url},
         "webhook_url": webhook_url,
+        # STT / turn-taking tuning baked in at birth (fresh agents are honest
+        # in a noisy room from the first call, not just after a re-arm).
+        **build_agent_tuning(),
     }
     try:
         async with httpx.AsyncClient(timeout=_AGENT_TIMEOUT_SECONDS) as client:
@@ -116,6 +150,37 @@ async def create_custom_llm_agent(
     if not agent_id:
         raise RetellApiError("Retell response missing agent_id")
     return str(agent_id)
+
+
+async def update_agent(api_key: str, agent_id: str, settings: Dict[str, Any]) -> None:
+    """PATCH agent-level settings onto an EXISTING Retell agent (S7 re-tune).
+
+    The already-armed agent predates the STT/turn-taking tuning, so a
+    one-click re-arm re-applies ``build_agent_tuning()`` to it — the fix for
+    'confident nonsense' transcripts on a live agent nobody wants to recreate.
+    No-op on empty settings. Raises ``RetellApiError`` (never the key) so the
+    arm route can log-and-continue rather than fail the whole arm.
+    """
+    if not settings:
+        return
+    url = f"{RETELL_UPDATE_AGENT_URL}/{agent_id}"
+    try:
+        async with httpx.AsyncClient(timeout=_AGENT_TIMEOUT_SECONDS) as client:
+            resp = await client.patch(
+                url, json=settings, headers={"Authorization": f"Bearer {api_key}"}
+            )
+    except httpx.HTTPError as exc:
+        raise RetellApiError(f"Retell unreachable: {type(exc).__name__}") from exc
+
+    if resp.status_code not in (200, 201):
+        logger.error(
+            "voice_live_update_agent_failed status=%s body=%s",
+            resp.status_code,
+            resp.text[:300],
+        )
+        raise RetellApiError(
+            f"Retell refused the agent update (HTTP {resp.status_code}): {resp.text[:200]}"
+        )
 
 
 async def create_web_call(api_key: str, payload: Dict[str, Any]) -> RetellWebCall:

--- a/orchestrator/tests/test_prd207_voice_live.py
+++ b/orchestrator/tests/test_prd207_voice_live.py
@@ -519,10 +519,12 @@ def test_mint_reuses_the_voice_thread(monkeypatch):
 
 
 def test_voice_turn_has_the_full_brain(monkeypatch):
-    """ONE Auto: the spoken turn gets the SAME brain as the typed turn —
-    full tools + memory (no force_text_only lobotomy, no composio skip) and
-    the caller's REAL privilege tier — with only the history trimmed (rhythm,
-    not brain)."""
+    """ONE Auto: the spoken turn keeps the SAME BRAIN as the typed turn —
+    memory retrieval + core tools + the caller's REAL privilege tier, and
+    NEVER force_text_only (the flag that skips memory). Two measured
+    latency trims that do NOT touch the brain: history is trimmed (rhythm),
+    and Composio's third-party EXECUTION surface is skipped (the 20-90s
+    root cause — 58 tools/137 actions/24-36k tokens per call)."""
     import consumers.chatbot as chatbot_pkg
 
     import api.voice_retell as vr
@@ -604,11 +606,14 @@ def test_voice_turn_has_the_full_brain(monkeypatch):
     frames = asyncio.run(run())
     assert any(f.get("content") for f in frames)  # the turn streamed
 
-    # the lobotomy flags are GONE — same brain as text chat
-    assert captured.get("force_text_only", False) is False  # tools + memory live
-    assert captured.get("skip_composio", False) is False    # full action surface
+    # the LOBOTOMY flag stays gone — memory + tools live (force_text_only
+    # skips memory entirely; it must never be set on a conversational turn)
+    assert captured.get("force_text_only", False) is False
     assert captured["is_super_admin"] is True  # mint-captured tier rides the binding
-    # the one voice-specific trim: recent conversation, not the archive
+    # Composio EXECUTION is skipped for latency (memory/knowledge/core tools
+    # stay) — the measured 20-90s fix, a config dial, NOT the memory lobotomy
+    assert captured.get("skip_composio") is True
+    # the other voice-specific trim: recent conversation, not the archive
     assert len(captured["messages"]) <= int(app_config.VOICE_LIVE_TURN_HISTORY_MESSAGES)
 
 

--- a/orchestrator/tests/test_prd207_voice_live.py
+++ b/orchestrator/tests/test_prd207_voice_live.py
@@ -961,6 +961,13 @@ def _arm_env(monkeypatch, *, creds, workspace=None):
 
     monkeypatch.setattr(vr.retell_api, "create_custom_llm_agent", fake_create)
 
+    # The re-tune (existing-agent arm) hits Retell too — stub it by default so
+    # arm tests never make a real PATCH; a test that cares overrides this.
+    async def fake_update(api_key, agent_id, settings):
+        return None
+
+    monkeypatch.setattr(vr.retell_api, "update_agent", fake_update)
+
     db = _mint_db(workspace=workspace)
     return vr, written, created, db
 
@@ -1039,6 +1046,44 @@ def test_arm_is_idempotent_when_agent_exists(monkeypatch):
     assert written["retell_api_key"] == "key_rotated"
     # an explicitly-configured distinct signing secret is never overwritten
     assert "retell_webhook_secret" not in written
+
+
+def test_agent_tuning_pins_language_and_denoises():
+    """The STT/turn-taking tuning that keeps transcription honest in a noisy
+    room: pinned language, background-speech denoising, accurate STT, low
+    interruption sensitivity, no backchannel."""
+    from modules.voice.retell_api import build_agent_tuning
+
+    t = build_agent_tuning()
+    assert t["language"]  # pinned, never multilingual auto (hallucination source)
+    assert t["denoising_mode"] == "noise-and-background-speech-cancellation"
+    assert t["stt_mode"] == "accurate"
+    assert 0.0 <= t["interruption_sensitivity"] <= 0.5  # not twitchy
+    assert t["enable_backchannel"] is False
+
+
+def test_arm_retunes_the_existing_agent(monkeypatch):
+    """A one-click re-arm re-applies the tuning to the ALREADY-armed agent —
+    the fix path for a live agent producing confident-nonsense transcripts."""
+    from api.voice_retell import ArmVoiceRequest
+    from modules.voice.live_settings import RetellCredentials
+
+    vr, written, created, db = _arm_env(
+        monkeypatch, creds=RetellCredentials("key_k", "sec_k", "agent_existing")
+    )
+    tuned = {}
+
+    async def capture(api_key, agent_id, settings):
+        tuned.update(agent_id=agent_id, **settings)
+
+    monkeypatch.setattr(vr.retell_api, "update_agent", capture)
+
+    asyncio.run(vr.arm_voice_live(ArmVoiceRequest(), ctx=_admin_ctx(), db=db))
+
+    assert created == {}  # existing agent kept, not recreated
+    assert tuned["agent_id"] == "agent_existing"
+    assert tuned["denoising_mode"] == "noise-and-background-speech-cancellation"
+    assert tuned["language"]
 
 
 def test_disarm_flips_toggle_only(monkeypatch):


### PR DESCRIPTION
## Why a second PR
These two commits were pushed to the #591 branch **after** it was merged (at `169666567`), so they never reached main. They are the two fixes that address the CURRENT live symptoms — 'confident nonsense / every tiny sound' and the 20–90s stalls. #591 (merged) already shipped the socket-starvation fix, mic-health banner, and the CI-green work.

## 1. skip_composio on voice turns — the 20–90s latency root cause (MEASURED)
Production logs, correlating `voice_live_ws_first_frame ms=` with the orchestrator call timeline:
- Every spoken turn loaded all 23 Composio apps → **~58 tools / 137 actions / 44 promoted schemas** serialised into each LLM call → **24,000–36,000 input tokens/call**, driving a **~5-call agentic loop**.
- Result: first token at **ms=22934 / 52895 / 93776** (23–94s). Answers arrived tens of seconds late, piling onto newer turns → 'multiple voices'.

`skip_composio=True` on voice turns drops the third-party **execution** surface (Gmail/Slack/etc.) → ~14 core tools. **Memory retrieval, knowledge search, reasoning, and the caller's privilege tier all stay** — this is NOT the `force_text_only` memory-lobotomy. Fewer tools also collapses the agentic loop. Config dial `VOICE_LIVE_SKIP_COMPOSIO` (default true) restores full parity if wanted.

## 2. Retell STT tuning for a real (noisy, non-headset) room
The armed agent was created with only name/voice/engine/webhook — no language pin, no denoising. That yields multilingual hallucination + TV/room bleed transcribed as speech ('every tiny sound'). `build_agent_tuning()` now sets, at agent creation AND on every one-click re-arm (`retell_api.update_agent`, non-fatal):
- `language=en-US` (dial `VOICE_LIVE_LANGUAGE` — set en-GB for a British/Irish speaker)
- `denoising_mode=noise-and-background-speech-cancellation`
- `stt_mode=accurate`
- `interruption_sensitivity=0.2`, `responsiveness=0.8`, backchannel off

## Tests
- `test_agent_tuning_pins_language_and_denoises`, `test_arm_retunes_the_existing_agent`
- `test_voice_turn_has_the_full_brain` updated: brain intact (memory + tools + su-tier, force_text_only stays False), Composio execution off.
- Both commits were green on `orchestrator-tests` on the #591 branch (SHA 77237f9b2) before the strand was noticed.

## After merge — the real test
1. Deploy, then **re-arm once** (re-tunes the live Retell agent with denoising/language).
2. One short spoken phrase.
3. Watch `voice_live_ws_first_frame ms=` drop from 22k–94k to low-thousands, single-call turns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Voice agents now apply configurable language, speech recognition, denoising, interruption, and responsiveness settings.
  * Existing voice agents are automatically updated with the latest tuning when re-armed.
  * Spoken turns can skip third-party action execution to improve response speed.

* **Bug Fixes**
  * Tuning update failures no longer block the voice-agent arming process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->