### PR TITLE
fix(missions): surface the final output as a mission deliverable + truncate header

### DIFF
--- a/frontend/components/missions/mission-detail-page.tsx
+++ b/frontend/components/missions/mission-detail-page.tsx
@@ -50,6 +50,21 @@ interface MissionDetailPageProps {
   missionId: string
 }
 
+/**
+ * Short display title for the header: an explicit config name wins, else the
+ * goal's first sentence-ish clause, hard-capped at 90 chars so a full mission
+ * brief never becomes the page headline. The complete goal stays visible in
+ * the mission Overview.
+ */
+function missionDisplayTitle(goal: string, config?: Record<string, unknown>): string {
+  const configured = config?.name
+  if (typeof configured === 'string' && configured.trim()) return configured.trim()
+  const trimmed = (goal || '').trim()
+  const firstStop = trimmed.search(/[.:!?]\s/)
+  const clause = firstStop > 15 ? trimmed.slice(0, firstStop) : trimmed
+  return clause.length > 90 ? `${clause.slice(0, 90).trimEnd()}…` : clause
+}
+
 export function MissionDetailPage({ missionId }: MissionDetailPageProps) {
   const router = useRouter()
   const { data: mission, isLoading } = useMission(missionId)
@@ -131,7 +146,7 @@ export function MissionDetailPage({ missionId }: MissionDetailPageProps) {
         {/* Title row */}
         <PageHeader
           title="Mission"
-          titleAccent={(mission.config as Record<string, unknown>)?.name as string || mission.goal.split(':')[0]}
+          titleAccent={missionDisplayTitle(mission.goal, mission.config as Record<string, unknown>)}
           eyebrow={`Operations · mission ${missionId.slice(0, 8)}`}
           lede={
             [

--- a/orchestrator/services/coordinator_service.py
+++ b/orchestrator/services/coordinator_service.py
@@ -614,6 +614,18 @@ async def _store_mission_memory_safe(
 # ---------------------------------------------------------------------------
 
 
+def pick_final_output_task(tasks):
+    """Last task in sequence order with a non-empty output — the mission's
+    final work product (e.g. a 'Finalize …' writer task). Ties within a
+    parallel group resolve to the later task in original order (sorted() is
+    stable). Returns None when no task produced output."""
+    final = None
+    for t in sorted(tasks or [], key=lambda t: (t.sequence_number or 0)):
+        if t.output and str(t.output).strip():
+            final = t
+    return final
+
+
 class CoordinatorService:
     """
     Stateless coordinator that orchestrates sequential missions.
@@ -925,7 +937,15 @@ class CoordinatorService:
                 logger.info("[Mission] Saved output document %s for mission %s", document_id, run.id)
 
             # --- PRD-167 wiring: emit a rendered document deliverable -------
-            await self._emit_mission_document(db, run, content)
+            emitted_deliverable = await self._emit_mission_document(db, run, content)
+
+            # 2026-07-30: emission was opt-in via the emit_document spec and
+            # nothing sets it by default — every mission's Deliverables tab was
+            # empty. When no spec produced a render, default-promote the FINAL
+            # task output as the mission deliverable (intermediates stay on the
+            # Reports surface).
+            if not emitted_deliverable:
+                await self._register_final_output_deliverable(db, run, tasks)
 
             # --- App builder: also save the zip bundle ---
             template_used = (run.config or {}).get("template_used")
@@ -955,6 +975,85 @@ class CoordinatorService:
                     "[Mission] Could not persist ingest-failure marker for run %s",
                     run.id, exc_info=True,
                 )
+            return None
+
+    async def _register_final_output_deliverable(
+        self,
+        db: Session,
+        run: OrchestrationRun,
+        tasks,
+    ) -> Optional[str]:
+        """Register the mission's final task output as a mission deliverable.
+
+        The mission Deliverables tab lists deliverables with
+        ``source_id == run.id``, but until 2026-07-30 nothing wrote
+        mission-sourced rows unless the run carried an explicit
+        ``emit_document`` spec — so the tab was empty for every mission ever
+        run. Promotes ONLY the final output (see ``pick_final_output_task``);
+        intermediate task outputs stay on the Reports surface. Fail-soft;
+        idempotent via ``config['emitted_deliverable_id']`` (shared with the
+        spec path so the two never double-emit).
+        """
+        if (run.config or {}).get("emitted_deliverable_id"):
+            return None
+        final_task = pick_final_output_task(tasks)
+        if final_task is None:
+            return None
+        try:
+            from core.workspace_client import WorkspaceClient
+            from services.deliverable_service import DeliverableService
+
+            slug = re.sub(
+                r"[^a-z0-9]+", "-", (final_task.title or run.goal or "")[:60].lower()
+            ).strip("-") or "final-output"
+            file_path = f"missions/{str(run.id)[:8]}-{slug}.md"
+            content = str(final_task.output)
+
+            ws_client = WorkspaceClient(str(run.workspace_id))
+            write_result = await ws_client.write_file(file_path, content)
+            if not write_result.get("success"):
+                logger.warning(
+                    "[Mission] Could not write final-output file for %s: %s",
+                    run.id, write_result.get("error", "unknown"),
+                )
+                return None
+
+            svc = DeliverableService(db, run.workspace_id)
+            registration = svc.register(
+                file_path=file_path,
+                title=final_task.title or f"Mission output: {run.goal[:80]}",
+                source_type="mission",
+                source_id=str(run.id),
+                # agent_name stays None — list_deliverables COALESCEs the
+                # agents join, so the real agent name renders from agent_id.
+                agent_id=final_task.assigned_agent_id,
+                # .md infers 'report', which register() refuses (native-service
+                # guard). This is the polished final document, not a filed
+                # report — classify it as such.
+                artifact_type="document",
+                summary=content[:280],
+                file_size_bytes=len(content.encode("utf-8")),
+            )
+            if not registration.get("success"):
+                logger.warning(
+                    "[Mission] Final-output deliverable registration failed for %s: %s",
+                    run.id, registration.get("error", "unknown"),
+                )
+                return None
+
+            deliverable_id = registration.get("deliverable_id")
+            run.config = {**(run.config or {}), "emitted_deliverable_id": str(deliverable_id)}
+            db.flush()
+            logger.info(
+                "[Mission] Registered final-output deliverable %s for mission %s",
+                deliverable_id, run.id,
+            )
+            return str(deliverable_id)
+        except Exception as e:
+            logger.warning(
+                "[Mission] Final-output deliverable promotion failed for %s: %s",
+                run.id, e, exc_info=True,
+            )
             return None
 
     async def _emit_mission_document(

--- a/orchestrator/tests/test_mission_final_output_promotion.py
+++ b/orchestrator/tests/test_mission_final_output_promotion.py
@@ -1,0 +1,54 @@
+"""Tests for the mission final-output deliverable promotion (2026-07-30).
+
+Covers the pure selection helper — the registration path itself is fail-soft
+and exercised by the coordinator integration suite.
+"""
+
+from types import SimpleNamespace
+
+from services.coordinator_service import pick_final_output_task
+
+
+def _task(seq, output, title="t"):
+    return SimpleNamespace(sequence_number=seq, output=output, title=title)
+
+
+def test_picks_last_sequence_with_output():
+    tasks = [
+        _task(1, "extraction"),
+        _task(2, "research"),
+        _task(6, "the final report"),
+        _task(5, "qa notes"),
+    ]
+    assert pick_final_output_task(tasks).output == "the final report"
+
+
+def test_skips_trailing_tasks_without_output():
+    tasks = [
+        _task(4, "draft"),
+        _task(5, None),
+        _task(6, "   "),
+    ]
+    assert pick_final_output_task(tasks).output == "draft"
+
+
+def test_parallel_group_tie_resolves_to_later_task():
+    tasks = [
+        _task(4, "draft report", title="Draft"),
+        _task(4, "validation appendix", title="Appendix"),
+    ]
+    assert pick_final_output_task(tasks).title == "Appendix"
+
+
+def test_no_outputs_returns_none():
+    assert pick_final_output_task([_task(1, None), _task(2, "")]) is None
+
+
+def test_empty_and_none_inputs():
+    assert pick_final_output_task([]) is None
+    assert pick_final_output_task(None) is None
+
+
+def test_none_sequence_sorts_first():
+    tasks = [_task(None, "early"), _task(3, "late")]
+    assert pick_final_output_task(tasks).output == "late"


### PR DESCRIPTION
## Problems (reported by Gerard off mission 65E1974B, the GOOG analyst report run)

1. **Deliverables tab always empty.** Every mission ever run shows 'No deliverables yet' while the polished final work sits invisible in the last task's output (10 KB, verified, 118k tokens for this run). Root cause: `_emit_mission_document` is opt-in via `run.config['emit_document']` and nothing sets that spec by default — prod `deliverables` has zero mission-sourced rows, ever.
2. **Header renders the whole mission brief** as the display headline — no cap, huge accent type.

## Fix

- **Coordinator**: on completion, when the spec path emitted nothing, promote the FINAL task output (last sequence with non-empty output) — write `missions/<run>-<slug>.md` via `WorkspaceClient` (same mechanism reports use) and `DeliverableService.register()` it with `source_type='mission'`, `source_id=run_id` — exactly what the mission tab filters on. Intermediate outputs stay on the Reports surface per Gerard's direction ('don't need every agent thought — MUST have the final work'). Idempotent via the existing `emitted_deliverable_id` key (shared with the spec path, so no double-emit); fail-soft like the surrounding output-doc flow.
- **`pick_final_output_task()`** pure helper + 6 unit tests.
- **Header**: `missionDisplayTitle()` — explicit `config.name` wins, else first clause capped at 90 chars with ellipsis. Full goal remains in the Overview.

## Notes for review

- `artifact_type='document'` passed explicitly: `.md` infers `report`, which `register()` refuses by design (native-service guard). This is the final document, not a filed report.
- `agent_name` left None so `list_deliverables`' agents join renders the real finalize agent.
- Existing mission 65E1974B was backfilled directly (idempotent SQL, deliverable points at the QUILL final-report file) so the tab is populated for today's demo regardless of deploy timing.

## Test plan

- Unit: `orchestrator/tests/test_mission_final_output_promotion.py`
- CI is the gate. Post-deploy: complete any mission → mission Deliverables tab shows exactly one 'document' row from the finalize agent; `missions/` file exists in workspace storage; re-completion doesn't duplicate (config key).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mission pages now display clearer, more consistent header titles based on configured names or mission goals.
  * Missions without a rendered document now receive a final-output deliverable containing the last available task result.

* **Bug Fixes**
  * Improved handling of long or punctuation-heavy mission goals in page headers.
  * Prevented missing final outputs when document generation is unavailable.

* **Tests**
  * Added coverage for selecting the correct final task output across ordering, missing-output, and tie scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->