### PR TITLE
fix(prd-211): drop deleted modules.evaluation from import-linter contract

### DIFF
--- a/orchestrator/.importlinter
+++ b/orchestrator/.importlinter
@@ -35,7 +35,6 @@ modules =
     modules.context
     modules.coordination
     modules.documents
-    modules.evaluation
     modules.intake
     modules.knowledge
     modules.learning


### PR DESCRIPTION
## One-line follow-up to greens main's `import-linter` lane

**Cause:** #601 (PRD-184) deleted `modules.evaluation`; #602 (PRD-211) landed the `.importlinter` independence contract ~3 min later. The contract — authored against pre-184 main — still listed `modules.evaluation`, so `lint-imports` on main fails fast:

```
Module 'modules.evaluation' does not exist.
```

This is precisely the watch-item called out in #602's description.

**Fix:** remove the single stale entry. Verified the other 18 feature modules all exist on main.

**Safety:**
- `test_import_contract_present.py` asserts `len(modules) >= 15` → now 18, still green.
- PRD-184's `test_prd184_us001_learning_evaluation_deleted.py` asserts `modules.evaluation` is **gone** — this change agrees with it.
- `orchestrator-tests` + `scan` were already green on the merged main tip; this greens the only remaining red lane.

Net: `.importlinter` −1 line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal module independence validation rules.
  * No user-facing functionality or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->