### PR TITLE
feat(tools): PR-B — platform_find_tools discovery, relevance floor, closed-pins fallback, shadow telemetry

### DIFF
--- a/orchestrator/config.py
+++ b/orchestrator/config.py
@@ -931,6 +931,28 @@ class Config:
     # Max seconds a live query embedding may take before narrowing falls back
     # to the full action enum (the embed keeps running and caches for next turn).
     SEMANTIC_TOOL_ROUTING_EMBED_TIMEOUT_S: float = float(os.getenv("SEMANTIC_TOOL_ROUTING_EMBED_TIMEOUT_S", "2.5"))
+    # Tool-surface deep review PR-B (docs/reviews/TOOL-SURFACE-DEEP-REVIEW-2026-07-23.md).
+    # Relevance floor on rank_actions: drop candidates scoring below
+    # max(FLOOR, best*FLOOR_RATIO) so a greeting stops surfacing 15
+    # least-dissimilar actions. 0 = off (today's blind top-K, default).
+    SEMANTIC_TOOL_ROUTING_FLOOR: float = float(os.getenv("SEMANTIC_TOOL_ROUTING_FLOOR", "0"))
+    SEMANTIC_TOOL_ROUTING_FLOOR_RATIO: float = float(os.getenv("SEMANTIC_TOOL_ROUTING_FLOOR_RATIO", "0"))
+    # What ships when narrowing CAN'T decide (no query / rank error / embed
+    # timeout) while SEMANTIC_TOOL_ROUTING is on:
+    #   open-full   — today's posture: full enum + full catalog (default)
+    #   closed-pins — the pin set below + platform_find_tools discovery
+    # (flag off entirely = operator chose the wide surface; always open-full).
+    TOOL_FALLBACK_MODE: str = os.getenv("TOOL_FALLBACK_MODE", "open-full")
+    TOOL_FALLBACK_PINS: str = os.getenv(
+        "TOOL_FALLBACK_PINS",
+        "platform_find_tools,platform_search_memory,platform_store_memory,platform_resume_context",
+    )
+    # Shadow telemetry: log (never ship) what the PR-C relevance-gated surface
+    # WOULD have been for each turn — the eval data for the flip.
+    TOOL_SURFACE_SHADOW: bool = os.getenv("TOOL_SURFACE_SHADOW", "true").lower() == "true"
+    # PR-C hybrid: max promoted actions that earn per-turn first-class schemas.
+    # Shadow-only until the flip.
+    TOOL_SURFACE_HYBRID_CAP: int = int(os.getenv("TOOL_SURFACE_HYBRID_CAP", "6"))
     PLATFORM_ACTIONS_MAX_TOKENS: int = int(os.getenv("PLATFORM_ACTIONS_MAX_TOKENS", "4000"))
     PLAYBOOK_CONTEXT_MAX_TOKENS: int = int(os.getenv("PLAYBOOK_CONTEXT_MAX_TOKENS", "2000"))
     MEMORY_SECTION_MAX_TOKENS: int = int(os.getenv("MEMORY_SECTION_MAX_TOKENS", "1500"))

--- a/orchestrator/consumers/chatbot/service.py
+++ b/orchestrator/consumers/chatbot/service.py
@@ -2137,19 +2137,18 @@ class StreamingChatService:
                 # surface as the full path.
                 try:
                     from modules.tools.discovery.action_registry import get_action_registry
-                    _allowed = None
-                    if _semantic_routing_enabled() and latest_text:
-                        _allowed = await _rank_actions_for_dispatcher_async(
-                            query=latest_text,
-                            top_k=_semantic_routing_top_k(),
-                            exclude_admin=True,
-                            exclude_promoted=True,
-                            include_super_admin=is_super_admin,
-                        )
+                    from modules.tools.tool_router import _narrow_dispatcher_actions_async
+                    # Shared narrowing contract (PR-B): same ranking + fallback
+                    # posture as the full path, so ATOM turns honor closed-pins
+                    # instead of failing open to the full enum.
+                    _allowed, _nreason, _from_pins = await _narrow_dispatcher_actions_async(
+                        latest_text, is_admin=False, is_super_admin=is_super_admin
+                    )
                     _dispatcher = get_action_registry().to_dispatcher_schema(
                         exclude_admin=True,
                         allowed_names=_allowed,
                         include_super_admin=is_super_admin,
+                        allow_promoted_in_allowlist=_from_pins,
                     )
                     # PRD-007 v0.5: proactive openers get zero tools — directive
                     # is self-contained (page context + graph related products).

--- a/orchestrator/modules/context/sections/platform_actions.py
+++ b/orchestrator/modules/context/sections/platform_actions.py
@@ -80,6 +80,15 @@ class PlatformActionsSection(BaseSection):
                 if filtered:
                     return filtered
 
