### PR TITLE
fix(llm): read platform provider keys live from operator workspace key store

### DIFF
--- a/orchestrator/config.py
+++ b/orchestrator/config.py
@@ -464,6 +464,10 @@ class Config:
     DEFAULT_WORKSPACE_ID: str = os.getenv("DEFAULT_WORKSPACE_ID")
     WORKSPACE_ID: str = os.getenv("WORKSPACE_ID")
     CREDENTIAL_ENCRYPTION_KEY: str = os.getenv("CREDENTIAL_ENCRYPTION_KEY")
+    # Workspace whose stored user_api_keys rows act as the platform-level
+    # provider keys for background workers (embeddings, system LLM) and the
+    # pilot chat fallback. Empty = disabled (legacy credential-store-only).
+    PLATFORM_KEY_WORKSPACE_ID: str = os.getenv("PLATFORM_KEY_WORKSPACE_ID", "")
 
     # =============================================================================
     # URLS (Backend, Frontend, API)

--- a/orchestrator/core/llm/embedding_manager.py
+++ b/orchestrator/core/llm/embedding_manager.py
@@ -96,10 +96,15 @@ class EmbeddingManager:
                 self.provider = DeterministicEmbeddingProvider(dimension=dimension)
                 return
             
-            # Get API key for provider (if needed)
+            # Get API key for provider (if needed).
+            # Operator workspace key first — the credential-store copy can
+            # drift (dead openrouter_api row served for months, 2026-07-30).
             api_key = None
             if provider_type != "huggingface_local":
-                api_key = get_credential_field(provider_type)
+                from core.llm.workspace_keys import get_platform_workspace_key
+                api_key = get_platform_workspace_key(provider_type)
+                if not api_key:
+                    api_key = get_credential_field(provider_type)
                 
                 # Fallback to environment variables
                 if not api_key:

--- a/orchestrator/core/llm/manager.py
+++ b/orchestrator/core/llm/manager.py
@@ -529,6 +529,17 @@ class LLMManager:
         elif provider == LLMProvider.OPENROUTER:
             api_key = cred_data.get("api_key") or cred_data.get("api_token")
 
