### PR TITLE
fix(voice): first-unit latency guard + un-red main after #607

### DIFF
--- a/orchestrator/config.py
+++ b/orchestrator/config.py
@@ -1373,6 +1373,14 @@ class Config:
     VOICE_LIVE_SPEECH_UNIT_MAX_CHARS: int = int(
         os.getenv("VOICE_LIVE_SPEECH_UNIT_MAX_CHARS", "180")
     )
+    # Time-to-first-audio guard (PRD-203's property: the caller hears something
+    # while the agent is still generating). The FIRST unit of a turn flushes at
+    # a much smaller ceiling than the rest, so an opening clause starts playing
+    # instead of waiting for the sentence to land. Later units use the full
+    # ceiling, where prosody matters more than milliseconds.
+    VOICE_LIVE_SPEECH_FIRST_UNIT_MAX_CHARS: int = int(
+        os.getenv("VOICE_LIVE_SPEECH_FIRST_UNIT_MAX_CHARS", "60")
+    )
     # Auto is told she is being HEARD on spoken turns (short sentences, no
     # markdown, no URLs read aloud). Same brain, different medium — false
     # restores the old behaviour of speaking her chat-formatted answer.

--- a/orchestrator/modules/voice/providers/retell.py
+++ b/orchestrator/modules/voice/providers/retell.py
@@ -146,6 +146,7 @@ async def retell_response_frames(
 
     unitised = bool(getattr(config, "VOICE_LIVE_SPEECH_UNITS", True))
     max_chars = int(getattr(config, "VOICE_LIVE_SPEECH_UNIT_MAX_CHARS", 180))
+    first_max = int(getattr(config, "VOICE_LIVE_SPEECH_FIRST_UNIT_MAX_CHARS", 60))
 
     def _frame(content: str) -> Dict[str, Any]:
         return {
@@ -170,7 +171,10 @@ async def retell_response_frames(
             continue
         buffer += text
         while True:
-            unit, buffer = split_speech_unit(buffer, max_chars)
+            # The opening unit flushes early (time-to-first-audio); the rest
+            # wait for a proper boundary.
+            ceiling = first_max if not spoken_any else max_chars
+            unit, buffer = split_speech_unit(buffer, ceiling)
             if not unit:
                 break
             said = speechify(unit)

--- a/orchestrator/tests/test_prd203_voice_retell.py
+++ b/orchestrator/tests/test_prd203_voice_retell.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import json
 import hmac
 
 import pytest
@@ -28,15 +29,22 @@ from modules.voice.providers.retell import (
 
 def test_first_audio_before_full_agent_stream():
     """A Retell content frame is emitted while the agent is still generating —
-    the exact property the collect-everything-then-speak path lacked."""
+    the exact property the collect-everything-then-speak path lacked.
+
+    Granularity note: frames are whole speech units, not raw tokens (the
+    markdown sanitizer can only work on a complete unit — ``**`` straddles
+    chunk boundaries). So the assertion is that audio starts mid-generation,
+    not that every token ships on arrival. The opening unit also flushes at a
+    lower character ceiling than later ones, so time-to-first-audio survives.
+    """
 
     async def scenario():
         events: list[str] = []
 
         async def agent_stream():
-            yield '0:"Hello "'
+            yield '0:"Hello there. "'
             events.append("agent_yield_1")
-            yield '0:"there"'
+            yield '0:"How can I help?"'
             events.append("agent_yield_2")
             yield 'd:{"finishReason":"stop"}'  # non-text terminal line
             events.append("agent_done")
@@ -52,11 +60,44 @@ def test_first_audio_before_full_agent_stream():
         assert events.index("frame_1") < events.index("agent_yield_2")
 
         content_frames = [f for f in frames if not f["content_complete"]]
-        assert [f["content"] for f in content_frames] == ["Hello ", "there"]
+        spoken = "".join(f["content"] for f in content_frames)
+        assert "Hello there." in spoken and "How can I help?" in spoken
         assert frames[0]["response_id"] == 7
         # A terminal complete frame closes the turn; the non-text 'd:' line
         # produced no content frame.
         assert frames[-1] == {"response_id": 7, "content": "", "content_complete": True}
+
+    asyncio.run(scenario())
+
+
+def test_opening_clause_ships_without_waiting_for_the_sentence():
+    """Time-to-first-audio guard: a long opening sentence must not hold the
+    whole turn silent — the first unit flushes at its own lower ceiling, so
+    audio starts before the sentence's full stop ever arrives."""
+
+    async def scenario():
+        events: list[str] = []
+        # Comfortably past the first-unit ceiling, with no terminator in sight.
+        long_open = (
+            "So the short version here is that everything running on the "
+            "platform right now looks "
+        )
+
+        async def agent_stream():
+            yield '0:' + json.dumps(long_open)
+            events.append("agent_yield_1")
+            yield '0:' + json.dumps("completely healthy.")
+            events.append("agent_yield_2")
+
+        frames = []
+        async for frame in retell_response_frames(1, agent_stream()):
+            frames.append(frame)
+            events.append(f"frame_{len(frames)}")
+
+        # Audio began on the opening clause — before the sentence completed.
+        assert events.index("frame_1") < events.index("agent_yield_2")
+        spoken = "".join(f["content"] for f in frames)
+        assert "completely healthy." in spoken  # nothing dropped on the way
 
     asyncio.run(scenario())
 

--- a/orchestrator/tests/test_prd207_voice_live.py
+++ b/orchestrator/tests/test_prd207_voice_live.py
@@ -1149,7 +1149,7 @@ def test_arm_retunes_the_existing_agent(monkeypatch):
 
     assert created == {}  # existing agent kept, not recreated
     assert tuned["agent_id"] == "agent_existing"
-    assert tuned["denoising_mode"] == "noise-and-background-speech-cancellation"
+    assert tuned["denoising_mode"] == "noise-cancellation"
     assert tuned["language"]
 
 

--- a/orchestrator/tests/test_voice_quality.py
+++ b/orchestrator/tests/test_voice_quality.py
@@ -183,7 +183,7 @@ async def test_legacy_passthrough_when_units_disabled() -> None:
 
 def test_contract_names_the_things_that_break_tts() -> None:
     lowered = SPOKEN_OUTPUT_CONTRACT.lower()
-    for token in ("markdown", "heard", "sentences", "url"):
+    for token in ("markdown", "hear", "sentences", "url"):
         assert token in lowered
 
 


### PR DESCRIPTION
#607 merged at its red commit; this is the already-written follow-up that was stranded on the branch (new branch, never push to a merged one).

**Not just stale assertions — one real regression.** Sentence-buffered frames weakened PRD-203's load-bearing property (*first audio before the agent finishes generating*): a long opening sentence would have held the line silent until its full stop, quietly trading back the latency work.

Fixed with a guard rather than a relaxed test: the **first** unit of a turn flushes at its own lower ceiling (`VOICE_LIVE_SPEECH_FIRST_UNIT_MAX_CHARS`, 60) so the opening clause starts playing, while later units keep the full 180 where prosody matters more than milliseconds. Verified locally: frame 1 ships before the agent's second chunk, with nothing dropped from the tail.

Also lands the three assertion fixes the new contract moved:
- `test_first_audio_before_full_agent_stream` — keeps its intent (progressive, not collect-then-speak) at the new sentence granularity, plus a sibling test pinning the guard directly.
- `test_arm_retunes_the_existing_agent` — the withdrawn aggressive-denoise value.
- `test_contract_names_the_things_that_break_tts` — mine, checked for a word the contract doesn't use.

Merge to un-red main. Then re-arm once and call.