### PR TITLE
revert: #616 — validate_security made fatal while SHOPIFY_INTERNAL_API_KEY is unset, API down

### DIFF
--- a/docs/workspace-execution/security-sandboxing.md
+++ b/docs/workspace-execution/security-sandboxing.md
@@ -96,8 +96,7 @@ The widget subsystem includes rate limiting using a thread-safe in-memory slidin
 
 ### CORS Policy
 Widget endpoints (`/api/widgets/*`) use a dedicated `WidgetCORSMiddleware`. This middleware is ASGI-native to avoid buffering `StreamingResponse` (SSE) data, ensuring real-time performance for chat streams [orchestrator/api/widgets/cors.py:5-8]().
-*   **Origin Allowlist:** There is no global widget origin env var. A merchant storefront is authorised from the per-key `SdkApiKey.allowed_domains` the merchant maintains — the same list `widget_auth` enforces on the real request. Preflights carry no `Authorization` header, so the middleware asks whether the origin is named on *any* active public key [orchestrator/api/widgets/cors.py]().
-*   **First-party Origins:** Our own dashboard and marketing site come from `config.CORS_ALLOW_ORIGINS`, the same list the app-wide `CORSMiddleware` uses. `/api/sites/*` (dashboard Sites CRUD, JWT-cookie auth) resolves from this list only and never consults merchant keys — otherwise any merchant could open CORS on the admin surface by naming that origin on their own key.
+*   **Origin Allowlist:** Origins are validated against `WIDGET_ORIGIN_ALLOWLIST` configured via environment variables [orchestrator/api/widgets/cors.py:18-21]().
 *   **Preflight Handling:** The middleware handles `OPTIONS` requests by validating the `Origin` and returning appropriate `Access-Control-Allow-*` headers [orchestrator/api/widgets/cors.py:57-77]().
 *   **Credentials:** If the origin is allowed, `access-control-allow-credentials: true` is set to support authenticated widget interactions [orchestrator/api/widgets/cors.py:88]().
 

