### PR TITLE
fix(tools): PR-A — ship the built surface, thread heartbeat/task queries, dedup query embeds

### DIFF
--- a/docs/reviews/TOOL-SURFACE-DEEP-REVIEW-2026-07-23.md
+++ b/docs/reviews/TOOL-SURFACE-DEEP-REVIEW-2026-07-23.md
@@ -1,0 +1,150 @@
+# Tool-Surface Deep Review — why "Good Morning" costs ~11,000 tokens
+
+**Date:** 2026-07-23 · **Trigger:** PRD-207 voice latency (5–12s/turn) traced to tool loading; Gerard: "Why does 40 tools load for 'Hey Good Morning'? … Must be a way WHEN REQUIRED Auto can see all Platform tools… I assumed that's what the tool registry was for."
+**Method:** 3 parallel static readers over the full selection stack (inventory / wiring / capability-safety). No code changed. All anchors verified against live source.
+
+---
+
+## 1. The bill — what one typical admin text turn actually ships
+
+| Component | Count | ~Tokens | Query-gated? |
+|---|---|---|---|
+| **Promoted first-class action schemas** | **44** | **~8,710** | **NO — never** |
+| Core ToolRegistry tools (general-context survivors) | ~11 | ~1,000–1,175 | No (context-category only) |
+| `platform_execute` dispatcher (enum top-15) | 1 | ~280 | Yes (semantic top-K) |
+| skill_tools | 0 | 0 | — (dead: always `[]`, `service.py:783`) |
+| **Tool block total** | **~56** | **~10,000–10,200** | |
+| + `PlatformActionsSection` prompt-text catalog | — | ~700–900 (narrowed) / **~4,000 (any fallback)** | Yes, but separate rank call |
+| + Composio (text chat, apps connected) | varies | up to tens of k (historic 24–36k) | SDK-side search |
+
+- **85% of the tool block is the 44 promoted schemas, and they are the one component with zero relevance gating** — `to_first_class_schemas()` filters by admin tier only (`tool_router.py:617-621`).
+- The semantic narrowing everyone assumed covers the surface (PRD-138) touches **only the dispatcher enum**: ~1,100 → ~280 tokens. It narrows the cheap part and never the expensive part.
+- Voice turns ride the same path (minus Composio via `VOICE_LIVE_SKIP_COMPOSIO`) — this block is roughly half the measured 5–12s voice first-frame; the rest is the model working through the bloat.
+
+### Promoted grew into a second, ungated surface
+46 actions carry `promoted=True` (44 visible to admin; 2 super-only): codegraph 9, workspace 8, blog 6, marketplace 5, agents 4, graph 3, workspace-misc 3, autonomy 2, field 2, shopify 2, analytics 1, search 1. Full table in §A1.
+
+**History:** `docs/reviews/COMPOSIO-TOOL-REGRESSION-REVIEW.md:174-194,395-410` already identified PRD-122 (the change that created first-class promoted schemas, ~18→~33 tools) as a contributor to the "agents went dumb" regression. Promotion has since grown to 46. **This review reverses a documented regression, not a considered design.**
+
+---
+
+## 2. Failure posture — every fallback fails OPEN wider
+
+Confirmed at every seam: when selection *can't* decide, the system ships the **maximum** surface:
+
+| Bypass | Anchor | Resulting surface |
+|---|---|---|
+| Promoted first-class (by design) | `tool_router.py:614-624`, dispatcher built `exclude_promoted=True` `:572` | 44 schemas every turn, query-independent |
+| **Query-embed timeout >2.5s** | `action_semantic_index.py:155-170,221-228` → `rank_actions` returns `[]` → `allowed_names=None` | **Full 132/137-action enum + full ~4k-token catalog** (seen repeatedly in prod logs during live calls) |
+| `SEMANTIC_TOOL_ROUTING=false` / empty query / rank error / empty intersection | `tool_router.py:208-217`, `action_registry.py:205-225` | Full enum + full catalog |
+| Heartbeat & task-execution `build_context` calls pass **no query** | `agent_factory.py:924-929`, `heartbeat_service.py:710-714` | Full 137 enum on **every** heartbeat/task run, forever |
+| Embedding provider unset → `DeterministicEmbeddingProvider` (hash vectors) | `embedding_manager.py:66-144` | Ranking silently degrades (previously measured 97.9%→57.4% in-set); fail-open masks it |
+
+A slow embed — the moment the system is already latency-stressed — is precisely when it ships the *most* tokens. Backwards on both axes (cost and quality).
+
+---
+
+## 3. Bugs found on the way (real, independent of any redesign)
+
+1. **The full chat path discards the tools it computes.** `service.py:2120` builds `all_tools` with `is_super_admin` + PRD-221 `page_actions` threaded in → passed to `smart_chat.prepare(available_tools=…)` which **ignores it** ("kept for backward compatibility — ContextService loads tools internally", `smart_orchestrator.py:175-176`). The surface the LLM actually gets is rebuilt in `ToolsSection._load_filtered` (`tools.py:186-191`) **without `page_actions` and without `is_super_admin`**. ⇒ **PRD-221 S4 page-prior never reaches the main lane; su widening doesn't either.**
+2. **Double ranking per turn** — `PlatformActionsSection` and the enum path each call `rank_actions` for the same query (`platform_actions.py:247` vs `tool_router.py:230`). Warm-cache second call, but two seams doing one job = drift risk (and they already disagree on fallback size).
+3. **skill_tools is dead plumbing** — `_load_agent_context` hardcodes `[]` (`service.py:783`).
+4. **`intent_classifier` hints name promoted actions** (`platform_list_agents`) that the hint-matcher can never match (promoted aren't in `available_tools` names it filters) — silent no-op (`intent_classifier.py:417-419` → `smart_tool_router.py:174-198`).
+5. **ATOM vs full inconsistency** — ATOM turns already ship **zero** promoted schemas (dispatcher only, `service.py:2149-2156`). So Auto's capability surface silently flips with the complexity classifier: same user, same question phrasing differences → different tool world.
+6. **No in-flight dedup on query embeds** — concurrent same-query turns each launch an embed (`action_semantic_index.py:134-177`).
+
+---
+
+## 4. Capability-safety verdicts (what a redesign can and cannot break)
+
+**PROVEN SAFE — execution never depended on the tool list.**
+- `unified_executor.py:713` resolves actions via unfiltered `registry.get()`; required-param validation `:724-742`; PRD-143 super-admin gate (`platform_executor.py:682-698`), admin gate `:706-739`, hierarchy `:831-902`, rate limits `:906-929`, destructive backstop `:931-948` — **all at execution time**, independent of surfacing.
+- Direct `platform_*` calls route and gate even when the schema was never in the tool list (`unified_executor.py:758-765`). Absence from the surface degrades *discovery only*, never enforcement or executability.
+
+**TRAP CONFIRMED — the dispatcher enum ceiling.**
+- `to_dispatcher_schema` drops promoted names from `valid_actions` **before** the allow-list intersects (`action_registry.py:196-225`) — `allowed_names` can never re-admit a promoted action, and the empty-intersection fallback is also promoted-excluded. A test pins this (`test_action_registry_filtered.py:329`).
+- ⇒ Naively deleting the first-class loading leaves 46 actions **invisible + unlisted + undescribed** on every surface. The fix must flip `exclude_promoted` at the enum/catalog build sites in the same change.
+
+**STRUCTURAL DEPENDENCY — the 8 `workspace_*` file tools.**
+- Their ToolRegistry fallbacks are deactivated ("SUPERSEDED by workspace_* promoted actions", `tool_registry.py:760-764`). Coder/mission templates instruct agents to call them by name (`templates.py:794-841,1256-1293`). They must stay guaranteed-discoverable in mission/coder contexts.
+
+**SOFT prose dependencies** — cadence prompts (`auto_cadence.py:50,60`), onboarding seeds (`seed_onboarding_agents.py:91-217`), mission template prose name promoted actions; they degrade gracefully **iff** those names are present in the dispatcher enum (or re-surfaced on demand).
+
+**Test pins** — ~10 files assert today's surface semantics (heaviest: `test_action_registry_filtered.py`, `test_tool_router_semantic.py`, `test_action_semantic_index.py` exact-count assertions, `test_prd143_su_*`). Full impact table in §A2.
+
+---
+
+## 5. Target design — "the registry becomes what Gerard assumed it was"
+
+> Requirement (Gerard): Auto has access to **all** tools; never loads 40+ schemas a turn; **when required** Auto can see everything available, with descriptions, and pick the best itself.
+
+### Tier 0 — small, stable, always-on (cache-friendly)
+1. ~11 core ToolRegistry tools (unchanged).
+2. **`platform_execute` dispatcher** — enum = semantic top-K **with a relevance floor** (absolute min + relative-to-best ratio; greeting ⇒ 0–3 names), **promoted names now eligible** (flip `exclude_promoted` once first-class loading is gated), unioned with: page-manifest actions (PRD-221 — fixed to actually arrive), context pins (the 8 `workspace_*` in mission/coder contexts), and a handful of telemetry-earned hot actions.
+3. **NEW `platform_find_tools(query)`** — the "WHEN REQUIRED" seam. Searches the action registry (`rank_actions` with `exclude_promoted=False`, generous top-N) and returns matches: name, description, full param schema, permission notes, examples. Auto reads → calls `platform_execute(action, params)`. Zero new tables; standard 3-file action registration; reuses the existing index. *This makes the full catalog reachable in one hop from any turn without ever shipping it wholesale.*
+
+### Tier 1 — earned first-class (optional hybrid)
+Actions ranking above a high-confidence bar for **this turn's** query (cap ~6) also get real first-class schemas — common flows keep one-hop calling with typed params. Everything else lives behind dispatcher + find_tools.
+
+### Posture flip — fail CLOSED-small
+On embed timeout / rank failure / no query: surface = core tools + dispatcher with **pin-set enum** (memory, resume_context, page actions, find_tools) + find_tools — **not** 137 names + 4k catalog. The catalog section on fallback renders one line ("discover more via platform_find_tools"), not 4k of text.
+
+### Consolidations riding along
+- **One rank call per turn**, shared by enum + catalog + (new) first-class gate.
+- Fix dead plumbing: thread `page_actions`/`is_super_admin` into the surface that actually ships (ToolsSection), or make the full path consume `_get_tools` output — one seam, not two.
+- Thread `task_description` as query on heartbeat/task-execution `build_context` calls.
+- ATOM and full paths converge on the same Tier-0 surface (ends the classifier-flips-capability inconsistency).
+
+### Expected effect (per turn, typical)
+| | Today | Target |
+|---|---|---|
+| Tool block | ~10,000–10,200 tok | **~1,500–2,500 tok** |
+| Catalog text | 700–900 / 4,000 fallback | ~300 / ~50 fallback |
+| Fallback posture | fail-open to max | fail-closed to pins |
+| Voice first-frame | 5–12s | expect ~2–4s (tool-load share ≈ gone; same path as text) |
+| Selection quality | 44 constant distractors | distractor-free + on-demand catalog |
+
+---
+
+## 6. Staged rollout (each stage independently shippable + revertible)
+
+**PR-A — bug fixes, no design change:** dead-plumbing fix (page_actions/su threading), heartbeat/task query threading, single-rank consolidation, embed in-flight dedup. CI: update nothing conceptually — behavior becomes what PRD-221/PRD-143 already claimed.
+
+**PR-B — additive, flags default-off:** `platform_find_tools` action; relevance floor (`SEMANTIC_TOOL_ROUTING_FLOOR`, `…_FLOOR_RATIO`); fail-closed-small fallback (`TOOL_FALLBACK_MODE=open-full|closed-pins`, default `open-full`); shadow telemetry — log the would-be surface per turn (`ToolSignalRecorder` extension) without changing what ships.
+
+**PR-C — the flip:** gate promoted first-class by relevance (`TOOL_SURFACE_PROMOTED_GATED=true`), enum/catalog stop excluding promoted, fallback flips to closed-pins. Test updates land here (~10 files, §A2). Revert = one flag.
+
+**Eval gate between B and C (no local runs — CI + shadow telemetry in prod):** replay shadow logs over real traffic for a day or two: (1) tool-intent turns — chosen action would still have been surfaced ≥ baseline 97.9% in-set rate; (2) greeting-class turns — surface ≤ 3 actions; (3) zero occurrences of a turn that *executed* an action the gated surface wouldn't have listed (executor logs make this measurable).
+
+---
+
+## 7. Open decisions (Gerard)
+
+1. **Hybrid first-class** (top-ranked ≤6 get typed schemas) vs dispatcher-only + find_tools? *Rec: hybrid — keeps hot paths one-hop.*
+2. **Fallback posture** after eval: default `closed-pins`? *Rec: yes — slow embed should never mean max tokens.*
+3. **`workspace_*` pinning:** always-on for mission/coder agent types via existing category machinery? *Rec: yes (structural dependency, §4).*
+4. **Catalog text:** keep a tiny top-8 list + find_tools pointer, or drop the section entirely? *Rec: keep tiny — costs ~300 tok, preserves zero-shot discoverability.*
+5. **Promotion diet:** demote never-used promoted actions outright (blog×6? shopify×2?) using `tool_execution_logs` usage — data pull first? *Rec: separate, after telemetry.*
+
+---
+
+## A1. Promoted inventory (46)
+
+platform_list_agents, platform_get_agent, platform_create_agent, platform_update_agent (agents) · platform_get_activity_feed (analytics) · platform_get_autonomy_level, platform_set_autonomy_level^su (autonomy) · platform_list_blog_posts, platform_get_blog_post, platform_create_blog_post, platform_update_blog_post, platform_publish_blog_post, platform_generate_cover_image (blog) · platform_codegraph_list_projects, _get_symbol, _search, _call_graph, _dependencies, _architecture, _index, _reindex, _set_auto_reindex (codegraph) · platform_field_inject, platform_field_query (field) · platform_query_graph, platform_graph_neighbors, platform_graph_path (graph) · platform_browse_marketplace_agents, _plugins, _skills, platform_install_plugin, platform_install_skill (marketplace) · platform_search_memory (search) · platform_shopify_sync_catalog, platform_shopify_sync_status (shopify) · platform_get_system_health^su, platform_resume_context, platform_store_memory (workspace-misc) · workspace_read_file, workspace_write_file, workspace_list_dir, workspace_grep, workspace_exec, workspace_git, workspace_get_public_url, workspace_html_to_png (workspace).
+Size: ~35.8k chars ≈ **8.9k tokens** (all 46); admin-visible 44 ≈ **8.7k tokens**.
+
+## A2. Test-impact map
+
+| File | Pins | Touched by |
+|---|---|---|
+| test_action_registry_filtered.py:244-350 | enum semantics incl. promoted-excluded-even-in-allowlist (:329) | flip + floor |
+| test_tool_router_semantic.py:427-720 | narrowed enum contents; rank-raise→full-enum invariant (:563) | floor + posture |
+| test_action_semantic_index.py:214-408 | exact result counts (:249,:261); timeout→[] (:366) | floor |
+| test_prd143_su_surface.py:322-338 | su never leaks; `assert names` non-empty (:329) | floor (empty-result case) |
+| test_prd143_selection_at_scale.py:391-460 | in-set metric across intents | floor + flip |
+| test_us015_registry_intent_filter.py / test_us014_graph_router_delegation.py | promoted-pin union behavior | flip |
+| test_prd143_su_registry.py:80-190 | to_first_class_schemas su/admin filters | flip |
+| test_prd143_concierge_journey.py:256-257 | surface = first_class + dispatcher composition | flip |
+
+## A3. Evidence trail
+Three reader reports (inventory / wiring / safety) captured in session transcripts 2026-07-23; all file:line anchors re-verifiable by grep. Key prod-log evidence: `voice_live_ws_first_frame ms=12292/13398`, "narrowing falls back to the full enum" warnings during live calls, "Available tools: [37 names]" per turn, `updates=469` noise-turn storm (pre-STT-retune).

--- a/orchestrator/consumers/chatbot/smart_orchestrator.py
+++ b/orchestrator/consumers/chatbot/smart_orchestrator.py
@@ -172,8 +172,10 @@ class SmartChatOrchestrator:
 
         Args:
             messages: Conversation messages
-            available_tools: All tools available to this agent (kept for
-                backward compatibility — ContextService loads tools internally)
+            available_tools: The tool surface the chat entrypoint already
+                assembled (with is_super_admin + PRD-221 page_actions threaded
+                in). Non-empty → ContextService ships it as-is instead of
+                rebuilding blind; empty → ContextService loads tools itself.
             chat_id: Optional chat session ID
             complexity_assessment: Optional PRD-68 AutoBrain assessment
             attachment_ids: PRD-127 ephemeral attachments to resolve
@@ -241,6 +243,11 @@ class SmartChatOrchestrator:
             skip_memory=not _wants_memory,
             chat_id=chat_id,
             query=latest_query,
+            # The surface service.py::_get_tools built for this turn — carries
+            # is_super_admin + page-prior that ToolsSection can't resolve.
+            # None when empty so a failed upstream build falls back to the
+            # section's own loader.
+            prebuilt_tools=available_tools or None,
             agent_name=self.agent_name,
             user_name=self.state.user_name,
             # PRD-206 S7: the driving human for the Q7 private-scope guard.

--- a/orchestrator/modules/agents/factory/agent_factory.py
+++ b/orchestrator/modules/agents/factory/agent_factory.py
@@ -926,6 +926,9 @@ class AgentFactory:
                         agent=db_agent,
                         workspace_id=agent_runtime.workspace_id,
                         task_description=prompt,
+                        # Narrow the dispatcher enum to task-relevant actions —
+                        # without a query this lane shipped all 137 every run.
+                        query=prompt,
                     )
                     # PRD-201 S4: carry the assembler's cache-stable prefix on the
                     # system message so the Anthropic client can place its