+            # PR-B (tool-surface review): when narrowing couldn't decide and
+            # the operator chose closed-pins, render the tiny pins card
+            # instead of the ~4k-token full catalog. Flag-off keeps the full
+            # dump (operator explicitly chose the wide surface).
+            if self._semantic_routing_enabled() and self._fallback_mode_closed():
+                pins_text = self._build_pins_text()
+                if pins_text:
+                    return pins_text
+
             return self._build()
         except Exception:
             logger.exception(
@@ -202,6 +211,49 @@ class PlatformActionsSection(BaseSection):
             sequence = " then ".join(f"`{a}`" for a in actions)
             lines.append(f"- call {sequence}")
         return "\n".join(lines)
+
+    def _fallback_mode_closed(self) -> bool:
+        """One source of truth: the router's fallback-mode reader."""
+        try:
+            from modules.tools.tool_router import _fallback_mode_closed
+            return _fallback_mode_closed()
+        except Exception:
+            return False
+
+    def _build_pins_text(self) -> str:
+        """The closed-pins fallback card: pins + the discovery pointer.
+
+        ~10 lines instead of the ~4k-token catalog. The model keeps a way
+        into EVERYTHING via platform_find_tools, so shipping less text here
+        loses no capability.
+        """
+        try:
+            from modules.tools.discovery.action_registry import get_action_registry
+            from modules.tools.tool_router import _fallback_pins
+
+            pins = _fallback_pins()
+            if not pins:
+                return ""
+            catalog = get_action_registry().build_filtered_prompt_summary(
+                pins,
+                exclude_admin=True,
+                exclude_promoted=False,  # pins are largely promoted by design
+                include_super_admin=False,
+            )
+            if not catalog:
+                return ""
+            return (
+                self._PREAMBLE
+                + catalog
+                + "\n\nNeed anything else? Search the full catalog with "
+                "`platform_find_tools(query=...)` — every platform action is "
+                "reachable through it.\n"
+            )
+        except Exception:
+            logger.warning(
+                "PlatformActionsSection._build_pins_text failed", exc_info=True
+            )
+            return ""
 
     def _build(self) -> str:
         from modules.tools.discovery.action_registry import get_action_registry

--- a/orchestrator/modules/context/sections/tools.py
+++ b/orchestrator/modules/context/sections/tools.py
@@ -138,24 +138,19 @@ class ToolsSection(BaseSection):
         awaited on this loop — never bridged through a helper thread.
         """
         from modules.tools.discovery.action_registry import get_action_registry
-        from modules.tools.tool_router import (
-            _rank_actions_for_dispatcher_async,
-            _semantic_routing_enabled,
-            _semantic_routing_top_k,
-        )
+        from modules.tools.tool_router import _narrow_dispatcher_actions_async
 
         registry = get_action_registry()
-        allowed_names: Optional[list[str]] = None
-        if query and _semantic_routing_enabled():
-            allowed_names = await _rank_actions_for_dispatcher_async(
-                query=query,
-                top_k=_semantic_routing_top_k(),
-                exclude_admin=True,
-                exclude_promoted=True,
-            )
+        # Shared narrowing contract (PR-B): ranking when possible, and the
+        # configured fallback posture (open-full / closed-pins) when not —
+        # this lane (heartbeat et al.) previously always failed open wide.
+        allowed_names, _reason, from_pins = await _narrow_dispatcher_actions_async(
+            query, is_admin=False, is_super_admin=False
+        )
         schema = registry.to_dispatcher_schema(
             exclude_admin=True,
             allowed_names=allowed_names,
+            allow_promoted_in_allowlist=from_pins,
         )
         return [schema], "auto"
 

--- a/orchestrator/modules/tools/discovery/action_registry.py
+++ b/orchestrator/modules/tools/discovery/action_registry.py
@@ -166,6 +166,7 @@ class ActionRegistry:
         exclude_promoted: bool = True,
         allowed_names: Optional[List[str]] = None,
         include_super_admin: bool = False,
+        allow_promoted_in_allowlist: bool = False,
     ) -> Dict[str, Any]:
         """
         Return a SINGLE OpenAI tool schema (platform_execute) that wraps
@@ -187,6 +188,13 @@ class ActionRegistry:
             include_super_admin: Fail-closed — super_admin_only actions are
                 excluded from the enum (and from every fallback path)
                 unless this is explicitly True.
+            allow_promoted_in_allowlist: PR-B (tool-surface review) — when
+                True, names in ``allowed_names`` that are promoted may enter
+                the enum despite ``exclude_promoted`` (role filters still
+                apply first). Used by the closed-pins fallback, whose pin set
+                (platform_find_tools et al.) is largely promoted; without
+                this the pins would intersect to nothing and fall open to
+                the full enum — the exact failure the mode exists to stop.
         """
         self._ensure_initialized()
 
@@ -212,7 +220,16 @@ class ActionRegistry:
             narrowed_actions = valid_actions
         else:
             allow_set = set(allowed_names)
-            narrowed_actions = [n for n in valid_actions if n in allow_set]
+            intersect_pool = valid_actions
+            if allow_promoted_in_allowlist and exclude_promoted:
+                # Same role gates as valid_actions, promoted admitted — the
+                # allow-list (pins) is the narrowing here, not the flag.
+                intersect_pool = sorted(
+                    a.name for a in self._actions.values()
+                    if (not exclude_admin or not a.admin_only)
+                    and (include_super_admin or not a.super_admin_only)
+                )
+            narrowed_actions = [n for n in intersect_pool if n in allow_set]
             # Defensive: if the intersection is empty (e.g. ranker returned
             # only admin actions for a non-admin caller), fall back to the
             # full eligible set rather than ship a schema with zero options.

--- a/orchestrator/modules/tools/discovery/action_semantic_index.py
+++ b/orchestrator/modules/tools/discovery/action_semantic_index.py
@@ -50,10 +50,17 @@ def _apply_relevance_floor(
     """
     if not scored or (floor <= 0 and ratio <= 0):
         return scored
-    best = scored[0][1]
-    cutoff = floor
-    if ratio > 0 and best > 0:
-        cutoff = max(cutoff, best * ratio)
+    cutoffs = []
+    if floor > 0:
+        cutoffs.append(floor)
+    if ratio > 0 and scored[0][1] > 0:
+        cutoffs.append(scored[0][1] * ratio)
+    if not cutoffs:
+        # Only the ratio dial is set and the best score is non-positive —
+        # there is no meaningful cutoff; dropping everything here would turn
+        # a hostile query into an empty surface by accident.
+        return scored
+    cutoff = max(cutoffs)
     return [(n, s) for n, s in scored if s >= cutoff]
 
 

--- a/orchestrator/modules/tools/discovery/action_semantic_index.py
+++ b/orchestrator/modules/tools/discovery/action_semantic_index.py
@@ -20,6 +20,43 @@ from .action_registry import ActionDefinition, get_action_registry
 logger = logging.getLogger(__name__)
 
 
+def _relevance_floor_config() -> Tuple[float, float]:
+    """(absolute_floor, ratio_floor) from the canonical config singleton.
+
+    Both default 0 (floor off). Read lazily so pure unit tests need no config.
+    """
+    try:
+        from config import config
+
+        return (
+            float(getattr(config, "SEMANTIC_TOOL_ROUTING_FLOOR", 0) or 0),
+            float(getattr(config, "SEMANTIC_TOOL_ROUTING_FLOOR_RATIO", 0) or 0),
+        )
+    except Exception:
+        return 0.0, 0.0
+
+
+def _apply_relevance_floor(
+    scored: List[Tuple[str, float]],
+    floor: float,
+    ratio: float,
+) -> List[Tuple[str, float]]:
+    """Drop candidates below max(floor, best*ratio). Pure; order-preserving.
+
+    ``scored`` must be sorted best-first. With both dials 0 this is the
+    identity — the legacy blind top-K. A ratio floor only bites when the
+    best score is positive (cosine can be negative on a hostile query;
+    a negative cutoff would keep everything and mean nothing).
+    """
+    if not scored or (floor <= 0 and ratio <= 0):
+        return scored
+    best = scored[0][1]
+    cutoff = floor
+    if ratio > 0 and best > 0:
+        cutoff = max(cutoff, best * ratio)
+    return [(n, s) for n, s in scored if s >= cutoff]
+
+
 class ActionSemanticIndex:
     """Per-process semantic index over platform ActionDefinitions."""
 
@@ -206,6 +243,14 @@ class ActionSemanticIndex:
         include_super_admin: bool = False,
         embed_timeout_s: Optional[float] = None,
     ) -> List[Tuple[str, float]]:
