### PR TITLE
fix(telemetry): own the session, and let user-less rows land

### DIFF
--- a/orchestrator/alembic/versions/prd185_s1b_toollog_user_nullable.py
+++ b/orchestrator/alembic/versions/prd185_s1b_toollog_user_nullable.py
@@ -1,0 +1,52 @@
+"""Telemetry rows must land without a user — repair the NOT NULL drift.
+
+``tool_execution_logs.user_id`` is nullable in the model (composio_cache.py)
+and in the prd142 DDL, and PRD-185 S1's design intent is explicit: an
+unresolvable principal coerces to ``None`` so the row STILL lands. The live
+production table predates all of that — it was born NOT NULL via
+``create_all`` of an older model shape, and ``create_all`` never alters an
+existing table, so the drift persisted invisibly.
+
+Consequence (2026-08-01 Inbuild incident): every user-less tool execution —
+heartbeat/cadence agent calls have no user by construction, and workspace
+members whose Clerk id has no ``users`` row resolve to ``None`` — failed its
+telemetry INSERT with NotNullViolation. The learning plane lost those rows,
+and on paths that share the caller's session the failed flush poisoned the
+caller's transaction.
+
+Verified against production before writing this migration:
+``information_schema.columns`` → ``user_id | is_nullable = NO``.
+
+``ALTER COLUMN ... DROP NOT NULL`` is a no-op on an already-nullable column,
+so this is safe wherever the drift does not exist (fresh clones, CI).
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "prd185_s1b_toollog_user_nullable"
+down_revision = "prd223_w1_model_approval"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column(
+        "tool_execution_logs",
+        "user_id",
+        existing_type=sa.Integer(),
+        nullable=True,
+    )
+
+
+def downgrade():
+    # Best-effort: SET NOT NULL fails if user-less rows exist by then — which
+    # is the expected state once heartbeat telemetry lands. Backfill or delete
+    # NULL rows before downgrading.
+    op.alter_column(
+        "tool_execution_logs",
+        "user_id",
+        existing_type=sa.Integer(),
+        nullable=False,
+    )

--- a/orchestrator/modules/tools/execution/telemetry.py
+++ b/orchestrator/modules/tools/execution/telemetry.py
@@ -9,7 +9,7 @@ composio, MCP).  Failure to write telemetry MUST NOT fail the tool call.
 import asyncio
 import logging
 import time
-from typing import Any, Dict, Optional
+from typing import Any, Callable, Dict, Optional
 from uuid import UUID
 
 from sqlalchemy.orm import Session
@@ -87,7 +87,6 @@ def _coerce_user_id(db: Session, raw: Any) -> Optional[int]:
 
 
 async def write_telemetry(
-    db: Session,
     *,
     tool_name: str,
     parameters: Dict[str, Any],
@@ -96,14 +95,36 @@ async def write_telemetry(
     result: Dict[str, Any],
     execution_time_ms: int,
     caller_context: Optional[Dict[str, Any]] = None,
+    session_factory: Optional[Callable[[], Session]] = None,
 ) -> None:
     """Write a single telemetry row to tool_execution_logs.
 
     This function is designed to be fired-and-forgotten via asyncio.create_task.
     It catches all exceptions internally so it never propagates failures.
