### PR TITLE
fix(ci): widget manifest scan anchors on the registered type literal

### DIFF
--- a/frontend/components/widgets/__tests__/registration-manifest.test.ts
+++ b/frontend/components/widgets/__tests__/registration-manifest.test.ts
@@ -39,7 +39,12 @@ function scanSelfRegisteringTypes(): { type: string; module: string }[] {
       if (!statSync(join(WIDGETS_DIR, entry)).isDirectory()) continue
       const src = readFileSync(indexPath, 'utf-8')
       if (!src.includes('registerWidget(')) continue
-      const m = src.match(/type:\s*['"]([a-z0-9_]+)['"]/)
+      // Anchor to the top-level def property (≤2-space indent): a widget's
+      // body can contain other `type: '...'` literals first (MemoryWidget's
+      // `type: 'fact'` item default, CodingCanvasWidget's `type: 'file_write'`
+      // tree event) and an unanchored first-match scans those instead of the
+      // registered type.
+      const m = src.match(/^ {0,2}type:\s*['"]([a-z0-9_]+)['"]/m)
       if (m) found.push({ type: m[1], module: entry })
     } catch {
       continue // no index.tsx — not a widget module


### PR DESCRIPTION
## Summary
Frontend CI has been red on every PR since #620/#621 landed the widget registration-manifest guard: the scan takes the **first** `type: '…'` literal in each widget's `index.tsx`, but MemoryWidget (`type: 'fact'`, item default) and CodingCanvasWidget (`type: 'file_write'`, tree-refresh event) declare other `type:` literals above their `registerWidget` defs. The guard then asserts registration of kinds that aren't widget types and fails. Both dependabot PRs since Aug 6 failed exactly this way; main-push doesn't trigger the workflow, so it stayed hidden until the next human PR (#625).

One-line fix: anchor the match to the top-level def property (`/^ {0,2}type:\s*['"]([a-z0-9_]+)['"]/m`). Verified against all 12 widget modules — exactly one match each, always the registered type, including the two previously mis-scanned.

## Test plan
- CI on this PR runs the fixed guard against the unchanged widgets — the two failing cases (`coding_canvas`, `memory`) now scan correctly and pass; the guard still catches a built-but-unwired widget (that path is untouched).

Unblocks #625.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved widget registration scanning to recognize only valid top-level widget type declarations.
  * Prevented nested type values from being incorrectly registered as widget types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->