### PR TITLE
feat(voice): Auto sounds like a person — spoken contract, TTS sanitizer, agent retune

### DIFF
--- a/orchestrator/api/voice_retell.py
+++ b/orchestrator/api/voice_retell.py
@@ -719,6 +719,9 @@ async def _agent_retell_stream_inner(req: RetellLLMRequest) -> AsyncIterator[dic
             # The measured voice-latency lever (memory/tools stay; only
             # third-party Composio EXECUTION is dropped from spoken turns).
             skip_composio=bool(config.VOICE_LIVE_SKIP_COMPOSIO),
+            # She is being HEARD, not read: short sentences, no markdown.
+            # Same brain — this is a medium instruction, not a lobotomy.
+            spoken_mode=True,
         )
 
         response_chars = 0
@@ -811,6 +814,11 @@ async def retell_llm_websocket(websocket: WebSocket, call_id: str) -> None:
     dynamic_vars: dict[str, Any] = {}
     speaking: asyncio.Task | None = None
     begun = False
+    # The slow-turn filler is a ONE-TIME courtesy per call. It used to fire on
+    # every slow turn, so a 3-turn utterance storm played "One moment. One
+    # moment. One moment." over itself — the "five people talking" Gerard
+    # heard. Once tells the caller the line is alive; twice is a stutter.
+    ack_spent = False
     stats = {"pings": 0, "updates": 0, "turns": 0, "frames": 0}
 
     async def safe_send(payload: dict) -> bool:
@@ -827,6 +835,7 @@ async def retell_llm_websocket(websocket: WebSocket, call_id: str) -> None:
             return False
 
     async def respond(req: RetellLLMRequest) -> None:
+        nonlocal ack_spent
         from time import monotonic
 
         started = monotonic()
@@ -835,18 +844,24 @@ async def retell_llm_websocket(websocket: WebSocket, call_id: str) -> None:
 
         # Slow-turn honesty: if the brain has said NOTHING by the deadline,
         # speak a short acknowledgment — the caller hears life (and the log
-        # gains the smoking gun) instead of dead air while tools run.
+        # gains the smoking gun) instead of dead air while tools run. Spoken
+        # AT MOST ONCE per call; the slow-turn WARNING still logs every time,
+        # so the telemetry keeps its teeth.
         ack_task: asyncio.Task | None = None
         ack_seconds = float(config.VOICE_LIVE_FIRST_FRAME_ACK_SECONDS or 0)
         ack_text = str(config.VOICE_LIVE_FIRST_FRAME_ACK_TEXT or "").strip()
         if ack_seconds > 0:
             async def _slow_turn_ack() -> None:
+                nonlocal ack_spent
                 await asyncio.sleep(ack_seconds)
                 logger.warning(
-                    "voice_live_ws_turn_slow call=%s rid=%s waited_ms=%d",
-                    call_id, req.response_id, int((monotonic() - started) * 1000),
+                    "voice_live_ws_turn_slow call=%s rid=%s waited_ms=%d spoken=%s",
+                    call_id, req.response_id,
+                    int((monotonic() - started) * 1000),
+                    not ack_spent,
                 )
