### PR TITLE
fix(analytics): workspace owners/admins can read their own LLM analytics

### DIFF
--- a/orchestrator/api/llm_analytics.py
+++ b/orchestrator/api/llm_analytics.py
@@ -44,6 +44,15 @@ admin_router = APIRouter(
     tags=["Admin Analytics"],
     dependencies=[Depends(require_super_admin)],
 )
+# Mutating obs routes never relax (authz boundary sweep enforces exactly one
+# auth bucket per route) — the OpenRouter sync POST lives on its own
+# super-admin-only router at the SAME path prefix, outside the workspace-admin
+# relax above.
+sync_router = APIRouter(
+    prefix="/api/analytics/llm",
+    tags=["LLM Analytics"],
+    dependencies=[Depends(require_super_admin)],
+)
 
 
 # ── Pydantic schemas ─────────────────────────────────────────────────
@@ -682,14 +691,10 @@ class OpenRouterKeyInfoResponse(BaseModel):
     rate_limit: Dict[str, Any] = Field(default_factory=dict)
 
 
-@router.post(
+@sync_router.post(
     "/openrouter/sync",
     response_model=OpenRouterSyncResponse,
     summary="Trigger OpenRouter activity sync",
-    # Mutating obs route: stays super-admin even though the router relaxed to
-    # workspace admins (2026-07-30) — enforced by
-    # test_p2w2_authz_boundary_sweep::test_obs_tier_mutating_routes_stay_super_admin_locked.
-    dependencies=[Depends(require_super_admin)],
 )
 async def sync_openrouter_activity(
     ctx: RequestContext = Depends(get_request_context_hybrid),

--- a/orchestrator/api/llm_analytics.py
+++ b/orchestrator/api/llm_analytics.py
@@ -18,6 +18,7 @@ from sqlalchemy import func, desc, and_
 from core.auth.dependencies import RequestContext
 from core.auth.hybrid import get_request_context_hybrid
 from core.auth.super_admin import require_super_admin
+from core.auth.workspace_admin import require_workspace_admin
 from core.database.database import get_db
 from core.models.core import LLMUsage, LLMModel, UserApiKey, Agent, RecipeExecution
 from core.models import WorkflowTemplate as WorkflowRecipe
@@ -27,12 +28,16 @@ from config import config
 
 logger = logging.getLogger(__name__)
 
-# PRD-143 S7: observability tier — router-wide super-admin lock (fail-closed)
-# on BOTH routers in this module.
+# PRD-143 S7 locked BOTH routers to super-admin; 2026-07-30 (Gerard) relaxes
+# the workspace-scoped router to workspace owners/admins: every endpoint here
+# already filters LLMUsage by ctx.workspace_id (audited — no cross-workspace
+# reads), so an owner/admin sees exactly their own workspace's analytics.
+# require_workspace_admin passes super_admin unconditionally. The cross-
+# workspace aggregate surface below (admin_router) stays super-admin-only.
 router = APIRouter(
     prefix="/api/analytics/llm",
     tags=["LLM Analytics"],
-    dependencies=[Depends(require_super_admin)],
+    dependencies=[Depends(require_workspace_admin)],
 )
 admin_router = APIRouter(
     prefix="/api/admin/analytics",

--- a/orchestrator/api/llm_analytics.py
+++ b/orchestrator/api/llm_analytics.py
@@ -686,6 +686,10 @@ class OpenRouterKeyInfoResponse(BaseModel):
     "/openrouter/sync",
     response_model=OpenRouterSyncResponse,
     summary="Trigger OpenRouter activity sync",
+    # Mutating obs route: stays super-admin even though the router relaxed to
+    # workspace admins (2026-07-30) — enforced by
+    # test_p2w2_authz_boundary_sweep::test_obs_tier_mutating_routes_stay_super_admin_locked.
+    dependencies=[Depends(require_super_admin)],
 )
 async def sync_openrouter_activity(
     ctx: RequestContext = Depends(get_request_context_hybrid),

--- a/orchestrator/main.py
+++ b/orchestrator/main.py
@@ -111,7 +111,7 @@ from api.agent_endpoints import router as agent_endpoints_router
 from api.models_endpoints import router as models_router  # PRD-15: Model management
 from api.llm_marketplace import router as llm_marketplace_router  # PRD-54: LLM Marketplace
 from api.openrouter_marketplace import router as openrouter_marketplace_router  # OpenRouter Model Cache
-from api.llm_analytics import router as llm_analytics_router, admin_router as llm_admin_analytics_router  # PRD-54: LLM Analytics
+from api.llm_analytics import router as llm_analytics_router, admin_router as llm_admin_analytics_router, sync_router as llm_sync_analytics_router  # PRD-54: LLM Analytics
 from api.composio_analytics import router as composio_analytics_router  # PRD-54: Composio Analytics
 from api.analytics_charts import router as analytics_charts_router  # PRD-54: PandasAI Charts
 from api.user_api_keys import router as user_api_keys_router  # PRD-54: BYOK API Keys
@@ -1024,6 +1024,7 @@ app.include_router(marketplace_plugins_router)  # PRD-42: Public Marketplace Plu
 app.include_router(llm_marketplace_router)  # PRD-54: LLM Provider Marketplace
 app.include_router(openrouter_marketplace_router)  # OpenRouter Model Cache (separate sync)
 app.include_router(llm_analytics_router)  # PRD-54: LLM Usage Analytics
+app.include_router(llm_sync_analytics_router)  # su-only mutating sync (same prefix)
 app.include_router(llm_admin_analytics_router)  # PRD-54: Admin Cost Analytics
 app.include_router(composio_analytics_router)  # PRD-54: Composio Analytics
 app.include_router(analytics_charts_router)  # PRD-54: PandasAI Charts

--- a/orchestrator/tests/test_prd143_obs_routers_batch2.py
+++ b/orchestrator/tests/test_prd143_obs_routers_batch2.py
@@ -55,7 +55,12 @@ SUPER_ADMIN = UserContext(id="u-gerard", role="admin", system_role="super_admin"
 # (router module, router attribute, representative GET path) — one per locked
 # router. llm_analytics carries TWO routers; both are part of the obs surface.
 ROUTERS = [
-    pytest.param("api.llm_analytics", "router", "/api/analytics/llm/usage", id="llm_analytics"),
+    # api.llm_analytics "router" moved OFF the su-locked list 2026-07-30:
+    # workspace owners/admins may read their own workspace's LLM analytics
+    # (every endpoint filters by ctx.workspace_id). New contract lives in the
+    # TestLlmAnalyticsWorkspaceAccess block below. Its mutating POST
+    # (/openrouter/sync) keeps a route-level su lock, asserted there and by
+    # the authz boundary sweep.
     pytest.param("api.llm_analytics", "admin_router", "/api/admin/analytics/costs", id="llm_admin_analytics"),
     pytest.param("api.statistics", "router", "/api/system/agents/statistics", id="statistics"),
     pytest.param("api.composio_analytics", "router", "/api/analytics/composio/apps", id="composio_analytics"),
@@ -137,6 +142,81 @@ def test_not_403_for_super_admin(module_name, router_attr, path):
     assert resp.status_code not in (401, 403), (
         f"super admin must pass the gate; got {resp.status_code}: {resp.text}"
     )
+
+
+# ── 2026-07-30: llm_analytics workspace-scoped router — new contract ────────
+#
+# Workspace owners/admins read their OWN workspace's LLM analytics
+# (require_workspace_admin). Members and API-key principals still 403.
+# The mutating POST /openrouter/sync keeps a route-level super-admin lock.
+
+_USAGE = "/api/analytics/llm/usage"
+_SYNC = "/api/analytics/llm/openrouter/sync"
+
+
+def _member_db(is_admin_member: bool) -> MagicMock:
+    """Fake db whose raw-SQL membership probe answers the workspace-admin
+    check; query-chain terminals stay empty like _fake_db."""
+    db = _fake_db()
+    result = MagicMock()
+    result.fetchone.return_value = (1,) if is_admin_member else None
+    result.fetchall.return_value = []
+    result.scalar.return_value = 0
+    db.execute.return_value = result
+    return db
+
+
+def _ws_client(user: UserContext, is_admin_member: bool) -> TestClient:
+    import importlib
+
+    module = importlib.import_module("api.llm_analytics")
+    app = FastAPI()
+    app.include_router(module.router)
+
+    def _override_ctx():
+        return RequestContext(workspace_id=_WS, user=user, auth_type="clerk")
+
+    def _override_db():
+        yield _member_db(is_admin_member)
+
+    app.dependency_overrides[get_request_context_hybrid] = _override_ctx
+    app.dependency_overrides[get_db] = _override_db
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def test_llm_analytics_member_still_403():
+    resp = _ws_client(MEMBER, is_admin_member=False).get(_USAGE)
+    assert resp.status_code == 403, f"expected 403, got {resp.status_code}: {resp.text}"
+    assert resp.json()["detail"] == "Workspace admin only"
+
+
+def test_llm_analytics_api_key_admin_still_403():
+    # API-key principals (system_role='admin') have no workspace membership —
+    # refused by require_workspace_admin.
+    resp = _ws_client(API_KEY_ADMIN, is_admin_member=False).get(_USAGE)
+    assert resp.status_code == 403, f"expected 403, got {resp.status_code}: {resp.text}"
+
+
+def test_llm_analytics_workspace_admin_and_owner_pass():
+    for user in (WS_ADMIN, WS_OWNER):
+        resp = _ws_client(user, is_admin_member=True).get(_USAGE)
+        assert resp.status_code not in (401, 403), (
+            f"workspace admin/owner must read own analytics; got {resp.status_code}: {resp.text}"
+        )
+
+
+def test_llm_analytics_super_admin_passes_without_membership():
+    resp = _ws_client(SUPER_ADMIN, is_admin_member=False).get(_USAGE)
+    assert resp.status_code not in (401, 403), (
+        f"super admin must pass; got {resp.status_code}: {resp.text}"
+    )
+
+
+def test_llm_analytics_openrouter_sync_stays_super_admin_locked():
+    # Even a legitimate workspace admin must not trigger the mutating sync.
+    resp = _ws_client(WS_ADMIN, is_admin_member=True).post(_SYNC)
+    assert resp.status_code == 403, f"expected 403, got {resp.status_code}: {resp.text}"
+    assert resp.json()["detail"] == "Super admin only"
 
 
 if __name__ == "__main__":

--- a/orchestrator/tests/test_prd143_obs_routers_batch2.py
+++ b/orchestrator/tests/test_prd143_obs_routers_batch2.py
@@ -153,6 +153,12 @@ def test_not_403_for_super_admin(module_name, router_attr, path):
 _USAGE = "/api/analytics/llm/usage"
 _SYNC = "/api/analytics/llm/openrouter/sync"
 
+# require_workspace_admin resolves membership by ctx.user.clerk_user_id —
+# principals without one refuse before the DB probe (workspace_admin.py).
+CK_MEMBER = UserContext(id="u-member", role="member", system_role="user", clerk_user_id="ck_member")
+CK_WS_ADMIN = UserContext(id="u-ws-admin", role="admin", system_role="user", clerk_user_id="ck_admin")
+CK_WS_OWNER = UserContext(id="u-ws-owner", role="owner", system_role="user", clerk_user_id="ck_owner")
+
 
 def _member_db(is_admin_member: bool) -> MagicMock:
     """Fake db whose raw-SQL membership probe answers the workspace-admin
@@ -172,6 +178,7 @@ def _ws_client(user: UserContext, is_admin_member: bool) -> TestClient:
     module = importlib.import_module("api.llm_analytics")
     app = FastAPI()
     app.include_router(module.router)
+    app.include_router(module.sync_router)
 
     def _override_ctx():
         return RequestContext(workspace_id=_WS, user=user, auth_type="clerk")
@@ -185,20 +192,21 @@ def _ws_client(user: UserContext, is_admin_member: bool) -> TestClient:
 
 
 def test_llm_analytics_member_still_403():
-    resp = _ws_client(MEMBER, is_admin_member=False).get(_USAGE)
+    # Clerk id present, but the membership probe finds no owner/admin row.
+    resp = _ws_client(CK_MEMBER, is_admin_member=False).get(_USAGE)
     assert resp.status_code == 403, f"expected 403, got {resp.status_code}: {resp.text}"
     assert resp.json()["detail"] == "Workspace admin only"
 
 
 def test_llm_analytics_api_key_admin_still_403():
-    # API-key principals (system_role='admin') have no workspace membership —
-    # refused by require_workspace_admin.
-    resp = _ws_client(API_KEY_ADMIN, is_admin_member=False).get(_USAGE)
+    # API-key principals (system_role='admin') carry no clerk_user_id —
+    # refused by require_workspace_admin before the DB probe.
+    resp = _ws_client(API_KEY_ADMIN, is_admin_member=True).get(_USAGE)
     assert resp.status_code == 403, f"expected 403, got {resp.status_code}: {resp.text}"
 
 
 def test_llm_analytics_workspace_admin_and_owner_pass():
-    for user in (WS_ADMIN, WS_OWNER):
+    for user in (CK_WS_ADMIN, CK_WS_OWNER):
         resp = _ws_client(user, is_admin_member=True).get(_USAGE)
         assert resp.status_code not in (401, 403), (
             f"workspace admin/owner must read own analytics; got {resp.status_code}: {resp.text}"
@@ -213,10 +221,15 @@ def test_llm_analytics_super_admin_passes_without_membership():
 
 
 def test_llm_analytics_openrouter_sync_stays_super_admin_locked():
-    # Even a legitimate workspace admin must not trigger the mutating sync.
-    resp = _ws_client(WS_ADMIN, is_admin_member=True).post(_SYNC)
+    # Even a legitimate workspace admin must not trigger the mutating sync —
+    # it lives on sync_router, super-admin-only.
+    resp = _ws_client(CK_WS_ADMIN, is_admin_member=True).post(_SYNC)
     assert resp.status_code == 403, f"expected 403, got {resp.status_code}: {resp.text}"
     assert resp.json()["detail"] == "Super admin only"
+    ok = _ws_client(SUPER_ADMIN, is_admin_member=False).post(_SYNC)
+    assert ok.status_code not in (401, 403), (
+        f"super admin must reach the sync handler; got {ok.status_code}: {ok.text}"
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem
The Analytics page shows 'no data' for everyone — every `/api/analytics/llm/*` request 403s (verified in prod logs). PRD-143 S7 locked the router to `require_super_admin` (exact-match `system_role == 'super_admin'` from Clerk metadata), and no active login carries that role. The frontend renders the 403s as empty charts, masking an authz failure as missing data. The data itself is fine — 14,112 `llm_usage` rows in the primary workspace over 90 days, written as recently as this morning.

## Fix (per Gerard's policy call)
Workspace owners/admins must see **their own** workspace's analytics:
- `/api/analytics/llm` router: `require_super_admin` → `require_workspace_admin` (owner/admin of the requesting workspace; super_admin passes unconditionally).
- **Audit performed**: all 9 endpoints on this router filter `LLMUsage.workspace_id == ctx.workspace_id` and 400 without a workspace — no cross-workspace read exists on this surface.
- `/api/admin/analytics` (cross-workspace aggregates) — unchanged, super-admin only.
- `api/analytics_real.py` (performance tiles) — **deliberately not relaxed**: several endpoints (system-load-trend, queue-depth) appear platform-global; needs a per-endpoint audit before widening. Follow-up.

## Also
Separate UX defect worth its own fix: the analytics frontend should distinguish 403 (no access) from empty data. The silent-empty rendering turned a role-grant issue into a 'where did my data go' incident.

## Test plan
CI gates. Post-deploy: workspace owner (non-super-admin) hits `/api/analytics/llm/summary?period=90d` → 200 with own-workspace rows; member (non-admin) → 403; `/api/admin/analytics/dashboard` without super_admin → 403.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Access Control**
  * Workspace administrators can now access workspace-scoped LLM analytics.
  * Cross-workspace analytics remain restricted to super administrators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->