### PR TITLE
fix(documents): persist upload tags + expose content_hash with by-hash lookup

### DIFF
--- a/orchestrator/api/documents.py
+++ b/orchestrator/api/documents.py
@@ -191,10 +191,18 @@ async def handle_request(
         elif file_extension in ['.json']:
             file_type = "json"
         
-        # Parse tags
-        tag_list = []
+        # Parse tags: comma-separated form field → stripped, de-duplicated
+        # (order-preserving) list[str]. Persisted to documents.tags (PostgreSQL
+        # text[]). The Academy corpus sync tags each doc 'academy,<vendor>,<track>,
+        # <domain>' so the tutor's knowledge graph can map chunks back to a course.
+        tag_list: list[str] = []
         if tags:
-            tag_list = [tag.strip() for tag in tags.split(",") if tag.strip()]
+            _seen: set[str] = set()
+            for _raw_tag in tags.split(","):
+                _tag = _raw_tag.strip()
+                if _tag and _tag not in _seen:
+                    _seen.add(_tag)
+                    tag_list.append(_tag)
 
         # PRD-124: Parse team_access (comma-separated → list, empty = all teams)
         from core.team_access import normalize_teams
@@ -202,12 +210,14 @@ async def handle_request(
         if team_access:
             team_access_list = normalize_teams(team_access.split(","))
 
-        # Create document record
-        # TEMPORARY FIX: Tags field commented out to unblock critical vector DB testing
-        # Tags are cosmetic metadata - not needed for embeddings, RAG, or semantic search
-        # Will add back with proper fix after core functionality is validated
+        # Create document record. tags persist to documents.tags — a real PostgreSQL
+        # text[] column (see migration 208275450a15: ARRAY(TEXT), default ARRAY[]::text[]).
+        # The prior "SQLAlchemy array bug" was a mis-diagnosis: team_access below uses the
+        # identical PG_ARRAY(String) column and writes a Python list on every upload without
+        # issue. Assigning a fresh list[str] to a new row is tracked correctly (no
+        # flag_modified needed — that only matters for in-place mutation of a loaded array).
         document = Document(
-        workspace_id=ctx.workspace_id,
+            workspace_id=ctx.workspace_id,
             filename=file.filename,
             original_filename=file.filename,
             file_type=file_type,
@@ -215,7 +225,7 @@ async def handle_request(
             file_path=str(file_path),
             content_hash=content_hash,
             status="uploaded",
-            # tags=tag_list if tag_list else None,  # TEMPORARILY DISABLED - SQLAlchemy array bug
+            tags=tag_list,
             description=description,
             team_access=team_access_list,
             created_by=ctx.clerk_user_id or "system",  # PRD-168 S4: real actor
@@ -556,6 +566,11 @@ async def list_documents(
     # callers/tests that omit it get None, not a truthy Query() sentinel that
     # would make `if source_type:` fire and filter on a Query object.
     source_type: Optional[str] = None,
+    # Exact-match lookup by SHA-256 of the file bytes. Lets a caller resolve a
+    # document by content (e.g. Academy's --replace) instead of by filename.
+    # Plain `= None` (like status/file_type/search) so direct-call callers/tests
+    # that omit it get None, not a truthy Query() sentinel.
+    content_hash: Optional[str] = None,
     db: Session = Depends(get_db)
 ):
     """List documents with filtering and pagination"""
@@ -567,6 +582,8 @@ async def list_documents(
             query = query.filter(Document.status == status)
         if file_type:
             query = query.filter(Document.file_type == file_type)
+        if content_hash:
+            query = query.filter(Document.content_hash == content_hash)
         if source_type:
             # PRD-164 S3 (Q58): agent outputs are a filterable team-like scope
             query = query.filter(Document.source_type == source_type)
@@ -601,6 +618,7 @@ async def list_documents(
                 original_filename=doc.original_filename,
                 file_type=doc.file_type,
                 file_size=doc.file_size,
+                content_hash=doc.content_hash,
                 status=doc.status,
                 chunk_count=doc.chunk_count,
                 tags=doc.tags or [],
@@ -738,6 +756,7 @@ async def get_document(
             original_filename=document.original_filename,
             file_type=document.file_type,
             file_size=document.file_size,
+            content_hash=document.content_hash,
             status=document.status,
             chunk_count=document.chunk_count,
             tags=document.tags or [],

--- a/orchestrator/core/models/core.py
+++ b/orchestrator/core/models/core.py
@@ -856,6 +856,9 @@ class DocumentResponse(BaseModel):
     original_filename: Optional[str]
     file_type: Optional[str]
     file_size: Optional[int]
+    # SHA-256 of the uploaded bytes. Exposed so callers (e.g. Academy corpus sync)
+    # can match a document by exact content rather than by filename.
+    content_hash: Optional[str] = None
     status: str
     chunk_count: Optional[int]
     tags: Optional[List[str]]

--- a/tests/api/test_document_journeys.py
+++ b/tests/api/test_document_journeys.py
@@ -3,6 +3,7 @@
 Pilot users will upload documents — this flow must work end to end.
 """
 
+import hashlib
 import io
 import time
 
@@ -11,26 +12,38 @@ import pytest
 
 @pytest.fixture(scope="module")
 def document_state():
-    return {"document_id": None, "filename": None}
+    return {
+        "document_id": None,
+        "filename": None,
+        "content_hash": None,
+        # Academy-style tags with intentional whitespace + a duplicate, to prove
+        # the upload handler strips and de-duplicates (order-preserving).
+        "tags_sent": "academy, aix, gen-ai-leader, foundations, academy",
+        "tags_expected": ["academy", "aix", "gen-ai-leader", "foundations"],
+    }
 
 
 def test_document_upload(client, document_state):
     """POST /api/documents/upload — upload a test document.
 
     Uses a small text file to validate the upload pipeline without
-    hitting size limits or slow processing.
+    hitting size limits or slow processing. The body is made unique per run
+    (filename carries a timestamp) so the content_hash duplicate-check creates
+    a fresh row rather than short-circuiting on a prior run's upload — otherwise
+    the tags under test would never be written.
     """
     filename = f"test-doc-{int(time.time())}.txt"
     content = (
-        "This is a test document for the journey test suite.\n"
+        f"This is a test document for the journey test suite ({filename}).\n"
         "It contains information about the Automatos AI Platform.\n"
         "The platform supports agents, workflows, and memory management.\n"
     )
     document_state["filename"] = filename
+    document_state["content_hash"] = hashlib.sha256(content.encode()).hexdigest()
 
     # httpx multipart upload
     files = {"file": (filename, io.BytesIO(content.encode()), "text/plain")}
-    data = {"description": "Journey test document", "tags": "journey-test"}
+    data = {"description": "Journey test document", "tags": document_state["tags_sent"]}
 
     r = client.post(
         "/api/documents/upload",
@@ -42,6 +55,12 @@ def test_document_upload(client, document_state):
         f"Document upload failed: {r.status_code} {r.text[:500]}"
     )
     resp = r.json()
+    # A byte-identical prior upload would come back status="duplicate"; the unique
+    # body above prevents that, so we expect a freshly created row here.
+    assert resp.get("status") != "duplicate", (
+        "Upload was deduplicated — content_hash collided with an existing row, "
+        "so the tags under test were not written. Body should be unique per run."
+    )
     doc_id = resp.get("id") or resp.get("document_id")
     if doc_id:
         document_state["document_id"] = doc_id
@@ -90,6 +109,81 @@ def test_document_search(client, document_state):
     assert r.status_code in (200, 404, 501), (
         f"Document search returned unexpected {r.status_code}: {r.text[:300]}"
     )
+
+
+def test_document_tags_persisted_on_get(client, document_state):
+    """GET /api/documents/{id} — tags survive upload and content_hash is exposed.
+
+    Fix 1: the upload handler previously commented out `tags=` ("SQLAlchemy array
+    bug"), so tags were silently dropped. Fix 2: content_hash was stored but never
+    returned. This asserts both are now present and correct on the detail response.
+    """
+    if not document_state["document_id"]:
+        pytest.skip("No document was uploaded")
+
+    r = client.get(f"/api/documents/{document_state['document_id']}")
+    assert r.status_code == 200
+    data = r.json()
+
+    # Fix 1: tags persisted, stripped + de-duplicated, order preserved.
+    assert data.get("tags") == document_state["tags_expected"], (
+        f"Expected tags {document_state['tags_expected']}, got {data.get('tags')!r}"
+    )
+
+    # Fix 2: content_hash exposed on the response and matches the uploaded bytes.
+    assert data.get("content_hash") == document_state["content_hash"], (
+        f"Expected content_hash {document_state['content_hash']}, "
+        f"got {data.get('content_hash')!r}"
+    )
+
+
+def test_document_tags_in_list(client, document_state):
+    """GET /api/documents/ — the list view also returns the persisted tags."""
+    if not document_state["document_id"]:
+        pytest.skip("No document was uploaded")
+
+    r = client.get("/api/documents/")
+    assert r.status_code == 200
+    docs = r.json()
+    ours = next(
+        (d for d in docs if str(d.get("id")) == str(document_state["document_id"])),
+        None,
+    )
+    assert ours is not None, "Uploaded document not found in list"
+    assert ours.get("tags") == document_state["tags_expected"], (
+        f"List view tags {ours.get('tags')!r} != expected "
+        f"{document_state['tags_expected']}"
+    )
+
+
+def test_document_lookup_by_content_hash(client, document_state):
+    """GET /api/documents/?content_hash=... — exact by-hash lookup returns the doc.
+
+    Fix 2: lets a caller (e.g. Academy's --replace) resolve a document by exact
+    content instead of by filename.
+    """
+    if not document_state["document_id"] or not document_state["content_hash"]:
+        pytest.skip("No document was uploaded")
+
+    r = client.get(
+        "/api/documents/",
+        params={"content_hash": document_state["content_hash"]},
+    )
+    assert r.status_code == 200
+    docs = r.json()
+    assert isinstance(docs, list) and docs, (
+        "by-hash lookup returned nothing for a hash we just uploaded"
+    )
+    ids = [str(d.get("id")) for d in docs]
+    assert str(document_state["document_id"]) in ids, (
+        f"Document {document_state['document_id']} not found via content_hash lookup"
+    )
+    # Every returned row must actually carry that hash (filter is exact-match).
+    for d in docs:
+        assert d.get("content_hash") == document_state["content_hash"], (
+            f"by-hash lookup leaked a non-matching doc: {d.get('id')} "
+            f"hash={d.get('content_hash')!r}"
+        )
 
 
 def test_document_delete(client, document_state):


### PR DESCRIPTION
## Summary

Two surgical fixes to the core documents plane (`orchestrator/api/documents.py`). The Automatos Academy syncs a per-course corpus into this plane, tagging each document `academy,<vendor>,<track>,<domain>` so the tutor's knowledge graph can map chunks back to their course. A code review found the platform **silently drops `tags` on upload**, breaking that contract. This PR fixes that, and exposes the already-computed `content_hash` for exact by-content lookup.

Scoped to exactly these two fixes — no unrelated changes.

## Fix 1 (CRITICAL) — persist `tags` on upload

- **Symptom:** the upload handler parsed `tags` but built the `Document` row with `tags=` **commented out** (`# TEMPORARILY DISABLED - SQLAlchemy array bug`), so tags were silently dropped; `DocumentResponse` always returned `[]`.
- **Root cause (investigated):** there is **no array bug**. `documents.tags` is a real PostgreSQL `text[]` column — migration `208275450a15` shows `ARRAY(TEXT)`, default `ARRAY[]::text[]` — and the sibling `team_access` column (identical `PG_ARRAY(String)` type) writes a Python list on **every** upload without issue. The "temporary" disable simply stuck for ~2 months. **No migration needed.**
- **Fix:** assign `tags=tag_list` (a fresh `list[str]` on a new row — SQLAlchemy tracks this correctly; `flag_modified` is only needed for in-place mutation of a loaded array). Parsing now **strips and de-duplicates, order-preserving**.
- `orchestrator/api/documents.py:194-205` (parse) and `:212-231` (constructor).

## Fix 2 — expose `content_hash` + by-hash lookup

- `content_hash` was computed (`documents.py:160`) and stored (`:216`) but never returned. Added `content_hash: Optional[str] = None` to `DocumentResponse` (`orchestrator/core/models/core.py:859`) and populated it in **both** `list_documents` and `get_document`.
- Added a `content_hash` query param to `GET /api/documents/` (`documents.py:569` + filter at `:585`) for exact by-content resolution (Academy's `--replace` matches by filename today; by-hash is exact).
- Route path/method unchanged → the committed `route-manifest.json` (tracks method+path only) needs **no update**.

## Files changed

| File | Change |
|---|---|
| `orchestrator/api/documents.py` | tags parse (strip+dedupe), persist `tags=tag_list`, `content_hash` param+filter, `content_hash` in both responses |
| `orchestrator/core/models/core.py` | `content_hash` field on `DocumentResponse` |
| `tests/api/test_document_journeys.py` | tag-persistence + content_hash + by-hash lookup assertions |

## How verified

- `python -m py_compile` passes on both edited source files and the test file.
- **Could not run pytest in this environment** (pytest not installed; and per project convention these `tests/api/*` are live-integration tests requiring `API_URL`/`WORKSPACE_ID`/`API_KEY` against a running server). **CI is the gate.** The new assertions:
  - upload sends `"academy, aix, gen-ai-leader, foundations, academy"` → expects persisted `["academy","aix","gen-ai-leader","foundations"]` on both `GET /{id}` and the list view (proves strip + dedupe + order).
  - asserts `content_hash` is exposed and equals the SHA-256 of the uploaded bytes.
  - asserts `GET /?content_hash=...` returns the doc and only exact matches.
  - upload body is made **unique per run** so the `content_hash` duplicate-check creates a fresh row instead of short-circuiting on `status="duplicate"` (which would skip the tag write).

## Risk to double-check (human)

- **SQLAlchemy tags write:** the reasoning is that `team_access` (same `PG_ARRAY(String)` column, written every upload) proves the array path is sound, so `tags=tag_list` is safe. Low risk, but worth a glance since `documents.py` is platform-wide. Assigning `[]` when no tags matches `team_access` behavior and the column's `ARRAY[]::text[]` default.

## Deferred (NOT in this PR — follow-ups, per scope)

These were explicitly **out of scope** for tonight and are left as follow-ups for Gerard to decide on:
- **Scoped `ak_srv` keys on the documents plane** — Academy service keys don't currently reach the documents plane (companion platform PRD).
- **KG auto-rebuild on upload** — no automatic knowledge-graph rebuild is triggered when a tagged document lands.
- **`/api/knowledge/share` stub** — the sharing endpoint remains a stub.

Do **not** merge without review.