### PR TITLE
fix: client can upload documents, delete them (vectors too), and approve gated actions

### DIFF
--- a/frontend/components/widgets/__tests__/registration-manifest.test.ts
+++ b/frontend/components/widgets/__tests__/registration-manifest.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Every built widget must be registered — the manifest cannot silently lag.
+ *
+ * Widgets self-register as an import side effect (`registerWidget(...Def)` at
+ * module scope), and `components/workspace/index.ts` is the hand-maintained
+ * manifest of those imports. PRD-163's MissionApprovalWidget and PRD-193's
+ * ToolApprovalWidget were built, tested, and exported — but never added to
+ * the manifest, so neither EVER rendered in production. The first
+ * confirmation-gated destructive action a client pushed through chat
+ * (delete agent, 2026-08-06) dead-ended on "Unknown widget type:
+ * tool_approval" instead of an Approve/Deny card.
+ *
+ * This test closes the class: it scans the widgets directory for every
+ * self-registering definition, imports ONLY the manifest (exactly what the
+ * app bundle does via the workspace components), and asserts every scanned
+ * type is registered. Building a widget without wiring it now fails CI.
+ */
+import { describe, it, expect } from 'vitest'
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// The manifest — the same side-effect imports the real app performs.
+import '@/components/workspace'
+
+import { isWidgetRegistered, getRegisteredTypes } from '../registry'
+
+const WIDGETS_DIR = join(dirname(fileURLToPath(import.meta.url)), '..')
+
+/** Scan components/widgets/*/index.tsx for self-registering definitions. */
+function scanSelfRegisteringTypes(): { type: string; module: string }[] {
+  const found: { type: string; module: string }[] = []
+  for (const entry of readdirSync(WIDGETS_DIR)) {
+    const indexPath = join(WIDGETS_DIR, entry, 'index.tsx')
+    try {
+      if (!statSync(join(WIDGETS_DIR, entry)).isDirectory()) continue
+      const src = readFileSync(indexPath, 'utf-8')
+      if (!src.includes('registerWidget(')) continue
+      const m = src.match(/type:\s*['"]([a-z0-9_]+)['"]/)
+      if (m) found.push({ type: m[1], module: entry })
+    } catch {
+      continue // no index.tsx — not a widget module
+    }
+  }
+  return found
+}
+
+describe('widget registration manifest', () => {
+  const scanned = scanSelfRegisteringTypes()
+
+  it('finds the widget definitions (sanity: scan is not empty)', () => {
+    expect(scanned.length).toBeGreaterThanOrEqual(10)
+  })
+
+  it.each(scanned)(
+    'importing the manifest registers $type ($module)',
+    ({ type, module }) => {
+      expect(
+        isWidgetRegistered(type as never),
+        `${module} self-registers '${type}' but components/workspace/index.ts ` +
+          `never imports it — the widget is built but can never render. ` +
+          `Registered: [${getRegisteredTypes().join(', ')}]`
+      ).toBe(true)
+    }
+  )
+
+  it('the approval cards specifically are registered (the 2026-08-06 regression)', () => {
+    expect(isWidgetRegistered('tool_approval' as never)).toBe(true)
+    expect(isWidgetRegistered('mission_approval' as never)).toBe(true)
+  })
+})

--- a/frontend/components/workspace/index.ts
+++ b/frontend/components/workspace/index.ts
@@ -16,6 +16,19 @@ import '@/components/widgets/MemoryWidget'
 import '@/components/widgets/FileWidget'
 // PRD-66: Coding Canvas Widget (workspace file browser + Monaco editor)
 import '@/components/widgets/CodingCanvasWidget'
+// PRD-163 S4: Mission plan approval card
+// PRD-193 S3: Tool-call approval card (confirmation-gated actions)
+//
+// Both cards self-register on import like every widget above — but neither
+// was ever added to this manifest, so neither had EVER rendered in
+// production: chat.tsx addWidget({type: 'tool_approval'}) hit the registry
+// with nothing registered and the user saw "Unknown widget type" instead of
+// Approve/Deny. First surfaced 2026-08-06 by the first confirmation-gated
+// destructive action a client pushed through chat (delete agent).
+// registration-manifest.test.ts now sweeps the widgets directory so a new
+// widget cannot be built-but-unregistered again.
+import '@/components/widgets/MissionApprovalWidget'
+import '@/components/widgets/ToolApprovalWidget'
 
 export { Canvas } from './Canvas'
 export { WidgetTray } from './WidgetTray'

--- a/orchestrator/api/activity.py
+++ b/orchestrator/api/activity.py
@@ -110,7 +110,7 @@ async def submit_digest_feedback(
         raise HTTPException(status_code=422, detail="rating must be -1 or 1")
     row = DigestFeedback(
         workspace_id=ctx.workspace_id,
-        user_id=ctx.clerk_user_id,
+        user_id=ctx.user.clerk_user_id if ctx.user else None,
         state_hash=body.state_hash,
         rating=body.rating,
     )

--- a/orchestrator/api/documents.py
+++ b/orchestrator/api/documents.py
@@ -860,11 +860,17 @@ async def delete_document(
                 os.remove(document.file_path)
             except Exception as e:
                 logger.warning(f"Could not delete file {document.file_path}: {e}")
-        
-        # Delete from database
-        db.delete(document)
-        db.commit()
-        
+
+        # Delegate the delete to the ingestion manager — it owns the §H
+        # contract "delete removes the vector": chunks + document row +
+        # the doc's S3 chunk-vectors (best-effort after commit). The bare
+        # ORM delete this replaced left the vectors in the per-workspace
+        # index, so a "deleted" document kept surfacing in RAG search.
+        # Workspace scoping stays HERE (the ownership check above) — the
+        # manager deletes by bare id and must never be reachable without it.
+        doc_manager = get_document_manager(str(ctx.workspace_id))
+        doc_manager.delete_document(document_id)
+
         return {"message": "Document deleted successfully"}
         
     except HTTPException:

--- a/orchestrator/api/documents.py
+++ b/orchestrator/api/documents.py
@@ -228,7 +228,10 @@ async def handle_request(
             tags=tag_list,
             description=description,
             team_access=team_access_list,
-            created_by=ctx.clerk_user_id or "system",  # PRD-168 S4: real actor
+            # PRD-168 S4: real actor. The principal lives on ctx.user —
+            # RequestContext itself has no clerk_user_id; reading it there
+            # raised AttributeError and 500'd every upload (2026-08-06).
+            created_by=(ctx.user.clerk_user_id if ctx.user else None) or "system",
         )
         
         db.add(document)

--- a/orchestrator/api/system.py
+++ b/orchestrator/api/system.py
@@ -217,7 +217,9 @@ async def create_rag_config(rag_data: RAGConfigCreate, ctx: RequestContext = Dep
             top_k=rag_data.top_k,
             similarity_threshold=rag_data.similarity_threshold,
             configuration=rag_data.configuration or {},
-            created_by=ctx.clerk_user_id or "system",  # PRD-168 S4: real actor
+            # PRD-168 S4: real actor — on ctx.user, not ctx (same 500 as the
+            # documents upload, fixed together).
+            created_by=(ctx.user.clerk_user_id if ctx.user else None) or "system",
         )
         
         db.add(rag_config)

--- a/orchestrator/tests/test_ctx_actor_attribute.py
+++ b/orchestrator/tests/test_ctx_actor_attribute.py
@@ -1,0 +1,63 @@
+"""The request principal lives on ``ctx.user`` — never on ``ctx`` itself.
+
+2026-08-06: ``POST /api/documents/upload`` 500'd for the Inbuild UK client
+with ``'RequestContext' object has no attribute 'clerk_user_id'``. PRD-168 S4
+(2026-06-12) threaded "real actor identity" through write paths as
+``ctx.clerk_user_id`` in three routes — but ``RequestContext`` has no such
+attribute; the principal is ``ctx.user.clerk_user_id`` (``UserContext``).
+Every request through those routes raised AttributeError from the day the
+commit landed.
+
+These tests pin both sides so the class of bug cannot return:
+
+1. A static sweep of ``api/`` for ``ctx.clerk_user_id`` — the exact broken
+   spelling — must find nothing.
+2. The dataclass contracts: ``RequestContext`` must NOT gain the attribute
+   (which would re-legalise the broken spelling and split the actor identity
+   across two homes), and ``UserContext`` must keep ``clerk_user_id``.
+
+Pure static/dataclass tests — no app boot, no DB.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import re
+import sys
+from pathlib import Path
+
+_orchestrator_root = Path(__file__).resolve().parent.parent
+if str(_orchestrator_root) not in sys.path:
+    sys.path.insert(0, str(_orchestrator_root))
+
+from core.auth.dependencies import RequestContext, UserContext  # noqa: E402
+
+# ``ctx.clerk_user_id`` / ``context.clerk_user_id`` — reading the principal
+# off the request context object instead of its ``.user``.
+_BROKEN_SPELLING = re.compile(r"\bctx\.clerk_user_id\b|\bcontext\.clerk_user_id\b")
+
+
+def test_no_route_reads_clerk_user_id_off_the_context():
+    offenders: list[str] = []
+    for py in sorted((_orchestrator_root / "api").rglob("*.py")):
+        text = py.read_text(encoding="utf-8", errors="replace")
+        for i, line in enumerate(text.splitlines(), 1):
+            if _BROKEN_SPELLING.search(line):
+                offenders.append(f"{py.relative_to(_orchestrator_root)}:{i}: {line.strip()}")
+    assert not offenders, (
+        "The principal lives on ctx.user, not ctx — these lines raise "
+        "AttributeError on every request:\n" + "\n".join(offenders)
+    )
+
+
+def test_request_context_has_no_clerk_user_id_field():
+    names = {f.name for f in dataclasses.fields(RequestContext)}
+    assert "clerk_user_id" not in names, (
+        "Adding clerk_user_id to RequestContext splits the actor identity "
+        "across two homes — it lives on UserContext"
+    )
+
+
+def test_user_context_keeps_clerk_user_id():
+    names = {f.name for f in dataclasses.fields(UserContext)}
+    assert "clerk_user_id" in names


### PR DESCRIPTION
## Live incident (Inbuild UK, 2026-08-06)

Client uploads a document, nothing appears. Backend, three attempts across the morning (ws `28a228aa…`):

```
09:03:17  api.documents ERROR  Error uploading document: 'RequestContext' object has no attribute 'clerk_user_id'
          POST /api/documents/upload → 500
09:13:33  same    09:17:07  same
```

## Root cause — broken since June 12

PRD-168 S4 (`e3f15db2a`) threaded "real actor identity" through write paths as `ctx.clerk_user_id`. `RequestContext` has no such attribute — the principal is **`ctx.user.clerk_user_id`** (`UserContext`, `dependencies.py:36`), the spelling every working route (`harness.py`, `board_tasks.py`) already uses. The route has raised AttributeError on every request since the commit landed; nothing merged since 08-01, and none of the recent PRs touch this path.

Same broken spelling, same commit, fixed together:

| Route | Line |
|---|---|
| `POST /api/documents/upload` | `documents.py:231` |
| `POST /api/system/rag` (create RAG config) | `system.py:220` |
| digest feedback (PRD-221 S10) | `activity.py:113` |

All three 500 on touch, deterministically.

## On "the client saw successful"

Traced and could not confirm a frontend defect: `api-client.uploadDocument` throws on `!response.ok`, and `useUploadDocument.onError` toasts *"Failed to upload document"*. The false "successful" did not come from this path — most likely Auto's chat reply or another surface. Reported as not-reproduced rather than fixed silently.

## Regression pin

`tests/test_ctx_actor_attribute.py` — static sweep of `api/` for the broken spelling must find nothing; `RequestContext` must not grow a `clerk_user_id` field (that would split the actor identity across two homes); `UserContext` must keep it.

Verified locally: byte-compile ×4, sweep clean, import-linter 1 kept / 0 broken.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed document uploads and RAG configuration creation failing for authenticated users.
  * Improved activity feedback handling when no authenticated user is available.
  * Added safe fallback attribution for system-generated actions.

* **Tests**
  * Added regression coverage to prevent invalid user identity access in request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->