### PR TITLE
fix(approvals): approve executes + the instruction is the approval for admin-directed actions

### DIFF
--- a/frontend/components/widgets/WidgetWrapper.tsx
+++ b/frontend/components/widgets/WidgetWrapper.tsx
@@ -63,7 +63,7 @@ export function WidgetWrapper({ widget, isActive }: WidgetWrapperProps) {
           title="Unknown Widget"
           icon={<AlertCircle className="h-4 w-4 text-destructive" />}
           isActive={isActive}
-          error={{ message: `Unknown widget type: ${widget.type}` }}
+          error={{ message: `This panel type isn't available in this build: ${widget.type}` }}
           onClose={handleClose}
           showDragHandle
         >

--- a/frontend/components/widgets/__tests__/registration-manifest.test.ts
+++ b/frontend/components/widgets/__tests__/registration-manifest.test.ts
@@ -27,7 +27,10 @@ import { isWidgetRegistered, getRegisteredTypes } from '../registry'
 
 const WIDGETS_DIR = join(dirname(fileURLToPath(import.meta.url)), '..')
 
-/** Scan components/widgets/*/index.tsx for self-registering definitions. */
+// Scan each widget folder's index.tsx for self-registering definitions.
+// (Line comment on purpose: the glob "star-slash" sequence inside a block
+// comment terminates it early — esbuild read the rest as code and the whole
+// suite failed at transform. See PR #621.)
 function scanSelfRegisteringTypes(): { type: string; module: string }[] {
   const found: { type: string; module: string }[] = []
   for (const entry of readdirSync(WIDGETS_DIR)) {

--- a/orchestrator/api/approval_grants.py
+++ b/orchestrator/api/approval_grants.py
@@ -114,8 +114,16 @@ async def grant_approval(
         raise HTTPException(status_code=422, detail=f"Grant is not pending (status: {grant.status})")
 
     grant_grant(grant, granted_by=_actor_ref(ctx))
+    # COMMIT THE YES BEFORE RESUMING (2026-08-06 incident, grant 77).
+    # SessionLocal runs autoflush=False, and the resume re-enters the
+    # confirmation gate, whose consume_tool_grant() runs real SQL — an
+    # uncommitted GRANTED row is still 'pending' to that query, so the gate
+    # re-asked and the human's approval executed nothing. Committing first
+    # makes the recorded yes visible to the gate AND durable even if the
+    # resume itself crashes; the follow-up commit persists executed_result.
+    db.commit()
     # PRD-193 S4: for tool_call subjects this re-dispatches the stored call
-    # (consume-then-execute inside this one transaction boundary).
+    # (consume-then-execute against the now-committed grant).
     await _requeue_subject(db, grant)
     db.commit()
     _audit(db, ctx, "approval_grant:granted", grant)

--- a/orchestrator/modules/tools/discovery/platform_executor.py
+++ b/orchestrator/modules/tools/discovery/platform_executor.py
@@ -324,6 +324,62 @@ _HIERARCHY_TARGETS: Dict[str, tuple[str, Optional[str]]] = {
 }
 
 
+def _workspace_role_for_clerk(db, workspace_id, clerk_user_id) -> Optional[str]:
+    """Resolve the driving user's workspace role, fresh, at the gate.
+
+    Keyed by the server-threaded clerk principal (``caller_context.user_id``)
+    — never by anything the model can write. Any failure returns ``None`` and
+    the caller falls closed to the ask.
+    """
+    try:
+        from core.models.core import User
+        from core.workspaces.models import WorkspaceMember
+
+        row = (
+            db.query(WorkspaceMember.role)
+            .join(User, User.id == WorkspaceMember.user_id)
+            .filter(
+                WorkspaceMember.workspace_id == workspace_id,
+                WorkspaceMember.is_active.is_(True),
+                User.clerk_user_id == str(clerk_user_id),
+            )
+            .first()
+        )
+        return str(row[0]).strip().lower() if row and row[0] else None
+    except Exception:
+        logger.warning(
+            "[PlatformExecutor] workspace-role resolve failed — falling closed to the ask",
+            exc_info=True,
+        )
+        return None
+
+
+def _human_directed_admin(db, workspace_id, caller_context) -> bool:
+    """The instruction IS the approval (Gerard, 2026-08-06).
+
+    The confirmation gate exists to stop the AGENT deciding to do something
+    destructive on its own — not to make a human repeat an instruction they
+    just gave. When the call originates from an interactive chat turn
+    (``conversation_id`` is server-threaded by build_tool_caller_context —
+    heartbeat/cadence/board/mission lanes never carry it) AND the driving
+    user holds owner/admin in this workspace (resolved fresh from
+    workspace_members, not from anything model-writable), the gate lets the
+    instructed action run and stamps ``human_directed`` for the audit trail.
+
+    Everything else — agent-initiated lanes, editors/viewers, a missing or
+    unresolvable principal, any lookup error — keeps the ask. The su tier is
+    untouched (its gate runs earlier and never consults this).
+    """
+    ctx = caller_context if isinstance(caller_context, dict) else {}
+    if not ctx.get("conversation_id"):
+        return False
+    clerk_id = ctx.get("user_id")
+    if not clerk_id or not isinstance(clerk_id, str):
+        return False
+    role = _workspace_role_for_clerk(db, workspace_id, clerk_id)
+    return role in ("owner", "admin")
+
+
 class PlatformActionExecutor:
     """
     Executes platform actions using direct database queries.
@@ -681,6 +737,7 @@ class PlatformActionExecutor:
         # grant-authorised — distinct from the full-autonomy dial skipping
         # the gate.
         approved_via_grant_id: Optional[int] = None
+        human_directed: bool = False
 
         # Permission check for write/destructive actions (fail-closed)
         try:
@@ -752,7 +809,29 @@ class PlatformActionExecutor:
                         ),
                     }
 
-            if action_def and action_def.requires_confirmation and not full_autonomy:
+            # 2026-08-06 (Gerard): a destructive/write action INSTRUCTED by a
+            # workspace owner/admin in an interactive chat turn does not ask
+            # again — the instruction is the approval. Agent-initiated lanes
+            # (heartbeat / cadence / board / mission) still get the card.
+            human_directed = bool(
+                action_def
+                and action_def.requires_confirmation
+                and not full_autonomy
+                and _human_directed_admin(self.db, self.workspace_id, caller_context)
+            )
+            if human_directed:
+                logger.info(
+                    "[PlatformExecutor] '%s' human-directed — instructing "
+                    "workspace admin's request is the approval (workspace=%s)",
+                    action_name, self.workspace_id,
+                )
+
+            if (
+                action_def
+                and action_def.requires_confirmation
+                and not full_autonomy
+                and not human_directed
+            ):
                 # PRD-193 S1/S2 (P2-12): the ask is no longer a dead end.
                 # S2 — consult FIRST: an authorising grant on this exact
                 # subject key (GRANTED + unexpired + params-hash equality)
@@ -1093,6 +1172,11 @@ class PlatformActionExecutor:
             # autonomous.
             if approved_via_grant_id is not None and isinstance(result, dict):
                 result = {**result, "approved_via_grant_id": approved_via_grant_id}
+            # 2026-08-06: executed because the instructing human admin's
+            # interactive request IS the approval — distinct from both the
+            # dial-skip (autonomous) and a card-approved grant.
+            if human_directed and isinstance(result, dict):
+                result = {**result, "human_directed": True}
             return result
         except Exception as e:
             logger.error(f"[PlatformExecutor] {action_name} failed: {e}", exc_info=True)

--- a/orchestrator/modules/tools/execution/telemetry.py
+++ b/orchestrator/modules/tools/execution/telemetry.py
@@ -161,6 +161,7 @@ async def write_telemetry(
                 ctx,
                 autonomous=result.get("autonomous") is True,
                 approved_via_grant_id=result.get("approved_via_grant_id"),
+                human_directed=result.get("human_directed") is True,
             ),
             intent_cluster_id=ctx.get("intent_cluster_id"),
             routing_source=ctx.get("routing_source"),
@@ -190,6 +191,7 @@ def _build_router_decision(
     ctx: Dict[str, Any],
     autonomous: bool = False,
     approved_via_grant_id: Optional[Any] = None,
+    human_directed: bool = False,
 ) -> Optional[Dict[str, Any]]:
     """Extract routing metadata from caller_context into router_decision JSONB."""
     decision = {}
@@ -202,6 +204,12 @@ def _build_router_decision(
         # approval grant — queryable and DISTINCT from the dial-skip marker
         # (router_decision->>'approved_via_grant_id').
         decision["approved_via_grant_id"] = approved_via_grant_id
+    if human_directed:
+        # 2026-08-06: executed because the instructing workspace admin's
+        # interactive request IS the approval — distinct from the dial-skip
+        # (autonomous) and from a card-approved grant
+        # (router_decision->>'human_directed').
+        decision["human_directed"] = True
     sel = ctx.get("selection_outcome")
     if isinstance(sel, dict) and sel:
         # PRD-143 S14: per-dispatch selection outcome (narrowed/hit/fallback)

--- a/orchestrator/tests/test_grant_approve_commit_ordering.py
+++ b/orchestrator/tests/test_grant_approve_commit_ordering.py
@@ -1,0 +1,74 @@
+"""The approval endpoint must commit the yes BEFORE resuming the call.
+
+2026-08-06 incident (grant 77, Inbuild UK): a human clicked Approve on a
+gated ``platform_delete_agent``; the resume re-dispatched the stored call;
+the confirmation gate re-asked; nothing executed. Root cause: SessionLocal
+is ``autoflush=False``. ``grant_grant`` mutates ``status`` only in the
+identity map, and the gate's ``consume_tool_grant`` → ``find_active_grant``
+runs REAL SQL — the database still said ``pending``, so the gate could not
+see the approval it was resuming under. Evidence: grant 77 sat GRANTED and
+unexpired with ``revoked_by`` empty — destructive consumes stamp
+``system:consumed``, so the gate provably never matched it.
+
+The existing S4 suite (test_p2w2_grant_resume.py) mocks the executor with a
+fake session, so the re-dispatch contract is pinned but the gate's SQL
+visibility is out of frame — which is exactly where this broke. This test
+pins the fix at the seam that failed: the endpoint's ordering. Same AST
+pattern as test_p2w2_cors_boot_guard's lifespan placement pin.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_API = Path(__file__).resolve().parent.parent / "api" / "approval_grants.py"
+
+
+def _grant_approval_call_order() -> list[str]:
+    """The ordered relevant calls inside grant_approval, by name."""
+    tree = ast.parse(_API.read_text(encoding="utf-8"))
+    fn = next(
+        node
+        for node in tree.body
+        if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef))
+        and node.name == "grant_approval"
+    )
+    interesting = {"grant_grant", "_requeue_subject", "commit"}
+    order: list[str] = []
+    for call in ast.walk(fn):
+        if not isinstance(call, ast.Call):
+            continue
+        name = None
+        if isinstance(call.func, ast.Name):
+            name = call.func.id
+        elif isinstance(call.func, ast.Attribute):
+            name = call.func.attr
+        if name in interesting:
+            order.append((call.lineno, name))  # type: ignore[arg-type]
+    return [n for _, n in sorted(order)]  # type: ignore[misc]
+
+
+def test_approval_is_committed_before_the_resume():
+    order = _grant_approval_call_order()
+    assert "grant_grant" in order and "_requeue_subject" in order, order
+
+    grant_i = order.index("grant_grant")
+    resume_i = order.index("_requeue_subject")
+    assert grant_i < resume_i, f"approve must precede resume: {order}"
+
+    between = order[grant_i + 1 : resume_i]
+    assert "commit" in between, (
+        "grant_approval must db.commit() between grant_grant and "
+        "_requeue_subject — with autoflush=False the gate's SQL cannot see "
+        f"an uncommitted GRANTED row and re-asks (grant 77). Order: {order}"
+    )
+
+
+def test_executed_result_still_persisted_after_resume():
+    """The follow-up commit (executed_result + audit path) must survive."""
+    order = _grant_approval_call_order()
+    resume_i = order.index("_requeue_subject")
+    assert "commit" in order[resume_i + 1 :], (
+        f"executed_result must be committed after the resume. Order: {order}"
+    )

--- a/orchestrator/tests/test_human_directed_gate.py
+++ b/orchestrator/tests/test_human_directed_gate.py
@@ -1,0 +1,135 @@
+"""The instruction is the approval — human-directed admin turns skip the ask.
+
+Gerard, 2026-08-06, after 12 approval cards for one "delete the agents":
+the confirmation gate exists to stop the AGENT deciding to do something
+destructive on its own — not to make a workspace admin repeat an instruction
+they just gave in chat. The gate now lets a confirmation-gated action run
+when the call is human-directed:
+
+    interactive chat lane      (server-threaded conversation_id — heartbeat/
+                                cadence/board/mission lanes never carry one)
+  AND driving user resolves to owner/admin in workspace_members
+                               (fresh DB lookup keyed by the server-threaded
+                                clerk principal — nothing model-writable)
+
+Everything else keeps the ask, and every failure falls closed to the ask.
+The execution is stamped ``human_directed`` — a third, distinct audit
+marker beside ``autonomous`` (dial-skip) and ``approved_via_grant_id``
+(card-approved grant). Attribution must be honest: instructed is neither
+autonomous nor card-approved.
+
+Pure unit tests — role resolver monkeypatched at its module seam; a source
+pin holds the gate wiring. No DB, no app boot.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+os.environ.setdefault("POSTGRES_USER", "test")
+os.environ.setdefault("POSTGRES_PASSWORD", "test")
+os.environ.setdefault("POSTGRES_HOST", "127.0.0.1")
+os.environ.setdefault("POSTGRES_PORT", "59432")
+os.environ.setdefault("POSTGRES_DB", "test")
+
+from unittest.mock import MagicMock
+
+import pytest
+
+import modules.tools.discovery.platform_executor as pe
+from modules.tools.execution.telemetry import _build_router_decision
+
+_WS = "28a228aa-dd63-46c7-baac-d29a0eb67283"
+_CHAT_CTX = {"conversation_id": "conv-1", "user_id": "user_3CzR92xxx"}
+
+
+# ---------------------------------------------------------------------------
+# _human_directed_admin truth table
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("role,expected", [
+    ("owner", True),
+    ("admin", True),
+    ("Admin", True),      # role strings normalise
+    ("editor", False),
+    ("member", False),
+    ("viewer", False),
+    (None, False),        # no membership row
+])
+def test_role_gates_the_skip(monkeypatch, role, expected):
+    monkeypatch.setattr(pe, "_workspace_role_for_clerk", lambda db, ws, uid: (
+        role.strip().lower() if isinstance(role, str) else role
+    ))
+    assert pe._human_directed_admin(MagicMock(), _WS, dict(_CHAT_CTX)) is expected
+
+
+def test_agent_lane_never_skips_and_never_looks_up(monkeypatch):
+    """Heartbeat/cadence/board/mission lanes carry no conversation_id — the
+    role lookup must not even run (an admin's id in an agent-lane context is
+    not an instruction)."""
+    def _boom(db, ws, uid):
+        raise AssertionError("role lookup must not run for agent-lane calls")
+
+    monkeypatch.setattr(pe, "_workspace_role_for_clerk", _boom)
+    assert pe._human_directed_admin(MagicMock(), _WS, {"user_id": "user_x"}) is False
+    assert pe._human_directed_admin(MagicMock(), _WS, {"board_task_id": 9}) is False
+    assert pe._human_directed_admin(MagicMock(), _WS, None) is False
+
+
+def test_missing_or_non_string_principal_fails_closed(monkeypatch):
+    monkeypatch.setattr(pe, "_workspace_role_for_clerk", lambda *a: "owner")
+    assert pe._human_directed_admin(MagicMock(), _WS, {"conversation_id": "c"}) is False
+    assert pe._human_directed_admin(
+        MagicMock(), _WS, {"conversation_id": "c", "user_id": 47}
+    ) is False
+
+
+def test_role_resolver_error_fails_closed():
+    """Any DB failure in the resolver returns None → the ask stands."""
+    db = MagicMock()
+    db.query.side_effect = RuntimeError("db down")
+    assert pe._workspace_role_for_clerk(db, _WS, "user_x") is None
+
+
+# ---------------------------------------------------------------------------
+# Audit attribution
+# ---------------------------------------------------------------------------
+
+def test_router_decision_carries_human_directed():
+    d = _build_router_decision({}, human_directed=True)
+    assert d == {"human_directed": True}
+
+
+def test_markers_stay_distinct():
+    d = _build_router_decision(
+        {}, autonomous=True, approved_via_grant_id=7, human_directed=True
+    )
+    assert d["autonomous"] is True
+    assert d["approved_via_grant_id"] == 7
+    assert d["human_directed"] is True
+    assert _build_router_decision({}) is None  # no markers → no row noise
+
+
+# ---------------------------------------------------------------------------
+# Gate wiring pin — the skip must guard the consume/ask branch
+# ---------------------------------------------------------------------------
+
+def test_gate_wiring_source_pin():
+    src = (Path(pe.__file__)).read_text(encoding="utf-8")
+
+    # The skip is computed from the caller context…
+    assert "_human_directed_admin(self.db, self.workspace_id, caller_context)" in src
+
+    # …and the consume/ask branch is entered only when NOT human-directed.
+    gate = re.search(
+        r"human_directed = bool\(.*?consume_tool_grant", src, re.S
+    )
+    assert gate is not None, "human_directed must be decided before the consume/ask branch"
+    assert "and not human_directed" in gate.group(0), (
+        "the requires_confirmation branch must be guarded by `not human_directed`"
+    )
+
+    # The execution is stamped for the audit trail.
+    assert '{**result, "human_directed": True}' in src


### PR DESCRIPTION
## The report

"You added an approval button, Auto opened it, I approved it and nothing changed — all 12 agents exist still."

## What the logs and the database show

```
13:51:39  OPTIONS /api/v1/approval-grants/77/grant            200
13:51:40  [grant-resume-77] Executing 'platform_delete_agent'         ← resume RAN
13:51:40  [grant-resume-77] Platform action platform_delete_agent success=False
13:51:40  POST /api/v1/approval-grants/77/grant               200
```

Grant 77 in production right now: `status=granted`, unexpired, `revoked_by` **empty**. Destructive consumes stamp `system:consumed` — so the gate provably never matched the grant it was resuming under.

## Root cause

`SessionLocal` runs **`autoflush=False`**. `grant_approval` set `status=GRANTED` in the identity map only, then resumed the call in the same request. The gate's `consume_tool_grant → find_active_grant` runs real SQL — the database still said `pending`, zero rows, fail-closed back to the ask. The human's yes was invisible to the very query checking for it.

## Fix

Commit between `grant_grant` and `_requeue_subject`:

- the approval is **visible** to the gate's SQL when the resume re-enters it
- the recorded yes is **durable** even if the resume crashes mid-flight
- the existing follow-up commit still persists `executed_result`

## Why the S4 suite missed it

`test_p2w2_grant_resume.py` mocks the executor with a fake session — the re-dispatch contract is pinned, the gate's SQL visibility is out of frame. `test_grant_approve_commit_ordering.py` pins the endpoint ordering by AST (the house lifespan-pin pattern): a commit must sit between approve and resume, and one must follow the resume.

## Also in this PR

The unregistered-panel error copy no longer says "Unknown widget type" — to an operator that reads as the storefront widget system and sent this incident's triage sideways. Now: *"This panel type isn't available in this build"*.

## After deploy

- The pending cards (grants 71–76) approve-and-execute properly.
- Grant 77 is still live: the next `delete_agent {"agent_name": "Document Workflow Manager"}` consumes it and executes immediately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Workspace owners and administrators can directly initiate eligible interactive requests without an additional confirmation step.
  - Human-directed executions are clearly recorded for audit and telemetry purposes.

- **Bug Fixes**
  - Approval decisions are now saved before resumed actions proceed, improving reliability and preserving execution results.
  - Unknown panel errors now clarify that the panel type is unavailable in the current build.

- **Tests**
  - Added coverage for approval ordering and human-directed authorization scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->