### PR TITLE
fix(prd-223): stop the pre-resolution flattener claiming attachments are unavailable

### DIFF
--- a/orchestrator/consumers/chatbot/prompt_analyzer.py
+++ b/orchestrator/consumers/chatbot/prompt_analyzer.py
@@ -14,6 +14,8 @@ import logging
 import re
 from typing import List, Dict, Any, Optional
 
+from core.attachment_refs import render_unresolved_file_part
+
 logger = logging.getLogger(__name__)
 
 # Simple message patterns that don't need tools
@@ -186,15 +188,20 @@ class PromptAnalyzer:
         self,
         messages: List[Dict[str, Any]],
         system_prompt: Optional[str] = None,
-        available_tools: Optional[List[Dict[str, Any]]] = None
+        available_tools: Optional[List[Dict[str, Any]]] = None,
+        resolved_attachment_ids: Optional[List[str]] = None
     ) -> List[Dict[str, str]]:
         """
         Convert chat messages to LLM format with system prompt.
-        
+
         Args:
             messages: List of message dicts with role and parts
             system_prompt: Optional custom system prompt
-            
+            resolved_attachment_ids: PRD-223 S0.4 — attachment ids the caller
+                will inject into this prompt via AttachmentResolver. Their
+                file parts are left for the resolver to render; every other
+                file part gets an explicit unavailable marker.
+
         Returns:
             List of LLM-formatted messages
         """
@@ -277,19 +284,25 @@ Let's get stuff done! What can I help you with?"""
         
         # Convert each message
         for msg in messages:
-            content = self._extract_message_content(msg)
+            content = self._extract_message_content(msg, resolved_attachment_ids)
             llm_messages.append({
                 'role': msg['role'],
                 'content': content
             })
-        
+
         return llm_messages
-    
-    def _extract_message_content(self, msg: Dict[str, Any]) -> str:
+
+    def _extract_message_content(
+        self,
+        msg: Dict[str, Any],
+        resolved_attachment_ids: Optional[List[str]] = None
+    ) -> str:
         """Extract text content from a message.
 
-        File parts should already be resolved to text by _resolve_file_parts
-        in the service layer, but we handle unresolved ones gracefully.
+        Legacy ``document://`` file parts are already resolved to text by
+        _resolve_file_parts in the service layer. Ephemeral attachments are
+        rendered by AttachmentResolver *after* this runs, so file parts it
+        owns are skipped here rather than described (PRD-223 S0.4).
         """
         if msg.get('parts'):
             text_parts = []
@@ -299,9 +312,9 @@ Let's get stuff done! What can I help you with?"""
                     if text_value is not None:
                         text_parts.append(str(text_value))
                 elif p.get('type') == 'file':
-                    # Fallback for unresolved file parts
-                    filename = p.get('filename', 'file')
-                    text_parts.append(f"[Attached file: {filename} — content not available]")
+                    marker = render_unresolved_file_part(p, resolved_attachment_ids)
+                    if marker:
+                        text_parts.append(marker)
             return '\n'.join(text_parts)
         return msg.get('content', '')
     

--- a/orchestrator/consumers/chatbot/service.py
+++ b/orchestrator/consumers/chatbot/service.py
@@ -1032,7 +1032,8 @@ class StreamingChatService:
             f"{_memory_block}"
         )
         llm_messages = self.prompt_analyzer.convert_to_llm_messages(
-            messages, system_prompt=_atom_prompt, available_tools=atom_tools
+            messages, system_prompt=_atom_prompt, available_tools=atom_tools,
+            resolved_attachment_ids=attachment_ids,
         )
 
         # PRD-127: Resolve ephemeral attachments for ATOM path.