--- a/orchestrator/modules/context/sections/tools.py
+++ b/orchestrator/modules/context/sections/tools.py
@@ -68,8 +68,18 @@ class ToolsSection(BaseSection):
         tool_hints: Optional[list[str]] = None,
         query: Optional[str] = None,
         conversation_context: Optional[list[dict]] = None,
+        prebuilt_tools: Optional[list[dict[str, Any]]] = None,
     ) -> tuple[list[dict[str, Any]], str]:
         """Load tool schemas and determine tool_choice.
+
+        ``prebuilt_tools``: a surface the entrypoint already assembled via
+        get_tools_for_agent_async — with ``is_super_admin`` and the PRD-221
+        ``page_actions`` prior threaded in, which this section cannot resolve
+        on its own. Non-empty → authoritative (no rebuild; the double build
+        was both a ~seconds-per-turn cost and the reason page-prior/su never
+        reached the LLM). Empty/None → build here as before (an empty list
+        means the entrypoint's build failed — tool_router returns [] on
+        error — so rebuilding is the resilient choice).
 
         Returns:
             (tool_schemas, tool_choice) — ready for ContextResult.
@@ -82,7 +92,13 @@ class ToolsSection(BaseSection):
                 return await self._load_dispatcher_only(query=query)
 
             if strategy == ToolLoadingStrategy.FULL:
-                return await self._load_full(agent_id, workspace_id, db_session, query=query)
+                return await self._load_full(
+                    agent_id,
+                    workspace_id,
+                    db_session,
+                    query=query,
+                    prebuilt_tools=prebuilt_tools,
+                )
 
             if strategy == ToolLoadingStrategy.FILTERED:
                 return await self._load_filtered(
@@ -93,6 +109,7 @@ class ToolsSection(BaseSection):
                     tool_hints=tool_hints,
                     query=query,
                     conversation_context=conversation_context,
+                    prebuilt_tools=prebuilt_tools,
                 )
 
             logger.warning("Unknown ToolLoadingStrategy %r — returning empty tools", strategy)
@@ -148,13 +165,18 @@ class ToolsSection(BaseSection):
         workspace_id: str,
         db_session: Any = None,
         query: Optional[str] = None,
+        prebuilt_tools: Optional[list[dict[str, Any]]] = None,
     ) -> tuple[list[dict[str, Any]], str]:
         """Return all assigned tools (core + platform dispatcher + composio).
 
         PRD-138 US-009: thread the query down to get_tools_for_agent_async
         so the platform_execute dispatcher's action enum narrows when the