-                if ack_text:
+                if ack_text and not ack_spent:
+                    ack_spent = True
                     await safe_send(
                         wrap_ws_response(
                             {

--- a/orchestrator/config.py
+++ b/orchestrator/config.py
@@ -1323,15 +1323,62 @@ class Config:
     # interruption sensitivity stops ambient noise from grabbing the turn
     # ("the mic is too sensitive"). All env-overridable — e.g. en-GB for a
     # British/Irish speaker whose accent transcribes better there.
-    VOICE_LIVE_LANGUAGE: str = os.getenv("VOICE_LIVE_LANGUAGE", "en-US")
+    VOICE_LIVE_LANGUAGE: str = os.getenv("VOICE_LIVE_LANGUAGE", "en-GB")
+    # ``noise-and-background-speech-cancellation`` (the aggressive mode) also
+    # cancelled the SPEAKER at normal volume — measured live: a whole call
+    # logged turns=0 because it treated his own voice as background and he had
+    # to shout. ``noise-cancellation`` filters steady room noise and keeps the
+    # person talking.
     VOICE_LIVE_DENOISING_MODE: str = os.getenv(
-        "VOICE_LIVE_DENOISING_MODE", "noise-and-background-speech-cancellation"
+        "VOICE_LIVE_DENOISING_MODE", "noise-cancellation"
     )
     VOICE_LIVE_STT_MODE: str = os.getenv("VOICE_LIVE_STT_MODE", "accurate")
+    # 0.2 made a normal-volume interruption unable to take the turn; 0.5 lets a
+    # person barge in without ambient noise doing it for them.
     VOICE_LIVE_INTERRUPTION_SENSITIVITY: float = float(
-        os.getenv("VOICE_LIVE_INTERRUPTION_SENSITIVITY", "0.2")
+        os.getenv("VOICE_LIVE_INTERRUPTION_SENSITIVITY", "0.5")
     )
-    VOICE_LIVE_RESPONSIVENESS: float = float(os.getenv("VOICE_LIVE_RESPONSIVENESS", "0.8"))
+    VOICE_LIVE_RESPONSIVENESS: float = float(os.getenv("VOICE_LIVE_RESPONSIVENESS", "0.9"))
+    # Auto's voice. Retell ships no Irish voice; an ElevenLabs voice imported
+    # into the Retell dashboard appears here as a normal voice id, so swapping
+    # her accent is this one dial. Verified present in list-voices.
+    VOICE_LIVE_VOICE_ID: str = os.getenv("VOICE_LIVE_VOICE_ID", "11labs-Willa")
+    # <1 slower, >1 faster. Retell's default reads a touch brisk for a
+    # colleague-across-the-desk register.
+    VOICE_LIVE_VOICE_SPEED: float = float(os.getenv("VOICE_LIVE_VOICE_SPEED", "0.95"))
+    # Prosody variation. Higher = more expressive, less predictable.
+    VOICE_LIVE_VOICE_TEMPERATURE: float = float(
+        os.getenv("VOICE_LIVE_VOICE_TEMPERATURE", "0.9")
+    )
+    # Let Retell speak "$5.20" / "2026-07-24" / "api.automatos.app" as words.
+    # Belt to speechify()'s braces: the model is told not to emit them, this
+    # rescues the ones that slip through.
+    VOICE_LIVE_NORMALIZE_FOR_SPEECH: bool = os.getenv(
+        "VOICE_LIVE_NORMALIZE_FOR_SPEECH", "true"
+    ).strip().lower() == "true"
+    # Retell nags ("are you still there?") when the caller goes quiet. One
+    # reminder after 15s beats a conversation that keeps prodding you.
+    VOICE_LIVE_REMINDER_TRIGGER_MS: int = int(
+        os.getenv("VOICE_LIVE_REMINDER_TRIGGER_MS", "15000")
+    )
+    VOICE_LIVE_REMINDER_MAX_COUNT: int = int(
+        os.getenv("VOICE_LIVE_REMINDER_MAX_COUNT", "1")
+    )
+    # Spoken replies are emitted as whole clauses rather than raw model tokens:
+    # the sanitizer that strips markdown can only work on a complete unit
+    # (``**`` straddles chunk boundaries). false = legacy token passthrough.
+    VOICE_LIVE_SPEECH_UNITS: bool = os.getenv(
+        "VOICE_LIVE_SPEECH_UNITS", "true"
+    ).strip().lower() == "true"
+    VOICE_LIVE_SPEECH_UNIT_MAX_CHARS: int = int(
+        os.getenv("VOICE_LIVE_SPEECH_UNIT_MAX_CHARS", "180")
+    )
+    # Auto is told she is being HEARD on spoken turns (short sentences, no
+    # markdown, no URLs read aloud). Same brain, different medium — false
+    # restores the old behaviour of speaking her chat-formatted answer.
+    VOICE_LIVE_SPOKEN_STYLE: bool = os.getenv(
+        "VOICE_LIVE_SPOKEN_STYLE", "true"
+    ).strip().lower() == "true"
     # Spoken turns skip the Composio EXECUTION surface (third-party app actions:
     # Gmail/Slack/etc.). Measured root cause of 20-90s voice latency: loading
     # all 23 Composio apps → 44 promoted action schemas + a 137-action

--- a/orchestrator/consumers/chatbot/service.py
+++ b/orchestrator/consumers/chatbot/service.py
@@ -840,9 +840,13 @@ class StreamingChatService:
         attachment_ids: Optional[List[str]] = None,
         model_id: Optional[str] = None,
         force_text_only: bool = False,
+        spoken_mode: bool = False,
     ) -> Tuple[List[Dict[str, Any]], Optional[List[Dict[str, Any]]], Any]:
         """
         Prepare LLM messages with orchestration, persona, CTO override, and context guard.
+
+        ``spoken_mode`` appends the spoken-output contract (short sentences, no
+        markdown) — the reply is played aloud, not read.
 
         Returns:
             (llm_messages, use_tools, orchestrated)
@@ -895,6 +899,12 @@ class StreamingChatService:
                 llm_messages, smart_chat, cto_check_result,
                 messages, use_tools, agent_runtime.agent_id,
             )
+
+        # Spoken turns: same brain, different medium. Appended LAST so it
+        # survives the CTO override — whatever persona is speaking, it is
+        # still being HEARD, and a markdown answer read aloud is broken.
+        if spoken_mode:
+            self._apply_spoken_style(llm_messages)
 
         # PRD-137 Fix #3: agent description + persona are injected by
         # IdentitySection (modules/context/sections/identity.py) into the
@@ -1091,6 +1101,34 @@ class StreamingChatService:
         use_tools = orchestrated.tools if orchestrated.requires_tools else None
 
         return llm_messages, use_tools, orchestrated
+
+    @staticmethod
+    def _apply_spoken_style(llm_messages: List[Dict[str, Any]]) -> None:
+        """Append the spoken-output contract to the system prompt, in place.
+
+        Auto's brain is unchanged (ONE AUTO — memory, tools and reasoning all
+        stay); this only tells it the answer will be HEARD. Without it she
+        writes her normal chat reply and the TTS reads the bullets and
+        asterisks out loud. Config dial ``VOICE_LIVE_SPOKEN_STYLE``.
+        """
+        try:
+            from config import config
+            if not getattr(config, "VOICE_LIVE_SPOKEN_STYLE", True):
+                return
+            from modules.voice.spoken_style import SPOKEN_OUTPUT_CONTRACT
+
+            for message in llm_messages:
+                if message.get("role") == "system":
+                    message["content"] = (
+                        f"{message.get('content', '')}\n\n{SPOKEN_OUTPUT_CONTRACT}"
+                    )
+                    return
+            # No system message (shouldn't happen) — lead with the contract.
+            llm_messages.insert(
+                0, {"role": "system", "content": SPOKEN_OUTPUT_CONTRACT}
+            )
+        except Exception:  # noqa: BLE001 — style must never break a live call
+            logger.warning("[voice] spoken-style injection failed", exc_info=True)
 
     def _apply_cto_override(
         self,
@@ -2001,10 +2039,16 @@ class StreamingChatService:
         force_text_only: bool = False,
         is_super_admin: bool = False,
         page_context: Optional[Dict[str, Any]] = None,
+        spoken_mode: bool = False,
     ) -> AsyncGenerator[str, None]:
         """
         Stream a chat response produced by the specified agent.
         Yields AISDK-formatted chunks for frontend consumption.
+
+        ``spoken_mode`` (PRD-207 voice): the reply is played aloud, so the
+        spoken-output contract is appended to the system prompt — short
+        sentences, no markdown, nothing that reads badly out loud. The brain
+        itself is untouched.
 
         ``page_context`` (PRD-221) is the SANITIZED reference set from
         services.page_context — never the raw client dict. It rides into the
@@ -2165,6 +2209,7 @@ class StreamingChatService:
                 attachment_ids=_attachment_ids,
                 model_id=_model_id,
                 force_text_only=force_text_only,
+                spoken_mode=spoken_mode,
             )
 
             # PRD-157 S5: keep the chat's pinned documents always in context.