+        """Rank eligible actions by cosine similarity to ``query``.
+
+        PR-B (tool-surface review): results below the configured relevance
+        floor — max(SEMANTIC_TOOL_ROUTING_FLOOR, best*FLOOR_RATIO) — are
+        dropped BEFORE the top_k cut, so a greeting can legitimately rank
+        zero actions instead of the 15 least-dissimilar. Both dials default
+        to 0 (floor off, exact legacy behavior).
+        """
         import time as _perf_t
         _perf_t0 = _perf_t.monotonic()
         await self.ensure_indexed(
@@ -259,6 +304,7 @@ class ActionSemanticIndex:
                 continue
             scored.append((name, float(np.dot(query_vec, vec) / (q_norm * v_norm))))
         scored.sort(key=lambda x: x[1], reverse=True)
+        scored = _apply_relevance_floor(scored, *_relevance_floor_config())
         logger.info(
             "[perf] rank_actions: ensure_indexed=%.0fms query_embed=%.0fms cosine=%.0fms n_candidates=%d cache_hit=%d",
             (_perf_t1 - _perf_t0) * 1000,

--- a/orchestrator/modules/tools/discovery/actions_capabilities.py
+++ b/orchestrator/modules/tools/discovery/actions_capabilities.py
@@ -1,0 +1,61 @@
+"""Capability-discovery ActionDefinitions (tool-surface deep review, PR-B).
+
+``platform_find_tools`` is the WHEN-REQUIRED seam: instead of shipping the
+whole action catalog into every turn, the agent searches the registry on
+demand and gets back names, descriptions and parameter schemas it can then
+call via ``platform_execute``. Promoted so its schema is always visible —
+it IS the discovery surface and must never itself need discovering.
+"""
+
+from .action_registry import ActionDefinition, ActionRegistry
+
+
+def register_capabilities_actions(registry: ActionRegistry) -> None:
+    """Register capability-discovery platform actions."""
+
+    registry.register(ActionDefinition(
+        name="platform_find_tools",
+        description=(
+            "Search the platform's full action catalog by describing what you "
+            "want to do. Returns matching actions with their description, "
+            "required/optional parameters and how to call them via "
+            "platform_execute. Use this whenever the task needs a capability "
+            "you don't currently see a tool for — every platform action is "
+            "reachable this way, so never assume something is impossible "
+            "without checking here first."
+        ),
+        category="capabilities",
+        parameters={
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": (
+                        "What you want to do, in plain language "
+                        "(e.g. 'publish a blog post', 'index a github repo')."
+                    ),
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Max matches to return (default 8, max 25).",
+                },
+                "include_params": {
+                    "type": "boolean",
+                    "description": (
+                        "Include each match's full parameter schema "
+                        "(default true; set false for a compact name+description list)."
+                    ),
+                },
+            },
+            "required": ["query"],
+        },
+        permission_level="read",
+        promoted=True,
+        tags=["tools", "capabilities", "discover", "search", "actions", "help", "can you"],
+        examples=[
+            "what tools do you have for blogs?",
+            "can you work with our codebase?",
+            "find a tool to sync the shopify catalog",
+            "what can you actually do on this platform?",
+        ],
+    ))

--- a/orchestrator/modules/tools/discovery/handlers_capabilities.py
+++ b/orchestrator/modules/tools/discovery/handlers_capabilities.py
@@ -1,0 +1,126 @@
+"""Capability-discovery handlers for PlatformActionExecutor (PR-B).
+
+``find_tools`` searches the action registry itself — semantic ranking first,
+keyword fallback when the ranker can't answer (embed timeout / empty index) —
+so discovery NEVER comes back empty-handed just because an upstream embed was
+slow. Results are fail-closed: admin/su-gated actions are never advertised
+here regardless of caller (execution-time gates in PlatformActionExecutor
+remain the enforcement point; privileged surfaces reach privileged callers
+through the enum/include_super_admin path instead).
+"""
+
+import logging
+from typing import Any, Dict, List
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_LIMIT = 8
+_MAX_LIMIT = 25
+
+
+def _compact_params(parameters: Dict[str, Any]) -> Dict[str, Any]:
+    """The parameter schema exactly as an LLM needs it to make a call."""
+    props = (parameters or {}).get("properties") or {}
+    return {
+        "required": list((parameters or {}).get("required") or []),
+        "properties": {
+            name: {
+                "type": spec.get("type", "string"),
+                "description": spec.get("description", ""),
+            }
+            for name, spec in props.items()
+            if isinstance(spec, dict)
+        },
+    }
+
+
+def _keyword_matches(actions: List[Any], query: str, limit: int) -> List[Any]:
+    """Ranker-less fallback: token overlap over name/description/tags."""
+    tokens = [t for t in query.lower().split() if len(t) > 2]
+    if not tokens:
+        return []
+    scored: List[tuple] = []
+    for action in actions:
+        haystack = " ".join(
+            [action.name, action.description or "", " ".join(action.tags or [])]
+        ).lower()
+        hits = sum(1 for t in tokens if t in haystack)
+        if hits:
+            scored.append((hits, action))
+    scored.sort(key=lambda x: x[0], reverse=True)
+    return [a for _, a in scored[:limit]]
+
+
+async def find_tools(db: Session, workspace_id: UUID, params: Dict[str, Any]) -> Dict[str, Any]:
+    """Search the full platform action catalog by natural-language intent."""
+    query = str(params.get("query") or "").strip()
+    if not query:
+        return {"success": False, "error": "query parameter is required"}
+    try:
+        limit = min(int(params.get("limit", _DEFAULT_LIMIT)), _MAX_LIMIT)
+    except (TypeError, ValueError):
+        limit = _DEFAULT_LIMIT
+    limit = max(1, limit)
+    include_params = params.get("include_params", True) is not False
+
+    from modules.tools.discovery.action_registry import get_action_registry
+
+    registry = get_action_registry()
+    # Fail-closed advertisement: never surface admin/su actions via discovery.
+    eligible = [
+        a for a in registry.get_all()
+        if not getattr(a, "admin_only", False)
+        and not getattr(a, "super_admin_only", False)
+    ]
+    by_name = {a.name: a for a in eligible}
+
+    matched: List[Any] = []
+    ranker = "semantic"
+    try:
+        from modules.tools.discovery.action_semantic_index import (
+            get_action_semantic_index,
+        )
+
+        ranked = await get_action_semantic_index().rank_actions(
+            query=query,
+            top_k=limit,
+            exclude_admin=True,
+            exclude_promoted=False,  # discovery spans the WHOLE catalog
+            include_super_admin=False,
+        )
+        matched = [by_name[n] for n, _ in ranked if n in by_name]
+    except Exception:
+        logger.warning("find_tools: semantic ranking failed — keyword fallback", exc_info=True)
+
+    if not matched:
+        ranker = "keyword"
+        matched = _keyword_matches(eligible, query, limit)
+
+    results = []
+    for action in matched:
+        row: Dict[str, Any] = {
+            "action": action.name,
+            "description": action.description,
+            "category": action.category,
+            "permission_level": getattr(action, "permission_level", "read"),
+            "call_with": f"platform_execute(action='{action.name}', params={{...}})",
+        }
+        if include_params:
+            row["params"] = _compact_params(getattr(action, "parameters", {}) or {})
+        results.append(row)
+
+    return {
+        "success": True,
+        "query": query,
+        "ranker": ranker,
+        "matches": results,
+        "catalog_size": len(eligible),
+        "note": (
+            "Call any match via platform_execute with its 'action' name and "
+            "required params. Nothing relevant? Rephrase the query — the "
+            "catalog is searched by meaning."
+        ),
+    }

