### PR TITLE
reland #616: per-key widget CORS + real boot guard — and the machine-lane key is not a boot concern

### DIFF
--- a/docs/workspace-execution/security-sandboxing.md
+++ b/docs/workspace-execution/security-sandboxing.md
@@ -96,7 +96,8 @@ The widget subsystem includes rate limiting using a thread-safe in-memory slidin
 
 ### CORS Policy
 Widget endpoints (`/api/widgets/*`) use a dedicated `WidgetCORSMiddleware`. This middleware is ASGI-native to avoid buffering `StreamingResponse` (SSE) data, ensuring real-time performance for chat streams [orchestrator/api/widgets/cors.py:5-8]().
-*   **Origin Allowlist:** Origins are validated against `WIDGET_ORIGIN_ALLOWLIST` configured via environment variables [orchestrator/api/widgets/cors.py:18-21]().
+*   **Origin Allowlist:** There is no global widget origin env var. A merchant storefront is authorised from the per-key `SdkApiKey.allowed_domains` the merchant maintains — the same list `widget_auth` enforces on the real request. Preflights carry no `Authorization` header, so the middleware asks whether the origin is named on *any* active public key [orchestrator/api/widgets/cors.py]().
+*   **First-party Origins:** Our own dashboard and marketing site come from `config.CORS_ALLOW_ORIGINS`, the same list the app-wide `CORSMiddleware` uses. `/api/sites/*` (dashboard Sites CRUD, JWT-cookie auth) resolves from this list only and never consults merchant keys — otherwise any merchant could open CORS on the admin surface by naming that origin on their own key.
 *   **Preflight Handling:** The middleware handles `OPTIONS` requests by validating the `Origin` and returning appropriate `Access-Control-Allow-*` headers [orchestrator/api/widgets/cors.py:57-77]().
 *   **Credentials:** If the origin is allowed, `access-control-allow-credentials: true` is set to support authenticated widget interactions [orchestrator/api/widgets/cors.py:88]().
 

--- a/orchestrator/api/shopify.py
+++ b/orchestrator/api/shopify.py
@@ -85,18 +85,19 @@ def _resolve_sync_workspace(ctx: RequestContext, requested: Optional[str]) -> st
 
 
 def _verify_internal_key(authorization: str = Header(...)) -> None:
-    """Verify the internal API key from the Shopify app server.
+    """Verify the machine-lane shared secret (Shopify app server, GDPR routes).
 
-    PRD-172 F004: fail-closed. There is NO "no key configured → accept all"
-    branch — an unset key is caught at boot by ``config.validate_security()``,
-    so by the time a request lands the key is guaranteed present and this only
-    ever compares against a real secret. A falsy configured key can no longer
-    wave through an arbitrary ``Authorization: Bearer x``.
+    PRD-172 F004: fail-closed, and THIS check is the whole guard — there is no
+    boot-abort behind it. An unset key means the machine lanes are deliberately
+    dark (503), which is the correct resting state of the current deployment
+    model: there is no Automatos-owned Shopify app; clients connect their own
+    stores and merchant traffic authenticates with per-workspace widget keys
+    (``SdkApiKey``). If the app-store wedge ever revives, one shared secret is
+    set on both sides and these lanes light up. A falsy configured key can
+    never wave through an arbitrary ``Authorization: Bearer x``.
     """
     expected = (config.SHOPIFY_INTERNAL_API_KEY or "").strip()
     if not expected:
-        # Defence in depth: boot should already have failed. Refuse rather than
-        # fall open if this is somehow reached (e.g. key blanked at runtime).
         raise HTTPException(status_code=503, detail="Shopify provisioning not configured")
     token = authorization.replace("Bearer ", "").strip()
     if not hmac.compare_digest(token, expected):

--- a/orchestrator/api/widgets/cors.py
+++ b/orchestrator/api/widgets/cors.py
@@ -10,18 +10,31 @@ Path coverage (PRD-008-A):
 - ``/api/widgets/*``  — storefront widget calls (any storefront origin)
 - ``/api/sites/*``    — Automatos dashboard Sites CRUD (admin operations)
 
-Both surfaces share the ``WIDGET_ORIGIN_ALLOWLIST`` env var. An empty
-allowlist is permissive ONLY in the ``local`` edition (dev default); in the
-``saas`` edition the boot guard (``config.validate_security``, PRD-194 S4 /
-P2-13) aborts boot on an empty allowlist, and this module fails CLOSED if
-that state is ever reached anyway. The actual security boundary on
-/api/sites is the JWT in cookies, not CORS — CORS just lets the dashboard
-browser issue the request in the first place.
+There is NO global widget origin allowlist. Storefront origins are authorised
+from the per-key ``SdkApiKey.allowed_domains`` the merchant already maintains
+— the same list ``widget_auth`` enforces on the real request, and the only
+place an origin is named. ``WIDGET_ORIGIN_ALLOWLIST`` used to sit in front of
+that as a second source of truth; because it was OR'd with the key lookup it
+could only ever WIDEN access beyond what a key permitted, so it bought no
+defence in depth while adding a second place to forget. Forgetting it threw a
+403 that read as a key problem. It is gone.
 
-Origins named on an active public SDK key's ``allowed_domains`` are honoured
-too (PRD-TUTOR-LIVE S0): preflights carry no Authorization, so a key-scoped
-origin used to die at OPTIONS with 403 before ``widget_auth`` ever saw the
-request it would have approved. See ``_origin_allowed_dynamic``.
+Two origin classes, one source of truth each:
+
+- **Platform origins** (``config.CORS_ALLOW_ORIGINS``) — our own dashboard and
+  marketing site calling our own API. Already trusted by the app-wide
+  CORSMiddleware for every other route; ``/api/sites`` (dashboard Sites CRUD,
+  JWT-cookie auth, no SDK key in play) and the deprecated first-party blog
+  embed ride this.
+- **Merchant origins** (``SdkApiKey.allowed_domains``) — storefronts. Applies
+  to ``/api/widgets`` only.
+
+The actual security boundary on /api/sites is the JWT in cookies, not CORS —
+CORS just lets the dashboard browser issue the request in the first place.
+
+Preflights carry no Authorization header, so this middleware cannot know WHICH
+key the real request will present; it asks whether the origin is named on ANY
+active public key (PRD-TUTOR-LIVE S0). See ``_origin_allowed_dynamic``.
 """
 
 import logging
@@ -40,43 +53,30 @@ COVERED_PATH_PREFIXES: tuple[str, ...] = (
     "/api/sites",
 )
 
