### PR TITLE
fix(tools): lazy-init the embed in-flight table — un-red main after #594

### DIFF
--- a/orchestrator/modules/tools/discovery/action_semantic_index.py
+++ b/orchestrator/modules/tools/discovery/action_semantic_index.py
@@ -159,14 +159,19 @@ class ActionSemanticIndex:
         # One live embed per (loop, model, query) — concurrent callers share
         # it. The finalize callback owns cleanup + the cache write, so the
         # vector lands in Redis whether the winner was awaited or timed out.
+        # Lazy-init like _get_lock(): tests construct the index via __new__,
+        # so instance state must not assume __init__ ran.
+        inflight = getattr(self, "_inflight", None)
+        if inflight is None:
+            inflight = self._inflight = {}
         key = (id(asyncio.get_running_loop()), model_key, query)
-        task = self._inflight.get(key)
+        task = inflight.get(key)
         if task is None:
             task = asyncio.ensure_future(self._embedding_manager.generate_embedding(query))
-            self._inflight[key] = task
+            inflight[key] = task
 
             def _finalize(t: "asyncio.Task", _key: tuple = key) -> None:
-                self._inflight.pop(_key, None)
+                inflight.pop(_key, None)
                 try:
                     self._cache.set_embeddings_batch({query: t.result()}, model=model_key)
                 except Exception:


### PR DESCRIPTION
#594 merged at the red commit; this is the already-written follow-up that was stranded on the branch (strand pattern — new branch, never push post-merge).

**All 39 orchestrator-tests failures on main are one cause:** `test_prd143_selection_at_scale` / `test_prd143_su_surface` construct `ActionSemanticIndex` via `__new__`, so instance state added in `__init__` doesn't exist for them. Fix mirrors the class's existing `_get_lock()` lazy idiom — the in-flight table initializes on first use.

Test-only breakage: production builds the index via `get_action_semantic_index()` → `__init__` runs → unaffected.

Merge as soon as orchestrator-tests is green to un-red main.