--- a/orchestrator/modules/tools/discovery/platform_actions.py
+++ b/orchestrator/modules/tools/discovery/platform_actions.py
@@ -45,6 +45,7 @@ from .actions_power import register_power_actions  # PRD-142 Wave 4 (W4-S5)
 from .actions_autonomy import register_autonomy_actions
 from .actions_deliverables import register_deliverables_actions  # PRD-164 S3
 from .actions_watches import register_watch_actions  # PRD-204 S9
+from .actions_capabilities import register_capabilities_actions  # tool-surface PR-B
 
 
 def register_all_actions(registry: ActionRegistry) -> None:
@@ -83,6 +84,7 @@ def register_all_actions(registry: ActionRegistry) -> None:
     register_autonomy_actions(registry)
     register_deliverables_actions(registry)  # PRD-164 S3: deliverable list/get tools
     register_watch_actions(registry)  # PRD-204 S9: watch create/list/get/cancel
+    register_capabilities_actions(registry)  # PR-B: platform_find_tools discovery seam
 
     # Workspace tools (file I/O, grep, exec, git)
     from .workspace_actions import register_workspace_actions

--- a/orchestrator/modules/tools/discovery/platform_executor.py
+++ b/orchestrator/modules/tools/discovery/platform_executor.py
@@ -102,6 +102,7 @@ from modules.tools.discovery.handlers_search import (
     browse_memories,
     delete_memory,
 )