@@ -1090,7 +1091,8 @@ class StreamingChatService:
         from consumers.chatbot.integration import apply_orchestration_to_messages
 
         llm_messages = self.prompt_analyzer.convert_to_llm_messages(
-            messages, system_prompt="", available_tools=all_tools
+            messages, system_prompt="", available_tools=all_tools,
+            resolved_attachment_ids=attachment_ids,
         )
 
         orchestrated = await smart_chat.prepare(

--- a/orchestrator/core/attachment_refs.py
+++ b/orchestrator/core/attachment_refs.py
@@ -1,0 +1,73 @@
+"""How an attachment is referenced in prompt text before it has been resolved.
+
+PRD-223 S0.4.
+
+A ``file`` content part gets flattened into plain prompt text at two points
+that both run **before** ``AttachmentResolver`` has looked the attachment up:
+
+- ``consumers.chatbot.prompt_analyzer._extract_message_content`` (ATOM + full)
+- ``modules.context.sections.conversation._parts_to_text`` (history)
+
+Neither of them knows whether the content arrived, so neither may state a
+verdict. Both used to hardcode ``— content not available``, which then sat in
+the prompt directly above the *successfully* resolved document text::
+
+    [Attached file: PRD-223.md — content not available]   <- written first
+    ### PRD-223.md
+    <23KB of real document text>                          <- appended second
+
+The model read the stale claim and reported it as truth (2026-07-31 incident:
+Auto quoted the marker back to the user while holding the full document).
+
+The resolver is the single writer of attachment availability — it emits
+``### <filename>`` plus the text on success, and ``build_unavailable_marker``
+on failure. These renderers therefore only speak for parts the resolver will
+*not* touch on this turn: attachments from earlier turns, and parts that never
+carried an ``attachment_id`` at all.
+
+Lives in ``core`` rather than ``modules.attachments`` so the context package
+can use it without opening a new feature-to-feature import edge — see the
+``feature-module-independence`` contract in ``.importlinter``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, Optional
+
+# Suffix marking a file whose content is NOT in the current prompt. Only ever
+# applied to parts the resolver is not resolving on this turn.
+UNAVAILABLE_SUFFIX = "content not available"
+
+
+def render_unresolved_file_part(
+    part: dict[str, Any],
+    resolved_attachment_ids: Optional[Iterable[str]] = None,
+) -> Optional[str]:
+    """Render a ``file`` part as prompt text, or ``None`` to emit nothing.
+
+    Args:
+        part: The ``{"type": "file", ...}`` content part.
+        resolved_attachment_ids: Attachment ids being resolved into *this*
+            prompt. A part in this set is owned end-to-end by
+            ``AttachmentResolver``; anything written here would either
+            duplicate its ``### <filename>`` header or contradict it.
+
+    Returns:
+        ``None`` when the resolver owns the part, otherwise an explicit
+        unavailable marker. Silence is not an option for unowned parts — a
+        bare filename with no content and no marker is what lets a model
+        infer the contents from the name.
+    """
+    attachment_id = part.get("attachment_id")
+    if attachment_id and attachment_id in _as_id_set(resolved_attachment_ids):
+        return None
+
+    filename = part.get("filename") or part.get("name") or "file"
+    return f"[Attached file: {filename} — {UNAVAILABLE_SUFFIX}]"
+
+
+def _as_id_set(ids: Optional[Iterable[str]]) -> frozenset[str]:
+    """Normalise an id collection to a set of strings (ids may be UUIDs)."""
+    if not ids:
+        return frozenset()
+    return frozenset(str(i) for i in ids)

--- a/orchestrator/modules/attachments/extract.py
+++ b/orchestrator/modules/attachments/extract.py
@@ -20,6 +20,25 @@ from typing import Optional
 
 logger = logging.getLogger(__name__)
 
+# Sentinel prefixes returned by extract_text when it could not produce real
+# document text. Callers MUST test with is_extraction_failure() rather than
+# sniffing for a leading "[" — a markdown file legitimately opens with one
+# (a link, or a CI badge like "[![build](...)](...)"), and treating that as a
+# failure silently drops a document the user did attach.
+EXTRACTION_FAILURE_PREFIXES = (
+    "[Extraction failed for ",
+    "[PDF extraction requires ",
+    "[PDF contains no extractable text",
+    "[DOCX extraction requires ",
+    "[XLSX extraction requires ",
+    "[Binary file: ",
+)
+
+
+def is_extraction_failure(text: str) -> bool:
+    """True when *text* is an extract_text failure sentinel, not real content."""
+    return bool(text) and text.startswith(EXTRACTION_FAILURE_PREFIXES)
+
 
 def extract_text(
     content: bytes,

--- a/orchestrator/modules/attachments/resolver.py
+++ b/orchestrator/modules/attachments/resolver.py
@@ -21,7 +21,7 @@ from modules.attachments.store import (
     MediaType,
     get_attachment_store,
 )
-from modules.attachments.extract import extract_text
+from modules.attachments.extract import extract_text, is_extraction_failure
 
 logger = logging.getLogger(__name__)
 
@@ -295,8 +295,9 @@ class AttachmentResolver:
                 content, ref.mime, ref.filename, max_chars=budget_chars
             )
 
-            if not text or text.startswith("["):
-                # Extraction failed or empty
+            if not text or is_extraction_failure(text):
+                # Extraction failed or empty — the caller records this as a
+                # failure and the model is told via build_unavailable_marker.
                 return None, 0
 
             formatted = f"### {ref.filename}\n\n{text}"

--- a/orchestrator/modules/context/sections/conversation.py
+++ b/orchestrator/modules/context/sections/conversation.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import logging
 from typing import Optional
 
+from core.attachment_refs import render_unresolved_file_part
 from core.context_guard import count_tokens
 from modules.context.sections.base import BaseSection, SectionContext
 
@@ -49,6 +50,7 @@ class ConversationSection(BaseSection):
         self,
         messages: list[dict] | None,
         budget_tokens: int | None = None,
+        resolved_attachment_ids: list[str] | None = None,
     ) -> list[dict[str, str]]:
         """Format, filter, and trim messages for the LLM call.
 
@@ -57,6 +59,11 @@ class ConversationSection(BaseSection):
             2. Convert ``parts`` format to plain text.
             3. Trim oldest messages if *budget_tokens* is exceeded.
 
+        Args:
+            resolved_attachment_ids: PRD-223 S0.4 — attachment ids the
+                ContextService will inject via AttachmentResolver after this
+                runs. Their file parts are left for the resolver to render.
+
         Returns:
             A new list of ``{"role": ..., "content": ...}`` dicts.
         """
@@ -64,7 +71,7 @@ class ConversationSection(BaseSection):
             return []
 
         try:
-            formatted = self._convert(messages)
+            formatted = self._convert(messages, resolved_attachment_ids)
             if budget_tokens and budget_tokens > 0:
                 formatted = self._trim(formatted, budget_tokens)
             return formatted
@@ -83,7 +90,10 @@ class ConversationSection(BaseSection):
     # ------------------------------------------------------------------
 
     @staticmethod
-    def _convert(messages: list[dict]) -> list[dict[str, str]]:
+    def _convert(
+        messages: list[dict],
+        resolved_attachment_ids: list[str] | None = None,
+    ) -> list[dict[str, str]]:
         """Strip system messages and normalise content to plain text."""
         result: list[dict[str, str]] = []
         for msg in messages:
@@ -98,7 +108,7 @@ class ConversationSection(BaseSection):
 
             # Handle "parts" format (list of typed content blocks)
             if isinstance(content, list):
-                content = _parts_to_text(content)
+                content = _parts_to_text(content, resolved_attachment_ids)
             elif not isinstance(content, str):
                 content = str(content) if content else ""
 
@@ -139,12 +149,17 @@ class ConversationSection(BaseSection):
 # ------------------------------------------------------------------
 
 
-def _parts_to_text(parts: list) -> str:
+def _parts_to_text(
+    parts: list,
+    resolved_attachment_ids: list[str] | None = None,
+) -> str:
     """Convert a list of content parts to plain text.
 
     Handles:
     - ``{"type": "text", "text": "..."}``  → extract text
-    - ``{"type": "file", "name": "..."}``  → placeholder
+    - ``{"type": "file", "name": "..."}``  → marker, unless the
+      AttachmentResolver is rendering that attachment into this prompt
+      (PRD-223 S0.4 — see ``core.attachment_refs``)
     - Unknown types                        → skip
     """
     texts: list[str] = []
@@ -160,7 +175,8 @@ def _parts_to_text(parts: list) -> str:
             if text:
                 texts.append(text)
         elif part_type == "file":
-            name = part.get("name", part.get("filename", "unknown"))
-            texts.append(f"[Attached file: {name} — content not available]")
+            marker = render_unresolved_file_part(part, resolved_attachment_ids)
+            if marker:
+                texts.append(marker)
         # Skip image_url and other non-text parts
     return "\n".join(texts)

--- a/orchestrator/modules/context/service.py
+++ b/orchestrator/modules/context/service.py
@@ -163,7 +163,7 @@ class ContextService:
 
         # --- 8. Format messages ---
         formatted_messages = self._format_messages(
-            config, ctx, budget, prompt_token_estimate
+            config, ctx, budget, prompt_token_estimate, attachment_ids
         )
 
         # --- 9. Compute final metadata ---
@@ -641,6 +641,7 @@ class ContextService:
         ctx: SectionContext,
         budget: TokenBudget,
         prompt_tokens: int,
+        attachment_ids: list[str] | None = None,
     ) -> list[dict[str, str]]:
         """Format conversation messages with budget-aware trimming."""
         if not ctx.messages:
@@ -662,4 +663,5 @@ class ContextService:
         return conversation.format_messages(
             messages=ctx.messages,
             budget_tokens=message_budget if message_budget > 0 else None,
+            resolved_attachment_ids=attachment_ids,
         )

--- a/orchestrator/tests/test_prd223_attachment_refs.py
+++ b/orchestrator/tests/test_prd223_attachment_refs.py
@@ -1,0 +1,181 @@
+"""PRD-223 S0.4 — the pre-resolution attachment reference must not state a verdict.
+
+Regression cover for the 2026-07-31 incident: an uploaded document resolved
+successfully and was injected into the prompt, but the message flattener had
+already written "[Attached file: X — content not available]" above it. The
+model read the stale claim and reported it as truth while holding the file.
+
+Pure unit tests: no app boot, no DB, no LLM.
+"""
+
+from uuid import uuid4
+
+from core.attachment_refs import render_unresolved_file_part
+from consumers.chatbot.prompt_analyzer import PromptAnalyzer
+from modules.attachments.extract import is_extraction_failure
+from modules.context.sections.conversation import _parts_to_text
+
+
+ATTACHMENT_ID = "6e7e8e6e-1335-48b8-b52b-38db187c6734"
+FILENAME = "PRD-223-MODEL-GOVERNANCE-PROMOTION-GATE.md"
+STALE_CLAIM = "content not available"
+
+
+def _file_part(attachment_id=ATTACHMENT_ID, filename=FILENAME):
+    part = {"type": "file", "filename": filename, "mediaType": "text/markdown"}
+    if attachment_id:
+        part["attachment_id"] = attachment_id
+    return part
+
+
+# ---------------------------------------------------------------------------
+# render_unresolved_file_part — the single rule
+# ---------------------------------------------------------------------------
+
+class TestRenderUnresolvedFilePart:
+    def test_resolver_owned_part_renders_nothing(self):
+        """The resolver emits '### <filename>' + text; we must not pre-empt it."""
+        assert render_unresolved_file_part(_file_part(), [ATTACHMENT_ID]) is None
+
+    def test_part_not_being_resolved_gets_explicit_marker(self):
+        """An attachment from an earlier turn is genuinely not in this prompt."""
+        marker = render_unresolved_file_part(_file_part(), [str(uuid4())])
+        assert marker is not None
+        assert STALE_CLAIM in marker
+        assert FILENAME in marker
+
+    def test_part_without_attachment_id_gets_marker(self):
+        """Nothing downstream will ever resolve it — silence would invite a guess."""
+        marker = render_unresolved_file_part(_file_part(attachment_id=None), [])
+        assert marker is not None
+        assert STALE_CLAIM in marker
+
+    def test_no_resolved_ids_at_all_gets_marker(self):
+        assert render_unresolved_file_part(_file_part(), None) is not None
+
+    def test_uuid_objects_in_resolved_set_are_matched(self):
+        """Callers pass UUIDs as often as strings; both must match."""
+        att_id = uuid4()
+        part = _file_part(attachment_id=str(att_id))
+        assert render_unresolved_file_part(part, [att_id]) is None
+
+    def test_missing_filename_falls_back_without_crashing(self):
+        marker = render_unresolved_file_part({"type": "file"}, [])
+        assert marker is not None
+
+
+# ---------------------------------------------------------------------------
+# prompt_analyzer — ATOM + full chat paths
+# ---------------------------------------------------------------------------
+
+class TestPromptAnalyzerFlattening:
+    def _messages(self):
+        return [{
+            "role": "user",
+            "parts": [
+                _file_part(),
+                {"type": "text", "text": "say if you can read this"},
+            ],
+        }]
+
+    def test_resolved_attachment_leaves_no_stale_claim(self):
+        analyzer = PromptAnalyzer()
+        out = analyzer.convert_to_llm_messages(
+            self._messages(),
+            system_prompt="",
+            resolved_attachment_ids=[ATTACHMENT_ID],
+        )
+        user = [m for m in out if m["role"] == "user"][0]
+        assert STALE_CLAIM not in user["content"]
+        assert "say if you can read this" in user["content"]
+
+    def test_unresolved_attachment_still_marked(self):
+        analyzer = PromptAnalyzer()
+        out = analyzer.convert_to_llm_messages(
+            self._messages(), system_prompt="", resolved_attachment_ids=[],
+        )
+        user = [m for m in out if m["role"] == "user"][0]
+        assert STALE_CLAIM in user["content"]
+
+    def test_default_call_site_is_unchanged(self):
+        """Callers that never resolve attachments keep the honest marker."""
+        analyzer = PromptAnalyzer()
+        out = analyzer.convert_to_llm_messages(self._messages(), system_prompt="")
+        user = [m for m in out if m["role"] == "user"][0]
+        assert STALE_CLAIM in user["content"]
+
+    def test_incident_reproduction(self):
+        """The full shape that misled the model, end to end at message level.
+
+        Flatten first (as the ATOM path does), then append the resolver's
+        real document part. The stale claim must not survive anywhere.
+        """
+        from modules.attachments.resolver import inject_parts_into_last_user_message
+
+        analyzer = PromptAnalyzer()
+        llm_messages = analyzer.convert_to_llm_messages(
+            self._messages(),
+            system_prompt="",
+            resolved_attachment_ids=[ATTACHMENT_ID],
+        )
+        inject_parts_into_last_user_message(
+            llm_messages,
+            [{"type": "text", "text": f"### {FILENAME}\n\n# PRD-223\nreal body"}],
+        )
+
+        blob = str(llm_messages)
+        assert STALE_CLAIM not in blob
+        assert "real body" in blob
+
+
+# ---------------------------------------------------------------------------
+# conversation section — history rendering
+# ---------------------------------------------------------------------------
+
+class TestConversationPartsToText:
+    def test_resolved_attachment_renders_nothing(self):
+        text = _parts_to_text([_file_part()], [ATTACHMENT_ID])
+        assert STALE_CLAIM not in text
+
+    def test_history_attachment_keeps_marker(self):
+        text = _parts_to_text([_file_part()], [str(uuid4())])
+        assert STALE_CLAIM in text
+
+    def test_text_parts_pass_through(self):
+        text = _parts_to_text(
+            [{"type": "text", "text": "hello"}, _file_part()], [ATTACHMENT_ID]
+        )
+        assert text == "hello"
+
+    def test_image_parts_still_skipped(self):
+        text = _parts_to_text(
+            [{"type": "image_url", "image_url": {"url": "data:..."}}], []
+        )
+        assert text == ""
+
+
+# ---------------------------------------------------------------------------
+# extract — failure sentinels must be explicit, not "starts with a bracket"
+# ---------------------------------------------------------------------------
+
+class TestIsExtractionFailure:
+    def test_markdown_opening_with_a_link_is_not_a_failure(self):
+        """The bug: any '[' was read as a failure, dropping a real document."""
+        assert is_extraction_failure("[See the docs](https://x) then read on") is False
+
+    def test_markdown_opening_with_a_ci_badge_is_not_a_failure(self):
+        assert is_extraction_failure("[![build](a.svg)](b)\n\n# Title") is False
+
+    def test_real_sentinels_are_detected(self):
+        for sentinel in (
+            "[Extraction failed for x.pdf: boom]",
+            "[PDF extraction requires pdfplumber]",
+            "[PDF contains no extractable text — may be image-only or scanned]",
+            "[DOCX extraction requires python-docx]",
+            "[XLSX extraction requires openpyxl]",
+            "[Binary file: x.bin]",
+        ):
+            assert is_extraction_failure(sentinel) is True
+
+    def test_empty_is_not_a_sentinel(self):
+        assert is_extraction_failure("") is False


### PR DESCRIPTION
## What broke

Auto reported `content not available` for an uploaded PRD it had **actually received in full**. The document pipeline was working. The prompt contained a hardcoded contradiction.

A `file` part is flattened to prompt text at two points that both run **before** `AttachmentResolver` looks the attachment up:

| Site | Path |
|---|---|
| `prompt_analyzer._extract_message_content` | ATOM + full chat |
| `conversation._parts_to_text` | history |

Both hardcoded `— content not available`. The resolver then **appended** the real text to the same message:

```
[Attached file: PRD-223.md — content not available]   <- written first
### PRD-223.md
<23KB of real document text>                          <- appended second
```

The model read the stale claim and reported it as truth — quoting the marker back to the user while holding the document.

## Evidence the content arrived (Railway, req=4c00ec170ad4)

```
Attachment stored: .../PRD-223-...md (23371 bytes, text/markdown)
[PRD-127] ATOM path: resolved 1 attachment parts from 1 ids
LLM_CALL model=openai/gpt-5.5 input_tokens=7021 status=success
```

No failure warning fired. Same ATOM path without an attachment cost **950** input tokens; this turn cost **7,021**. The ~6.1k delta matches the document (23,191 chars ≈ 6,024 tokens).

## The fix

`AttachmentResolver` becomes the **single writer** of attachment availability. Both flatteners now take the set of ids being resolved into this prompt and stay silent about those parts, leaving the resolver to emit `### <filename>` + text on success, or `build_unavailable_marker` on failure.

Parts **not** in that set — an attachment from an earlier turn, or one that never carried an `attachment_id` — keep the explicit marker. Nothing downstream renders them, and a bare filename with no content invites the model to infer contents from the name.

Shared rule lives in `core.attachment_refs` rather than `modules.attachments` so the context package can use it without opening a new feature-to-feature import edge. The import-linter `feature-module-independence` contract stays **KEPT** (verified locally: 362 files, 519 dependencies, 1 kept / 0 broken).

## Second defect fixed in the same path

`_resolve_document` treated **any** extracted text starting with `[` as an extraction failure. A markdown file opening with a link or a CI badge (`[![build](...)](...)`) was silently dropped. Failure sentinels are now explicit via `is_extraction_failure()`.

## Test plan

New `orchestrator/tests/test_prd223_attachment_refs.py` — pure unit, no boot/DB/LLM:

- resolver-owned part renders nothing; unresolved part still gets the marker
- history attachment (different id) keeps the marker — the case that must not regress
- UUID objects and strings both match in the resolved set
- **incident reproduction**: flatten then inject, assert `content not available` appears nowhere and the real body survives
- `is_extraction_failure` — markdown opening with a link or CI badge is not a failure; all six real sentinels are

Paths that never resolve attachments (`stream_response`, `extract_latest_user_text`) keep the honest marker via the parameter default — verified by sweeping every caller of the four changed signatures.

Post-merge: retest a document upload in chat and confirm Auto reports the contents rather than the marker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unavailable attachments with explicit unavailability indicators.
  * Enhanced detection of extraction failures to prevent false content misinterpretation.

* **New Features**
  * Added clearer messaging for unresolved file attachments in conversations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->