--- a/orchestrator/modules/voice/providers/retell.py
+++ b/orchestrator/modules/voice/providers/retell.py
@@ -128,20 +128,65 @@ async def retell_response_frames(
 ) -> AsyncIterator[Dict[str, Any]]:
     """Stream the agent's AI-SDK output as Retell custom-LLM response frames.
 
-    THE streaming contract (V·S4): each text chunk is emitted as a
-    ``content_complete=False`` frame **the moment it arrives** — Retell begins
-    speaking (first audio) before the full agent generation completes, instead of
-    the old collect-everything-then-speak posture. A terminal
+    THE streaming contract (V·S4): frames are emitted **as the reply forms** —
+    Retell begins speaking before the agent finishes generating, instead of the
+    old collect-everything-then-speak posture. A terminal
     ``content_complete=True`` frame closes the turn.
+
+    Frames are whole speech units (a sentence, or a clause once one runs past
+    ``VOICE_LIVE_SPEECH_UNIT_MAX_CHARS``), not raw tokens. Buffering to a
+    boundary is what makes ``speechify()`` correct: markdown markers straddle
+    stream chunks — ``**`` arrives as ``*`` then ``*`` — so sanitizing token
+    fragments cannot work. The cost is the tail of the first sentence; the
+    return is that nothing reads ``**`` or ``- `` aloud. Set
+    ``VOICE_LIVE_SPEECH_UNITS=false`` to fall back to raw token passthrough.
     """
+    from config import config
+    from modules.voice.spoken_style import speechify, split_speech_unit
+
+    unitised = bool(getattr(config, "VOICE_LIVE_SPEECH_UNITS", True))
+    max_chars = int(getattr(config, "VOICE_LIVE_SPEECH_UNIT_MAX_CHARS", 180))
+
+    def _frame(content: str) -> Dict[str, Any]:
+        return {
+            "response_id": response_id,
+            "content": content,
+            "content_complete": False,
+        }
+
+    if not unitised:
+        async for chunk in agent_chunks:
+            text = extract_agent_text(chunk)
+            if text:
+                yield _frame(text)
+        yield {"response_id": response_id, "content": "", "content_complete": True}
+        return
+
+    buffer = ""
+    spoken_any = False
     async for chunk in agent_chunks:
         text = extract_agent_text(chunk)
-        if text:
-            yield {
-                "response_id": response_id,
-                "content": text,
-                "content_complete": False,
-            }
+        if not text:
+            continue
+        buffer += text
+        while True:
+            unit, buffer = split_speech_unit(buffer, max_chars)
+            if not unit:
+                break
+            said = speechify(unit)
+            if said:
+                spoken_any = True
+                # Space-separate units so the engine doesn't run them together.
+                yield _frame(said + " ")
+
+    tail = speechify(buffer)
+    if tail:
+        spoken_any = True
+        yield _frame(tail)
+    if not spoken_any:
+        logger.info(
+            "retell_frames: nothing speakable in this turn (rid=%s)", response_id
+        )
     yield {"response_id": response_id, "content": "", "content_complete": True}
 
 