-# Explicit origin allowlist — comma-separated in env var.
-# Only these origins may make credentialed requests to widget endpoints.
-_RAW_ALLOWLIST = config.WIDGET_ORIGIN_ALLOWLIST or ""
-WIDGET_ORIGIN_ALLOWLIST: set[str] = {
-    o.strip().rstrip("/") for o in _RAW_ALLOWLIST.split(",") if o.strip()
+# Only /api/widgets consults merchant keys. /api/sites is first-party.
+_KEY_SCOPED_PATH_PREFIX = "/api/widgets"
+
+# Platform origins — our own dashboard and marketing site. Same list the
+# app-wide CORSMiddleware uses for every other route; not a widget-specific
+# allowlist, and never a place to name a merchant storefront.
+PLATFORM_ORIGINS: set[str] = {
+    o.strip().rstrip("/")
+    for o in (config.CORS_ALLOW_ORIGINS or "").split(",")
+    if o.strip()
 }
 
 
-def _origin_allowed(origin: str) -> bool:
-    """Return True if *origin* is in the configured allowlist.
-
-    Empty allowlist (P2-13, PRD-194 S4): permissive ONLY in the ``local``
-    edition — choosing ``AUTH_EDITION=local`` is the explicit dev opt-in. In
-    the ``saas`` edition the boot guard (``config.validate_security``)
-    guarantees a non-empty allowlist, so this branch is unreachable there;
-    if it is ever reached anyway (guard bypassed), the public plane fails
-    CLOSED, loudly — never allow-all in production.
-    """
-    if not WIDGET_ORIGIN_ALLOWLIST:
-        if config.IS_LOCAL_EDITION:
-            return True
-        logger.error(
-            "WIDGET_ORIGIN_ALLOWLIST is empty in the saas edition — denying "
-            "origin %s (fail closed; the boot guard should have prevented this)",
-            origin,
-        )
-        return False
-    return origin.rstrip("/") in WIDGET_ORIGIN_ALLOWLIST
+def _origin_is_platform(origin: str) -> bool:
+    """True when *origin* is one of our own first-party origins."""
+    return origin.rstrip("/") in PLATFORM_ORIGINS
 
 
 # ── Key-allowlist fallback (PRD-TUTOR-LIVE S0) ──────────────────────────
 # A browser preflight carries no Authorization header, so this middleware
 # cannot know WHICH ak_pub_ key the actual request will present — but it can
 # ask whether the origin is explicitly named on ANY active public key's
-# ``allowed_domains``. Without this, an origin that widget_auth would approve
-# (academy.automatos.app, a provisioned storefront) 403s at OPTIONS unless it
-# is duplicated into WIDGET_ORIGIN_ALLOWLIST. The lookup reuses the exact
+# ``allowed_domains``. This is the ONLY way a merchant origin is authorised —
+# there is no global widget allowlist to fall back on. The lookup reuses the exact
 # matcher widget_auth uses (``ApiKeyService.check_domain``) so the preflight
 # and the request can never disagree, and it is cached per origin: one DB
 # scan per origin per TTL, cache bounded so origin-scanning clients cannot
@@ -101,10 +101,18 @@ def _origin_allowed_by_key_sync(origin: str) -> bool:
         db.close()
 
 
-async def _origin_allowed_dynamic(origin: str) -> bool:
-    """Env allowlist fast path, then the cached key-allowlist fallback."""
-    if _origin_allowed(origin):
+async def _origin_allowed_dynamic(origin: str, path: str) -> bool:
+    """Platform origins, then — on /api/widgets only — the merchant key lookup.
+
+    ``/api/sites`` is first-party dashboard CRUD: no SDK key names the
+    dashboard origin, so it never reaches the key lookup. Letting it would
+    mean any merchant could open CORS on the admin surface by naming that
+    origin on their own key.
+    """
+    if _origin_is_platform(origin):
         return True
+    if not path.startswith(_KEY_SCOPED_PATH_PREFIX):
+        return False
     now = time.monotonic()
     cached = _dynamic_origin_cache.get(origin)
     if cached and cached[1] > now:
@@ -149,7 +157,7 @@ class WidgetCORSMiddleware:
 
         # Handle OPTIONS preflight
         if scope["method"] == "OPTIONS":
-            if not origin or not await _origin_allowed_dynamic(origin):
+            if not origin or not await _origin_allowed_dynamic(origin, path):
                 response_headers = [
                     (b"content-type", b"text/plain"),
                     (b"vary", b"Origin"),
@@ -183,7 +191,7 @@ class WidgetCORSMiddleware:
         # upstream middleware (e.g. FastAPI's CORSMiddleware) already added —
         # duplicate Access-Control-Allow-* headers cause Chrome to reject the
         # response with "Failed to fetch".
-        allowed = await _origin_allowed_dynamic(origin) if origin else False
+        allowed = await _origin_allowed_dynamic(origin, path) if origin else False
 
         _CORS_HEADERS_TO_OVERRIDE = (
             b"access-control-allow-origin",

--- a/orchestrator/config.py
+++ b/orchestrator/config.py
@@ -552,7 +552,6 @@ class Config:
     # this from now (mirrors Slack's documented v0 5-minute window).
     WEBHOOK_TIMESTAMP_SKEW_SECONDS: int = int(os.getenv("WEBHOOK_TIMESTAMP_SKEW_SECONDS", "300"))
     WIDGET_TOKEN_SECRET: str = os.getenv("WIDGET_TOKEN_SECRET", "")
-    WIDGET_ORIGIN_ALLOWLIST: str = os.getenv("WIDGET_ORIGIN_ALLOWLIST", "")
     # PRD-194 S5 (P2-13): Redis-backed shared widget rate limiter (replaces
     # the per-process in-memory window). One window length; per-key limits by
     # key type; and a per-IP ceiling on the two money-spending endpoints
@@ -1467,10 +1466,10 @@ class Config:
           shared bucket with no ``{workspace_id}`` placeholder is allowed —
           tenant isolation is enforced per-query by ``S3VectorsBackend.search()``
           (fail-closed on ``workspace_id``), not by the bucket layout.)
-        - PRD-194 S4 (P2-13): ``WIDGET_ORIGIN_ALLOWLIST`` is empty in the
-          ``saas`` edition — widget CORS would rest at allow-all on the
-          internet-facing plane. Boot-abort in saas (same posture as F004 /
-          the Clerk edition guard); ``local`` keeps the permissive dev default.
+        Widget CORS is deliberately NOT checked here. Storefront origins are
+        authorised from the per-key ``SdkApiKey.allowed_domains`` the merchant
+        already maintains — there is no global widget allowlist to validate.
+        See ``api/widgets/cors.py``.
         """
         errors: list[str] = []
 
@@ -1489,21 +1488,6 @@ class Config:
             self.assert_vector_config_integrity()
         except RuntimeError as e:
             errors.append(str(e))
-
-        # PRD-194 S4 (P2-13) — the internet-facing widget plane must not rest
-        # at allow-all CORS in production. In the saas edition an empty
-        # WIDGET_ORIGIN_ALLOWLIST is a boot error (locked decision: boot-abort,
-        # matching the F004 and Clerk edition guards). The local edition keeps
-        # the permissive dev default — choosing AUTH_EDITION=local IS the
-        # explicit opt-in.
-        if self.IS_SAAS_EDITION and not (self.WIDGET_ORIGIN_ALLOWLIST or "").strip():
-            errors.append(
-                "WIDGET_ORIGIN_ALLOWLIST is unset in the saas edition — widget "
-                "CORS (/api/widgets, /api/sites) would allow ALL origins on the "
-                "internet-facing plane (fail-open). Set WIDGET_ORIGIN_ALLOWLIST "
-                "to the comma-separated allowed storefront/dashboard origins, or "
-                "run AUTH_EDITION=local for a dev instance."
-            )
 
         if errors:
             raise RuntimeError(

--- a/orchestrator/config.py
+++ b/orchestrator/config.py
@@ -1453,33 +1453,33 @@ class Config:
     def validate_security(self) -> None:
         """PRD-172: fail-closed validation of tenant-isolation secrets.
 
-        Called from the hard-fail boot phase (``main._boot_phase_1_core``) so a
+        Called from ``lifespan`` — outside any swallowing ``run_stage`` — so a
         misconfigured multi-tenant secret turns a silent cross-tenant leak into a
         loud boot failure rather than shipping fail-open.
 
         Raises ``RuntimeError`` (which aborts boot) when:
 
-        - F004: ``SHOPIFY_INTERNAL_API_KEY`` is unset while the Shopify
-          provisioning surface is reachable — an empty key previously made
-          ``_verify_internal_key`` accept any ``Authorization`` header.
         - F005: S3 Vectors is enabled but ``S3_VECTORS_BUCKET`` is unset. (A
           shared bucket with no ``{workspace_id}`` placeholder is allowed —
           tenant isolation is enforced per-query by ``S3VectorsBackend.search()``
           (fail-closed on ``workspace_id``), not by the bucket layout.)
-        Widget CORS is deliberately NOT checked here. Storefront origins are
-        authorised from the per-key ``SdkApiKey.allowed_domains`` the merchant
-        already maintains — there is no global widget allowlist to validate.
-        See ``api/widgets/cors.py``.
+
+        Deliberately NOT checked here:
+
+        - Widget CORS. Storefront origins are authorised from the per-key
+          ``SdkApiKey.allowed_domains`` the merchant already maintains — there
+          is no global widget allowlist to validate. See ``api/widgets/cors.py``.
+        - ``SHOPIFY_INTERNAL_API_KEY`` (F004). The machine lanes it guards
+          (Shopify app-install provisioning, GDPR verticals) fail CLOSED at the
+          endpoint — ``_verify_internal_key`` returns 503 when the key is unset,
+          with no fail-open branch. In the current deployment model there IS no
+          Automatos-owned Shopify app: clients connect their own stores and all
+          merchant traffic authenticates with per-workspace widget keys, so the
+          key is intentionally absent and a boot-abort here would make every
+          saas boot fail for a surface that is correctly dark (2026-08-01
+          incident: exactly that, via #616).
         """
         errors: list[str] = []
-
-        # F004 — Shopify provisioning must not be fail-open.
-        if not (self.SHOPIFY_INTERNAL_API_KEY or "").strip():
-            errors.append(
-                "SHOPIFY_INTERNAL_API_KEY is unset — the Shopify provisioning "
-                "surface (/api/shopify/provision|connect|deactivate) would accept "
-                "any Authorization header (fail-open). Set SHOPIFY_INTERNAL_API_KEY."
-            )
 
         # F005 / PRD-186 S3 — vector-plane config integrity, extracted so CI
         # can pin the same rules the boot phase enforces (one assertion, no

--- a/orchestrator/main.py
+++ b/orchestrator/main.py
@@ -510,12 +510,15 @@ async def lifespan(app: FastAPI):
     logger.info("Starting Automotas AI API Server...")
     app.state.ready = False
 
-    # PRD-172 F004/F005 + PRD-186 S3: fail-closed on tenant-isolation secrets
-    # and vector-plane config integrity BEFORE any traffic is served. Raises
-    # RuntimeError (aborting boot) if the Shopify internal key is unset, or
+    # PRD-172 F005 + PRD-186 S3: fail-closed on vector-plane config integrity
+    # BEFORE any traffic is served. Raises RuntimeError (aborting boot) if
     # S3 Vectors is enabled without a bucket or with an incoherent dimension.
     # (A shared bucket with no {workspace_id} placeholder is valid — isolation
-    # is enforced per-query, fail-closed, by S3VectorsBackend.search().)
+    # is enforced per-query, fail-closed, by S3VectorsBackend.search(). The
+    # Shopify/GDPR machine-lane key is NOT a boot concern: those endpoints
+    # fail closed on their own — _verify_internal_key → 503 when unset — and
+    # the key is intentionally absent while there is no Automatos-owned
+    # Shopify app. Demanding it at boot was the #616 outage.)
     #
     # This MUST stay outside run_stage. It used to live in _boot_phase_1_core,
     # which run_stage wraps in `except Exception` — recording the stage as

--- a/orchestrator/main.py
+++ b/orchestrator/main.py
@@ -173,15 +173,6 @@ async def _boot_phase_1_core():
     from core.database.database import create_tables, get_db_session, engine
     from core.database.boot_lock import boot_leader_lock
 
-    # PRD-172 F004/F005 + PRD-186 S3: fail-closed on tenant-isolation secrets
-    # and vector-plane config integrity BEFORE any traffic is served — outside
-    # any swallowing run_stage. Raises RuntimeError (aborting boot) if the
-    # Shopify internal key is unset, S3 Vectors is enabled without a bucket or
-    # with an incoherent dimension, or saas widget CORS would rest allow-all.
-    # (A shared bucket with no {workspace_id} placeholder is valid — isolation
-    # is enforced per-query, fail-closed, by S3VectorsBackend.search().)
-    config.validate_security()
-
     # DDL — safe for all workers (idempotent, fast no-op when tables exist)
     create_tables()
 
@@ -518,6 +509,23 @@ async def lifespan(app: FastAPI):
 
     logger.info("Starting Automotas AI API Server...")
     app.state.ready = False
+
+    # PRD-172 F004/F005 + PRD-186 S3: fail-closed on tenant-isolation secrets
+    # and vector-plane config integrity BEFORE any traffic is served. Raises
+    # RuntimeError (aborting boot) if the Shopify internal key is unset, or
+    # S3 Vectors is enabled without a bucket or with an incoherent dimension.
+    # (A shared bucket with no {workspace_id} placeholder is valid — isolation
+    # is enforced per-query, fail-closed, by S3VectorsBackend.search().)
+    #
+    # This MUST stay outside run_stage. It used to live in _boot_phase_1_core,
+    # which run_stage wraps in `except Exception` — recording the stage as
+    # failed, logging a warning, and letting boot continue. The guard landed
+    # 2026-07-11; that wrapper predates it by two months, so it had never once
+    # aborted a boot. Production served traffic with the exact config it was
+    # written to reject, and everything after the raise in _boot_phase_1_core
+    # (create_tables, the idempotent column migrations) was skipped on every
+    # boot. A fail-closed guard that serves traffic anyway is not a guard.
+    config.validate_security()
 
     try:
         # ── Phase 1: Core Infrastructure ──

--- a/orchestrator/tests/security/test_prd172_tenant_isolation.py
+++ b/orchestrator/tests/security/test_prd172_tenant_isolation.py
@@ -229,23 +229,28 @@ class TestF003ShopifySyncScope:
 # ===========================================================================
 
 class TestF004ShopifyFailClosed:
-    """Unset SHOPIFY_INTERNAL_API_KEY must fail at boot; a falsy key can no
-    longer wave through an arbitrary Authorization header."""
+    """F004's property — no fail-open machine lane — lives at the ENDPOINT:
+    ``_verify_internal_key`` 503s when the key is unset and 401s a wrong
+    bearer. It is deliberately NOT a boot concern: the key is intentionally
+    absent in the no-Shopify-app deployment model (clients connect their own
+    stores; merchants use widget keys), and a boot-abort demanding it took
+    production down (#616, 2026-08-01)."""
 
-    def test_boot_fails_when_shopify_key_unset(self, monkeypatch):
+    def test_boot_passes_when_shopify_key_unset(self, monkeypatch):
         from config import Config
         cfg = Config()
         monkeypatch.setattr(cfg, "SHOPIFY_INTERNAL_API_KEY", "", raising=False)
         monkeypatch.setattr(cfg, "S3_VECTORS_ENABLED", False, raising=False)
-        with pytest.raises(RuntimeError, match="SHOPIFY_INTERNAL_API_KEY"):
-            cfg.validate_security()
+        cfg.validate_security()  # no raise — the endpoint 503 is the guard
 
-    def test_boot_passes_when_shopify_key_set(self, monkeypatch):
-        from config import Config
-        cfg = Config()
-        monkeypatch.setattr(cfg, "SHOPIFY_INTERNAL_API_KEY", "real-secret", raising=False)
-        monkeypatch.setattr(cfg, "S3_VECTORS_ENABLED", False, raising=False)
-        cfg.validate_security()  # no raise
+    def test_verify_internal_key_503s_when_unset(self, monkeypatch):
+        """Unset key ⇒ the machine lane is dark, not open."""
+        import api.shopify as sh
+        from fastapi import HTTPException
+        monkeypatch.setattr(sh.config, "SHOPIFY_INTERNAL_API_KEY", "", raising=False)
+        with pytest.raises(HTTPException) as ei:
+            sh._verify_internal_key("Bearer anything-at-all")
+        assert ei.value.status_code == 503
 
     def test_verify_internal_key_rejects_arbitrary_header(self, monkeypatch):
         import api.shopify as sh
@@ -338,7 +343,6 @@ class TestF005VectorIsolation:
         # working shared-bucket deployment on 2026-07-02.
         from config import Config
         cfg = Config()
-        monkeypatch.setattr(cfg, "SHOPIFY_INTERNAL_API_KEY", "x", raising=False)
         monkeypatch.setattr(cfg, "S3_VECTORS_ENABLED", True, raising=False)
         monkeypatch.setattr(cfg, "S3_VECTORS_BUCKET", "shared-no-placeholder", raising=False)
         monkeypatch.setattr(cfg, "validate_auth_edition", lambda: None, raising=False)

--- a/orchestrator/tests/security/test_prd172_tenant_isolation.py
+++ b/orchestrator/tests/security/test_prd172_tenant_isolation.py
@@ -245,9 +245,6 @@ class TestF004ShopifyFailClosed:
         cfg = Config()
         monkeypatch.setattr(cfg, "SHOPIFY_INTERNAL_API_KEY", "real-secret", raising=False)
         monkeypatch.setattr(cfg, "S3_VECTORS_ENABLED", False, raising=False)
-        # PRD-194 S4: saas boots also require a widget CORS allowlist —
-        # satisfied here so this test stays scoped to the Shopify guard.
-        monkeypatch.setattr(cfg, "WIDGET_ORIGIN_ALLOWLIST", "https://app.automatos.app", raising=False)
         cfg.validate_security()  # no raise
 
     def test_verify_internal_key_rejects_arbitrary_header(self, monkeypatch):
@@ -344,9 +341,6 @@ class TestF005VectorIsolation:
         monkeypatch.setattr(cfg, "SHOPIFY_INTERNAL_API_KEY", "x", raising=False)
         monkeypatch.setattr(cfg, "S3_VECTORS_ENABLED", True, raising=False)
         monkeypatch.setattr(cfg, "S3_VECTORS_BUCKET", "shared-no-placeholder", raising=False)
-        # PRD-194 S4: saas boots also require a widget CORS allowlist —
-        # satisfied here so this test stays scoped to the bucket layout.
-        monkeypatch.setattr(cfg, "WIDGET_ORIGIN_ALLOWLIST", "https://app.automatos.app", raising=False)
         monkeypatch.setattr(cfg, "validate_auth_edition", lambda: None, raising=False)
         cfg.validate_security()  # must not raise on the bucket layout
 

--- a/orchestrator/tests/test_p2w2_cors_boot_guard.py
+++ b/orchestrator/tests/test_p2w2_cors_boot_guard.py
@@ -103,7 +103,6 @@ def test_run_stage_still_swallows_which_is_why_placement_matters():
 @pytest.fixture()
 def _security_baseline(monkeypatch):
     """Satisfy every other validate_security check so one is isolated."""
-    monkeypatch.setattr(cfg, "SHOPIFY_INTERNAL_API_KEY", "test-internal-key")
     monkeypatch.setattr(cfg, "S3_VECTORS_ENABLED", False)
     monkeypatch.setattr(cfg, "CLERK_JWKS_URL", "https://x/.well-known/jwks.json")
     monkeypatch.setattr(cfg, "CLERK_SECRET_KEY", "sk_test")
@@ -111,13 +110,16 @@ def _security_baseline(monkeypatch):
     return monkeypatch
 
 
-def test_shopify_fail_open_still_aborts(_security_baseline):
-    """F004 is untouched by the widget-allowlist removal."""
+def test_saas_boot_requires_no_shopify_key(_security_baseline):
+    """There is no Automatos-owned Shopify app in this deployment model —
+    clients connect their own stores and merchants authenticate with widget
+    keys, so SHOPIFY_INTERNAL_API_KEY is intentionally absent. The machine
+    lanes it guards fail CLOSED at the endpoint (_verify_internal_key → 503);
+    a boot-abort demanding the key made every saas boot fail (the #616
+    outage). A bare-env saas boot must pass this guard."""
     mp = _security_baseline
     mp.setattr(cfg, "SHOPIFY_INTERNAL_API_KEY", "")
-    with pytest.raises(RuntimeError) as ei:
-        cfg.validate_security()
-    assert "SHOPIFY_INTERNAL_API_KEY" in str(ei.value)
+    cfg.validate_security()  # must not raise
 
 
 def test_widget_cors_is_no_longer_a_boot_concern(_security_baseline):

--- a/orchestrator/tests/test_p2w2_cors_boot_guard.py
+++ b/orchestrator/tests/test_p2w2_cors_boot_guard.py
@@ -1,23 +1,36 @@
-"""PRD-194 S4 (P2-13, security §1.2.b) — widget CORS empty-allowlist boot guard.
+"""The security boot guard must actually abort a boot, and widget CORS must
+fail closed for origins nobody named.
 
-``api/widgets/cors.py`` allowed ALL origins when ``WIDGET_ORIGIN_ALLOWLIST``
-was unset — which is the default — and nothing enforced the docstring's "in
-production the env var should always be set". These tests pin the locked
-decision: **a saas boot with an empty widget allowlist ABORTS** (added to
-``config.validate_security``, the same hard-fail boot phase and posture as
-the ``SHOPIFY_INTERNAL_API_KEY`` and Clerk edition guards), while the
-``local`` edition keeps the permissive dev default — choosing
-``AUTH_EDITION=local`` is the explicit opt-in. Belt-and-braces: if the
-empty-allowlist state is ever reached in saas anyway, ``_origin_allowed``
-fails CLOSED instead of allow-all.
+History. PRD-194 S4 added a guard that aborted a saas boot when
+``WIDGET_ORIGIN_ALLOWLIST`` was empty. Two things were wrong with it:
 
-Pure config-object tests — attributes are monkeypatched on the singleton
-(the established ``validate_*`` shape); no env reloads, no boot, no network.
+1. **It never ran.** ``config.validate_security()`` was called inside
+   ``_boot_phase_1_core``, which ``run_stage`` wraps in ``except Exception``
+   — the stage is recorded failed, a warning is logged, and boot continues.
+   The guard landed 2026-07-11; that wrapper predates it by two months, so it
+   had never once aborted a boot. Production served traffic with the exact
+   config the guard was written to reject, and everything after the raise in
+   ``_boot_phase_1_core`` (``create_tables``, the idempotent column
+   migrations) was skipped on every boot.
+
+2. **It guarded the wrong thing.** ``WIDGET_ORIGIN_ALLOWLIST`` was OR'd with
+   the per-key ``SdkApiKey.allowed_domains`` lookup, so it could only ever
+   WIDEN access beyond what a key permitted — no defence in depth, and a
+   second place to forget that threw a 403 reading as a key problem. The var
+   is deleted; merchant origins resolve from the key, first-party origins
+   from ``config.CORS_ALLOW_ORIGINS``.
+
+These tests pin both: the guard is reachable, and the plane fails closed.
+
+Pure tests — static AST read of main.py, plus config-object and pure-function
+checks. No boot, no DB, no network.
 """
 
 from __future__ import annotations
 
+import ast
 import os
+from pathlib import Path
 
 os.environ.setdefault("POSTGRES_USER", "test")
 os.environ.setdefault("POSTGRES_PASSWORD", "test")
@@ -33,11 +46,63 @@ _conftest._restore_real_app_modules()
 
 from config import config as cfg  # noqa: E402
 
+_MAIN_PY = Path(__file__).resolve().parent.parent / "main.py"
+
+
+# ---------------------------------------------------------------------------
+# The guard must be reachable — not wrapped in a swallowing run_stage
+# ---------------------------------------------------------------------------
+
+def _calls_validate_security(func_name: str) -> bool:
+    """True if the named top-level function calls config.validate_security()."""
+    tree = ast.parse(_MAIN_PY.read_text(encoding="utf-8"))
+    for node in tree.body:
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if node.name != func_name:
+            continue
+        return any(
+            isinstance(call.func, ast.Attribute)
+            and call.func.attr == "validate_security"
+            for call in ast.walk(node)
+            if isinstance(call, ast.Call)
+        )
+    raise AssertionError(f"{func_name} not found in main.py")
+
+
+def test_lifespan_calls_validate_security_directly():
+    """It must run in lifespan, where a raise aborts the boot."""
+    assert _calls_validate_security("lifespan") is True
+
+
+def test_boot_phase_1_core_does_not_call_validate_security():
+    """The regression guard. _boot_phase_1_core runs inside
+    run_stage(...), which swallows every exception — a fail-closed check in
+    there logs a warning and lets the server serve traffic anyway."""
+    assert _calls_validate_security("_boot_phase_1_core") is False
+
+
+def test_run_stage_still_swallows_which_is_why_placement_matters():
+    """Documents the mechanism the tests above defend against. run_stage is
+    deliberately forgiving (a failed extension must not stop boot) — that is
+    exactly why a hard security guard cannot live inside one."""
+    import inspect
+
+    from core.models.bootstrap import run_stage
+
+    src = inspect.getsource(run_stage)
+    assert "except Exception" in src
+    # No bare re-raise of the captured stage exception.
+    assert "raise" not in src.split("except Exception")[1]
+
+
+# ---------------------------------------------------------------------------
+# validate_security still enforces the checks it kept
+# ---------------------------------------------------------------------------
 
 @pytest.fixture()
 def _security_baseline(monkeypatch):
-    """Satisfy every OTHER validate_security check so the widget-allowlist
-    guard is the only variable under test."""
+    """Satisfy every other validate_security check so one is isolated."""
     monkeypatch.setattr(cfg, "SHOPIFY_INTERNAL_API_KEY", "test-internal-key")
     monkeypatch.setattr(cfg, "S3_VECTORS_ENABLED", False)
     monkeypatch.setattr(cfg, "CLERK_JWKS_URL", "https://x/.well-known/jwks.json")
@@ -46,73 +111,45 @@ def _security_baseline(monkeypatch):
     return monkeypatch
 
 
-def test_saas_empty_widget_allowlist_aborts_boot(_security_baseline):
-    """AUTH_EDITION=saas + empty WIDGET_ORIGIN_ALLOWLIST ⇒ RuntimeError
-    (boot abort) — the public plane must never rest at allow-all in prod."""
+def test_shopify_fail_open_still_aborts(_security_baseline):
+    """F004 is untouched by the widget-allowlist removal."""
     mp = _security_baseline
-    mp.setattr(cfg, "AUTH_EDITION", "saas")
-    mp.setattr(cfg, "WIDGET_ORIGIN_ALLOWLIST", "")
+    mp.setattr(cfg, "SHOPIFY_INTERNAL_API_KEY", "")
     with pytest.raises(RuntimeError) as ei:
         cfg.validate_security()
-    assert "WIDGET_ORIGIN_ALLOWLIST" in str(ei.value)
+    assert "SHOPIFY_INTERNAL_API_KEY" in str(ei.value)
 
 
-def test_saas_whitespace_allowlist_also_aborts(_security_baseline):
-    """A whitespace-only value is still 'unset' — no accidental pass."""
+def test_widget_cors_is_no_longer_a_boot_concern(_security_baseline):
+    """No global widget allowlist exists, so boot has nothing to validate —
+    a saas boot with no widget env config must succeed."""
     mp = _security_baseline
     mp.setattr(cfg, "AUTH_EDITION", "saas")
-    mp.setattr(cfg, "WIDGET_ORIGIN_ALLOWLIST", "   ")
-    with pytest.raises(RuntimeError):
-        cfg.validate_security()
-
-
-def test_saas_with_allowlist_boots(_security_baseline):
-    mp = _security_baseline
-    mp.setattr(cfg, "AUTH_EDITION", "saas")
-    mp.setattr(
-        cfg, "WIDGET_ORIGIN_ALLOWLIST",
-        "https://inbuilduk.myshopify.com,https://app.automatos.app",
-    )
     cfg.validate_security()  # must not raise
 
-
-def test_local_empty_allowlist_permitted(_security_baseline):
-    """The local edition keeps the permissive dev default — an empty
-    allowlist must NOT abort a local boot."""
-    mp = _security_baseline
-    mp.setattr(cfg, "AUTH_EDITION", "local")
-    mp.setattr(cfg, "WIDGET_ORIGIN_ALLOWLIST", "")
-    cfg.validate_security()  # must not raise
-
-
-# ---------------------------------------------------------------- runtime belt
-
-def test_cors_empty_allowlist_denies_in_saas(monkeypatch):
-    """If the empty-allowlist state is ever reached in saas (guard bypassed),
-    _origin_allowed fails CLOSED — never allow-all in production."""
-    import api.widgets.cors as cors_mod
-
-    monkeypatch.setattr(cors_mod, "WIDGET_ORIGIN_ALLOWLIST", set())
-    monkeypatch.setattr(cors_mod.config, "AUTH_EDITION", "saas")
-    assert cors_mod._origin_allowed("https://any-store.example") is False
-
-
-def test_cors_empty_allowlist_permits_in_local(monkeypatch):
-    import api.widgets.cors as cors_mod
-
-    monkeypatch.setattr(cors_mod, "WIDGET_ORIGIN_ALLOWLIST", set())
-    monkeypatch.setattr(cors_mod.config, "AUTH_EDITION", "local")
-    assert cors_mod._origin_allowed("https://any-store.example") is True
-
-
-def test_cors_configured_allowlist_still_authoritative(monkeypatch):
-    """A configured allowlist behaves identically in both editions."""
-    import api.widgets.cors as cors_mod
-
-    monkeypatch.setattr(
-        cors_mod, "WIDGET_ORIGIN_ALLOWLIST", {"https://app.automatos.app"}
+    assert not hasattr(cfg, "WIDGET_ORIGIN_ALLOWLIST"), (
+        "WIDGET_ORIGIN_ALLOWLIST is deleted — a merchant origin belongs on "
+        "the merchant's key, not in a global env var"
     )
-    for edition in ("saas", "local"):
-        monkeypatch.setattr(cors_mod.config, "AUTH_EDITION", edition)
-        assert cors_mod._origin_allowed("https://app.automatos.app") is True
-        assert cors_mod._origin_allowed("https://evil.example") is False
+
+
+# ---------------------------------------------------------------------------
+# Runtime: the plane fails closed
+# ---------------------------------------------------------------------------
+
+def test_unknown_origin_denied_when_no_platform_origins(monkeypatch):
+    """Empty platform origins is not allow-all. It denies."""
+    import api.widgets.cors as cors_mod
+
+    monkeypatch.setattr(cors_mod, "PLATFORM_ORIGINS", set())
+    assert cors_mod._origin_is_platform("https://any-store.example") is False
+
+
+def test_platform_origin_matching_is_exact(monkeypatch):
+    """No suffix/substring matching — evil-automatos.app is not automatos.app."""
+    import api.widgets.cors as cors_mod
+
+    monkeypatch.setattr(cors_mod, "PLATFORM_ORIGINS", {"https://automatos.app"})
+    assert cors_mod._origin_is_platform("https://automatos.app") is True
+    assert cors_mod._origin_is_platform("https://evil-automatos.app") is False
+    assert cors_mod._origin_is_platform("https://automatos.app.evil.com") is False

--- a/orchestrator/tests/test_prd008a_cors_coverage.py
+++ b/orchestrator/tests/test_prd008a_cors_coverage.py
@@ -58,39 +58,19 @@ def test_path_is_covered_excludes_unrelated_paths():
     assert _path_is_covered("/api/some-other-resource/sites") is False
 
 
-def test_origin_allowed_when_no_allowlist_configured(monkeypatch):
-    """Empty allowlist → permissive ONLY in the local edition (PRD-194 S4 /
-    P2-13). In saas the boot guard forbids the state; if reached anyway the
-    public plane fails CLOSED."""
-    from api.widgets.cors import _origin_allowed
+def test_platform_origins_are_our_own_domains_only(monkeypatch):
+    """First-party origins come from config.CORS_ALLOW_ORIGINS — the same list
+    the app-wide CORSMiddleware uses. A merchant storefront is NOT in it; it is
+    authorised from its key instead."""
     import api.widgets.cors as cors_mod
 
-    monkeypatch.setattr(cors_mod, "WIDGET_ORIGIN_ALLOWLIST", set())
-
-    monkeypatch.setattr(cors_mod.config, "AUTH_EDITION", "local")
-    assert _origin_allowed("https://random-store.myshopify.com") is True
-    assert _origin_allowed("https://app.automatos.app") is True
-
-    monkeypatch.setattr(cors_mod.config, "AUTH_EDITION", "saas")
-    assert _origin_allowed("https://random-store.myshopify.com") is False
-    assert _origin_allowed("https://app.automatos.app") is False
-
-
-def test_origin_allowed_with_explicit_allowlist():
-    from api.widgets.cors import _origin_allowed
-    import api.widgets.cors as cors_mod
-
-    original = cors_mod.WIDGET_ORIGIN_ALLOWLIST
-    cors_mod.WIDGET_ORIGIN_ALLOWLIST = {
-        "https://app.automatos.app",
-        "https://besafe-ltd.myshopify.com",
-    }
-    try:
-        assert _origin_allowed("https://app.automatos.app") is True
-        assert _origin_allowed("https://besafe-ltd.myshopify.com") is True
-        assert _origin_allowed("https://malicious.example.com") is False
-    finally:
-        cors_mod.WIDGET_ORIGIN_ALLOWLIST = original
+    monkeypatch.setattr(
+        cors_mod, "PLATFORM_ORIGINS", {"https://app.automatos.app", "https://automatos.app"}
+    )
+    assert cors_mod._origin_is_platform("https://app.automatos.app") is True
+    assert cors_mod._origin_is_platform("https://automatos.app/") is True  # trailing slash
+    assert cors_mod._origin_is_platform("https://besafe-ltd.myshopify.com") is False
+    assert cors_mod._origin_is_platform("https://malicious.example.com") is False
 
 
 # ---------------------------------------------------------------------------
@@ -101,41 +81,70 @@ import asyncio  # noqa: E402
 from types import SimpleNamespace  # noqa: E402
 
 
+WIDGET_PATH = "/api/widgets/config"
+SITES_PATH = "/api/sites/123/settings"
+
+
 def _isolated_dynamic(monkeypatch):
-    """Fresh cache + saas edition + an env allowlist that misses the origin,
-    so every test exercises the fallback path deliberately."""
+    """Fresh cache + a platform-origin set that misses the storefront, so every
+    test exercises the merchant-key path deliberately."""
     import api.widgets.cors as cors_mod
 
     monkeypatch.setattr(cors_mod, "_dynamic_origin_cache", {})
-    monkeypatch.setattr(cors_mod, "WIDGET_ORIGIN_ALLOWLIST", {"https://app.automatos.app"})
-    monkeypatch.setattr(cors_mod.config, "AUTH_EDITION", "saas")
+    monkeypatch.setattr(cors_mod, "PLATFORM_ORIGINS", {"https://app.automatos.app"})
     return cors_mod
 
 
-def test_preflight_falls_back_to_key_allowlist(monkeypatch):
-    """An origin absent from the env allowlist but named on an active public
-    key's allowed_domains passes the dynamic check (the academy case)."""
+def test_preflight_resolves_from_key_allowlist(monkeypatch):
+    """A storefront origin named on an active public key's allowed_domains
+    passes — this is the ONLY way a merchant origin is authorised."""
     cors_mod = _isolated_dynamic(monkeypatch)
     monkeypatch.setattr(cors_mod, "_origin_allowed_by_key_sync", lambda origin: True)
 
-    assert asyncio.run(cors_mod._origin_allowed_dynamic("https://academy.automatos.app")) is True
+    assert asyncio.run(
+        cors_mod._origin_allowed_dynamic("https://academy.automatos.app", WIDGET_PATH)
+    ) is True
 
 
 def test_key_fallback_denies_unknown_origin(monkeypatch):
     cors_mod = _isolated_dynamic(monkeypatch)
     monkeypatch.setattr(cors_mod, "_origin_allowed_by_key_sync", lambda origin: False)
 
-    assert asyncio.run(cors_mod._origin_allowed_dynamic("https://malicious.example.com")) is False
+    assert asyncio.run(
+        cors_mod._origin_allowed_dynamic("https://malicious.example.com", WIDGET_PATH)
+    ) is False
 
 
-def test_env_fast_path_skips_the_db(monkeypatch):
+def test_platform_fast_path_skips_the_db(monkeypatch):
     cors_mod = _isolated_dynamic(monkeypatch)
 
     def _boom(origin):
-        raise AssertionError("DB lookup must not run for env-allowlisted origins")
+        raise AssertionError("DB lookup must not run for platform origins")
 
     monkeypatch.setattr(cors_mod, "_origin_allowed_by_key_sync", _boom)
-    assert asyncio.run(cors_mod._origin_allowed_dynamic("https://app.automatos.app")) is True
+    assert asyncio.run(
+        cors_mod._origin_allowed_dynamic("https://app.automatos.app", WIDGET_PATH)
+    ) is True
+
+
+def test_sites_never_consults_merchant_keys(monkeypatch):
+    """/api/sites is first-party dashboard CRUD. If a merchant could authorise
+    that origin by naming it on their own key, any merchant could open CORS on
+    the admin surface."""
+    cors_mod = _isolated_dynamic(monkeypatch)
+
+    def _boom(origin):
+        raise AssertionError("/api/sites must never reach the key lookup")
+
+    monkeypatch.setattr(cors_mod, "_origin_allowed_by_key_sync", _boom)
+
+    assert asyncio.run(
+        cors_mod._origin_allowed_dynamic("https://besafe-ltd.myshopify.com", SITES_PATH)
+    ) is False
+    # ...but our own dashboard still gets through.
+    assert asyncio.run(
+        cors_mod._origin_allowed_dynamic("https://app.automatos.app", SITES_PATH)
+    ) is True
 
 
 def test_key_fallback_verdict_is_cached(monkeypatch):
@@ -148,8 +157,12 @@ def test_key_fallback_verdict_is_cached(monkeypatch):
         return True
 
     monkeypatch.setattr(cors_mod, "_origin_allowed_by_key_sync", _count)
-    assert asyncio.run(cors_mod._origin_allowed_dynamic("https://academy.automatos.app")) is True
-    assert asyncio.run(cors_mod._origin_allowed_dynamic("https://academy.automatos.app")) is True
+    assert asyncio.run(
+        cors_mod._origin_allowed_dynamic("https://academy.automatos.app", WIDGET_PATH)
+    ) is True
+    assert asyncio.run(
+        cors_mod._origin_allowed_dynamic("https://academy.automatos.app", WIDGET_PATH)
+    ) is True
     assert len(calls) == 1
 
 
@@ -162,10 +175,14 @@ def test_key_fallback_fails_closed_and_does_not_cache_failures(monkeypatch):
         raise RuntimeError("db unavailable")
 
     monkeypatch.setattr(cors_mod, "_origin_allowed_by_key_sync", _down)
-    assert asyncio.run(cors_mod._origin_allowed_dynamic("https://academy.automatos.app")) is False
+    assert asyncio.run(
+        cors_mod._origin_allowed_dynamic("https://academy.automatos.app", WIDGET_PATH)
+    ) is False
 
     monkeypatch.setattr(cors_mod, "_origin_allowed_by_key_sync", lambda origin: True)
-    assert asyncio.run(cors_mod._origin_allowed_dynamic("https://academy.automatos.app")) is True
+    assert asyncio.run(
+        cors_mod._origin_allowed_dynamic("https://academy.automatos.app", WIDGET_PATH)
+    ) is True
 
 
 def test_origin_allowed_by_any_key_uses_check_domain_matcher():

--- a/orchestrator/tests/test_prd186_s3_hardening.py
+++ b/orchestrator/tests/test_prd186_s3_hardening.py
@@ -219,7 +219,6 @@ def test_boot_aborts_on_bad_vector_config(monkeypatch):
     """validate_security (the hard-fail boot phase, main.py — OUTSIDE any
     swallowing run_stage) carries the vector-integrity failure."""
     _vector_config(monkeypatch, enabled=True, bucket="")
-    monkeypatch.setattr(app_config, "SHOPIFY_INTERNAL_API_KEY", "k", raising=False)
     with pytest.raises(RuntimeError, match="S3_VECTORS_BUCKET"):
         app_config.validate_security()
 

--- a/orchestrator/tests/test_prd186_s3_hardening.py
+++ b/orchestrator/tests/test_prd186_s3_hardening.py
@@ -220,7 +220,6 @@ def test_boot_aborts_on_bad_vector_config(monkeypatch):
     swallowing run_stage) carries the vector-integrity failure."""
     _vector_config(monkeypatch, enabled=True, bucket="")
     monkeypatch.setattr(app_config, "SHOPIFY_INTERNAL_API_KEY", "k", raising=False)
-    monkeypatch.setattr(app_config, "WIDGET_ORIGIN_ALLOWLIST", "https://x.example", raising=False)
     with pytest.raises(RuntimeError, match="S3_VECTORS_BUCKET"):
         app_config.validate_security()
 


### PR DESCRIPTION
## What this is

Two commits, one decision each:

1. **Reapply #616** (revert of #617's revert): `WIDGET_ORIGIN_ALLOWLIST` deleted — storefront origins resolve from per-key `SdkApiKey.allowed_domains`, `/api/sites` from platform `CORS_ALLOW_ORIGINS`, `/api/sites` never consults merchant keys — and `validate_security()` hoisted out of the swallowing `run_stage` so it actually aborts a bad boot. Also closes the admin-surface CORS scope finding the revert reinstated.

2. **Drop the F004 boot-abort clause.** There is no Automatos-owned Shopify app in this deployment model: clients connect their own stores, and all merchant traffic authenticates with per-workspace widget keys. `SHOPIFY_INTERNAL_API_KEY` exists only for the app-install handshake of a wedge that is not deployed — intentionally absent, permanently. F004's *property* (no fail-open machine lane) stays where it actually lives: `_verify_internal_key` **503s when the key is unset** and 401s a wrong bearer — covering both Shopify provisioning and the GDPR verticals lanes. The boot clause demanding the key is what took production down on 2026-07-31.

## Why this boots clean — verified against the live env, full list this time

The current production boot's `validate_security` failure names **exactly two bullets** (pulled from today's 17:28 boot log, continuation lines included):

```
- SHOPIFY_INTERNAL_API_KEY is unset — ...   ← clause removed by commit 2
- WIDGET_ORIGIN_ALLOWLIST is unset — ...    ← var deleted by commit 1
```

Nothing else fails. The hoisted guard passes against today's environment with **zero new variables to set**. (The 07-31 outage happened because I armed the guard having read only the first line of that error list; this PR exists because the full list has now been read.)

Side effect worth having: `database_init` stops failing at `validate_security`, so `create_tables()` and the idempotent column migrations run at boot again — they have been silently skipped on every boot to date.

## Test changes (commit 2)

- `test_saas_boot_requires_no_shopify_key` — bare-env saas boot passes the guard (replaces the abort assertion)
- `test_verify_internal_key_503s_when_unset` — unset key ⇒ machine lane dark, not open
- kept: wrong bearer ⇒ 401, correct key ⇒ pass, AST placement pins (`lifespan` yes / `_boot_phase_1_core` no)
- dead `SHOPIFY_INTERNAL_API_KEY` baselines removed from the S3/shared-bucket boot tests

Verified locally: byte-compile (6 files), import-linter 1 kept / 0 broken.

## Known CI condition

`orchestrator-tests` currently fails 4 tests on **main itself** (`test_prd170_exec_surface` + 3× `test_route_manifest`, `python -m scripts.dump_routes` → `No module named 'scripts'`) — identical trees were green 07-31 and red 08-01, so it's runner-environment drift, not content. This PR will inherit those 4 until that's fixed; being diagnosed separately.