### PR TITLE
fix(prd-207): one live call per user — stop Auto talking over herself

### DIFF
--- a/orchestrator/api/voice_retell.py
+++ b/orchestrator/api/voice_retell.py
@@ -228,6 +228,33 @@ async def mint_web_call(
         logger.error("voice_live_mint_denied reason=vendor_error workspace=%s err=%s", ctx.workspace_id, exc)
         raise HTTPException(status_code=502, detail=f"Could not start the call: {exc}")
 
+    # ONE LIVE CALL PER USER. A client that mints again (device switch, a
+    # re-press, a re-render, two LiveVoiceMode instances during a view
+    # transition) would otherwise leave several web calls connected to the
+    # SAME mic, each streaming Auto's reply — the caller hears Auto talking
+    # over herself ("five people at once"). Supersede the caller's prior
+    # active calls here; their sockets close on their next turn (below) so no
+    # superseded call ever speaks again. Best-effort, same transaction.
+    superseded = (
+        db.query(VoiceCall)
+        .filter(
+            VoiceCall.user_id == user_int_id,
+            VoiceCall.status.in_(("minted", "started")),
+        )
+        .update(
+            {
+                VoiceCall.status: "superseded",
+                VoiceCall.disconnect_reason: "superseded_by_newer_call",
+            },
+            synchronize_session=False,
+        )
+    )
+    if superseded:
+        logger.info(
+            "voice_live_superseded_prior count=%s user=%s (new call=%s)",
+            superseded, user_int_id, web_call.call_id,
+        )
+
     # The row is BORN at mint — the webhook validates against it (S2/S3).
     # PRD-143 discipline: su derives from Clerk-claims system_role ONLY —
     # captured HERE (the one place the session exists) for the webhook.
@@ -763,10 +790,19 @@ async def retell_llm_websocket(websocket: WebSocket, call_id: str) -> None:
     from core.models.voice_calls import VoiceCall
 
     with get_db_session() as db:
-        minted = db.query(VoiceCall.id).filter(VoiceCall.call_id == str(call_id)).first()
+        minted = (
+            db.query(VoiceCall.status).filter(VoiceCall.call_id == str(call_id)).first()
+        )
     if minted is None:
         logger.warning("voice_live_ws_rejected reason=unminted_call call=%s", call_id)
         await websocket.close(code=4401)
+        return
+    if minted[0] == "superseded":
+        # A newer call already owns this user's conversation — refuse before
+        # accept so an auto_reconnect of a superseded call can't loop back in
+        # and start a second voice.
+        logger.info("voice_live_ws_rejected reason=superseded call=%s", call_id)
+        await websocket.close(code=4409)
         return
 
     await websocket.accept()
@@ -889,6 +925,23 @@ async def retell_llm_websocket(websocket: WebSocket, call_id: str) -> None:
                     "voice_live_ws_turn call=%s rid=%s type=%s",
                     call_id, message.get("response_id"), itype,
                 )