+from modules.tools.discovery.handlers_capabilities import find_tools
 from modules.tools.discovery.handlers_tools_llms import (
     list_tools,
     list_llms,
@@ -372,6 +373,7 @@ class PlatformActionExecutor:
             "platform_query_prometheus": query_prometheus,
             "platform_get_alerts": get_alerts,
             # Visibility / discovery
+            "platform_find_tools": find_tools,  # PR-B: search the action catalog itself
             "platform_list_tools": list_tools,
             "platform_list_llms": list_llms,
             "platform_list_datasources": list_datasources,

--- a/orchestrator/modules/tools/tool_router.py
+++ b/orchestrator/modules/tools/tool_router.py
@@ -217,16 +217,57 @@ def _narrow_dispatcher_actions_async_inputs(
     return None
 
 
+def _fallback_pins() -> List[str]:
+    """The configured pin set for closed-pins fallback (CSV, whitespace-safe)."""
+    try:
+        from config import config
+        raw = str(getattr(config, "TOOL_FALLBACK_PINS", "") or "")
+    except Exception:
+        raw = ""
+    return [p.strip() for p in raw.split(",") if p.strip()]
+
+
+def _fallback_mode_closed() -> bool:
+    """True when TOOL_FALLBACK_MODE=closed-pins (PR-B; default open-full)."""
+    try:
+        from config import config
+        return str(getattr(config, "TOOL_FALLBACK_MODE", "open-full")).strip().lower() == "closed-pins"
+    except Exception:
+        return False
+
+
+def _fallback_narrowing(reason: str) -> Tuple[Optional[List[str]], Optional[str], bool]:
+    """What ships when narrowing CAN'T decide (no query / rank fail / timeout).
+
+    open-full (default): (None, reason, False) — today's fail-open full enum.
+    closed-pins: the pin set, marked from_pins=True so the dispatcher build
+    may admit promoted pins (platform_find_tools et al.) into the enum. A
+    slow embed stops meaning maximum context.
+    """
+    if _fallback_mode_closed():
+        pins = _fallback_pins()
+        if pins:
+            return pins, f"closed-pins ({reason})", True
+    return None, reason, False
+
+
 async def _narrow_dispatcher_actions_async(
     query: Optional[str],
     is_admin: bool,
     is_super_admin: bool,
-) -> Tuple[Optional[List[str]], Optional[str]]:
-    """Resolve (allowed_names, narrow_reason) for the dispatcher enum —
-    async-native (awaits ranking on the caller's loop)."""
+) -> Tuple[Optional[List[str]], Optional[str], bool]:
+    """Resolve (allowed_names, narrow_reason, from_pins) for the dispatcher
+    enum — async-native (awaits ranking on the caller's loop).
+
+    from_pins marks a closed-pins fallback surface: the allow-list may then
+    contain promoted names that to_dispatcher_schema should admit. A flag-off
+    operator choice is always honored as open-full.
+    """
     skip_reason = _narrow_dispatcher_actions_async_inputs(query)
     if skip_reason is not None:
-        return None, skip_reason
+        if skip_reason.startswith("flag "):
+            return None, skip_reason, False
+        return _fallback_narrowing(skip_reason)
     allowed = await _rank_actions_for_dispatcher_async(
         query=query,
         top_k=_semantic_routing_top_k(),
@@ -235,8 +276,8 @@ async def _narrow_dispatcher_actions_async(
         include_super_admin=is_super_admin,
     )
     if allowed is None:
-        return None, "rank_actions returned empty or raised"
-    return allowed, None
+        return _fallback_narrowing("rank_actions returned empty or raised")
+    return allowed, None, False
 
 
 def _page_action_passes_gate(
@@ -263,20 +304,20 @@ def _page_action_passes_gate(
 
 
 def _apply_page_prior(
-    narrowing: Tuple[Optional[List[str]], Optional[str]],
+    narrowing: Tuple[Optional[List[str]], Optional[str], bool],
     page_actions: Optional[List[str]],
     is_admin: bool,
     is_super_admin: bool,
-) -> Tuple[Optional[List[str]], Optional[str]]:
+) -> Tuple[Optional[List[str]], Optional[str], bool]:
     """Union gate-cleared page actions into the narrowed enum (PRD-221 S4).
 
     - No page actions, or a full-enum narrowing (allowed is None → every action
       already exposed): returned unchanged.
     - Otherwise the gate-passing page actions are appended to the ranked
       allow-list (dedup, order-stable) and the result is capped at
-      ``TOOL_ROUTING_ENUM_CAP`` to bound prompt cost.
+      ``TOOL_ROUTING_ENUM_CAP`` to bound prompt cost. from_pins passes through.
     """
-    allowed, reason = narrowing
+    allowed, reason, from_pins = narrowing
     if not page_actions or allowed is None:
         return narrowing
     cleared = [
@@ -298,18 +339,20 @@ def _apply_page_prior(
         cap = 40
     if cap > 0 and len(merged) > cap:
         merged = merged[:cap]
-    return merged, (reason or "page_prior")
+    return merged, (reason or "page_prior"), from_pins
 
 
 def _narrow_dispatcher_actions_sync(
     query: Optional[str],
     is_admin: bool,
     is_super_admin: bool,
-) -> Tuple[Optional[List[str]], Optional[str]]:
+) -> Tuple[Optional[List[str]], Optional[str], bool]:
     """Sync twin of _narrow_dispatcher_actions_async (thread bridge)."""
     skip_reason = _narrow_dispatcher_actions_async_inputs(query)
     if skip_reason is not None:
-        return None, skip_reason
+        if skip_reason.startswith("flag "):
+            return None, skip_reason, False
+        return _fallback_narrowing(skip_reason)
     allowed = _rank_actions_for_dispatcher(
         query=query,
         top_k=_semantic_routing_top_k(),
@@ -318,8 +361,8 @@ def _narrow_dispatcher_actions_sync(
         include_super_admin=is_super_admin,
     )
     if allowed is None:
-        return None, "rank_actions returned empty or raised"
-    return allowed, None
+        return _fallback_narrowing("rank_actions returned empty or raised")
+    return allowed, None, False
 
 
 def _resolve_relative_date_window_utc(intent: str) -> Optional[tuple[datetime.date, datetime.date]]:
@@ -565,13 +608,16 @@ def _get_tools_for_agent_core(
 
             # Narrowing was resolved by the public entry (sync bridge or
             # native await) BEFORE this loop-free body ran.
-            allowed_names, narrow_reason = narrowing
+            allowed_names, narrow_reason, from_pins = narrowing
 
             dispatcher_schema = action_registry.to_dispatcher_schema(
                 exclude_admin=not is_admin,
                 exclude_promoted=True,  # promoted actions have first-class schemas below
                 allowed_names=allowed_names,
                 include_super_admin=is_super_admin,
+                # closed-pins fallback pins include promoted names
+                # (platform_find_tools et al.) — admit them into the enum.
+                allow_promoted_in_allowlist=from_pins,
             )
             openai_tools.append(dispatcher_schema)
             all_actions = action_registry.get_all()
@@ -693,6 +739,57 @@ def get_tools_for_agent(
             session_used.close()
 
 
+async def _maybe_log_shadow_surface(
+    query: Optional[str],
+    is_admin: bool,
+    is_super_admin: bool,
+    shipped_tools: List[Dict[str, Any]],
+    trace_id: str,
+) -> None:
+    """PR-C eval data (tool-surface review): log — never ship — what the
+    relevance-gated surface WOULD have been for this turn.
+
+    One line per turn: how many first-class promoted schemas would survive
+    the hybrid cap vs the ~44 shipped today, and the floored enum size. The
+    rank call shares the turn's deduped/cached query embed, so this costs a
+    cosine pass, not a network call. Any failure is swallowed — shadow may
+    never affect a live turn.
+    """
+    try:
+        from config import config
+        if not getattr(config, "TOOL_SURFACE_SHADOW", False) or not query:
+            return
+        from modules.tools.discovery import get_action_registry
+        from modules.tools.discovery.action_semantic_index import (
+            get_action_semantic_index,
+        )
+
+        ranked = await get_action_semantic_index().rank_actions(
+            query=query,
+            top_k=_semantic_routing_top_k(),
+            exclude_admin=not is_admin,
+            exclude_promoted=False,  # the would-be surface spans promoted too
+            include_super_admin=is_super_admin,
+        )
+        registry = get_action_registry()
+        cap = int(getattr(config, "TOOL_SURFACE_HYBRID_CAP", 6))
+        would_first_class = [
+            n for n, _ in ranked
+            if getattr(registry.get(n), "promoted", False)
+        ][: max(cap, 0)]
+        logger.info(
+            "[tool-shadow %s] shipped_tools=%d would_first_class=%d "
+            "would_enum=%d names=%s",
+            trace_id,
+            len(shipped_tools),
+            len(would_first_class),
+            len(ranked),
+            would_first_class,
+        )
+    except Exception:
+        logger.debug("[tool-shadow %s] failed", trace_id, exc_info=True)
+
+
 async def get_tools_for_agent_async(
     agent_id: Optional[int] = None,
     db_session=None,
@@ -714,7 +811,7 @@ async def get_tools_for_agent_async(
         # Gate-filtered by the SAME predicate as ranking — a manifest can never
         # expose an admin/su tool to an unauthorized principal.
         narrowing = _apply_page_prior(narrowing, page_actions, is_admin, is_super_admin)
-        return _get_tools_for_agent_core(
+        tools = _get_tools_for_agent_core(
             agent_id=agent_id,
             session_used=session_used,
             workspace_id=workspace_id,
@@ -725,6 +822,8 @@ async def get_tools_for_agent_async(
             trace_id=trace_id,
             start_time=start_time,
         )
+        await _maybe_log_shadow_surface(query, is_admin, is_super_admin, tools, trace_id)
+        return tools
     except Exception as e:
         logger.error(f"[tool-trace {trace_id}] Error loading tools from registry: {e}")
         return []

--- a/orchestrator/tests/test_prd221_page_prior_tools.py
+++ b/orchestrator/tests/test_prd221_page_prior_tools.py
@@ -44,8 +44,8 @@ def _patch_registry(monkeypatch, mapping):
 
 def test_page_actions_unioned(monkeypatch):
     monkeypatch.setattr(tr, "_page_action_passes_gate", lambda n, ia, isa: True)
-    narrowing = (["ranked_1", "ranked_2"], "semantic")
-    out, reason = tr._apply_page_prior(
+    narrowing = (["ranked_1", "ranked_2"], "semantic", False)
+    out, reason, _pins = tr._apply_page_prior(
         narrowing, ["page_x", "page_y"], is_admin=False, is_super_admin=False
     )
     # ranked survive AND page actions are folded in even though the query
@@ -56,20 +56,20 @@ def test_page_actions_unioned(monkeypatch):
 
 
 def test_no_page_context_unchanged():
-    narrowing = (["a", "b"], "semantic")
+    narrowing = (["a", "b"], "semantic", False)
     # No page actions → identity (same tuple object).
     assert tr._apply_page_prior(narrowing, None, False, False) is narrowing
     assert tr._apply_page_prior(narrowing, [], False, False) is narrowing
     # Full-enum narrowing (allowed is None → every action already exposed):
     # nothing to union, returned unchanged.
-    full = (None, "routing_off")
+    full = (None, "routing_off", False)
     assert tr._apply_page_prior(full, ["x"], False, False) is full
 
 
 def test_page_actions_dedup_and_order(monkeypatch):
     monkeypatch.setattr(tr, "_page_action_passes_gate", lambda n, ia, isa: True)
-    narrowing = (["a", "b"], "s")
-    out, _ = tr._apply_page_prior(narrowing, ["b", "c", "c"], False, False)
+    narrowing = (["a", "b"], "s", False)
+    out, _, _ = tr._apply_page_prior(narrowing, ["b", "c", "c"], False, False)
     # 'b' already present (not duplicated); 'c' appended once, after ranked.
     assert out == ["a", "b", "c"]
 
@@ -78,7 +78,7 @@ def test_page_actions_cap(monkeypatch):
     monkeypatch.setattr(tr, "_page_action_passes_gate", lambda n, ia, isa: True)
     ranked = [f"r{i}" for i in range(38)]
     page = [f"p{i}" for i in range(10)]
-    out, _ = tr._apply_page_prior((ranked, "s"), page, False, False)
+    out, _, _ = tr._apply_page_prior((ranked, "s", False), page, False, False)
     assert len(out) == 40  # TOOL_ROUTING_ENUM_CAP default
     # ranked kept in full; only the first 2 page actions fit under the cap.
     assert out[:38] == ranked
@@ -93,10 +93,10 @@ def test_page_actions_respect_super_admin_gate(monkeypatch):
         "su_only": _FakeAction(super_admin_only=True),
         "admin_x": _FakeAction(admin_only=True),
     })
-    narrowing = (["ranked"], "s")
+    narrowing = (["ranked"], "s", False)
 
     # non-admin, non-super principal: only the ungated action folds in.
-    out, _ = tr._apply_page_prior(
+    out, _, _ = tr._apply_page_prior(
         narrowing, ["normal", "su_only", "admin_x"],
         is_admin=False, is_super_admin=False,
     )
@@ -105,11 +105,11 @@ def test_page_actions_respect_super_admin_gate(monkeypatch):
     assert "admin_x" not in out
 
     # super-admin sees the su-only action; admin sees the admin-only action.
-    out_su, _ = tr._apply_page_prior(
+    out_su, _, _ = tr._apply_page_prior(
         narrowing, ["su_only"], is_admin=True, is_super_admin=True
     )
     assert "su_only" in out_su
-    out_admin, _ = tr._apply_page_prior(
+    out_admin, _, _ = tr._apply_page_prior(
         narrowing, ["admin_x"], is_admin=True, is_super_admin=False
     )
     assert "admin_x" in out_admin
@@ -124,5 +124,5 @@ def test_gate_drops_unknown_action(monkeypatch):
 def test_gate_unregistered_yields_no_union(monkeypatch):
     # Every page action unknown → nothing clears the gate → narrowing unchanged.
     _patch_registry(monkeypatch, {})
-    narrowing = (["ranked"], "s")
+    narrowing = (["ranked"], "s", False)
     assert tr._apply_page_prior(narrowing, ["ghost1", "ghost2"], True, True) is narrowing

--- a/orchestrator/tests/test_tool_surface_prb.py
+++ b/orchestrator/tests/test_tool_surface_prb.py
@@ -1,0 +1,367 @@
+"""Tool-surface PR-B: platform_find_tools + relevance floor + closed-pins.
+
+(docs/reviews/TOOL-SURFACE-DEEP-REVIEW-2026-07-23.md §5/§6, stage PR-B.)
+
+Everything lands behind default-off dials — these tests pin BOTH postures:
+the defaults must behave exactly like today, and the new modes must do what
+the dossier says when switched on.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional, Tuple
+from unittest.mock import patch
+
+import pytest
+
+_ORCH = Path(__file__).resolve().parents[1]
+
+
+# ---------------------------------------------------------------------------
+# 1. platform_find_tools — registration + executor wiring
+# ---------------------------------------------------------------------------
+
+
+def _fresh_registry():
+    from modules.tools.discovery.action_registry import ActionRegistry
+
+    reg = ActionRegistry()
+    reg._initialized = True
+    return reg
+
+
+def test_find_tools_registers_promoted_read_action() -> None:
+    from modules.tools.discovery.actions_capabilities import (
+        register_capabilities_actions,
+    )
+
+    reg = _fresh_registry()
+    register_capabilities_actions(reg)
+    action = reg.get("platform_find_tools")
+    assert action is not None
+    assert action.promoted is True, "discovery must always be first-class visible"
+    assert action.permission_level == "read"
+    assert getattr(action, "super_admin_only", False) is False
+    assert "query" in (action.parameters.get("required") or [])
+
+
+def test_find_tools_wired_into_registrar_and_executor() -> None:
+    registrar = (_ORCH / "modules" / "tools" / "discovery" / "platform_actions.py").read_text()
+    assert "register_capabilities_actions(registry)" in registrar
+    executor = (_ORCH / "modules" / "tools" / "discovery" / "platform_executor.py").read_text()
+    assert re.search(r'"platform_find_tools":\s*find_tools', executor), (
+        "platform_find_tools has no executor handler — registered but uncallable"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. find_tools handler
+# ---------------------------------------------------------------------------
+
+
+def _action(name: str, desc: str, tags: List[str], su: bool = False, admin: bool = False):
+    return SimpleNamespace(
+        name=name,
+        description=desc,
+        category="test",
+        tags=tags,
+        permission_level="read",
+        parameters={
+            "type": "object",
+            "properties": {"topic": {"type": "string", "description": "what"}},
+            "required": ["topic"],
+        },
+        admin_only=admin,
+        super_admin_only=su,
+        promoted=False,
+    )
+
+
+_CATALOG = [
+    _action("platform_publish_blog_post", "Write and publish a blog post", ["blog", "publish"]),
+    _action("platform_codegraph_search", "Search a codebase by meaning", ["code", "search"]),
+    _action("platform_get_logs", "Read service logs", ["logs"], su=True),
+]
+
+
+class _FakeIndex:
+    def __init__(self, ranked: Optional[List[Tuple[str, float]]] = None, raise_it: bool = False):
+        self.ranked = ranked or []
+        self.raise_it = raise_it
+
+    async def rank_actions(self, **kwargs: Any) -> List[Tuple[str, float]]:
+        if self.raise_it:
+            raise RuntimeError("embed upstream down")
+        return self.ranked
+
+
+class _FakeRegistry:
+    def get_all(self):
+        return list(_CATALOG)
+
+
+@pytest.mark.asyncio
+async def test_find_tools_returns_schema_rich_matches() -> None:
+    from modules.tools.discovery import handlers_capabilities as mod
+
+    fake = _FakeIndex(ranked=[("platform_publish_blog_post", 0.81)])
+    with patch(
+        "modules.tools.discovery.action_semantic_index.get_action_semantic_index",
+        return_value=fake,
+    ), patch(
+        "modules.tools.discovery.action_registry.get_action_registry",
+        return_value=_FakeRegistry(),
+    ):
+        out = await mod.find_tools(None, None, {"query": "publish a blog"})
+
+    assert out["success"] is True
+    assert out["ranker"] == "semantic"
+    assert out["matches"][0]["action"] == "platform_publish_blog_post"
+    assert out["matches"][0]["params"]["required"] == ["topic"]
+    assert "platform_execute" in out["matches"][0]["call_with"]
+
+
+@pytest.mark.asyncio
+async def test_find_tools_never_advertises_su_actions() -> None:
+    from modules.tools.discovery import handlers_capabilities as mod
+
+    # Ranker leaks an su name (defense in depth): the handler's eligible set
+    # must drop it anyway.
+    fake = _FakeIndex(ranked=[("platform_get_logs", 0.9), ("platform_codegraph_search", 0.5)])
+    with patch(
+        "modules.tools.discovery.action_semantic_index.get_action_semantic_index",
+        return_value=fake,
+    ), patch(
+        "modules.tools.discovery.action_registry.get_action_registry",
+        return_value=_FakeRegistry(),
+    ):
+        out = await mod.find_tools(None, None, {"query": "logs"})
+
+    names = [m["action"] for m in out["matches"]]
+    assert "platform_get_logs" not in names
+
+
+@pytest.mark.asyncio
+async def test_find_tools_keyword_fallback_when_ranker_fails() -> None:
+    from modules.tools.discovery import handlers_capabilities as mod
+
+    with patch(
+        "modules.tools.discovery.action_semantic_index.get_action_semantic_index",
+        return_value=_FakeIndex(raise_it=True),
+    ), patch(
+        "modules.tools.discovery.action_registry.get_action_registry",
+        return_value=_FakeRegistry(),
+    ):
+        out = await mod.find_tools(None, None, {"query": "publish blog post"})
+
+    assert out["success"] is True
+    assert out["ranker"] == "keyword"
+    assert out["matches"], "keyword fallback found nothing for an obvious match"
+    assert out["matches"][0]["action"] == "platform_publish_blog_post"
+
+
+@pytest.mark.asyncio
+async def test_find_tools_requires_query() -> None:
+    from modules.tools.discovery import handlers_capabilities as mod
+
+    out = await mod.find_tools(None, None, {})
+    assert out["success"] is False
+
+
+# ---------------------------------------------------------------------------
+# 3. Relevance floor (pure)
+# ---------------------------------------------------------------------------
+
+
+def test_floor_off_is_identity() -> None:
+    from modules.tools.discovery.action_semantic_index import _apply_relevance_floor
+
+    scored = [("a", 0.9), ("b", 0.1), ("c", -0.2)]
+    assert _apply_relevance_floor(scored, 0, 0) == scored
+
+
+def test_absolute_floor_drops_low_scores() -> None:
+    from modules.tools.discovery.action_semantic_index import _apply_relevance_floor
+
+    scored = [("a", 0.9), ("b", 0.4), ("c", 0.2)]
+    assert _apply_relevance_floor(scored, 0.35, 0) == [("a", 0.9), ("b", 0.4)]
+
+
+def test_ratio_floor_scales_with_best() -> None:
+    from modules.tools.discovery.action_semantic_index import _apply_relevance_floor
+
+    scored = [("a", 0.8), ("b", 0.5), ("c", 0.3)]
+    # cutoff = 0.8 * 0.6 = 0.48
+    assert _apply_relevance_floor(scored, 0, 0.6) == [("a", 0.8), ("b", 0.5)]
+
+
+def test_ratio_floor_ignores_negative_best() -> None:
+    from modules.tools.discovery.action_semantic_index import _apply_relevance_floor
+
+    scored = [("a", -0.1), ("b", -0.5)]
+    # A negative best * ratio would be a meaningless cutoff — ratio must not bite.
+    assert _apply_relevance_floor(scored, 0, 0.6) == scored
+
+
+def test_floor_can_empty_the_list() -> None:
+    from modules.tools.discovery.action_semantic_index import _apply_relevance_floor
+
+    scored = [("a", 0.11), ("b", 0.08)]
+    assert _apply_relevance_floor(scored, 0.3, 0) == []
+
+
+# ---------------------------------------------------------------------------
+# 4. Closed-pins fallback narrowing
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def _cfg(monkeypatch):
+    import config as config_module
+
+    def set_(key: str, value: Any) -> None:
+        monkeypatch.setattr(config_module.config, key, value, raising=False)
+
+    return set_
+
+
+@pytest.mark.asyncio
+async def test_default_open_full_on_rank_failure(_cfg) -> None:
+    import modules.tools.tool_router as tr
+
+    _cfg("SEMANTIC_TOOL_ROUTING", True)
+    _cfg("TOOL_FALLBACK_MODE", "open-full")
+
+    async def _none(**kwargs: Any):
+        return None
+
+    with patch.object(tr, "_rank_actions_for_dispatcher_async", _none):
+        allowed, reason, from_pins = await tr._narrow_dispatcher_actions_async(
+            "hello", is_admin=False, is_super_admin=False
+        )
+    assert allowed is None and from_pins is False
+
+
+@pytest.mark.asyncio
+async def test_closed_pins_on_rank_failure(_cfg) -> None:
+    import modules.tools.tool_router as tr
+
+    _cfg("SEMANTIC_TOOL_ROUTING", True)
+    _cfg("TOOL_FALLBACK_MODE", "closed-pins")
+    _cfg("TOOL_FALLBACK_PINS", "platform_find_tools, platform_store_memory")
+
+    async def _none(**kwargs: Any):
+        return None
+
+    with patch.object(tr, "_rank_actions_for_dispatcher_async", _none):
+        allowed, reason, from_pins = await tr._narrow_dispatcher_actions_async(
+            "hello", is_admin=False, is_super_admin=False
+        )
+    assert allowed == ["platform_find_tools", "platform_store_memory"]
+    assert from_pins is True
+    assert "closed-pins" in (reason or "")
+
+
+@pytest.mark.asyncio
+async def test_closed_pins_on_missing_query(_cfg) -> None:
+    import modules.tools.tool_router as tr
+
+    _cfg("SEMANTIC_TOOL_ROUTING", True)
+    _cfg("TOOL_FALLBACK_MODE", "closed-pins")
+    _cfg("TOOL_FALLBACK_PINS", "platform_find_tools")
+
+    allowed, _reason, from_pins = await tr._narrow_dispatcher_actions_async(
+        None, is_admin=False, is_super_admin=False
+    )
+    assert allowed == ["platform_find_tools"] and from_pins is True
+
+
+@pytest.mark.asyncio
+async def test_flag_off_is_always_open_full(_cfg) -> None:
+    """Operator turned routing OFF — that's an explicit wide-surface choice;
+    closed-pins must not override it."""
+    import modules.tools.tool_router as tr
+
+    _cfg("SEMANTIC_TOOL_ROUTING", False)
+    _cfg("TOOL_FALLBACK_MODE", "closed-pins")
+
+    allowed, reason, from_pins = await tr._narrow_dispatcher_actions_async(
+        "hello", is_admin=False, is_super_admin=False
+    )
+    assert allowed is None and from_pins is False
+
+
+# ---------------------------------------------------------------------------
+# 5. Dispatcher enum admits promoted pins ONLY under the flag
+# ---------------------------------------------------------------------------
+
+
+def _registry_with_promoted():
+    from modules.tools.discovery.action_registry import ActionDefinition
+
+    reg = _fresh_registry()
+    reg.register(ActionDefinition(
+        name="plain_action", description="plain", category="t",
+        parameters={"type": "object", "properties": {}},
+    ))
+    reg.register(ActionDefinition(
+        name="promoted_action", description="promoted", category="t",
+        parameters={"type": "object", "properties": {}}, promoted=True,
+    ))
+    reg.register(ActionDefinition(
+        name="su_promoted_action", description="su", category="t",
+        parameters={"type": "object", "properties": {}}, promoted=True,
+        super_admin_only=True,
+    ))
+    return reg
+
+
+def _enum(schema: Dict[str, Any]) -> List[str]:
+    return schema["function"]["parameters"]["properties"]["action"].get("enum", [])
+
+
+def test_promoted_pin_dropped_without_flag() -> None:
+    reg = _registry_with_promoted()
+    schema = reg.to_dispatcher_schema(
+        exclude_admin=True,
+        allowed_names=["promoted_action", "plain_action"],
+    )
+    assert _enum(schema) == ["plain_action"]
+
+
+def test_promoted_pin_admitted_with_flag() -> None:
+    reg = _registry_with_promoted()
+    schema = reg.to_dispatcher_schema(
+        exclude_admin=True,
+        allowed_names=["promoted_action", "plain_action"],
+        allow_promoted_in_allowlist=True,
+    )
+    assert _enum(schema) == ["plain_action", "promoted_action"]
+
+
+def test_su_promoted_pin_never_admitted_for_operator() -> None:
+    """Fail-closed survives the new flag: su stays out even when pinned."""
+    reg = _registry_with_promoted()
+    schema = reg.to_dispatcher_schema(
+        exclude_admin=True,
+        allowed_names=["su_promoted_action", "plain_action"],
+        allow_promoted_in_allowlist=True,
+    )
+    assert _enum(schema) == ["plain_action"]
+
+
+# ---------------------------------------------------------------------------
+# 6. Config dial defaults (PR-B must be inert out of the box)
+# ---------------------------------------------------------------------------
+
+
+def test_prb_dials_default_inert() -> None:
+    import config as config_module
+
+    cfg = config_module.config
+    assert float(getattr(cfg, "SEMANTIC_TOOL_ROUTING_FLOOR", 0)) == 0.0
+    assert float(getattr(cfg, "SEMANTIC_TOOL_ROUTING_FLOOR_RATIO", 0)) == 0.0
+    assert str(getattr(cfg, "TOOL_FALLBACK_MODE", "open-full")) == "open-full"
+    assert "platform_find_tools" in str(getattr(cfg, "TOOL_FALLBACK_PINS", ""))


### PR DESCRIPTION
## PR-B of the Tool-Surface Deep Review

Dossier: `docs/reviews/TOOL-SURFACE-DEEP-REVIEW-2026-07-23.md` · Stages: PR-A #594+#595 (merged) → **PR-B (this — additive, dials default to today's behavior)** → PR-C (the flip, after the eval gate).

### What lands

**1. `platform_find_tools` — the WHEN-REQUIRED seam.** New promoted read-action: Auto searches the full action catalog by intent and gets back names, descriptions, param schemas, and exactly how to call each via `platform_execute`. Semantic ranking with a keyword fallback (a slow embed can't make discovery come back empty). Fail-closed: admin/su actions are never advertised through it. This is the piece that makes "Auto has access to ALL tools without loading 44 schemas a turn" true.

**2. Relevance floor** (`SEMANTIC_TOOL_ROUTING_FLOOR` / `_FLOOR_RATIO`, default **0/0 = off**): rank_actions can now drop below-floor candidates *before* the top-K cut — "Good Morning" can legitimately rank zero actions instead of the 15 least-dissimilar.

**3. Closed-pins fallback** (`TOOL_FALLBACK_MODE`, default **open-full = today**): when narrowing can't decide (no query / rank error / embed timeout), ship `TOOL_FALLBACK_PINS` + find_tools instead of the full 137-enum + ~4k-token catalog. The dossier's worst finding — *slow embed ⇒ maximum context* — dies when this flips. Routing flag OFF is honored as an explicit operator wide-surface choice. `to_dispatcher_schema` gains `allow_promoted_in_allowlist` so promoted pins enter the enum (role gates run first; su never re-admitted — test-pinned).

**4. One narrowing contract everywhere:** ATOM path and the dispatcher-only lane (heartbeats) now use the same `(allowed, reason, from_pins)` helper as the full path — both previously had private fail-open logic.

**5. Shadow telemetry** (`TOOL_SURFACE_SHADOW`, default on): one log line per turn — `[tool-shadow] shipped_tools=N would_first_class=K would_enum=M` — the would-be PR-C surface under `TOOL_SURFACE_HYBRID_CAP`. This is the eval-gate data; it never affects the shipped surface.

### Inert-by-default proof
- floor 0/0 → identity (test-pinned) · fallback open-full → today's posture (test-pinned) · promoted-pin admission only under the new flag; default drop behavior test-pinned (complements `test_action_registry_filtered.py:329`)
- Only visible changes with defaults: +1 promoted schema (find_tools, ~150 tokens), the shadow log line.

### Tests
`orchestrator/tests/test_tool_surface_prb.py` — registration + executor wiring probes; handler (semantic path, su exclusion defense-in-depth, keyword fallback, empty-query); floor pure-function semantics incl. negative-best guard; closed-pins on rank-failure/no-query; flag-off honored; enum pin admission + su-never; config defaults inert.

### After merge
Shadow data accumulates on real traffic → eval gate (in-set ≥ 97.9% baseline, greetings ≤3 actions) → PR-C flips `TOOL_SURFACE_PROMOTED_GATED` + closed-pins default and updates the ~10 pinned test files.