-        flag is on.
+        flag is on. A non-empty ``prebuilt_tools`` surface (already built by
+        the entrypoint, with su/page-prior context) is used as-is.
         """
+        if prebuilt_tools:
+            return prebuilt_tools, "auto"
+
         from modules.tools.tool_router import get_tools_for_agent_async
 
         tools = await get_tools_for_agent_async(
@@ -174,21 +196,26 @@ class ToolsSection(BaseSection):
         tool_hints: Optional[list[str]] = None,
         query: Optional[str] = None,
         conversation_context: Optional[list[dict]] = None,
+        prebuilt_tools: Optional[list[dict[str, Any]]] = None,
     ) -> tuple[list[dict[str, Any]], str]:
         """Return intent-filtered subset of tools via SmartToolRouter."""
-        from modules.tools.tool_router import get_tools_for_agent_async
+        # Step 1: the tool surface. A non-empty prebuilt surface from the
+        # entrypoint is authoritative — it was built with is_super_admin and
+        # the PRD-221 page-actions prior, which don't reach this section.
+        # Otherwise load here (PRD-138 US-009: pass query so the
+        # platform_execute dispatcher's enum narrows even before
+        # SmartToolRouter sees the list — both filters compose).
+        if prebuilt_tools:
+            all_tools = prebuilt_tools
+        else:
+            from modules.tools.tool_router import get_tools_for_agent_async
 
-        # Step 1: Load all available tools
-        # PRD-138 US-009: pass query so the platform_execute dispatcher's
-        # enum narrows even before SmartToolRouter sees the list. Both
-        # filters compose — semantic narrowing trims the platform_execute
-        # action enum, SmartToolRouter trims the top-level tools list.
-        all_tools = await get_tools_for_agent_async(
-            agent_id=agent_id,
-            db_session=db_session,
-            workspace_id=workspace_id,
-            query=query,
-        )
+            all_tools = await get_tools_for_agent_async(
+                agent_id=agent_id,
+                db_session=db_session,
+                workspace_id=workspace_id,
+                query=query,
+            )
 
         if not all_tools:
             return [], "none"

--- a/orchestrator/modules/context/service.py
+++ b/orchestrator/modules/context/service.py
@@ -611,6 +611,10 @@ class ContextService:
             tool_hints=ctx.tool_hints,
             query=ctx.kwargs.get("query"),
             conversation_context=ctx.messages,
+            # Surface already assembled by the entrypoint (su + PRD-221
+            # page-prior threaded in) — ToolsSection uses it instead of
+            # rebuilding blind.
+            prebuilt_tools=ctx.kwargs.get("prebuilt_tools"),
         )
 
     @staticmethod

--- a/orchestrator/modules/tools/discovery/action_semantic_index.py
+++ b/orchestrator/modules/tools/discovery/action_semantic_index.py
@@ -33,6 +33,12 @@ class ActionSemanticIndex:
         self._action_embeddings: Dict[str, List[float]] = {}
         self._indexed: bool = False
         self._lock: Optional[asyncio.Lock] = None
+        # In-flight live query embeds, keyed by (loop id, model_key, query):
+        # concurrent same-query callers (enum narrowing + the prompt catalog
+        # rank the same turn text) share ONE upstream embed instead of racing
+        # duplicates. Loop id in the key because a task is only awaitable on
+        # the loop that created it (the sync bridge runs on its own loop).
+        self._inflight: Dict[tuple, asyncio.Task] = {}
 
     def _get_lock(self) -> asyncio.Lock:
         if self._lock is None:
@@ -150,16 +156,26 @@ class ActionSemanticIndex:
         if cached:
             return cached, True, False
 
-        task = asyncio.ensure_future(self._embedding_manager.generate_embedding(query))
-        done, pending = await asyncio.wait({task}, timeout=timeout_s)
-        if pending:
-            def _stash_when_done(t: "asyncio.Task") -> None:
+        # One live embed per (loop, model, query) — concurrent callers share
+        # it. The finalize callback owns cleanup + the cache write, so the
+        # vector lands in Redis whether the winner was awaited or timed out.
+        key = (id(asyncio.get_running_loop()), model_key, query)
+        task = self._inflight.get(key)
+        if task is None:
+            task = asyncio.ensure_future(self._embedding_manager.generate_embedding(query))
+            self._inflight[key] = task
+
+            def _finalize(t: "asyncio.Task", _key: tuple = key) -> None:
+                self._inflight.pop(_key, None)
                 try:
                     self._cache.set_embeddings_batch({query: t.result()}, model=model_key)
                 except Exception:
                     logger.debug("query-embed background cache write failed", exc_info=True)
 
-            task.add_done_callback(_stash_when_done)
+            task.add_done_callback(_finalize)
+
+        done, pending = await asyncio.wait({task}, timeout=timeout_s)
+        if pending:
             logger.warning(
                 "ActionSemanticIndex: query embed exceeded %.1fs — narrowing "
                 "falls back to the full enum; embed continues in background "

--- a/orchestrator/services/heartbeat_service.py
+++ b/orchestrator/services/heartbeat_service.py
@@ -712,6 +712,9 @@ class HeartbeatService:
                 agent=orchestrator_agent,
                 workspace_id=workspace_id,
                 task_description=task_description,
+                # Narrow the dispatcher enum to heartbeat-relevant actions —
+                # without a query this lane shipped all 137 on every run.
+                query=task_description,
             )
 
             system_prompt = context.system_prompt

--- a/orchestrator/tests/test_tool_surface_bugfixes.py
+++ b/orchestrator/tests/test_tool_surface_bugfixes.py
@@ -1,0 +1,337 @@
+"""Tool-surface bug fixes (PR-A of TOOL-SURFACE-DEEP-REVIEW-2026-07-23).
+
+Three plumbing faults, no design change:
+
+1. The full chat path computed its tool surface (with ``is_super_admin`` and
+   PRD-221 ``page_actions`` threaded in) at service.py::_get_tools — then
+   ``smart_chat.prepare(available_tools=…)`` documented it as ignored and
+   ToolsSection rebuilt the surface WITHOUT them. The page-prior union and su
+   widening never reached the LLM, and get_tools_for_agent_async ran twice
+   per turn. Fix: the prebuilt surface rides ``prebuilt_tools`` through
+   build_context into ToolsSection, which uses it instead of rebuilding.
+
+2. Heartbeat / task-execution build_context calls passed ``task_description``
+   but no ``query`` — so the dispatcher enum never narrowed on those lanes
+   (full 137 actions on every heartbeat, forever).
+
+3. ActionSemanticIndex launched a live query-embed per caller with no
+   in-flight dedup — concurrent same-query turns each paid for (and raced)
+   the same embedding.
+
+Pure unit tests — no DB, no Redis, no network.
+"""
+from __future__ import annotations
+
+import asyncio
+import re
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional
+from unittest.mock import patch
+
+import pytest
+
+_ORCH = Path(__file__).resolve().parents[1]
+
+
+# ---------------------------------------------------------------------------
+# 1a. ToolsSection honors a prebuilt surface (FILTERED + FULL strategies)
+# ---------------------------------------------------------------------------
+
+
+class _Boom:
+    """get_tools_for_agent_async stand-in that must NOT be called."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def __call__(self, **kwargs: Any) -> List[Dict[str, Any]]:
+        self.calls += 1
+        raise AssertionError(
+            "get_tools_for_agent_async was called although a prebuilt surface "
+            "was supplied — the double-build is back"
+        )
+
+
+class _Rebuilt:
+    """get_tools_for_agent_async stand-in returning a sentinel surface."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+        self.kwargs: List[Dict[str, Any]] = []
+
+    async def __call__(self, **kwargs: Any) -> List[Dict[str, Any]]:
+        self.calls += 1
+        self.kwargs.append(kwargs)
+        return [_tool("rebuilt_tool")]
+
+
+def _tool(name: str) -> Dict[str, Any]:
+    return {"type": "function", "function": {"name": name, "description": name, "parameters": {}}}
+
+
+@pytest.mark.asyncio
+async def test_filtered_strategy_ships_the_prebuilt_surface() -> None:
+    """A non-empty prebuilt surface is authoritative: no rebuild happens and
+    the prebuilt tools (which carry the page-prior + su threading from the
+    chat entrypoint) are what ships."""
+    from modules.context.sections.tools import ToolsSection, ToolLoadingStrategy
+
+    prebuilt = [_tool("platform_execute"), _tool("page_prior_tool")]
+    boom = _Boom()
+    with patch("modules.tools.tool_router.get_tools_for_agent_async", new=boom):
+        tools, tool_choice = await ToolsSection().load_tools(
+            agent_id=1,
+            workspace_id="ws-1",
+            strategy=ToolLoadingStrategy.FILTERED,
+            db_session=None,
+            prebuilt_tools=prebuilt,
+            # No query/hints/context → SmartToolRouter step is skipped; the
+            # prebuilt short-circuit is what's under test here.
+        )
+    assert boom.calls == 0
+    assert tools == prebuilt
+    assert tool_choice == "auto"
+
+
+@pytest.mark.asyncio
+async def test_full_strategy_ships_the_prebuilt_surface() -> None:
+    from modules.context.sections.tools import ToolsSection, ToolLoadingStrategy
+
+    prebuilt = [_tool("platform_execute")]
+    boom = _Boom()
+    with patch("modules.tools.tool_router.get_tools_for_agent_async", new=boom):
+        tools, _ = await ToolsSection().load_tools(
+            agent_id=1,
+            workspace_id="ws-1",
+            strategy=ToolLoadingStrategy.FULL,
+            db_session=None,
+            prebuilt_tools=prebuilt,
+        )
+    assert boom.calls == 0
+    assert tools == prebuilt
+
+
+@pytest.mark.asyncio
+async def test_empty_prebuilt_falls_back_to_rebuild() -> None:
+    """An EMPTY prebuilt list means the entrypoint's build failed (tool_router
+    returns [] on error) — the section rebuilds rather than shipping nothing."""
+    from modules.context.sections.tools import ToolsSection, ToolLoadingStrategy
+
+    rebuilt = _Rebuilt()
+    with patch("modules.tools.tool_router.get_tools_for_agent_async", new=rebuilt):
+        tools, _ = await ToolsSection().load_tools(
+            agent_id=1,
+            workspace_id="ws-1",
+            strategy=ToolLoadingStrategy.FILTERED,
+            db_session=None,
+            prebuilt_tools=[],
+        )
+    assert rebuilt.calls == 1
+    assert tools == [_tool("rebuilt_tool")]
+
+
+@pytest.mark.asyncio
+async def test_no_prebuilt_keeps_todays_rebuild_path() -> None:
+    from modules.context.sections.tools import ToolsSection, ToolLoadingStrategy
+
+    rebuilt = _Rebuilt()
+    with patch("modules.tools.tool_router.get_tools_for_agent_async", new=rebuilt):
+        tools, _ = await ToolsSection().load_tools(
+            agent_id=7,
+            workspace_id="ws-2",
+            strategy=ToolLoadingStrategy.FILTERED,
+            db_session=None,
+        )
+    assert rebuilt.calls == 1
+    assert tools == [_tool("rebuilt_tool")]
+    assert rebuilt.kwargs[0]["agent_id"] == 7
+
+
+# ---------------------------------------------------------------------------
+# 1b. ContextService threads ctx.kwargs["prebuilt_tools"] into ToolsSection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_context_service_threads_prebuilt_tools() -> None:
+    from modules.context.service import ContextService
+    from modules.context.sections import SectionContext
+    from modules.context.sections.tools import ToolsSection
+
+    captured: Dict[str, Any] = {}
+
+    async def _capture(self: Any, **kwargs: Any):  # noqa: ANN401
+        captured.update(kwargs)
+        return kwargs.get("prebuilt_tools") or [], "auto"
+
+    ctx = SectionContext(
+        agent=SimpleNamespace(id=1),
+        workspace_id="ws-1",
+        db_session=None,
+        messages=[],
+        kwargs={"prebuilt_tools": [_tool("threaded")], "query": "hello"},
+    )
+    config = SimpleNamespace(tool_loading="filtered")
+    with patch.object(ToolsSection, "load_tools", _capture):
+        tools, _ = await ContextService._load_tools(config, ctx)
+
+    assert captured.get("prebuilt_tools") == [_tool("threaded")]
+    assert tools == [_tool("threaded")]
+
+
+# ---------------------------------------------------------------------------
+# 1c. prepare_request forwards available_tools as the prebuilt surface
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_prepare_request_forwards_available_tools_as_prebuilt() -> None:
+    """The orchestrator's ``available_tools`` parameter stops being decorative:
+    it must reach build_context as ``prebuilt_tools``."""
+    from consumers.chatbot.smart_orchestrator import SmartChatOrchestrator, ConversationState
+    import modules.context as context_pkg
+
+    orch = SmartChatOrchestrator.__new__(SmartChatOrchestrator)
+    orch.workspace_id = "ws-1"
+    orch.agent_id = 1
+    orch.agent_name = "Auto"
+    orch.widget_mode = False
+    orch._db_session = None
+    orch.state = ConversationState()
+    orch.classifier = SimpleNamespace(
+        classify=lambda q, m: SimpleNamespace(
+            primary_intent=SimpleNamespace(value="chat"),
+            requires_tools=False,
+            requires_memory=False,
+            confidence=1.0,
+        )
+    )
+    orch._load_agent = lambda: SimpleNamespace(id=1)
+    orch._build_compat_memory_result = lambda context: None
+
+    captured: Dict[str, Any] = {}
+
+    class _FakeContextService:
+        def __init__(self, _db: Any) -> None:  # noqa: ANN401
+            pass
+
+        async def build_context(self, **kwargs: Any):  # noqa: ANN401
+            captured.update(kwargs)
+            return SimpleNamespace(
+                system_prompt="",
+                messages=[],
+                tools=kwargs.get("prebuilt_tools") or [],
+                tool_choice="auto",
+                memory_context=None,
+                user_name=None,
+                to_assembly_trace=lambda: [],
+            )
+
+    sentinel = [_tool("prebuilt_marker")]
+    with patch.object(context_pkg, "ContextService", _FakeContextService):
+        result = await orch.prepare_request(
+            messages=[{"role": "user", "content": "hi"}],
+            available_tools=sentinel,
+        )
+
+    assert captured.get("prebuilt_tools") == sentinel
+    assert result.tools == sentinel
+
+
+# ---------------------------------------------------------------------------
+# 2. Heartbeat + task-execution lanes thread a query for enum narrowing
+# ---------------------------------------------------------------------------
+# Source-probes (authz_sweep_probe precedent): these call sites sit deep in
+# DB-bound methods; what matters — and what regressed silently before — is
+# that the build_context call passes a query so _load_dispatcher_only /
+# _load_full can narrow the enum.
+
+
+def _call_site(text: str, anchor: str, window: int = 900) -> str:
+    idx = text.index(anchor)
+    return text[idx : idx + window]
+
+
+def test_heartbeat_build_context_threads_query() -> None:
+    src = (_ORCH / "services" / "heartbeat_service.py").read_text()
+    site = _call_site(src, "ContextMode.HEARTBEAT_ORCHESTRATOR")
+    assert re.search(r"query\s*=", site), (
+        "heartbeat build_context passes no query — the dispatcher enum ships "
+        "all 137 actions on every heartbeat run"
+    )
+
+
+def test_task_execution_build_context_threads_query() -> None:
+    src = (_ORCH / "modules" / "agents" / "factory" / "agent_factory.py").read_text()
+    site = _call_site(src, "context_result = await ContextService")
+    assert re.search(r"query\s*=", site), (
+        "agent_factory build_context passes no query — the dispatcher enum "
+        "ships all 137 actions on every task execution"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. Concurrent same-query embeds dedup to ONE live call
+# ---------------------------------------------------------------------------
+
+
+class _SlowEmbedder:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def generate_embedding(self, text: str) -> List[float]:
+        self.calls += 1
+        await asyncio.sleep(0.05)
+        return [1.0, 0.0, 0.0]
+
+
+class _MissCache:
+    def __init__(self) -> None:
+        self.set_calls: List[Dict[str, Any]] = []
+
+    def get_embeddings_batch(self, texts: List[str], model: str = "d") -> Dict[str, Optional[List[float]]]:
+        return {t: None for t in texts}
+
+    def set_embeddings_batch(self, embeddings: Dict[str, List[float]], model: str = "d") -> None:
+        self.set_calls.append(dict(embeddings))
+
+
+def _bare_index() -> Any:  # noqa: ANN401
+    from modules.tools.discovery.action_semantic_index import ActionSemanticIndex
+
+    idx = ActionSemanticIndex.__new__(ActionSemanticIndex)
+    idx._embedding_manager = _SlowEmbedder()
+    idx._cache = _MissCache()
+    idx._inflight = {}
+    return idx
+
+
+@pytest.mark.asyncio
+async def test_concurrent_same_query_embeds_once() -> None:
+    idx = _bare_index()
+    v1, v2 = await asyncio.gather(
+        idx._embed_query_bounded("hello there", "mk", timeout_s=5.0),
+        idx._embed_query_bounded("hello there", "mk", timeout_s=5.0),
+    )
+    assert idx._embedding_manager.calls == 1, "two live embeds for one query"
+    assert v1[0] == v2[0] == [1.0, 0.0, 0.0]
+    assert not v1[2] and not v2[2]  # neither timed out
+
+
+@pytest.mark.asyncio
+async def test_inflight_entry_cleared_after_completion() -> None:
+    idx = _bare_index()
+    await idx._embed_query_bounded("hello there", "mk", timeout_s=5.0)
+    await asyncio.sleep(0)  # let done-callbacks run
+    assert idx._inflight == {}, "in-flight table leaked a completed task"
+
+
+@pytest.mark.asyncio
+async def test_distinct_queries_do_not_dedup() -> None:
+    idx = _bare_index()
+    await asyncio.gather(
+        idx._embed_query_bounded("alpha", "mk", timeout_s=5.0),
+        idx._embed_query_bounded("beta", "mk", timeout_s=5.0),
+    )
+    assert idx._embedding_manager.calls == 2


### PR DESCRIPTION
## PR-A of the Tool-Surface Deep Review (bug fixes, no design change)

Dossier: `docs/reviews/TOOL-SURFACE-DEEP-REVIEW-2026-07-23.md` (included in this PR). Stages: **PR-A (this)** → PR-B (find_tools + floor + flags, default-off) → PR-C (the flip).

### Fixes

**1. The full chat path now ships the tool surface it already built.**
`service.py::_get_tools` threads `is_super_admin` + PRD-221 `page_actions` into the surface — but `smart_chat.prepare(available_tools=…)` documented it as *ignored* and ToolsSection rebuilt the surface without them. Consequences fixed: PRD-221 S4 page-prior and su widening never reached the LLM on the main lane, and `get_tools_for_agent_async` ran **twice per turn**. The prebuilt surface now rides `prepare_request → build_context(prebuilt_tools=) → ToolsSection` (non-empty = authoritative; empty = rebuild, preserving error resilience). SmartToolRouter filtering is unchanged and still composes on top.

**2. Heartbeat + task-execution lanes narrow their enum.**
Both `build_context` calls passed `task_description` but no `query` — the dispatcher enum shipped all 137 actions on every heartbeat and task run, forever. One-liners: thread the query.

**3. Query-embed in-flight dedup.**
The enum path and the prompt-catalog path each launch the same live embed per turn (plus any concurrent turns). One task per (loop, model, query) now; its finalize callback owns cleanup + the Redis cache write, so the timeout path still warms the cache.

### Not in this PR (by design)
- No relevance floor, no promoted gating, no find_tools — PR-B/PR-C, per the staged plan Gerard approved.
- Single-rank consolidation (catalog + enum share one rank call) moved to PR-C where the rank call gets reworked anyway; the dedup above removes the duplicate *upstream embed* cost today.

### Tests
`orchestrator/tests/test_tool_surface_bugfixes.py`:
- prebuilt surface honored (FILTERED + FULL), empty-prebuilt rebuild fallback, no-prebuilt legacy path
- ContextService threads `prebuilt_tools`; `prepare_request` forwards `available_tools`
- heartbeat/factory call-site probes for query threading
- concurrent same-query embeds → one live call; in-flight table drains; distinct queries don't dedup

### Expected observable effects
- `[tool-trace]` "dispatcher enum narrowed" lines appear on heartbeat/task lanes
- One `Loaded N tools` trace per chat turn instead of two
- Page-manifest actions present in the enum when chatting from a page (PRD-221 finally live on the main lane)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool selection is now narrowed to actions relevant to the current request, reducing unnecessary tool exposure.
  * Preassembled tool selections can be preserved throughout request processing.
  * Concurrent identical tool-discovery requests now share embedding work for improved efficiency.

* **Bug Fixes**
  * Corrected cases where selected tools were discarded or task-specific actions were omitted.
  * Added fallback behavior when no preassembled tool selection is available.

* **Documentation**
  * Added a review documenting tool-surface behavior, identified issues, safety considerations, and a staged improvement plan.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->