+                # ONE LIVE CALL PER USER: a newer mint marked this call
+                # 'superseded'. It must NOT speak — several superseded calls on
+                # one mic is the "Auto talking over herself" bug. Close quietly
+                # (the newest call owns the conversation). Checked at the turn
+                # boundary: exactly where a stale call would otherwise talk.
+                with get_db_session() as _db:
+                    _status = (
+                        _db.query(VoiceCall.status)
+                        .filter(VoiceCall.call_id == str(call_id))
+                        .scalar()
+                    )
+                if _status == "superseded":
+                    logger.info("voice_live_ws_superseded_closing call=%s", call_id)
+                    if speaking is not None and not speaking.done():
+                        speaking.cancel()  # silence any in-flight reply at once
+                    await websocket.close(code=1000)
+                    break
                 if speaking is not None and not speaking.done():
                     speaking.cancel()
                 req = parse_llm_request(

--- a/orchestrator/tests/test_prd207_voice_live.py
+++ b/orchestrator/tests/test_prd207_voice_live.py
@@ -518,6 +518,62 @@ def test_mint_reuses_the_voice_thread(monkeypatch):
     assert out["chat_id"] == str(existing_id)  # same thread, conversation continues
 
 
+def test_mint_supersedes_prior_active_calls(monkeypatch):
+    """One live call per user: a fresh mint marks the caller's prior active
+    (minted/started) calls 'superseded' so only the newest speaks — the guard
+    against 'Auto talking over herself' from overlapping web calls."""
+    import api.voice_retell as vr
+    from core.models.core import Chat as ChatModel
+    from core.models.voice_calls import VoiceCall
+    from core.models.workspaces import Workspace as WorkspaceModel
+    from modules.voice.live_settings import RetellCredentials
+    from modules.voice.retell_api import RetellWebCall
+    from modules.voice.voice_meter import MeterReading
+
+    monkeypatch.setattr(vr.live_settings, "voice_live_enabled", lambda: True)
+    monkeypatch.setattr(
+        vr.live_settings, "retell_credentials", lambda: RetellCredentials("k", "s", "a")
+    )
+    monkeypatch.setattr(vr.voice_meter, "monthly_meter", lambda db, w: MeterReading(0, 0, 10))
+
+    async def fake_vendor(api_key, payload):
+        return RetellWebCall(call_id="call_new", access_token="tok")
+
+    monkeypatch.setattr(vr.retell_api, "create_web_call", fake_vendor)
+
+    ws_id = uuid.uuid4()
+    ws = SimpleNamespace(settings={"voice_live": {"enabled": True}})
+    existing = SimpleNamespace(id=uuid.uuid4(), user_id=7, workspace_id=ws_id, title="Voice call")
+    updates = []
+
+    db = MagicMock()
+
+    def dispatch(model):
+        q = MagicMock()
+        if model is WorkspaceModel:
+            q.filter.return_value.first.return_value = ws
+        elif model is ChatModel:
+            q.filter.return_value.first.return_value = existing
+            q.filter.return_value.order_by.return_value.first.return_value = existing
+        elif model is VoiceCall:
+            def _upd(vals, **k):
+                updates.append(vals)
+                return 2
+
+            q.filter.return_value.update.side_effect = _upd
+        else:
+            q.filter.return_value.first.return_value = None
+        return q
+
+    db.query.side_effect = dispatch
+
+    out = _run_mint(ctx=_mint_ctx(ws_id=ws_id, user_int=7), db=db)
+
+    assert out["call_id"] == "call_new"
+    assert updates, "mint did not supersede prior calls"
+    assert "superseded" in list(updates[0].values())  # status -> superseded
+
+
 def test_voice_turn_has_the_full_brain(monkeypatch):
     """ONE Auto: the spoken turn keeps the SAME BRAIN as the typed turn —
     memory retrieval + core tools + the caller's REAL privilege tier, and
@@ -1182,6 +1238,76 @@ def test_ws_closes_4401_for_unminted_call(monkeypatch):
     ws = _FakeWebSocket([])
     asyncio.run(vr.retell_llm_websocket(ws, "call_forged"))
     assert ws.close_code == 4401  # the minted call_id IS the credential
+    assert ws.accepted is False
+
+
+def test_ws_superseded_call_closes_without_speaking(monkeypatch):
+    """One live call per user: a call a newer mint marked 'superseded' must
+    NOT speak on its next turn — it closes instead. Several superseded calls
+    on one mic each streaming a reply is the 'Auto talking over herself' bug."""
+    import api.voice_retell as vr
+
+    monkeypatch.setattr(vr.live_settings, "voice_live_enabled", lambda: True)
+
+    from contextlib import contextmanager
+
+    db = MagicMock()
+    # open-time minted check (.first()) passes; the per-turn status check
+    # (.scalar()) reports this call was superseded by a newer mint.
+    db.query.return_value.filter.return_value.first.return_value = (1,)
+    db.query.return_value.filter.return_value.scalar.return_value = "superseded"
+
+    @contextmanager
+    def fake_session():
+        yield db
+
+    monkeypatch.setattr(vr, "get_db_session", fake_session)
+
+    async def must_not_stream(req):
+        raise AssertionError("a superseded call must never reach the brain")
+        yield  # pragma: no cover
+
+    monkeypatch.setattr(vr, "_agent_retell_stream", must_not_stream)
+
+    ws = _FakeWebSocket(
+        [
+            {"interaction_type": "call_details",
+             "call": {"retell_llm_dynamic_variables": {"workspace_id": "ws-9"}}},
+            {"interaction_type": "response_required", "response_id": 1,
+             "transcript": [{"role": "user", "content": "hello"}]},
+        ]
+    )
+    asyncio.run(vr.retell_llm_websocket(ws, "call_superseded"))
+
+    assert ws.close_code == 1000  # closed cleanly, did not speak
+    # no turn response frame was ever sent (only the config + begin handshake)
+    assert not any(
+        m.get("response_type") == "response" and m.get("response_id") == 1
+        for m in ws.sent
+    )
+
+
+def test_ws_rejects_superseded_call_at_open(monkeypatch):
+    """A superseded call must be refused BEFORE accept — so an auto_reconnect
+    of a call a newer mint replaced can't loop back and start a second voice."""
+    import api.voice_retell as vr
+
+    monkeypatch.setattr(vr.live_settings, "voice_live_enabled", lambda: True)
+
+    from contextlib import contextmanager
+
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = ("superseded",)
+
+    @contextmanager
+    def fake_session():
+        yield db
+
+    monkeypatch.setattr(vr, "get_db_session", fake_session)
+
+    ws = _FakeWebSocket([])
+    asyncio.run(vr.retell_llm_websocket(ws, "call_superseded_open"))
+    assert ws.close_code == 4409
     assert ws.accepted is False
 
 


### PR DESCRIPTION
## Symptom
Gerard, live: 'when Auto speaks I hear many voices of her speaking over herself… like 5 people at the same time.'

## Root cause (from prod logs)
The client minted **multiple web calls for the same user/chat** and they ran **concurrently**, each connected to the same mic and each streaming Auto's reply → overlapping TTS:
```
11:47:47 ws_open call_6e0e9b...     11:47:47 ws_open call_cb1c3c...
11:48:09 first_frame 6e0e9b         11:48:10 first_frame cb1c3c
11:49:36 summary 6e0e9b turns=4     11:49:35 summary cb1c3c turns=4
```
Two Autos, one mic, 2 minutes. (Also visible: skip_composio landed — first-frame is now ~5–6s, down from 20–90s.) There was **no server-side guard** against a user holding several live calls; whatever caused the client to mint again (device switch, re-press, re-render, view transition) left every call speaking.

## Fix — one live call per user, enforced server-side
- **Mint** marks the caller's prior active (`minted`/`started`) calls `superseded` in the same transaction.
- **WS open** refuses a `superseded` call (code 4409) *before accept* — so Retell's `auto_reconnect` can't loop a replaced call back in.
- **WS turn**: if a live call is superseded mid-session, it closes at its next turn (cancelling any in-flight reply) **before it can speak**. The newest call always owns the conversation.

This is the robust catch-all: no matter why the client mints again, only the newest call ever produces audio.

## Tests
- `test_mint_supersedes_prior_active_calls` — mint issues the supersede update.
- `test_ws_rejects_superseded_call_at_open` — 4409, never accepted.
- `test_ws_superseded_call_closes_without_speaking` — closes on turn, brain never reached.
- Existing WS/mint tests unchanged in behaviour.

## Follow-up (not in this PR)
The client *should* also stop minting duplicates (likely a re-render / device-restart interaction). Worth a frontend pass, but the server guard makes the overlap impossible regardless.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enforced one active voice call per user by superseding older calls when a new call begins.
  * Prevented superseded calls from speaking or streaming responses.
  * Added clear connection handling for calls that are no longer active.

* **Bug Fixes**
  * Resolved an issue where multiple concurrent voice calls could continue speaking simultaneously.

* **Tests**
  * Added coverage for call supersession, connection rejection, and clean shutdown behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->