--- a/orchestrator/api/widgets/cors.py
+++ b/orchestrator/api/widgets/cors.py
@@ -10,31 +10,18 @@ Path coverage (PRD-008-A):
 - ``/api/widgets/*``  — storefront widget calls (any storefront origin)
 - ``/api/sites/*``    — Automatos dashboard Sites CRUD (admin operations)
 
-There is NO global widget origin allowlist. Storefront origins are authorised
-from the per-key ``SdkApiKey.allowed_domains`` the merchant already maintains
-— the same list ``widget_auth`` enforces on the real request, and the only
-place an origin is named. ``WIDGET_ORIGIN_ALLOWLIST`` used to sit in front of
-that as a second source of truth; because it was OR'd with the key lookup it
-could only ever WIDEN access beyond what a key permitted, so it bought no
-defence in depth while adding a second place to forget. Forgetting it threw a
-403 that read as a key problem. It is gone.
+Both surfaces share the ``WIDGET_ORIGIN_ALLOWLIST`` env var. An empty
+allowlist is permissive ONLY in the ``local`` edition (dev default); in the
+``saas`` edition the boot guard (``config.validate_security``, PRD-194 S4 /
+P2-13) aborts boot on an empty allowlist, and this module fails CLOSED if
+that state is ever reached anyway. The actual security boundary on
+/api/sites is the JWT in cookies, not CORS — CORS just lets the dashboard
+browser issue the request in the first place.
 
-Two origin classes, one source of truth each:
-
-- **Platform origins** (``config.CORS_ALLOW_ORIGINS``) — our own dashboard and
-  marketing site calling our own API. Already trusted by the app-wide
-  CORSMiddleware for every other route; ``/api/sites`` (dashboard Sites CRUD,
-  JWT-cookie auth, no SDK key in play) and the deprecated first-party blog
-  embed ride this.
-- **Merchant origins** (``SdkApiKey.allowed_domains``) — storefronts. Applies
-  to ``/api/widgets`` only.
-
-The actual security boundary on /api/sites is the JWT in cookies, not CORS —
-CORS just lets the dashboard browser issue the request in the first place.
-
-Preflights carry no Authorization header, so this middleware cannot know WHICH
-key the real request will present; it asks whether the origin is named on ANY
-active public key (PRD-TUTOR-LIVE S0). See ``_origin_allowed_dynamic``.
+Origins named on an active public SDK key's ``allowed_domains`` are honoured
+too (PRD-TUTOR-LIVE S0): preflights carry no Authorization, so a key-scoped
+origin used to die at OPTIONS with 403 before ``widget_auth`` ever saw the
+request it would have approved. See ``_origin_allowed_dynamic``.
 """
 
 import logging
@@ -53,30 +40,43 @@ COVERED_PATH_PREFIXES: tuple[str, ...] = (
     "/api/sites",
 )
 
-# Only /api/widgets consults merchant keys. /api/sites is first-party.
-_KEY_SCOPED_PATH_PREFIX = "/api/widgets"
-
-# Platform origins — our own dashboard and marketing site. Same list the
-# app-wide CORSMiddleware uses for every other route; not a widget-specific
-# allowlist, and never a place to name a merchant storefront.
-PLATFORM_ORIGINS: set[str] = {
-    o.strip().rstrip("/")
-    for o in (config.CORS_ALLOW_ORIGINS or "").split(",")
-    if o.strip()
+# Explicit origin allowlist — comma-separated in env var.
+# Only these origins may make credentialed requests to widget endpoints.
+_RAW_ALLOWLIST = config.WIDGET_ORIGIN_ALLOWLIST or ""
+WIDGET_ORIGIN_ALLOWLIST: set[str] = {
+    o.strip().rstrip("/") for o in _RAW_ALLOWLIST.split(",") if o.strip()
 }
 
 
-def _origin_is_platform(origin: str) -> bool:
-    """True when *origin* is one of our own first-party origins."""
-    return origin.rstrip("/") in PLATFORM_ORIGINS
+def _origin_allowed(origin: str) -> bool:
+    """Return True if *origin* is in the configured allowlist.
+
+    Empty allowlist (P2-13, PRD-194 S4): permissive ONLY in the ``local``
+    edition — choosing ``AUTH_EDITION=local`` is the explicit dev opt-in. In
+    the ``saas`` edition the boot guard (``config.validate_security``)
+    guarantees a non-empty allowlist, so this branch is unreachable there;
+    if it is ever reached anyway (guard bypassed), the public plane fails
+    CLOSED, loudly — never allow-all in production.
+    """
+    if not WIDGET_ORIGIN_ALLOWLIST:
+        if config.IS_LOCAL_EDITION:
+            return True
+        logger.error(
+            "WIDGET_ORIGIN_ALLOWLIST is empty in the saas edition — denying "
+            "origin %s (fail closed; the boot guard should have prevented this)",
+            origin,
+        )
+        return False
+    return origin.rstrip("/") in WIDGET_ORIGIN_ALLOWLIST
 
 
 # ── Key-allowlist fallback (PRD-TUTOR-LIVE S0) ──────────────────────────
 # A browser preflight carries no Authorization header, so this middleware
 # cannot know WHICH ak_pub_ key the actual request will present — but it can
 # ask whether the origin is explicitly named on ANY active public key's
-# ``allowed_domains``. This is the ONLY way a merchant origin is authorised —
-# there is no global widget allowlist to fall back on. The lookup reuses the exact
+# ``allowed_domains``. Without this, an origin that widget_auth would approve
+# (academy.automatos.app, a provisioned storefront) 403s at OPTIONS unless it
+# is duplicated into WIDGET_ORIGIN_ALLOWLIST. The lookup reuses the exact
 # matcher widget_auth uses (``ApiKeyService.check_domain``) so the preflight
 # and the request can never disagree, and it is cached per origin: one DB
 # scan per origin per TTL, cache bounded so origin-scanning clients cannot
@@ -101,18 +101,10 @@ def _origin_allowed_by_key_sync(origin: str) -> bool:
         db.close()
 
 
-async def _origin_allowed_dynamic(origin: str, path: str) -> bool:
-    """Platform origins, then — on /api/widgets only — the merchant key lookup.
-
-    ``/api/sites`` is first-party dashboard CRUD: no SDK key names the
-    dashboard origin, so it never reaches the key lookup. Letting it would
-    mean any merchant could open CORS on the admin surface by naming that
-    origin on their own key.
-    """
-    if _origin_is_platform(origin):
+async def _origin_allowed_dynamic(origin: str) -> bool:
+    """Env allowlist fast path, then the cached key-allowlist fallback."""
+    if _origin_allowed(origin):
         return True
-    if not path.startswith(_KEY_SCOPED_PATH_PREFIX):
-        return False
     now = time.monotonic()
     cached = _dynamic_origin_cache.get(origin)
     if cached and cached[1] > now:
@@ -157,7 +149,7 @@ class WidgetCORSMiddleware:
 
         # Handle OPTIONS preflight
         if scope["method"] == "OPTIONS":
-            if not origin or not await _origin_allowed_dynamic(origin, path):
+            if not origin or not await _origin_allowed_dynamic(origin):
                 response_headers = [
                     (b"content-type", b"text/plain"),
                     (b"vary", b"Origin"),
@@ -191,7 +183,7 @@ class WidgetCORSMiddleware:
         # upstream middleware (e.g. FastAPI's CORSMiddleware) already added —
         # duplicate Access-Control-Allow-* headers cause Chrome to reject the
         # response with "Failed to fetch".
-        allowed = await _origin_allowed_dynamic(origin, path) if origin else False
+        allowed = await _origin_allowed_dynamic(origin) if origin else False
 
         _CORS_HEADERS_TO_OVERRIDE = (
             b"access-control-allow-origin",

--- a/orchestrator/config.py
+++ b/orchestrator/config.py
@@ -552,6 +552,7 @@ class Config:
     # this from now (mirrors Slack's documented v0 5-minute window).
     WEBHOOK_TIMESTAMP_SKEW_SECONDS: int = int(os.getenv("WEBHOOK_TIMESTAMP_SKEW_SECONDS", "300"))
     WIDGET_TOKEN_SECRET: str = os.getenv("WIDGET_TOKEN_SECRET", "")
+    WIDGET_ORIGIN_ALLOWLIST: str = os.getenv("WIDGET_ORIGIN_ALLOWLIST", "")
     # PRD-194 S5 (P2-13): Redis-backed shared widget rate limiter (replaces
     # the per-process in-memory window). One window length; per-key limits by
     # key type; and a per-IP ceiling on the two money-spending endpoints
@@ -1466,10 +1467,10 @@ class Config:
           shared bucket with no ``{workspace_id}`` placeholder is allowed —
           tenant isolation is enforced per-query by ``S3VectorsBackend.search()``
           (fail-closed on ``workspace_id``), not by the bucket layout.)
-        Widget CORS is deliberately NOT checked here. Storefront origins are
-        authorised from the per-key ``SdkApiKey.allowed_domains`` the merchant
-        already maintains — there is no global widget allowlist to validate.
-        See ``api/widgets/cors.py``.
+        - PRD-194 S4 (P2-13): ``WIDGET_ORIGIN_ALLOWLIST`` is empty in the
+          ``saas`` edition — widget CORS would rest at allow-all on the
+          internet-facing plane. Boot-abort in saas (same posture as F004 /
+          the Clerk edition guard); ``local`` keeps the permissive dev default.
         """
         errors: list[str] = []
 
@@ -1488,6 +1489,21 @@ class Config:
             self.assert_vector_config_integrity()
         except RuntimeError as e:
             errors.append(str(e))
+
+        # PRD-194 S4 (P2-13) — the internet-facing widget plane must not rest
+        # at allow-all CORS in production. In the saas edition an empty
+        # WIDGET_ORIGIN_ALLOWLIST is a boot error (locked decision: boot-abort,
+        # matching the F004 and Clerk edition guards). The local edition keeps
+        # the permissive dev default — choosing AUTH_EDITION=local IS the
+        # explicit opt-in.
+        if self.IS_SAAS_EDITION and not (self.WIDGET_ORIGIN_ALLOWLIST or "").strip():
+            errors.append(
+                "WIDGET_ORIGIN_ALLOWLIST is unset in the saas edition — widget "
+                "CORS (/api/widgets, /api/sites) would allow ALL origins on the "
+                "internet-facing plane (fail-open). Set WIDGET_ORIGIN_ALLOWLIST "
+                "to the comma-separated allowed storefront/dashboard origins, or "
+                "run AUTH_EDITION=local for a dev instance."
+            )
 
         if errors:
             raise RuntimeError(

--- a/orchestrator/main.py
+++ b/orchestrator/main.py
@@ -173,6 +173,15 @@ async def _boot_phase_1_core():
     from core.database.database import create_tables, get_db_session, engine
     from core.database.boot_lock import boot_leader_lock
 
+    # PRD-172 F004/F005 + PRD-186 S3: fail-closed on tenant-isolation secrets
+    # and vector-plane config integrity BEFORE any traffic is served — outside
+    # any swallowing run_stage. Raises RuntimeError (aborting boot) if the
+    # Shopify internal key is unset, S3 Vectors is enabled without a bucket or
+    # with an incoherent dimension, or saas widget CORS would rest allow-all.
+    # (A shared bucket with no {workspace_id} placeholder is valid — isolation
+    # is enforced per-query, fail-closed, by S3VectorsBackend.search().)
+    config.validate_security()
+
     # DDL — safe for all workers (idempotent, fast no-op when tables exist)
     create_tables()
 
@@ -509,23 +518,6 @@ async def lifespan(app: FastAPI):
 
     logger.info("Starting Automotas AI API Server...")
     app.state.ready = False
-
-    # PRD-172 F004/F005 + PRD-186 S3: fail-closed on tenant-isolation secrets
-    # and vector-plane config integrity BEFORE any traffic is served. Raises
-    # RuntimeError (aborting boot) if the Shopify internal key is unset, or
-    # S3 Vectors is enabled without a bucket or with an incoherent dimension.
-    # (A shared bucket with no {workspace_id} placeholder is valid — isolation
-    # is enforced per-query, fail-closed, by S3VectorsBackend.search().)
-    #
-    # This MUST stay outside run_stage. It used to live in _boot_phase_1_core,
-    # which run_stage wraps in `except Exception` — recording the stage as
-    # failed, logging a warning, and letting boot continue. The guard landed
-    # 2026-07-11; that wrapper predates it by two months, so it had never once
-    # aborted a boot. Production served traffic with the exact config it was
-    # written to reject, and everything after the raise in _boot_phase_1_core
-    # (create_tables, the idempotent column migrations) was skipped on every
-    # boot. A fail-closed guard that serves traffic anyway is not a guard.
-    config.validate_security()
 
     try:
         # ── Phase 1: Core Infrastructure ──

--- a/orchestrator/tests/security/test_prd172_tenant_isolation.py
+++ b/orchestrator/tests/security/test_prd172_tenant_isolation.py
@@ -245,6 +245,9 @@ class TestF004ShopifyFailClosed:
         cfg = Config()
         monkeypatch.setattr(cfg, "SHOPIFY_INTERNAL_API_KEY", "real-secret", raising=False)
         monkeypatch.setattr(cfg, "S3_VECTORS_ENABLED", False, raising=False)
+        # PRD-194 S4: saas boots also require a widget CORS allowlist —
+        # satisfied here so this test stays scoped to the Shopify guard.
+        monkeypatch.setattr(cfg, "WIDGET_ORIGIN_ALLOWLIST", "https://app.automatos.app", raising=False)
         cfg.validate_security()  # no raise
 
     def test_verify_internal_key_rejects_arbitrary_header(self, monkeypatch):
@@ -341,6 +344,9 @@ class TestF005VectorIsolation:
         monkeypatch.setattr(cfg, "SHOPIFY_INTERNAL_API_KEY", "x", raising=False)
         monkeypatch.setattr(cfg, "S3_VECTORS_ENABLED", True, raising=False)
         monkeypatch.setattr(cfg, "S3_VECTORS_BUCKET", "shared-no-placeholder", raising=False)
+        # PRD-194 S4: saas boots also require a widget CORS allowlist —
+        # satisfied here so this test stays scoped to the bucket layout.
+        monkeypatch.setattr(cfg, "WIDGET_ORIGIN_ALLOWLIST", "https://app.automatos.app", raising=False)
         monkeypatch.setattr(cfg, "validate_auth_edition", lambda: None, raising=False)
         cfg.validate_security()  # must not raise on the bucket layout
 

--- a/orchestrator/tests/test_p2w2_cors_boot_guard.py
+++ b/orchestrator/tests/test_p2w2_cors_boot_guard.py
@@ -1,36 +1,23 @@
-"""The security boot guard must actually abort a boot, and widget CORS must
-fail closed for origins nobody named.
+"""PRD-194 S4 (P2-13, security §1.2.b) — widget CORS empty-allowlist boot guard.
 
-History. PRD-194 S4 added a guard that aborted a saas boot when
-``WIDGET_ORIGIN_ALLOWLIST`` was empty. Two things were wrong with it:
+``api/widgets/cors.py`` allowed ALL origins when ``WIDGET_ORIGIN_ALLOWLIST``
+was unset — which is the default — and nothing enforced the docstring's "in
+production the env var should always be set". These tests pin the locked
+decision: **a saas boot with an empty widget allowlist ABORTS** (added to
+``config.validate_security``, the same hard-fail boot phase and posture as
+the ``SHOPIFY_INTERNAL_API_KEY`` and Clerk edition guards), while the
+``local`` edition keeps the permissive dev default — choosing
+``AUTH_EDITION=local`` is the explicit opt-in. Belt-and-braces: if the
+empty-allowlist state is ever reached in saas anyway, ``_origin_allowed``
+fails CLOSED instead of allow-all.
 
-1. **It never ran.** ``config.validate_security()`` was called inside
-   ``_boot_phase_1_core``, which ``run_stage`` wraps in ``except Exception``
-   — the stage is recorded failed, a warning is logged, and boot continues.
-   The guard landed 2026-07-11; that wrapper predates it by two months, so it
-   had never once aborted a boot. Production served traffic with the exact
-   config the guard was written to reject, and everything after the raise in
-   ``_boot_phase_1_core`` (``create_tables``, the idempotent column
-   migrations) was skipped on every boot.
-
-2. **It guarded the wrong thing.** ``WIDGET_ORIGIN_ALLOWLIST`` was OR'd with
-   the per-key ``SdkApiKey.allowed_domains`` lookup, so it could only ever
-   WIDEN access beyond what a key permitted — no defence in depth, and a
-   second place to forget that threw a 403 reading as a key problem. The var
-   is deleted; merchant origins resolve from the key, first-party origins
-   from ``config.CORS_ALLOW_ORIGINS``.
-
-These tests pin both: the guard is reachable, and the plane fails closed.
-
-Pure tests — static AST read of main.py, plus config-object and pure-function
-checks. No boot, no DB, no network.
+Pure config-object tests — attributes are monkeypatched on the singleton
+(the established ``validate_*`` shape); no env reloads, no boot, no network.
 """
 
 from __future__ import annotations
 
-import ast
 import os
-from pathlib import Path
 
 os.environ.setdefault("POSTGRES_USER", "test")
 os.environ.setdefault("POSTGRES_PASSWORD", "test")
@@ -46,63 +33,11 @@ _conftest._restore_real_app_modules()
 
 from config import config as cfg  # noqa: E402
 
-_MAIN_PY = Path(__file__).resolve().parent.parent / "main.py"
-
-
-# ---------------------------------------------------------------------------
-# The guard must be reachable — not wrapped in a swallowing run_stage
-# ---------------------------------------------------------------------------
-
-def _calls_validate_security(func_name: str) -> bool:
-    """True if the named top-level function calls config.validate_security()."""
-    tree = ast.parse(_MAIN_PY.read_text(encoding="utf-8"))
-    for node in tree.body:
-        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            continue
-        if node.name != func_name:
-            continue
-        return any(
-            isinstance(call.func, ast.Attribute)
-            and call.func.attr == "validate_security"
-            for call in ast.walk(node)
-            if isinstance(call, ast.Call)
-        )
-    raise AssertionError(f"{func_name} not found in main.py")
-
-
-def test_lifespan_calls_validate_security_directly():
-    """It must run in lifespan, where a raise aborts the boot."""
-    assert _calls_validate_security("lifespan") is True
-
-
-def test_boot_phase_1_core_does_not_call_validate_security():
-    """The regression guard. _boot_phase_1_core runs inside
-    run_stage(...), which swallows every exception — a fail-closed check in
-    there logs a warning and lets the server serve traffic anyway."""
-    assert _calls_validate_security("_boot_phase_1_core") is False
-
-
-def test_run_stage_still_swallows_which_is_why_placement_matters():
-    """Documents the mechanism the tests above defend against. run_stage is
-    deliberately forgiving (a failed extension must not stop boot) — that is
-    exactly why a hard security guard cannot live inside one."""
-    import inspect
-
-    from core.models.bootstrap import run_stage
-
-    src = inspect.getsource(run_stage)
-    assert "except Exception" in src
-    # No bare re-raise of the captured stage exception.
-    assert "raise" not in src.split("except Exception")[1]
-
-
-# ---------------------------------------------------------------------------
-# validate_security still enforces the checks it kept
-# ---------------------------------------------------------------------------
 
 @pytest.fixture()
 def _security_baseline(monkeypatch):
-    """Satisfy every other validate_security check so one is isolated."""
+    """Satisfy every OTHER validate_security check so the widget-allowlist
+    guard is the only variable under test."""
     monkeypatch.setattr(cfg, "SHOPIFY_INTERNAL_API_KEY", "test-internal-key")
     monkeypatch.setattr(cfg, "S3_VECTORS_ENABLED", False)
     monkeypatch.setattr(cfg, "CLERK_JWKS_URL", "https://x/.well-known/jwks.json")
@@ -111,45 +46,73 @@ def _security_baseline(monkeypatch):
     return monkeypatch
 
 
-def test_shopify_fail_open_still_aborts(_security_baseline):
-    """F004 is untouched by the widget-allowlist removal."""
-    mp = _security_baseline
-    mp.setattr(cfg, "SHOPIFY_INTERNAL_API_KEY", "")
-    with pytest.raises(RuntimeError) as ei:
-        cfg.validate_security()
-    assert "SHOPIFY_INTERNAL_API_KEY" in str(ei.value)
-
-
-def test_widget_cors_is_no_longer_a_boot_concern(_security_baseline):
-    """No global widget allowlist exists, so boot has nothing to validate —
-    a saas boot with no widget env config must succeed."""
+def test_saas_empty_widget_allowlist_aborts_boot(_security_baseline):
+    """AUTH_EDITION=saas + empty WIDGET_ORIGIN_ALLOWLIST ⇒ RuntimeError
+    (boot abort) — the public plane must never rest at allow-all in prod."""
     mp = _security_baseline
     mp.setattr(cfg, "AUTH_EDITION", "saas")
+    mp.setattr(cfg, "WIDGET_ORIGIN_ALLOWLIST", "")
+    with pytest.raises(RuntimeError) as ei:
+        cfg.validate_security()
+    assert "WIDGET_ORIGIN_ALLOWLIST" in str(ei.value)
+
+
+def test_saas_whitespace_allowlist_also_aborts(_security_baseline):
+    """A whitespace-only value is still 'unset' — no accidental pass."""
+    mp = _security_baseline
+    mp.setattr(cfg, "AUTH_EDITION", "saas")
+    mp.setattr(cfg, "WIDGET_ORIGIN_ALLOWLIST", "   ")
+    with pytest.raises(RuntimeError):
+        cfg.validate_security()
+
+
+def test_saas_with_allowlist_boots(_security_baseline):
+    mp = _security_baseline
+    mp.setattr(cfg, "AUTH_EDITION", "saas")
+    mp.setattr(
+        cfg, "WIDGET_ORIGIN_ALLOWLIST",
+        "https://inbuilduk.myshopify.com,https://app.automatos.app",
+    )
     cfg.validate_security()  # must not raise
 
-    assert not hasattr(cfg, "WIDGET_ORIGIN_ALLOWLIST"), (
-        "WIDGET_ORIGIN_ALLOWLIST is deleted — a merchant origin belongs on "
-        "the merchant's key, not in a global env var"
+
+def test_local_empty_allowlist_permitted(_security_baseline):
+    """The local edition keeps the permissive dev default — an empty
+    allowlist must NOT abort a local boot."""
+    mp = _security_baseline
+    mp.setattr(cfg, "AUTH_EDITION", "local")
+    mp.setattr(cfg, "WIDGET_ORIGIN_ALLOWLIST", "")
+    cfg.validate_security()  # must not raise
+
+
+# ---------------------------------------------------------------- runtime belt
+
+def test_cors_empty_allowlist_denies_in_saas(monkeypatch):
+    """If the empty-allowlist state is ever reached in saas (guard bypassed),
+    _origin_allowed fails CLOSED — never allow-all in production."""
+    import api.widgets.cors as cors_mod
+
+    monkeypatch.setattr(cors_mod, "WIDGET_ORIGIN_ALLOWLIST", set())
+    monkeypatch.setattr(cors_mod.config, "AUTH_EDITION", "saas")
+    assert cors_mod._origin_allowed("https://any-store.example") is False
+
+
+def test_cors_empty_allowlist_permits_in_local(monkeypatch):
+    import api.widgets.cors as cors_mod
+
+    monkeypatch.setattr(cors_mod, "WIDGET_ORIGIN_ALLOWLIST", set())
+    monkeypatch.setattr(cors_mod.config, "AUTH_EDITION", "local")
+    assert cors_mod._origin_allowed("https://any-store.example") is True
+
+
+def test_cors_configured_allowlist_still_authoritative(monkeypatch):
+    """A configured allowlist behaves identically in both editions."""
+    import api.widgets.cors as cors_mod
+
+    monkeypatch.setattr(
+        cors_mod, "WIDGET_ORIGIN_ALLOWLIST", {"https://app.automatos.app"}
     )
-
-
-# ---------------------------------------------------------------------------
-# Runtime: the plane fails closed
-# ---------------------------------------------------------------------------
-
-def test_unknown_origin_denied_when_no_platform_origins(monkeypatch):
-    """Empty platform origins is not allow-all. It denies."""
-    import api.widgets.cors as cors_mod
-
-    monkeypatch.setattr(cors_mod, "PLATFORM_ORIGINS", set())
-    assert cors_mod._origin_is_platform("https://any-store.example") is False
-
-
-def test_platform_origin_matching_is_exact(monkeypatch):
-    """No suffix/substring matching — evil-automatos.app is not automatos.app."""
-    import api.widgets.cors as cors_mod
-
-    monkeypatch.setattr(cors_mod, "PLATFORM_ORIGINS", {"https://automatos.app"})
-    assert cors_mod._origin_is_platform("https://automatos.app") is True
-    assert cors_mod._origin_is_platform("https://evil-automatos.app") is False
-    assert cors_mod._origin_is_platform("https://automatos.app.evil.com") is False
+    for edition in ("saas", "local"):
+        monkeypatch.setattr(cors_mod.config, "AUTH_EDITION", edition)
+        assert cors_mod._origin_allowed("https://app.automatos.app") is True
+        assert cors_mod._origin_allowed("https://evil.example") is False

--- a/orchestrator/tests/test_prd008a_cors_coverage.py
+++ b/orchestrator/tests/test_prd008a_cors_coverage.py
@@ -58,19 +58,39 @@ def test_path_is_covered_excludes_unrelated_paths():
     assert _path_is_covered("/api/some-other-resource/sites") is False
 
 
-def test_platform_origins_are_our_own_domains_only(monkeypatch):
-    """First-party origins come from config.CORS_ALLOW_ORIGINS — the same list
-    the app-wide CORSMiddleware uses. A merchant storefront is NOT in it; it is
-    authorised from its key instead."""
+def test_origin_allowed_when_no_allowlist_configured(monkeypatch):
+    """Empty allowlist → permissive ONLY in the local edition (PRD-194 S4 /
+    P2-13). In saas the boot guard forbids the state; if reached anyway the
+    public plane fails CLOSED."""
+    from api.widgets.cors import _origin_allowed
     import api.widgets.cors as cors_mod
 
-    monkeypatch.setattr(
-        cors_mod, "PLATFORM_ORIGINS", {"https://app.automatos.app", "https://automatos.app"}
-    )
-    assert cors_mod._origin_is_platform("https://app.automatos.app") is True
-    assert cors_mod._origin_is_platform("https://automatos.app/") is True  # trailing slash
-    assert cors_mod._origin_is_platform("https://besafe-ltd.myshopify.com") is False
-    assert cors_mod._origin_is_platform("https://malicious.example.com") is False
+    monkeypatch.setattr(cors_mod, "WIDGET_ORIGIN_ALLOWLIST", set())
+
+    monkeypatch.setattr(cors_mod.config, "AUTH_EDITION", "local")
+    assert _origin_allowed("https://random-store.myshopify.com") is True
+    assert _origin_allowed("https://app.automatos.app") is True
+
+    monkeypatch.setattr(cors_mod.config, "AUTH_EDITION", "saas")
+    assert _origin_allowed("https://random-store.myshopify.com") is False
+    assert _origin_allowed("https://app.automatos.app") is False
+
+
+def test_origin_allowed_with_explicit_allowlist():
+    from api.widgets.cors import _origin_allowed
+    import api.widgets.cors as cors_mod
+
+    original = cors_mod.WIDGET_ORIGIN_ALLOWLIST
+    cors_mod.WIDGET_ORIGIN_ALLOWLIST = {
+        "https://app.automatos.app",
+        "https://besafe-ltd.myshopify.com",
+    }
+    try:
+        assert _origin_allowed("https://app.automatos.app") is True
+        assert _origin_allowed("https://besafe-ltd.myshopify.com") is True
+        assert _origin_allowed("https://malicious.example.com") is False
+    finally:
+        cors_mod.WIDGET_ORIGIN_ALLOWLIST = original
 
 
 # ---------------------------------------------------------------------------
@@ -81,70 +101,41 @@ import asyncio  # noqa: E402
 from types import SimpleNamespace  # noqa: E402
 
 
-WIDGET_PATH = "/api/widgets/config"
-SITES_PATH = "/api/sites/123/settings"
-
-
 def _isolated_dynamic(monkeypatch):
-    """Fresh cache + a platform-origin set that misses the storefront, so every
-    test exercises the merchant-key path deliberately."""
+    """Fresh cache + saas edition + an env allowlist that misses the origin,
+    so every test exercises the fallback path deliberately."""
     import api.widgets.cors as cors_mod
 
     monkeypatch.setattr(cors_mod, "_dynamic_origin_cache", {})
-    monkeypatch.setattr(cors_mod, "PLATFORM_ORIGINS", {"https://app.automatos.app"})
+    monkeypatch.setattr(cors_mod, "WIDGET_ORIGIN_ALLOWLIST", {"https://app.automatos.app"})
+    monkeypatch.setattr(cors_mod.config, "AUTH_EDITION", "saas")
     return cors_mod
 
 
-def test_preflight_resolves_from_key_allowlist(monkeypatch):
-    """A storefront origin named on an active public key's allowed_domains
-    passes — this is the ONLY way a merchant origin is authorised."""
+def test_preflight_falls_back_to_key_allowlist(monkeypatch):
+    """An origin absent from the env allowlist but named on an active public
+    key's allowed_domains passes the dynamic check (the academy case)."""
     cors_mod = _isolated_dynamic(monkeypatch)
     monkeypatch.setattr(cors_mod, "_origin_allowed_by_key_sync", lambda origin: True)
 
-    assert asyncio.run(
-        cors_mod._origin_allowed_dynamic("https://academy.automatos.app", WIDGET_PATH)
-    ) is True
+    assert asyncio.run(cors_mod._origin_allowed_dynamic("https://academy.automatos.app")) is True
 
 
 def test_key_fallback_denies_unknown_origin(monkeypatch):
     cors_mod = _isolated_dynamic(monkeypatch)
     monkeypatch.setattr(cors_mod, "_origin_allowed_by_key_sync", lambda origin: False)
 
-    assert asyncio.run(
-        cors_mod._origin_allowed_dynamic("https://malicious.example.com", WIDGET_PATH)
-    ) is False
+    assert asyncio.run(cors_mod._origin_allowed_dynamic("https://malicious.example.com")) is False
 
 
-def test_platform_fast_path_skips_the_db(monkeypatch):
+def test_env_fast_path_skips_the_db(monkeypatch):
     cors_mod = _isolated_dynamic(monkeypatch)
 
     def _boom(origin):
-        raise AssertionError("DB lookup must not run for platform origins")
+        raise AssertionError("DB lookup must not run for env-allowlisted origins")
 
     monkeypatch.setattr(cors_mod, "_origin_allowed_by_key_sync", _boom)
-    assert asyncio.run(
-        cors_mod._origin_allowed_dynamic("https://app.automatos.app", WIDGET_PATH)
-    ) is True
-
-
-def test_sites_never_consults_merchant_keys(monkeypatch):
-    """/api/sites is first-party dashboard CRUD. If a merchant could authorise
-    that origin by naming it on their own key, any merchant could open CORS on
-    the admin surface."""
-    cors_mod = _isolated_dynamic(monkeypatch)
-
-    def _boom(origin):
-        raise AssertionError("/api/sites must never reach the key lookup")
-
-    monkeypatch.setattr(cors_mod, "_origin_allowed_by_key_sync", _boom)
-
-    assert asyncio.run(
-        cors_mod._origin_allowed_dynamic("https://besafe-ltd.myshopify.com", SITES_PATH)
-    ) is False
-    # ...but our own dashboard still gets through.
-    assert asyncio.run(
-        cors_mod._origin_allowed_dynamic("https://app.automatos.app", SITES_PATH)
-    ) is True
+    assert asyncio.run(cors_mod._origin_allowed_dynamic("https://app.automatos.app")) is True
 
 
 def test_key_fallback_verdict_is_cached(monkeypatch):
@@ -157,12 +148,8 @@ def test_key_fallback_verdict_is_cached(monkeypatch):
         return True
 
     monkeypatch.setattr(cors_mod, "_origin_allowed_by_key_sync", _count)
-    assert asyncio.run(
-        cors_mod._origin_allowed_dynamic("https://academy.automatos.app", WIDGET_PATH)
-    ) is True
-    assert asyncio.run(
-        cors_mod._origin_allowed_dynamic("https://academy.automatos.app", WIDGET_PATH)
-    ) is True
+    assert asyncio.run(cors_mod._origin_allowed_dynamic("https://academy.automatos.app")) is True
+    assert asyncio.run(cors_mod._origin_allowed_dynamic("https://academy.automatos.app")) is True
     assert len(calls) == 1
 
 
@@ -175,14 +162,10 @@ def test_key_fallback_fails_closed_and_does_not_cache_failures(monkeypatch):
         raise RuntimeError("db unavailable")
 
     monkeypatch.setattr(cors_mod, "_origin_allowed_by_key_sync", _down)
-    assert asyncio.run(
-        cors_mod._origin_allowed_dynamic("https://academy.automatos.app", WIDGET_PATH)
-    ) is False
+    assert asyncio.run(cors_mod._origin_allowed_dynamic("https://academy.automatos.app")) is False
 
     monkeypatch.setattr(cors_mod, "_origin_allowed_by_key_sync", lambda origin: True)
-    assert asyncio.run(
-        cors_mod._origin_allowed_dynamic("https://academy.automatos.app", WIDGET_PATH)
-    ) is True
+    assert asyncio.run(cors_mod._origin_allowed_dynamic("https://academy.automatos.app")) is True
 
 
 def test_origin_allowed_by_any_key_uses_check_domain_matcher():

--- a/orchestrator/tests/test_prd186_s3_hardening.py
+++ b/orchestrator/tests/test_prd186_s3_hardening.py
@@ -220,6 +220,7 @@ def test_boot_aborts_on_bad_vector_config(monkeypatch):
     swallowing run_stage) carries the vector-integrity failure."""
     _vector_config(monkeypatch, enabled=True, bucket="")
     monkeypatch.setattr(app_config, "SHOPIFY_INTERNAL_API_KEY", "k", raising=False)
+    monkeypatch.setattr(app_config, "WIDGET_ORIGIN_ALLOWLIST", "https://x.example", raising=False)
     with pytest.raises(RuntimeError, match="S3_VECTORS_BUCKET"):
         app_config.validate_security()
 


### PR DESCRIPTION
## Incident

**api.automatos.app returned 502 on every route** after #616 deployed at 18:06.

```
GET  /health                 502
GET  /api/widgets/health     502
OPTIONS /api/widgets/config  502
```

The app was crash-looping in `lifespan` — Railway rate-limited the logs at 500/sec from the restart loop.

## Cause — mine

#616 hoisted `config.validate_security()` out of the swallowing `run_stage` so it would abort boot. It now does. And it has something to abort on:

```
SHOPIFY_INTERNAL_API_KEY = ABSENT   (F004 check → errors.append → RuntimeError)
```

I read this boot log yesterday:

```
Bootstrap [database_init] failed after 0ms: Tenant-isolation security config invalid (PRD-172):
```

and concluded it was the widget allowlist. `errors` is a **list** — that line is truncated at the colon and the entries follow on lines I never read. The widget allowlist was *one* entry. `SHOPIFY_INTERNAL_API_KEY` was another. I removed the widget clause, made the guard fatal, and shipped it without checking what else was in that list or whether production satisfied the remaining checks.

## This PR

Full revert of #616 — back to known-good. The guard is swallowed again (wrong, but not fatal), and `WIDGET_ORIGIN_ALLOWLIST` returns.

Reverting whole rather than surgically removing the hoist: mixing surgery into an outage is how you get a second outage. #616's branch is intact and re-lands cleanly once the environment is ready.

## Re-landing

Order matters, and it is the opposite of what I did:

1. Set `SHOPIFY_INTERNAL_API_KEY` on the API service — this is a real secret and Gerard's call. Note the value is currently *unset*, which means the Shopify provisioning surface accepts any Authorization header today (fail-open, F004). That hole is open regardless of this revert.
2. Confirm `validate_security()` passes against production env with nothing else in `errors`.
3. Re-land #616.

Step 2 is the one I skipped. A guard that aborts boot must be proven green against the real environment *before* it is armed, not after.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Widget access is now controlled by a configurable origin allowlist.
  * SaaS deployments require an explicit allowlist and fail closed when origins are not approved.
  * Local development continues to support an empty allowlist.
  * Origins associated with active public SDK keys remain supported.

* **Bug Fixes**
  * Security configuration is validated earlier during application startup, before database setup.

* **Documentation**
  * Updated CORS security guidance to reflect the new origin validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->