+        # Operator workspace key overrides a drifted credential-store copy —
+        # the stored platform slot held a provider-side-deleted key for months
+        # while every background LLM call 401'd (2026-07-30).
+        from core.llm.workspace_keys import get_platform_workspace_key
+        ws_key = get_platform_workspace_key(provider.value)
+        if ws_key:
+            api_key = ws_key
+            base_url = None
+            organization_id = None
+            secret_key = None
+
         # Fallback to environment variables if credentials not found (except HuggingFace)
         if not api_key and provider != LLMProvider.HUGGINGFACE:
             fallback_env_vars = {

--- a/orchestrator/core/llm/workspace_keys.py
+++ b/orchestrator/core/llm/workspace_keys.py
@@ -1,0 +1,68 @@
+"""Resolve provider API keys from the operator workspace's own key store.
+
+Background workers (embeddings, system LLM) and the pilot chat fallback
+historically read only the platform credential store (``credentials`` table,
+e.g. the ``openrouter_api`` row). When the operator's real key lives in their
+workspace key store (``user_api_keys``), that credential-store copy drifts —
+it held a key deleted on the provider side for months while every memory
+write/search 401'd (2026-07-30 incident).
+
+This helper points those paths at the workspace key store directly, so the
+key is read from where it actually lives instead of being duplicated into a
+second slot. Enabled only when ``PLATFORM_KEY_WORKSPACE_ID`` is set; returns
+``None`` otherwise so other deployments keep the legacy behaviour unchanged.
+
+Row selection mirrors ``AgentFactory._resolve_api_key`` BYOK ordering
+(``last_used_at DESC NULLS LAST``) so these paths use the exact key already
+proven live by chat.
+"""
+
+import logging
+from typing import Optional
+
+from config import config
+
+logger = logging.getLogger(__name__)
+
+
+def get_platform_workspace_key(provider: str) -> Optional[str]:
+    """Return the operator workspace's active key for ``provider``, or None.
+
+    Never raises: any lookup/decrypt failure logs a warning and returns None
+    so callers fall through to the credential store / env resolution tiers.
+    """
+    workspace_id = (config.PLATFORM_KEY_WORKSPACE_ID or "").strip()
+    if not workspace_id:
+        return None
+
+    try:
+        from core.database.database import SessionLocal
+        from core.models.core import UserApiKey
+        from core.credentials.encryption import get_encryption_service
+
+        db = SessionLocal()
+        try:
+            row = (
+                db.query(UserApiKey)
+                .filter(
+                    UserApiKey.workspace_id == workspace_id,
+                    UserApiKey.provider == provider,
+                    UserApiKey.is_active.is_(True),
+                )
+                .order_by(UserApiKey.last_used_at.desc().nullslast())
+                .first()
+            )
+            if not row:
+                return None
+            key = get_encryption_service().decrypt(row.encrypted_key)
+            logger.info(
+                "Resolved '%s' key from operator workspace key store "
+                "(PLATFORM_KEY_WORKSPACE_ID)",
+                provider,
+            )
+            return key
+        finally:
+            db.close()
+    except Exception as e:  # noqa: BLE001 — resolution must never break callers
+        logger.warning("Workspace-key resolution failed for '%s': %s", provider, e)
+        return None

--- a/orchestrator/modules/agents/factory/agent_factory.py
+++ b/orchestrator/modules/agents/factory/agent_factory.py
@@ -454,6 +454,17 @@ class AgentFactory:
             except Exception as e:
                 self.logger.error(f"BYOK key lookup failed for {provider_name}: {e}")
 
+        # 1.5 Operator workspace key (PLATFORM_KEY_WORKSPACE_ID) — the pilot
+        # "platform key" lane, read live from user_api_keys instead of a
+        # duplicated credential-store copy that can drift (2026-07-30).
+        from core.llm.workspace_keys import get_platform_workspace_key
+        ws_key = get_platform_workspace_key(provider_name)
+        if ws_key:
+            self.logger.info(
+                f"Resolved platform key from operator workspace store for '{provider_name}' ({agent_name})"
+            )
+            return ResolvedKey(api_key=ws_key, source="platform_workspace", is_byok=False, provider=provider_name)
+
         # 2. Credential store (platform keys)
         cred_names = [
             f"development_{provider_name}_api",

--- a/orchestrator/tests/test_workspace_keys.py
+++ b/orchestrator/tests/test_workspace_keys.py
@@ -1,0 +1,51 @@
+"""Tests for core.llm.workspace_keys — operator workspace key resolution."""
+
+from unittest import mock
+
+from config import config as app_config
+from core.llm.workspace_keys import get_platform_workspace_key
+
+WS = "ae8320bc-95e1-4de1-bbe9-396bef19cbf8"
+
+
+def test_disabled_when_setting_empty(monkeypatch):
+    monkeypatch.setattr(app_config, "PLATFORM_KEY_WORKSPACE_ID", "")
+    assert get_platform_workspace_key("openrouter") is None
+
+
+def test_resolves_active_row(monkeypatch):
+    monkeypatch.setattr(app_config, "PLATFORM_KEY_WORKSPACE_ID", WS)
+
+    row = mock.Mock(encrypted_key="enc-blob")
+    session = mock.MagicMock()
+    session.query.return_value.filter.return_value.order_by.return_value.first.return_value = row
+
+    enc = mock.Mock()
+    enc.decrypt.return_value = "sk-or-live"
+
+    with mock.patch("core.database.database.SessionLocal", return_value=session), \
+         mock.patch("core.credentials.encryption.get_encryption_service", return_value=enc):
+        assert get_platform_workspace_key("openrouter") == "sk-or-live"
+
+    enc.decrypt.assert_called_once_with("enc-blob")
+    session.close.assert_called_once()
+
+
+def test_no_active_row_returns_none(monkeypatch):
+    monkeypatch.setattr(app_config, "PLATFORM_KEY_WORKSPACE_ID", WS)
+
+    session = mock.MagicMock()
+    session.query.return_value.filter.return_value.order_by.return_value.first.return_value = None
+
+    with mock.patch("core.database.database.SessionLocal", return_value=session):
+        assert get_platform_workspace_key("openrouter") is None
+    session.close.assert_called_once()
+
+
+def test_lookup_failure_swallowed(monkeypatch):
+    monkeypatch.setattr(app_config, "PLATFORM_KEY_WORKSPACE_ID", WS)
+
+    with mock.patch(
+        "core.database.database.SessionLocal", side_effect=RuntimeError("db down")
+    ):
+        assert get_platform_workspace_key("openrouter") is None


### PR DESCRIPTION
## Problem

Embeddings, the system LLM (memory workers), and the pilot chat fallback resolve their provider key ONLY from the platform credential store (`openrouter_api` row) + env. That stored copy drifted: it held a provider-side-deleted key (`test_status=failed`, untouched since May) while chat — running on the operator's live `user_api_keys` row — kept working.

Net effect in prod (2026-07-29/30): every memory store/search and background LLM call 401'd (`User not found`) while chat looked healthy. Full incident: 11 consecutive `memory_integration` errors, all `store_long_term`/`search_long_term` failing, pilot workspace chat dead on the fallback lane.

## Fix

New `PLATFORM_KEY_WORKSPACE_ID` config (empty = feature off, legacy behaviour unchanged). When set, the named workspace's `user_api_keys` rows act as the platform-level provider keys, decrypted in-process from the same row chat already uses — the secret is never duplicated into a second slot.

Resolution order per path:
- **embeddings** (`embedding_manager`): workspace key → credential store → env
- **system LLM** (`load_llm_config`): workspace key overrides credential store
- **agent factory pilot fallback**: client BYOK → workspace key → credential store → env (client keys still win)

Row selection mirrors the factory BYOK ordering (`last_used_at DESC NULLS LAST`) so all paths use the exact key proven live.

## Test plan

- Unit tests: `orchestrator/tests/test_workspace_keys.py` (off-switch, happy path, no-row, DB-failure swallow)
- CI is the gate; after merge+deploy verify in Railway logs: `/api/v1/embeddings` returns 200, `[UnifiedMemoryService] store_long_term` succeeds, no `401 User not found`
- Requires `PLATFORM_KEY_WORKSPACE_ID` set on `automatos-ai-api` (operator workspace UUID — non-secret)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for operator workspace API keys for LLM, embedding, and agent providers.
  * Workspace keys can override standard credential and environment-based key resolution.
  * Added configuration to enable or disable workspace key support.

* **Bug Fixes**
  * Workspace key lookup failures now fall back safely to existing credential resolution without interrupting provider loading.

* **Tests**
  * Added coverage for disabled, successful, missing, and failed workspace key lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->