--- a/orchestrator/modules/voice/retell_api.py
+++ b/orchestrator/modules/voice/retell_api.py
@@ -28,16 +28,23 @@ _TIMEOUT_SECONDS = 10.0
 _AGENT_TIMEOUT_SECONDS = 25.0
 
 
-def build_agent_tuning() -> Dict[str, Any]:
-    """The STT / turn-taking settings that keep transcription honest in a real
-    (noisy, non-headset) room — applied at agent creation AND re-applied on
-    every one-click re-arm.
+def build_agent_tuning(include_voice: bool = True) -> Dict[str, Any]:
+    """Everything about HOW Auto hears and sounds — applied at agent creation
+    AND re-applied on every one-click re-arm.
 
-    Pinning ``language`` stops multilingual STT from hallucinating confident
-    nonsense; ``noise-and-background-speech-cancellation`` strips TV / room
-    bleed (the "multiple voices" corruptor); ``accurate`` STT trades a little
-    latency for far fewer garbage transcripts; low ``interruption_sensitivity``
-    stops every tiny sound from grabbing the turn. All config-driven dials.
+    Hearing: pinning ``language`` stops multilingual STT hallucinating
+    confident nonsense; ``noise-cancellation`` strips steady room noise while
+    leaving the speaker audible (the aggressive
+    ``noise-and-background-speech-cancellation`` mode cancelled him too — a
+    whole measured call logged zero turns until he shouted); ``accurate`` STT
+    trades a little latency for far fewer garbage transcripts.
+
+    Sounding: the voice itself, its pace and expressiveness, and Retell's
+    ``normalize_for_speech`` so prices, dates and hostnames are spoken as
+    words. ``include_voice=False`` re-tunes hearing only, leaving a voice a
+    human picked in the dashboard untouched.
+
+    All config-driven dials — no literals here.
     """
     from config import config
 
@@ -45,6 +52,9 @@ def build_agent_tuning() -> Dict[str, Any]:
         "interruption_sensitivity": float(config.VOICE_LIVE_INTERRUPTION_SENSITIVITY),
         "responsiveness": float(config.VOICE_LIVE_RESPONSIVENESS),
         "enable_backchannel": False,
+        "normalize_for_speech": bool(config.VOICE_LIVE_NORMALIZE_FOR_SPEECH),
+        "reminder_trigger_ms": int(config.VOICE_LIVE_REMINDER_TRIGGER_MS),
+        "reminder_max_count": int(config.VOICE_LIVE_REMINDER_MAX_COUNT),
     }
     language = str(config.VOICE_LIVE_LANGUAGE or "").strip()
     if language:
@@ -55,6 +65,12 @@ def build_agent_tuning() -> Dict[str, Any]:
     stt_mode = str(config.VOICE_LIVE_STT_MODE or "").strip()
     if stt_mode:
         tuning["stt_mode"] = stt_mode
+    if include_voice:
+        voice_id = str(config.VOICE_LIVE_VOICE_ID or "").strip()
+        if voice_id:
+            tuning["voice_id"] = voice_id
+        tuning["voice_speed"] = float(config.VOICE_LIVE_VOICE_SPEED)
+        tuning["voice_temperature"] = float(config.VOICE_LIVE_VOICE_TEMPERATURE)
     return tuning
 
 

--- a/orchestrator/modules/voice/spoken_style.py
+++ b/orchestrator/modules/voice/spoken_style.py
@@ -1,0 +1,149 @@
+"""How Auto sounds when she is HEARD rather than read.
+
+Two halves of one contract:
+
+* ``SPOKEN_OUTPUT_CONTRACT`` — the directive appended to the system prompt on
+  spoken turns. Auto's brain is the same brain (ONE AUTO); this only tells it
+  which medium the answer lands in. Without it she writes her normal chat
+  reply — markdown bullets, ``**bold**``, headers, numbered lists — and the
+  TTS reads the punctuation out loud.
+* ``speechify()`` — the belt-and-braces sanitizer. Even a well-steered model
+  emits the occasional asterisk or bullet, and a stray ``**`` costs a whole
+  sentence of credibility when spoken. Never trust the prompt alone for
+  something the user HEARS.
+
+Both are pure and dependency-free so they unit-test without a DB, a socket or
+a model.
+"""
+from __future__ import annotations
+
+import re
+
+# The directive. Written to be read by a model mid-conversation: concrete,
+# example-led, and short enough to survive prompt budgeting.
+SPOKEN_OUTPUT_CONTRACT = """
+## YOU ARE SPEAKING OUT LOUD
+This reply is converted to speech and played to a person in a room. They HEAR
+it; they cannot see it. Write for the ear.
+
+- Keep it to one to three short sentences, then stop and let them answer. A
+  spoken paragraph is unbearable; a spoken list is worse.
+- NEVER use markdown. No bullets, numbered lists, headings, bold, italics,
+  code blocks, tables, links or emoji — they are read aloud literally and
+  sound broken.
+- Say it the way you'd say it to someone across a desk: contractions, plain
+  words, one idea per sentence.
+- Speak numbers, money, dates and times as words — "about twenty quid",
+  "half three", "the twelfth" — never symbols or digits-with-punctuation.
+- Don't read out URLs, file paths, IDs, hashes or code. Say "I've put it in
+  the chat" and carry on.
+- If the honest answer is long or structured, give the headline out loud and
+  offer the rest: "there are four of them — want me to run through it?"
+- While working, say so in a handful of words. Don't narrate each step.
+- If you didn't catch them, say so plainly and ask them to say it again.
+""".strip()
+
+
+# ── speechify ──────────────────────────────────────────────────────────────
+# Order matters: fences before inline code, images before links, emphasis
+# after structure (so "**- item**" is fully unwrapped).
+
+_CODE_FENCE_RE = re.compile(r"```[\s\S]*?(?:```|\Z)")
+_INLINE_CODE_RE = re.compile(r"`+([^`]*)`+")
+_IMAGE_RE = re.compile(r"!\[[^\]]*\]\([^)]*\)")
+_LINK_RE = re.compile(r"\[([^\]]*)\]\([^)]*\)")
+_HEADER_RE = re.compile(r"^[ \t]{0,3}#{1,6}[ \t]*", re.M)
+_BLOCKQUOTE_RE = re.compile(r"^[ \t]{0,3}>[ \t]?", re.M)
+_HR_RE = re.compile(r"^[ \t]{0,3}([-*_])(?:[ \t]*\1){2,}[ \t]*$", re.M)
+_TABLE_ROW_RE = re.compile(r"^[ \t]*\|.*$", re.M)
+_BULLET_RE = re.compile(r"^[ \t]*(?:[-*+•‣▪]|\d{1,2}[.)])[ \t]+", re.M)
+# Paired emphasis only — a lone asterisk in prose ("2 * 3") is left alone.
+_EMPHASIS_RE = re.compile(r"(\*\*\*|\*\*|\*|___|__|_)(\S[\s\S]*?\S|\S)\1")
+_EMOJI_RE = re.compile(
+    "["
+    "\U0001F300-\U0001FAFF"
+    "\U00002600-\U000027BF"
+    "\U0001F1E6-\U0001F1FF"
+    "\U00002190-\U000021FF"
+    "\U0000FE00-\U0000FE0F"
+    "\U00002B00-\U00002BFF"
+    "]+"
+)
+_MULTI_SPACE_RE = re.compile(r"[ \t]{2,}")
+_MULTI_STOP_RE = re.compile(r"(?:\s*\.){2,}")
+_SPACE_BEFORE_PUNCT_RE = re.compile(r"\s+([,.;:!?])")
+# A line ending in ":" (a lead-in to a list) that we then terminated becomes
+# ":." — keep the colon, drop the stop.
+_PUNCT_THEN_STOP_RE = re.compile(r"([,;:!?])\s*\.")
+
+
+def speechify(text: str) -> str:
+    """Strip anything that a text-to-speech engine would mangle.
+
+    Markdown structure becomes plain clauses: a bullet list turns into
+    sentences, a link into its label, a code span into its contents. Returns
+    "" when nothing speakable survives (e.g. a lone code fence), which the
+    caller treats as "emit no frame".
+    """
+    if not text:
+        return ""
+
+    out = _CODE_FENCE_RE.sub(" ", text)
+    out = _IMAGE_RE.sub(" ", out)
+    out = _LINK_RE.sub(r"\1", out)
+    out = _INLINE_CODE_RE.sub(r"\1", out)
+    out = _HR_RE.sub(" ", out)
+    out = _TABLE_ROW_RE.sub(" ", out)
+    out = _HEADER_RE.sub("", out)
+    out = _BLOCKQUOTE_RE.sub("", out)
+    # A bullet ends the previous clause: "one\n- two" → "one. two"
+    out = _BULLET_RE.sub("", out)
+    # Emphasis can nest (***x***) — unwrap repeatedly, bounded.
+    for _ in range(3):
+        new = _EMPHASIS_RE.sub(r"\2", out)
+        if new == out:
+            break
+        out = new
+    out = _EMOJI_RE.sub(" ", out)
+
+    # Newlines become sentence boundaries so list items don't run together.
+    out = re.sub(r"\n{2,}", ". ", out)
+    out = out.replace("\n", ". ")
+    out = _MULTI_STOP_RE.sub(".", out)
+    out = _PUNCT_THEN_STOP_RE.sub(r"\1", out)
+    out = _SPACE_BEFORE_PUNCT_RE.sub(r"\1", out)
+    out = _MULTI_SPACE_RE.sub(" ", out).strip()
+    # A unit that reduced to punctuation only says nothing.
+    if not re.search(r"[A-Za-z0-9]", out):
+        return ""
+    return out
+
+
+# ── speech units ───────────────────────────────────────────────────────────
+# TTS wants whole clauses, not tokens. Buffering to a boundary is also what
+# makes speechify() correct: markdown markers routinely straddle two stream
+# chunks ("**" arrives as "*" then "*"), so sanitizing raw tokens can't work.
+
+_BOUNDARY_RE = re.compile(r"[.!?…](?=[\s\"')\]]|$)|[\n]")
+
+
+def split_speech_unit(buffer: str, max_chars: int) -> tuple[str, str]:
+    """Split off one speakable unit; returns ``(unit, remainder)``.
+
+    ``unit`` is "" when the buffer holds no complete unit yet. A buffer past
+    ``max_chars`` with no terminator is cut at the last space so one runaway
+    sentence can't hold the whole reply hostage.
+    """
+    if not buffer:
+        return "", ""
+    match = _BOUNDARY_RE.search(buffer)
+    if match:
+        cut = match.end()
+        return buffer[:cut], buffer[cut:]
+    if max_chars > 0 and len(buffer) >= max_chars:
+        window = buffer[:max_chars]
+        cut = window.rfind(" ")
+        if cut <= 0:
+            cut = max_chars
+        return buffer[:cut], buffer[cut:]
+    return "", buffer

--- a/orchestrator/tests/test_prd207_voice_live.py
+++ b/orchestrator/tests/test_prd207_voice_live.py
@@ -1111,15 +1111,21 @@ def test_arm_is_idempotent_when_agent_exists(monkeypatch):
 
 def test_agent_tuning_pins_language_and_denoises():
     """The STT/turn-taking tuning that keeps transcription honest in a noisy