+
+    It OWNS its session. It used to take the caller's ``db`` and commit or
+    roll it back from a detached task at an arbitrary later moment — a
+    fire-and-forget writer sharing a live session it doesn't own. On paths
+    with a long-lived session, a failed telemetry flush left the caller's
+    transaction in pending-rollback and every subsequent flush on it died
+    (2026-08-01 Inbuild incident: board-task creation failed on a session
+    poisoned by a telemetry NotNullViolation). The write now opens, commits,
+    rolls back, and closes its own session; the caller's transaction is
+    untouchable from here.
+
+    ``session_factory`` exists for tests to inject a session; production
+    callers must not pass one built from a live request session.
     """
+    db: Optional[Session] = None
     try:
         from core.models.composio_cache import ToolExecutionLog
+
+        if session_factory is None:
+            # Lazy: telemetry loads in contexts where the DB layer isn't up
+            # yet, and unit tests load this module with stubbed models.
+            from core.database.database import SessionLocal
+            session_factory = SessionLocal
+        db = session_factory()
 
         ctx = caller_context or {}
 
@@ -152,10 +173,17 @@ async def write_telemetry(
         # Loud on purpose (PRD-185 S1): a DEBUG swallow here hid a 2-month,
         # 0-organic-rows telemetry outage. Failures must be visible.
         logger.warning(f"[telemetry] Failed to write tool execution log: {exc}")
-        try:
-            db.rollback()
-        except Exception:
-            pass
+        if db is not None:
+            try:
+                db.rollback()
+            except Exception:
+                pass
+    finally:
+        if db is not None:
+            try:
+                db.close()
+            except Exception:
+                pass
 
 
 def _build_router_decision(
@@ -191,7 +219,6 @@ def _build_router_decision(
 
 
 def fire_telemetry(
-    db: Session,
     *,
     tool_name: str,
     parameters: Dict[str, Any],
@@ -200,17 +227,22 @@ def fire_telemetry(
     result: Dict[str, Any],
     execution_time_ms: int,
     caller_context: Optional[Dict[str, Any]] = None,
+    session_factory: Optional[Callable[[], Session]] = None,
 ) -> None:
     """Fire-and-forget telemetry write as a background task.
 
     Safe to call from sync or async context -- schedules the write on the
     running event loop.  If no loop is running, logs a warning and skips.