-    room: pinned language, background-speech denoising, accurate STT, low
-    interruption sensitivity, no backchannel."""
+    room: pinned language, denoising, accurate STT, sane interruption
+    sensitivity, no backchannel.
+
+    ``noise-and-background-speech-cancellation`` was WITHDRAWN after live
+    measurement — the aggressive mode cancelled the speaker himself at normal
+    volume (a whole call logged turns=0 until he shouted). Plain
+    ``noise-cancellation`` filters the room and keeps the person.
+    """
     from modules.voice.retell_api import build_agent_tuning
 
     t = build_agent_tuning()
     assert t["language"]  # pinned, never multilingual auto (hallucination source)
-    assert t["denoising_mode"] == "noise-and-background-speech-cancellation"
+    assert t["denoising_mode"] == "noise-cancellation"
     assert t["stt_mode"] == "accurate"
-    assert 0.0 <= t["interruption_sensitivity"] <= 0.5  # not twitchy
+    assert 0.2 < t["interruption_sensitivity"] <= 0.7  # barge-in works, noise doesn't
     assert t["enable_backchannel"] is False
 
 

--- a/orchestrator/tests/test_voice_quality.py
+++ b/orchestrator/tests/test_voice_quality.py
@@ -1,0 +1,251 @@
+"""Voice quality: Auto sounds like a person, not a read-aloud chat log.
+
+The fault these cover: nothing in the voice path ever told Auto she was being
+HEARD, and her raw text went straight to TTS — so a normal chat answer
+(bullets, ``**bold**``, headers, links) was read out with the punctuation
+pronounced. Plus the slow-turn filler fired per turn, so an utterance storm
+played "One moment." over itself.
+
+Pure unit tests — no DB, no socket, no model.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any, AsyncIterator, Dict, List
+from unittest.mock import patch
+
+import pytest
+
+from modules.voice.spoken_style import (
+    SPOKEN_OUTPUT_CONTRACT,
+    speechify,
+    split_speech_unit,
+)
+
+
+# ── speechify ──────────────────────────────────────────────────────────────
+
+
+def test_bullets_and_bold_become_plain_speech() -> None:
+    said = speechify("Here's the state:\n\n- **Auth** is broken\n- Billing is fine")
+    assert "*" not in said and "-" not in said
+    assert "Auth is broken" in said and "Billing is fine" in said
+    assert ":." not in said  # the lead-in colon isn't doubled up
+
+
+def test_numbered_list_loses_its_numbering() -> None:
+    said = speechify("1. Fix it\n2. Ship it")
+    assert said.startswith("Fix it")
+    assert "1." not in said and "2." not in said
+
+
+def test_headers_and_rules_are_dropped() -> None:
+    said = speechify("## Next steps\n---\nWe ship on Friday.")
+    assert "#" not in said and "---" not in said
+    assert "Next steps" in said and "We ship on Friday." in said
+
+
+def test_link_speaks_its_label_not_its_url() -> None:
+    said = speechify("Check [the dashboard](https://app.automatos.app/x?y=1) now")
+    assert "the dashboard" in said
+    assert "http" not in said and "automatos.app" not in said
+
+
+def test_code_fence_says_nothing() -> None:
+    assert speechify("```python\nprint('hi')\n```") == ""
+
+
+def test_inline_code_keeps_its_contents() -> None:
+    assert "db.py" in speechify("It's in `db.py` line 42")
+
+
+def test_emoji_are_stripped() -> None:
+    said = speechify("All green 🎉✅")
+    assert "🎉" not in said and "✅" not in said
+    assert "All green" in said
+
+
+def test_plain_prose_is_untouched() -> None:
+    text = "Evening, Gerard. All good here."
+    assert speechify(text) == text
+
+
+def test_lone_asterisk_in_prose_is_not_emphasis() -> None:
+    # "2 * 3" must not be eaten as an unclosed emphasis marker.
+    assert speechify("The cost is 2 * 3 dollars") == "The cost is 2 * 3 dollars"
+
+
+def test_punctuation_only_unit_is_silent() -> None:
+    assert speechify("---") == ""
+    assert speechify("   ") == ""
+
+
+# ── speech units ───────────────────────────────────────────────────────────
+
+
+def test_unit_splits_on_sentence_end() -> None:
+    unit, rest = split_speech_unit("Hello there. How are", 180)
+    assert unit == "Hello there."
+    assert rest == " How are"
+
+
+def test_incomplete_sentence_waits() -> None:
+    unit, rest = split_speech_unit("no terminator yet", 180)
+    assert unit == ""
+    assert rest == "no terminator yet"
+
+
+def test_runaway_sentence_is_cut_at_a_word_boundary() -> None:
+    buf = "word " * 60  # no terminator at all
+    unit, rest = split_speech_unit(buf, 50)
+    assert unit and len(unit) <= 50
+    assert not unit.endswith("wor")  # cut on a space, never mid-word
+    assert rest
+
+
+def test_newline_is_a_boundary() -> None:
+    unit, _ = split_speech_unit("First line\nsecond", 180)
+    assert unit.strip() == "First line"
+
+
+# ── frame streaming ────────────────────────────────────────────────────────
+
+
+async def _chunks(*texts: str) -> AsyncIterator[str]:
+    for t in texts:
+        yield "0:" + json.dumps(t)
+
+
+async def _collect(gen: AsyncIterator[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    return [f async for f in gen]
+
+
+class _Cfg:
+    VOICE_LIVE_SPEECH_UNITS = True
+    VOICE_LIVE_SPEECH_UNIT_MAX_CHARS = 180
+
+
+@pytest.mark.asyncio
+async def test_frames_are_sanitised_across_chunk_boundaries() -> None:
+    """The reason units exist: '**' arrives split over two chunks, so raw
+    per-token sanitising could never catch it."""
+    from modules.voice.providers import retell as mod
+
+    with patch("config.config", _Cfg):
+        frames = await _collect(
+            mod.retell_response_frames(7, _chunks("Auth is *", "*broken*", "* now."))
+        )
+    spoken = "".join(f["content"] for f in frames)
+    assert "*" not in spoken
+    assert "Auth is broken now." in spoken
+    assert frames[-1]["content_complete"] is True
+    assert all(f["response_id"] == 7 for f in frames)
+
+
+@pytest.mark.asyncio
+async def test_terminal_frame_always_closes_the_turn() -> None:
+    from modules.voice.providers import retell as mod
+
+    with patch("config.config", _Cfg):
+        frames = await _collect(mod.retell_response_frames(3, _chunks("```\ncode\n```")))
+    # Nothing speakable, but Retell still needs the turn closed or it hangs.
+    assert frames[-1] == {"response_id": 3, "content": "", "content_complete": True}
+
+
+@pytest.mark.asyncio
+async def test_multi_sentence_reply_streams_progressively() -> None:
+    """First audio must not wait for the whole generation."""
+    from modules.voice.providers import retell as mod
+
+    with patch("config.config", _Cfg):
+        frames = await _collect(
+            mod.retell_response_frames(1, _chunks("One. ", "Two. ", "Three."))
+        )
+    speech = [f for f in frames if f["content"].strip()]
+    assert len(speech) >= 3, "sentences should ship as they complete, not in one lump"
+
+
+@pytest.mark.asyncio
+async def test_legacy_passthrough_when_units_disabled() -> None:
+    from modules.voice.providers import retell as mod
+
+    class _Off(_Cfg):
+        VOICE_LIVE_SPEECH_UNITS = False
+
+    with patch("config.config", _Off):
+        frames = await _collect(mod.retell_response_frames(2, _chunks("**raw**")))
+    assert frames[0]["content"] == "**raw**"
+
+
+# ── the spoken-output contract ─────────────────────────────────────────────
+
+
+def test_contract_names_the_things_that_break_tts() -> None:
+    lowered = SPOKEN_OUTPUT_CONTRACT.lower()
+    for token in ("markdown", "heard", "sentences", "url"):
+        assert token in lowered
+
+
+def test_spoken_style_appends_to_the_system_prompt() -> None:
+    from consumers.chatbot.service import StreamingChatService as S
+
+    msgs = [
+        {"role": "system", "content": "You are Auto."},
+        {"role": "user", "content": "hi"},
+    ]
+    S._apply_spoken_style(msgs)
+    assert msgs[0]["content"].startswith("You are Auto.")
+    assert "YOU ARE SPEAKING OUT LOUD" in msgs[0]["content"]
+    assert msgs[1] == {"role": "user", "content": "hi"}  # user turn untouched
+
+
+def test_spoken_style_is_dial_gated() -> None:
+    from consumers.chatbot.service import StreamingChatService as S
+
+    class _Off:
+        VOICE_LIVE_SPOKEN_STYLE = False
+
+    msgs = [{"role": "system", "content": "You are Auto."}]
+    with patch("config.config", _Off):
+        S._apply_spoken_style(msgs)
+    assert msgs[0]["content"] == "You are Auto."
+
+
+def test_spoken_style_survives_a_missing_system_message() -> None:
+    from consumers.chatbot.service import StreamingChatService as S
+
+    msgs = [{"role": "user", "content": "hi"}]
+    S._apply_spoken_style(msgs)
+    assert msgs[0]["role"] == "system"
+
+
+# ── agent tuning ───────────────────────────────────────────────────────────
+
+
+def test_tuning_no_longer_cancels_the_speaker() -> None:
+    """The aggressive mode cancelled Gerard's own voice — a whole live call
+    logged zero turns until he shouted."""
+    from modules.voice import retell_api
+
+    tuning = retell_api.build_agent_tuning()
+    assert tuning["denoising_mode"] == "noise-cancellation"
+    assert tuning["interruption_sensitivity"] >= 0.4, "0.2 blocked normal barge-in"
+
+
+def test_tuning_carries_voice_and_speech_normalisation() -> None:
+    from modules.voice import retell_api
+
+    tuning = retell_api.build_agent_tuning()
+    assert tuning["voice_id"]
+    assert tuning["normalize_for_speech"] is True
+    assert tuning["reminder_max_count"] == 1  # stop the "still there?" nagging
+    assert "voice_speed" in tuning and "voice_temperature" in tuning
+
+
+def test_tuning_can_leave_a_human_picked_voice_alone() -> None:
+    from modules.voice import retell_api
+
+    tuning = retell_api.build_agent_tuning(include_voice=False)
+    assert "voice_id" not in tuning
+    assert tuning["denoising_mode"] == "noise-cancellation"  # hearing still tuned


### PR DESCRIPTION
## Why it sounded bad

Not latency this time. **Auto never knew she was being heard.** There was no spoken-mode prompt anywhere in the voice path (grepped), and `extract_agent_text` piped her raw text straight to Retell's TTS. So she wrote her normal chat answer — bullets, `**bold**`, headers, numbered lists, links, emoji — and the engine read the punctuation out loud, at chat length.

Confirmed live from the Retell API on the armed agent:

| Setting | Was | Now |
|---|---|---|
| `denoising_mode` | `noise-and-background-speech-cancellation` | `noise-cancellation` |
| `language` | `en-US` | `en-GB` |
| `interruption_sensitivity` | 0.2 | 0.5 |
| `normalize_for_speech` | unset | on |
| `voice_id` / speed / temperature | unset defaults | config dials |

The aggressive denoise is not a preference — it **cancelled the speaker**: a whole measured call logged `turns=0` until he shouted.

## What's in here

- **Spoken-output contract** — spoken turns append a directive: 1–3 short sentences, no markdown, numbers/dates as words, never read a URL or path aloud, offer detail rather than reciting it. Same brain (ONE AUTO — memory/tools/reasoning untouched); this is a *medium* instruction, not the `force_text_only` lobotomy. Appended after the CTO override so whatever persona is speaking still obeys it.
- **`speechify()`** — belt to that prompt's braces. Fences, inline code, images, links (label kept), headers, rules, tables, bullets, numbering, emphasis, emoji; newlines become sentence boundaries. A model slips an asterisk eventually, and one `**` spoken aloud costs a sentence of credibility.
- **Frames are whole speech units, not tokens** — and this is what makes the sanitizer *correct*: markdown markers straddle stream chunks (`**` arrives as `*` then `*`), so per-token sanitizing can never work. Sentences still ship as they complete, so first audio doesn't wait for the full generation.
- **Agent retune** (above) + one reminder instead of endless "still there?".
- **"One moment." once per call**, not per turn — a 3-turn utterance storm played it over itself (part of the "five people talking"). The slow-turn WARNING still logs every time, so telemetry keeps its teeth.

## Dials (all default to the new behaviour, all reversible)
`VOICE_LIVE_SPOKEN_STYLE` · `VOICE_LIVE_SPEECH_UNITS` · `VOICE_LIVE_SPEECH_UNIT_MAX_CHARS` · `VOICE_LIVE_VOICE_ID` · `VOICE_LIVE_VOICE_SPEED` · `VOICE_LIVE_VOICE_TEMPERATURE` · `VOICE_LIVE_NORMALIZE_FOR_SPEECH` · `VOICE_LIVE_REMINDER_*` · plus the retuned STT dials.

## Tests
`orchestrator/tests/test_voice_quality.py` — sanitizer (incl. markdown split across chunks, prose left alone, `2 * 3` not eaten as emphasis), unit splitting incl. runaway-sentence cut, frame streaming + terminal frame always closing the turn, contract injection + dial gating, tuning assertions. `test_prd207_voice_live.py`'s denoise assertion updated to the withdrawn-mode reality with the reason recorded.

## After merge
Re-arm once (applies voice + STT tuning to the live agent), then call. Expect: short spoken answers, no punctuation read aloud, normal speaking volume works, one "One moment." at most.

**Irish Auto:** Retell ships no Irish voice (295 checked — American/British/Australian/Indian only). Import one from the ElevenLabs voice library into the Retell dashboard, then set `VOICE_LIVE_VOICE_ID` to the id it gets. Interim voice is British (`11labs-Willa`).