+
+    Takes NO session on purpose: the write runs after this call returns, on
+    a session write_telemetry opens and owns. Handing it a live request
+    session is how a background flush failure rolled back foreground work.
+    ``session_factory`` is a test-injection point only.
     """
     try:
         loop = asyncio.get_running_loop()
         loop.create_task(
             write_telemetry(
-                db,
                 tool_name=tool_name,
                 parameters=parameters,
                 agent_id=agent_id,
@@ -218,6 +250,7 @@ def fire_telemetry(
                 result=result,
                 execution_time_ms=execution_time_ms,
                 caller_context=caller_context,
+                session_factory=session_factory,
             )
         )
     except RuntimeError:

--- a/orchestrator/modules/tools/execution/unified_executor.py
+++ b/orchestrator/modules/tools/execution/unified_executor.py
@@ -844,7 +844,6 @@ class UnifiedToolExecutor:
             # PRD-139: Universal telemetry — fire-and-forget, never fails the tool call
             _exec_ms = int((_time.monotonic() - _exec_start) * 1000)
             fire_telemetry(
-                self.db,
                 tool_name=tool_name,
                 parameters=parameters if isinstance(parameters, dict) else {},
                 agent_id=agent_id,

--- a/orchestrator/tests/test_p2w0_telemetry_user_id.py
+++ b/orchestrator/tests/test_p2w0_telemetry_user_id.py
@@ -137,7 +137,7 @@ async def test_logged_in_clerk_user_row_is_written(mock_db):
     telemetry_mod._CLERK_ID_CACHE.clear()
     mock_db.query.return_value.filter.return_value.first.return_value = (123,)
     await write_telemetry(
-        mock_db,
+        session_factory=lambda: mock_db,
         tool_name="platform_list_agents",
         parameters={"workspace_id": "x"},
         agent_id=None,
@@ -159,7 +159,7 @@ async def test_unresolved_user_still_writes_row(mock_db):
     telemetry_mod._CLERK_ID_CACHE.clear()
     mock_db.query.return_value.filter.return_value.first.return_value = None
     await write_telemetry(
-        mock_db,
+        session_factory=lambda: mock_db,
         tool_name="platform_list_agents",
         parameters={},
         agent_id=None,
@@ -179,7 +179,7 @@ async def test_write_failure_is_loud(mock_db, caplog):
     mock_db.commit.side_effect = RuntimeError("boom")
     with caplog.at_level(logging.WARNING):
         await write_telemetry(
-            mock_db,
+            session_factory=lambda: mock_db,
             tool_name="platform_list_agents",
             parameters={},
             agent_id=None,

--- a/orchestrator/tests/test_prd139_telemetry.py
+++ b/orchestrator/tests/test_prd139_telemetry.py
@@ -86,7 +86,7 @@ class TestTelemetryWrite:
     async def test_writes_one_row_with_correct_fields(self, mock_db, sample_workspace_id):
         """AC-9: Mocked tool execution writes one row with correct fields."""
         await write_telemetry(
-            mock_db,
+            session_factory=lambda: mock_db,
             tool_name="platform_list_agents",
             parameters={"workspace_id": str(sample_workspace_id)},
             agent_id=42,
@@ -130,7 +130,7 @@ class TestTelemetryWrite:
     async def test_agent_id_none_for_zero(self, mock_db, sample_workspace_id):
         """agent_id=0 should be stored as None (nullable FK)."""
         await write_telemetry(
-            mock_db,
+            session_factory=lambda: mock_db,
             tool_name="workspace_read_file",
             parameters={"path": "/tmp/test.txt"},
             agent_id=0,
@@ -146,7 +146,7 @@ class TestTelemetryWrite:
     async def test_error_result_captured(self, mock_db, sample_workspace_id):
         """Error results should capture error_message and status='error'."""
         await write_telemetry(
-            mock_db,
+            session_factory=lambda: mock_db,
             tool_name="platform_execute",
             parameters={"action": "unknown"},
             agent_id=5,
@@ -163,7 +163,7 @@ class TestTelemetryWrite:
     async def test_composio_app_name_detection(self, mock_db, sample_workspace_id):
         """Composio tools should derive app_name correctly."""
         await write_telemetry(
-            mock_db,
+            session_factory=lambda: mock_db,
             tool_name="COMPOSIO_SEARCH_WEB",
             parameters={"query": "test"},
             agent_id=10,
@@ -179,7 +179,7 @@ class TestTelemetryWrite:
     async def test_workspace_app_name_detection(self, mock_db, sample_workspace_id):
         """Workspace tools should derive app_name as WORKSPACE."""
         await write_telemetry(
-            mock_db,
+            session_factory=lambda: mock_db,
             tool_name="workspace_read_file",
             parameters={"path": "/tmp/test.txt"},
             agent_id=3,
@@ -202,7 +202,7 @@ class TestTelemetryFailureIsolation:
 
         # Should NOT raise
         await write_telemetry(
-            mock_db,
+            session_factory=lambda: mock_db,
             tool_name="platform_list_agents",
             parameters={},
             agent_id=1,
@@ -221,7 +221,7 @@ class TestTelemetryFailureIsolation:
 
         # Should NOT raise
         await write_telemetry(
-            mock_db,
+            session_factory=lambda: mock_db,
             tool_name="test_tool",
             parameters={},
             agent_id=1,
@@ -238,13 +238,13 @@ class TestTelemetryFailureIsolation:
         """fire_telemetry uses create_task and does not block."""
         # fire_telemetry should schedule a task without blocking
         fire_telemetry(
-            mock_db,
             tool_name="platform_list_agents",
             parameters={},
             agent_id=1,
             workspace_id=sample_workspace_id,
             result={"success": True},
             execution_time_ms=100,
+            session_factory=lambda: mock_db,
         )
 
         # Allow the event loop to process the task

--- a/orchestrator/tests/test_prd143_boundary_sweep.py
+++ b/orchestrator/tests/test_prd143_boundary_sweep.py
@@ -652,7 +652,7 @@ def test_audit_distinguishes_autonomous_actions():
 
     async def _write(tool: str, result: Dict[str, Any]):
         await write_telemetry(
-            db,
+            session_factory=lambda: db,
             tool_name=tool,
             parameters={},
             agent_id=9,

--- a/orchestrator/tests/test_prd143_concierge_journey.py
+++ b/orchestrator/tests/test_prd143_concierge_journey.py
@@ -376,7 +376,7 @@ async def _audit_rows(telemetry: List[Dict[str, Any]]) -> list:
     rows = []
     for kw in telemetry:
         db = MagicMock()
-        await write_telemetry(db, **kw)
+        await write_telemetry(session_factory=lambda: db, **kw)
         assert db.add.call_count == 1, f"telemetry write failed for {kw['tool_name']}"
         rows.append(db.add.call_args[0][0])
         db.commit.assert_called_once()

--- a/orchestrator/tests/test_prd143_concierge_journey.py
+++ b/orchestrator/tests/test_prd143_concierge_journey.py
@@ -331,7 +331,12 @@ def _arc(real_registry: ActionRegistry, *, full_autonomy: bool):
         ))
         stack.enter_context(patch.object(
             ue_mod, "fire_telemetry",
-            side_effect=lambda db, **kw: telemetry.append(kw),
+            # Keyword-only since the session-ownership fix: fire_telemetry
+            # takes NO session (PR #618) — a db-first capture here raises
+            # inside execute_tool's finally and fails every journey step.
+            side_effect=lambda **kw: telemetry.append(
+                {k: v for k, v in kw.items() if k != "session_factory"}
+            ),
         ))
         stack.enter_context(patch.object(
             pe.PlatformActionExecutor, "_full_autonomy",

--- a/orchestrator/tests/test_prd143_full_surface_positive.py
+++ b/orchestrator/tests/test_prd143_full_surface_positive.py
@@ -336,7 +336,7 @@ async def test_audit_row_written_for_autonomous_action(real_registry):
     # (b) the universal telemetry hook persists the marker on the row.
     db = MagicMock()
     await write_telemetry(
-        db,
+        session_factory=lambda: db,
         tool_name=_DESTRUCTIVE,
         parameters={"agent_id": 42},
         agent_id=9,
@@ -355,7 +355,7 @@ async def test_audit_row_written_for_autonomous_action(real_registry):
     # Control row: a non-autonomous result writes NO autonomous marker.
     db2 = MagicMock()
     await write_telemetry(
-        db2,
+        session_factory=lambda: db2,
         tool_name=_READ,
         parameters={},
         agent_id=9,

--- a/orchestrator/tests/test_prd143_selection_metric.py
+++ b/orchestrator/tests/test_prd143_selection_metric.py
@@ -232,7 +232,7 @@ def test_selection_outcome_recorded_on_narrowed_dispatch(fresh_recorder):
     db = MagicMock()
     asyncio.run(
         write_telemetry(
-            db,
+            session_factory=lambda: db,
             tool_name="platform_execute",
             parameters={"action": _OP_LIST},
             agent_id=_AGENT,
@@ -281,7 +281,7 @@ def test_fallback_recorded_when_rank_fails(fresh_recorder):
     db = MagicMock()
     asyncio.run(
         write_telemetry(
-            db,
+            session_factory=lambda: db,
             tool_name="platform_execute",
             parameters={"action": _OP_LIST},
             agent_id=_AGENT,

--- a/orchestrator/tests/test_prd177_composio_telemetry.py
+++ b/orchestrator/tests/test_prd177_composio_telemetry.py
@@ -119,7 +119,7 @@ async def test_composio_action_telemetry(mock_db):
     the real action node. Secret param values are never logged (keys only)."""
     ws = uuid4()
     await write_telemetry(
-        mock_db,
+        session_factory=lambda: mock_db,
         tool_name="composio_execute",
         parameters={"action": "SLACK_SEND_MESSAGE", "params": {"text": "secret-body"}},
         agent_id=7,

--- a/orchestrator/tests/test_telemetry_session_ownership.py
+++ b/orchestrator/tests/test_telemetry_session_ownership.py
@@ -1,0 +1,141 @@
+"""The telemetry writer owns its session — a background flush can never touch foreground work.
+
+2026-08-01 Inbuild incident: ``fire_telemetry(self.db, ...)`` scheduled a
+detached task holding the CALLER's session. When the telemetry INSERT failed
+(NotNullViolation — ``tool_execution_logs.user_id`` was NOT NULL in prod for
+user-less heartbeat calls), the task's rollback poisoned the caller's live
+transaction: board-task creation died with "This Session's transaction has
+been rolled back due to a previous exception during flush".
+
+These tests pin the repaired contract:
+
+1. write_telemetry opens its session from a factory and closes it — commit,
+   rollback, and close all happen on the session it owns.
+2. A write failure rolls back and closes the OWNED session and never raises.
+3. Neither write_telemetry nor fire_telemetry accepts a session — only a
+   factory. The signature IS the contract; this fails loudly if someone
+   reintroduces a ``db`` parameter.
+4. The user-less row (user_id=None) builds and commits — the PRD-185 S1
+   intent ("the row STILL lands") that the prod NOT NULL drift was breaking.
+
+Same loading pattern as tests/test_prd139_telemetry.py: telemetry.py is
+loaded directly with a stubbed ToolExecutionLog, no app boot, no DB.
+"""
+import asyncio
+import importlib.util
+import inspect
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+_orchestrator_root = str(Path(__file__).resolve().parent.parent)
+if _orchestrator_root not in sys.path:
+    sys.path.insert(0, _orchestrator_root)
+
+_telemetry_path = Path(_orchestrator_root) / "modules" / "tools" / "execution" / "telemetry.py"
+_spec = importlib.util.spec_from_file_location("telemetry_ownership_mod", _telemetry_path)
+telemetry_mod = importlib.util.module_from_spec(_spec)
+
+
+class _CapturedLog:
+    """Stands in for ToolExecutionLog; captures constructor kwargs."""
+
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+
+@pytest.fixture(autouse=True)
+def _stub_models(monkeypatch):
+    fake_models = MagicMock()
+    fake_models.ToolExecutionLog = _CapturedLog
+    monkeypatch.setitem(sys.modules, "core.models.composio_cache", fake_models)
+    fake_user_mod = MagicMock()
+    monkeypatch.setitem(sys.modules, "core.models.core", fake_user_mod)
+    _spec.loader.exec_module(telemetry_mod)
+    yield
+
+
+def _kwargs(**over):
+    base = dict(
+        tool_name="platform_update_agent",
+        parameters={"agent_id": 7},
+        agent_id=540,
+        workspace_id=uuid4(),
+        result={"success": True},
+        execution_time_ms=42,
+    )
+    base.update(over)
+    return base
+
+
+@pytest.mark.asyncio
+async def test_write_uses_factory_session_and_closes_it():
+    own = MagicMock()
+    factory = MagicMock(return_value=own)
+
+    await telemetry_mod.write_telemetry(session_factory=factory, **_kwargs())
+
+    factory.assert_called_once()
+    assert own.add.call_count == 1
+    own.commit.assert_called_once()
+    own.close.assert_called_once()
+    own.rollback.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_write_failure_rolls_back_own_session_never_raises():
+    own = MagicMock()
+    own.commit.side_effect = RuntimeError("NotNullViolation: user_id")
+
+    # Must not raise — fire-and-forget contract.
+    await telemetry_mod.write_telemetry(
+        session_factory=lambda: own, **_kwargs()
+    )
+
+    own.rollback.assert_called_once()
+    own.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_userless_row_still_lands():
+    """Heartbeat/cadence calls have no user. The row must build with
+    user_id=None and commit — the intent the prod NOT NULL drift broke."""
+    own = MagicMock()
+
+    await telemetry_mod.write_telemetry(
+        session_factory=lambda: own,
+        **_kwargs(caller_context={}),  # no user_id at all
+    )
+
+    own.commit.assert_called_once()
+    row = own.add.call_args[0][0]
+    assert row.user_id is None
+
+
+def test_signatures_accept_no_session():
+    """The signature is the contract: a session cannot be handed in, only a
+    factory. Reintroducing a ``db`` parameter is the incident vector."""
+    for fn in (telemetry_mod.write_telemetry, telemetry_mod.fire_telemetry):
+        params = inspect.signature(fn).parameters
+        assert "db" not in params, f"{fn.__name__} must not accept a session"
+        assert "session_factory" in params
+        # Everything is keyword-only — no positional slot a session could
+        # silently occupy.
+        positional = [
+            p for p in params.values()
+            if p.kind in (p.POSITIONAL_ONLY, p.POSITIONAL_OR_KEYWORD)
+        ]
+        assert positional == [], f"{fn.__name__} must be keyword-only"
+
+
+@pytest.mark.asyncio
+async def test_fire_telemetry_background_write_lands_on_factory_session():
+    own = MagicMock()
+    telemetry_mod.fire_telemetry(session_factory=lambda: own, **_kwargs())
+    await asyncio.sleep(0.05)
+    assert own.add.call_count == 1
+    own.close.assert_called_once()


### PR DESCRIPTION
## The incident (2026-08-01, Inbuild UK workspace)

Auto appeared unable to do any setup work and kept narrating the same plan. Log forensics decomposed it into three separate facts:

| What | Verdict | Evidence |
|---|---|---|
| 4× `platform_update_agent` 15:54:50 | **Landed** — all `success=True`, committed by the router's per-call session | `execute_tool done ... success=True` ×4 |
| 5× `platform_add_playbook_step` + 1× `platform_create_mission` 16:03–16:04 | Failed on **missing required params** (`prompt_template`, `goal`) — six parallel calls in one turn, model never saw the first error | `platform_execute failed: Missing required params` |
| Board-task creation 16:03:46 | Died on a **poisoned session** | `This Session's transaction has been rolled back due to a previous exception during flush` |

This PR fixes the poisoning and its trigger. The missing-params/routing UX is separate work.

## Defect 1 — production schema drift (the trigger)

`tool_execution_logs.user_id` is **NOT NULL in production** — verified directly:

```
column_name | is_nullable
user_id     | NO
```

The model (`Column(Integer)`), the prd142 DDL (`nullable=True`), and PRD-185 S1's explicit intent (*"unresolvable → None so the row STILL lands"*) all say nullable. The live table predates them — born via `create_all` of an older model shape, and `create_all` never alters existing tables.

Consequence: every **user-less** tool execution fails its telemetry INSERT with `NotNullViolation`. Heartbeat/cadence agent calls have no user *by construction* — the 4 violations in the incident window line up exactly with 4 `no-trace` cadence calls (`platform_get_activity_feed`, `platform_get_agent`×3). Those rows have been silently lost, starving the learning plane (operating graph, affinities, selection metrics).

**Fix:** migration `prd185_s1b_toollog_user_nullable` (parent `prd223_w1_model_approval`, keeps exactly one head). `DROP NOT NULL` is a no-op where the drift doesn't exist, so CI and fresh clones are unaffected. Runs via `docker-entrypoint.sh` → `alembic upgrade heads` — **not** the boot path that the swallowed guard skips.

## Defect 2 — fire-and-forget on a borrowed session (the poison)

`fire_telemetry(self.db, ...)` scheduled a detached asyncio task holding the **caller's** session, then committed or rolled it back at an arbitrary later moment. On the router path this was masked (`execute_and_format` commits and closes its per-call session before the task runs). On long-lived-session paths, the failed telemetry flush left the caller's transaction in pending-rollback — and every later flush on it died, which is what killed board-task creation.

**Fix:** `write_telemetry` opens, commits, rolls back, and closes a session it **owns** (lazy `SessionLocal`, or an injected `session_factory` for tests). Both functions are keyword-only with **no `db` parameter** — the signature is the contract.

## Tests

New `tests/test_telemetry_session_ownership.py` (same stubbed-module pattern as `test_prd139_telemetry.py`, no DB):

- write uses the factory session; commit + close on the owned session, caller untouchable
- a write failure rolls back + closes the owned session and never raises
- the **user-less row builds with `user_id=None` and commits** — the PRD-185 intent the drift broke
- signature pin: no `db` param, keyword-only — reintroducing the incident vector fails this test by construction
- `fire_telemetry` background write lands on the factory session

10 existing call sites across 7 test files migrated to `session_factory=lambda: db` injection (same assertions, same mocks).

Verified locally: byte-compile on all 11 changed files, import-linter 1 kept / 0 broken. Full suite is CI's job.

## Deliberately NOT in this PR

- **Missing-params UX / tool routing** — the six failed calls are a routing+schema problem (the 30-tool cap pushed Auto onto the schemaless `platform_execute` passthrough). Different evidence, different risk.
- **`SHOPIFY_INTERNAL_API_KEY` / #616 re-land** — still parked on the env var being set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Telemetry can now be recorded even when no user is identified.
  * Telemetry writes are isolated from the surrounding operation, improving reliability when recording fails.
* **Bug Fixes**
  * Telemetry failures no longer interfere with tool execution.
  * Database sessions are consistently cleaned up after telemetry attempts.
* **Tests**
  * Added coverage for successful writes, failures, background recording, session cleanup, and user-less telemetry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->