### PR TITLE
feat(verticals): register budstacks vertical — per-vertical internal keys, reuse-not-rotate, domains re-sync

### DIFF
--- a/orchestrator/api/verticals.py
+++ b/orchestrator/api/verticals.py
@@ -8,27 +8,56 @@ forking ``api/shopify.py``. The Shopify Remix app targets
 ``/api/verticals/shopify/provision``; ``api/shopify.py`` retains only its thin
 compat wrapper that delegates here.
 
-Authenticated with the same fail-closed internal API key as the Shopify routes
-(the integration/app server is the caller, not a browser).
+Authenticated with a fail-closed PER-VERTICAL internal API key (the
+integration/app server is the caller, not a browser): each vertical's secret is
+declared in ``config.py`` and resolved from the path's ``{vertical}`` — so the
+BudStacks app cannot provision Shopify workspaces with its own key, and an
+unconfigured vertical answers 503 (dark), mirroring ``_verify_internal_key``'s
+posture (see the 2026-08-01 boot-guard outage note in config.py for why this is
+a request-time check, never a boot-fatal one).
 """
 
 from __future__ import annotations
 
+import hmac
 import logging
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, Header, HTTPException
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
+from config import config
 from core.database.database import get_db
 from core.models.workspaces import Workspace
-from api.shopify import _verify_internal_key
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/verticals", tags=["Verticals"])
+
+
+# Vertical → the config attribute holding its server-to-server secret. A
+# vertical absent here (or with an empty secret) is dark: 503, never open.
+_VERTICAL_INTERNAL_KEYS: Dict[str, str] = {
+    "shopify": "SHOPIFY_INTERNAL_API_KEY",
+    "budstacks": "BUDSTACKS_INTERNAL_API_KEY",
+}
+
+
+def _verify_vertical_internal_key(
+    vertical: str, authorization: str = Header(...)
+) -> None:
+    """Fail-closed per-vertical twin of ``api.shopify._verify_internal_key``."""
+    attr = _VERTICAL_INTERNAL_KEYS.get(vertical)
+    expected = (getattr(config, attr, "") or "").strip() if attr else ""
+    if not expected:
+        raise HTTPException(
+            status_code=503, detail=f"{vertical} provisioning not configured"
+        )
+    token = authorization.replace("Bearer ", "").strip()
+    if not hmac.compare_digest(token, expected):
+        raise HTTPException(status_code=401, detail="Invalid internal API key")
 
 
 def _resolve_workspace_by_external_id(db: Session, vertical: str, external_id: str) -> Workspace:
@@ -87,7 +116,17 @@ class VerticalProvisionResponse(BaseModel):
     id: str
     public_id: str
     name: str
-    api_key: str = Field(..., description="Public widget API key — shown once.")
+    api_key: Optional[str] = Field(
+        None,
+        description=(
+            "Public widget API key — shown once when minted. Null when the "
+            "vertical declares reuse_existing_key and an active key already "
+            "exists (the caller keeps its stored copy)."
+        ),
+    )
+    key_minted: bool = Field(
+        True, description="Whether this call minted a new key."
+    )
     agents_installed: int
     is_new: bool
 
@@ -97,7 +136,7 @@ async def provision_vertical_workspace(
     vertical: str,
     request: VerticalProvisionRequest,
     db: Session = Depends(get_db),
-    _auth: None = Depends(_verify_internal_key),
+    _auth: None = Depends(_verify_vertical_internal_key),
 ):
     """Provision a workspace for ``vertical`` via the generic provisioner.
 
@@ -105,7 +144,7 @@ async def provision_vertical_workspace(
     without re-seeding). Returns 404 for a vertical with no registered
     provisioner.
     """
-    from integrations.provisioning import provision_vertical
+    from integrations.provisioning import VerticalConfigError, provision_vertical
 
     try:
         result = provision_vertical(
@@ -115,6 +154,9 @@ async def provision_vertical_workspace(
             name=request.name,
             metadata=request.metadata,
         )
+    except VerticalConfigError as e:
+        # Malformed by the vertical's own rules (e.g. missing origin allowlist).
+        raise HTTPException(status_code=422, detail=str(e))
     except ValueError as e:
         # Unknown vertical → 404 (no provisioner registered).
         raise HTTPException(status_code=404, detail=str(e))
@@ -124,6 +166,70 @@ async def provision_vertical_workspace(
         vertical, result["id"], request.external_id, result["agents_installed"],
     )
     return VerticalProvisionResponse(**result)
+
+
+class VerticalDomainsRequest(BaseModel):
+    external_id: str = Field(..., description="Vertical-scoped external id.")
+    domains: List[str] = Field(
+        ..., min_length=1, description="Replacement origin allowlist (hostnames or origins)."
+    )
+
+
+@router.patch("/{vertical}/provision/domains")
+async def update_vertical_key_domains(
+    vertical: str,
+    request: VerticalDomainsRequest,
+    db: Session = Depends(get_db),
+    _auth: None = Depends(_verify_vertical_internal_key),
+) -> Dict[str, Any]:
+    """Re-sync the origin allowlist on the workspace's active public widget keys.
+
+    Public keys are origin-locked; when a tenant's storefront hostname changes
+    (e.g. a BudStacks custom-domain move) the allowlist must follow or the
+    widget 403s on the new host. Replaces ``allowed_domains`` on every ACTIVE
+    public key of the workspace resolved from ``external_id`` — inactive and
+    server keys are untouched. Domains are normalized through the vertical's
+    own ``allowed_domains`` rule so the same validation applies as at
+    provision time. 404 when no workspace matches; 422 when the vertical's
+    rules reject the list.
+    """
+    from core.models.sdk_api_keys import SdkApiKey
+    from integrations.provisioning import (
+        PROVISIONER_REGISTRY,
+        VerticalConfigError,
+    )
+
+    workspace = _resolve_workspace_by_external_id(db, vertical, request.external_id)
+
+    provisioner = PROVISIONER_REGISTRY.get(vertical)
+    if provisioner is None:
+        raise HTTPException(status_code=404, detail=f"Unknown vertical '{vertical}'")
+
+    try:
+        domains = provisioner.allowed_domains(
+            request.external_id, {"domains": request.domains}
+        )
+    except VerticalConfigError as e:
+        raise HTTPException(status_code=422, detail=str(e))
+
+    keys = (
+        db.query(SdkApiKey)
+        .filter(
+            SdkApiKey.workspace_id == workspace.id,
+            SdkApiKey.key_type == "public",
+            SdkApiKey.is_active.is_(True),
+        )
+        .all()
+    )
+    for key in keys:
+        key.allowed_domains = list(domains)
+    db.commit()
+
+    logger.info(
+        "[verticals] domains re-sync vertical=%s external_id=%s workspace=%s keys=%d domains=%d",
+        vertical, request.external_id, workspace.id, len(keys), len(domains),
+    )
+    return {"updated_keys": len(keys), "domains": domains}
 
 
 # ===================================================================
@@ -160,7 +266,7 @@ async def gdpr_erase_subject(
     vertical: str,
     request: VerticalGdprEraseSubjectRequest,
     db: Session = Depends(get_db),
-    _auth: None = Depends(_verify_internal_key),
+    _auth: None = Depends(_verify_vertical_internal_key),
 ) -> Dict[str, Any]:
     """Erase a single data subject within the workspace resolved from ``external_id``.
 
@@ -190,7 +296,7 @@ async def gdpr_erase_workspace(
     vertical: str,
     request: VerticalGdprEraseRequest,
     db: Session = Depends(get_db),
-    _auth: None = Depends(_verify_internal_key),
+    _auth: None = Depends(_verify_vertical_internal_key),
 ) -> Dict[str, Any]:
     """Erase the whole workspace resolved from ``external_id`` (irreversible cascade).
 
@@ -222,7 +328,7 @@ async def gdpr_export_workspace(
     external_id: str,
     customer_id: Optional[str] = None,
     db: Session = Depends(get_db),
-    _auth: None = Depends(_verify_internal_key),
+    _auth: None = Depends(_verify_vertical_internal_key),
 ) -> JSONResponse:
     """Export the workspace resolved from ``external_id`` as a portable JSON bundle.
 

--- a/orchestrator/config.py
+++ b/orchestrator/config.py
@@ -563,6 +563,9 @@ class Config:
     WIDGET_CHAT_IP_LIMIT_PER_WINDOW: int = int(os.getenv("WIDGET_CHAT_IP_LIMIT_PER_WINDOW", "30"))
     WIDGET_CALLBACK_IP_LIMIT_PER_WINDOW: int = int(os.getenv("WIDGET_CALLBACK_IP_LIMIT_PER_WINDOW", "10"))
     SHOPIFY_INTERNAL_API_KEY: str = os.getenv("SHOPIFY_INTERNAL_API_KEY", "")
+    # BudStacks vertical (api/verticals.py) — same fail-closed posture: unset ⇒
+    # the budstacks provision surface answers 503, never open.
+    BUDSTACKS_INTERNAL_API_KEY: str = os.getenv("BUDSTACKS_INTERNAL_API_KEY", "")
     # PRD-189 S3: per-workspace debounce window (seconds) for catalog-webhook
     # re-syncs. A merchant bulk edit emits a burst of products/update webhooks;
     # /events coalesces the burst into ONE full Bulk-Op re-sync once it has

--- a/orchestrator/integrations/budstacks/__init__.py
+++ b/orchestrator/integrations/budstacks/__init__.py
@@ -1,0 +1,16 @@
+"""BudStacks vertical package.
+
+Importing this package self-registers the ``"budstacks"`` VerticalProvisioner
+into ``integrations.provisioning.PROVISIONER_REGISTRY`` — same import-time
+registration pattern as :mod:`integrations.shopify`. BudStacks has no widget
+plugin (the generic widget chat path serves it), so unlike the Shopify package
+nothing is added to ``PLUGIN_REGISTRY``.
+"""
+
+from __future__ import annotations
+
+from . import provision
+
+provision.register()
+
+__all__ = ["provision"]

--- a/orchestrator/integrations/budstacks/provision.py
+++ b/orchestrator/integrations/budstacks/provision.py
@@ -1,0 +1,107 @@
+"""BudStacks vertical provisioner.
+
+BudStacks (budstacks.io) is a multi-tenant cannabis-storefront SaaS — the
+second vertical to provision through the generic
+``POST /api/verticals/{v}/provision`` plane (PRD-183 S5). Its partner app
+calls with a BudStacks tenant id as ``external_id`` and the tenant's storefront
+hostnames in ``metadata.domains``; the flow stands up a workspace and mints an
+``ak_pub_*`` widget key origin-locked to those hostnames.
+
+Deliberate differences from the Shopify provisioner:
+
+* ``reuse_existing_key = True`` — the BudStacks app persists the minted key in
+  its own tenant row, so a re-provision call must NOT rotate the key out from
+  under a live storefront (the Shopify app relies on the opposite behaviour as
+  its key-recovery path, hence the per-vertical opt-in rather than a global
+  change).
+* ``allowed_domains`` comes entirely from ``metadata.domains`` (subdomain,
+  custom domain, www variant) and is REQUIRED — there is no wildcard fallback
+  like ``*.myshopify.com``. An empty list raises
+  :class:`~integrations.provisioning.VerticalConfigError` (HTTP 422), because a
+  public key without an origin allowlist is exactly what the api-keys HTTP
+  layer refuses to create.
+* ``agent_slugs`` is empty for now: no cannabis-storefront marketplace roster
+  exists yet, and seeding the Shopify-branded agents into a dispensary
+  workspace would be wrong. The BudStacks app keeps configuring its agent id
+  explicitly until a roster lands (surfaced in the integration PRD as an open
+  question — not silently descoped).
+
+Importing ``integrations.budstacks`` self-registers this provisioner into
+``integrations.provisioning.PROVISIONER_REGISTRY``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List
+
+from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+
+# No marketplace roster yet — see module docstring.
+BUDSTACKS_AGENT_SLUGS: List[str] = []
+
+
+# Proactive engagement stays off until a tenant opts in from the platform side.
+DEFAULT_WIDGET_PROACTIVE_CONFIG: Dict[str, Any] = {
+    "enabled": False,
+    "respect_consent": True,
+}
+
+
+class BudstacksProvisioner:
+    """VerticalProvisioner implementation for the BudStacks vertical."""
+
+    vertical = "budstacks"
+    agent_slugs = BUDSTACKS_AGENT_SLUGS
+    ops_manager_slug = None
+    default_widget_config = DEFAULT_WIDGET_PROACTIVE_CONFIG
+    key_permissions = ["chat"]
+    key_type = "public"
+    site_type = None
+    # BudStacks resolves tenants by their own tenant id, stamped alongside the
+    # canonical source_external_id.
+    external_id_key = "budstacks_tenant_id"
+    # Never rotate a live storefront's key on re-provision (see module docstring).
+    reuse_existing_key = True
+
+    def allowed_domains(self, external_id: str, metadata: Dict[str, Any]) -> List[str]:
+        """Origin allowlist from ``metadata.domains`` — required, normalized, deduped.
+
+        Accepts bare hostnames or full origins; normalizes to ``https://host``.
+        """
+        from integrations.provisioning import VerticalConfigError
+
+        raw = (metadata or {}).get("domains") or []
+        hosts: List[str] = []
+        for entry in raw:
+            if not isinstance(entry, str):
+                continue
+            host = entry.split("://", 1)[-1].strip().strip("/").split("/", 1)[0]
+            if host:
+                hosts.append(f"https://{host}")
+
+        if not hosts:
+            raise VerticalConfigError(
+                "budstacks provisioning requires metadata.domains — the storefront "
+                "hostnames the public widget key is origin-locked to"
+            )
+
+        seen: set[str] = set()
+        return [d for d in hosts if not (d in seen or seen.add(d))]
+
+    def on_provisioned(self, db: Session, workspace: Any) -> None:
+        """No vertical-specific post-provision step for BudStacks."""
+
+
+# Module-level singleton — the registered provisioner instance.
+provisioner = BudstacksProvisioner()
+
+
+def register() -> None:
+    """Self-register the BudStacks provisioner (called from ``__init__.py``)."""
+    from integrations.provisioning import PROVISIONER_REGISTRY
+
+    PROVISIONER_REGISTRY["budstacks"] = provisioner

--- a/orchestrator/integrations/provisioning.py
+++ b/orchestrator/integrations/provisioning.py
@@ -38,6 +38,12 @@ from core.models.workspaces import Workspace
 logger = logging.getLogger(__name__)
 
 
+class VerticalConfigError(ValueError):
+    """A provision request that is malformed for the vertical's own rules
+    (e.g. a missing origin allowlist) — distinct from ``ValueError`` for an
+    unregistered vertical so the HTTP layer can answer 422, not 404."""
+
+
 @runtime_checkable
 class VerticalProvisioner(Protocol):
     """Everything the generic provision flow needs to stand up a vertical.
@@ -60,6 +66,12 @@ class VerticalProvisioner(Protocol):
     # this key AND the canonical ``source_external_id`` so lookups either way
     # resolve. Defaults to the canonical key when a vertical does not override.
     external_id_key: str
+    # When True, re-provisioning a workspace that already holds an active
+    # public key returns it un-rotated (``api_key: None`` in the response)
+    # instead of minting a replacement. Verticals whose partner app persists
+    # the key (BudStacks) set this; Shopify keeps the default False because
+    # its runbook uses re-provision AS the key-recovery path.
+    reuse_existing_key: bool
 
     def allowed_domains(self, external_id: str, metadata: Dict[str, Any]) -> List[str]:
         """Origins permitted to use the minted public widget key."""
@@ -223,8 +235,11 @@ def provision_vertical(
     """Provision a workspace for any registered vertical.
 
     Idempotent: an existing active workspace for ``external_id`` is returned
-    (roster not re-seeded); the widget key is regenerated each call. Raises
-    ``ValueError`` for an unregistered vertical.
+    (roster not re-seeded). The widget key is regenerated each call UNLESS the
+    vertical declares ``reuse_existing_key`` and an active public key already
+    exists — then ``api_key`` is ``None`` and the caller keeps its stored copy.
+    Raises ``ValueError`` for an unregistered vertical and
+    :class:`VerticalConfigError` for a request the vertical's own rules reject.
     """
     provisioner = PROVISIONER_REGISTRY.get(vertical)
     if provisioner is None:
@@ -281,14 +296,35 @@ def provision_vertical(
     if existing_agent_count == 0:
         agents_installed = _seed_roster(db, workspace.id, provisioner)
 
-    key_result = _create_widget_key(
-        db=db,
-        workspace_id=workspace.id,
-        name=f"{vertical.title()} Widget Key ({external_id})",
-        key_type=getattr(provisioner, "key_type", "public"),
-        permissions=list(provisioner.key_permissions),
-        allowed_domains=provisioner.allowed_domains(external_id, metadata),
-    )
+    # Resolve the allowlist BEFORE any key decision so a malformed request
+    # (VerticalConfigError) rejects without side effects either way.
+    domains = provisioner.allowed_domains(external_id, metadata)
+
+    existing_key = None
+    if getattr(provisioner, "reuse_existing_key", False):
+        from core.models.sdk_api_keys import SdkApiKey
+
+        existing_key = (
+            db.query(SdkApiKey)
+            .filter(
+                SdkApiKey.workspace_id == workspace.id,
+                SdkApiKey.key_type == "public",
+                SdkApiKey.is_active.is_(True),
+            )
+            .order_by(SdkApiKey.created_at.desc())
+            .first()
+        )
+
+    key_result = None
+    if existing_key is None:
+        key_result = _create_widget_key(
+            db=db,
+            workspace_id=workspace.id,
+            name=f"{vertical.title()} Widget Key ({external_id})",
+            key_type=getattr(provisioner, "key_type", "public"),
+            permissions=list(provisioner.key_permissions),
+            allowed_domains=domains,
+        )
 
     # Optional vertical-specific post-provision step (e.g. ensure a Site).
     hook = getattr(provisioner, "on_provisioned", None)
@@ -304,7 +340,8 @@ def provision_vertical(
         "id": str(workspace.id),
         "public_id": str(workspace.id),
         "name": workspace.name,
-        "api_key": key_result["key"],
+        "api_key": key_result["key"] if key_result else None,
+        "key_minted": key_result is not None,
         "agents_installed": agents_installed,
         "is_new": is_new,
     }
@@ -321,6 +358,7 @@ def _slugify(external_id: str) -> str:
 
 __all__ = [
     "VerticalProvisioner",
+    "VerticalConfigError",
     "PROVISIONER_REGISTRY",
     "GRAPH_SOURCE_MAPPERS",
     "register_graph_source_mappers",

--- a/orchestrator/integrations/shopify/provision.py
+++ b/orchestrator/integrations/shopify/provision.py
@@ -73,6 +73,9 @@ class ShopifyProvisioner:
     # workspace by settings.shopify_domain, so the generic flow must stamp that
     # key too — not only the canonical source_external_id.
     external_id_key = "shopify_domain"
+    # Rotate-on-reprovision is Shopify's documented key-recovery path
+    # (runbooks/client-onboarding) — keep minting a fresh key every call.
+    reuse_existing_key = False
 
     def allowed_domains(self, external_id: str, metadata: Dict[str, Any]) -> List[str]:
         """Origins permitted to use the minted widget key.

--- a/orchestrator/main.py
+++ b/orchestrator/main.py
@@ -34,6 +34,7 @@ from core.database.database import init_database, get_db, SessionLocal
 from core.models import Base
 
 # Import API routers
+import integrations.budstacks  # noqa: F401 — self-registers the budstacks VerticalProvisioner
 from api.agents import router as agents_router
 from api.workflows import router as workflows_router
 from api.workflow_templates import router as workflow_templates_router

--- a/orchestrator/reports/route-manifest.json
+++ b/orchestrator/reports/route-manifest.json
@@ -1,5 +1,5 @@
 {
-  "route_count": 766,
+  "route_count": 767,
   "routes": [
     {
       "method": "GET",

--- a/orchestrator/reports/route-manifest.json
+++ b/orchestrator/reports/route-manifest.json
@@ -2430,6 +2430,10 @@
       "path": "/api/verticals/{vertical}/provision"
     },
     {
+      "method": "PATCH",
+      "path": "/api/verticals/{vertical}/provision/domains"
+    },
+    {
       "method": "POST",
       "path": "/api/voice/arm"
     },

--- a/orchestrator/tests/test_budstacks_vertical_provision.py
+++ b/orchestrator/tests/test_budstacks_vertical_provision.py
@@ -1,0 +1,248 @@
+"""BudStacks vertical provisioning — unit tests.
+
+Covers the three behaviours the BudStacks vertical adds to the generic
+provisioning plane (PRD-183 S5 seam, extended):
+
+* the required, normalized origin allowlist (``VerticalConfigError`` on empty);
+* ``reuse_existing_key`` — a re-provision against a workspace holding an active
+  public key must NOT rotate it (``api_key: None`` / ``key_minted: False``),
+  while a fresh workspace still mints;
+* the per-vertical internal-key verifier's fail-closed triad
+  (unset ⇒ 503 dark, wrong ⇒ 401, correct ⇒ pass).
+
+No real DB: the provision flow is exercised through a minimal fake Session,
+with ``_create_widget_key`` monkeypatched to count mints — the same seams the
+PRD-183 S5 suite patches.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+import integrations.budstacks  # noqa: F401 — registers the provisioner
+from integrations.budstacks.provision import provisioner as budstacks_provisioner
+from integrations.provisioning import (
+    PROVISIONER_REGISTRY,
+    VerticalConfigError,
+    provision_vertical,
+)
+
+
+# ── Registration + declaration ──────────────────────────────────────────
+
+
+def test_budstacks_provisioner_registered():
+    assert PROVISIONER_REGISTRY.get("budstacks") is budstacks_provisioner
+    assert budstacks_provisioner.reuse_existing_key is True
+    assert budstacks_provisioner.key_permissions == ["chat"]
+    assert budstacks_provisioner.external_id_key == "budstacks_tenant_id"
+
+
+# ── allowed_domains ─────────────────────────────────────────────────────
+
+
+def test_allowed_domains_normalizes_and_dedupes():
+    domains = budstacks_provisioner.allowed_domains(
+        "tenant-1",
+        {
+            "domains": [
+                "healingbuds.budstacks.io",
+                "https://healingbuds.co.za/",
+                "www.healingbuds.co.za",
+                "healingbuds.budstacks.io",  # duplicate
+            ]
+        },
+    )
+    assert domains == [
+        "https://healingbuds.budstacks.io",
+        "https://healingbuds.co.za",
+        "https://www.healingbuds.co.za",
+    ]
+
+
+@pytest.mark.parametrize("metadata", [{}, {"domains": []}, {"domains": [42, ""]}])
+def test_allowed_domains_required(metadata):
+    with pytest.raises(VerticalConfigError):
+        budstacks_provisioner.allowed_domains("tenant-1", metadata)
+
+
+# ── provision flow: reuse_existing_key ──────────────────────────────────
+
+
+class _FakeQuery:
+    def __init__(self, first_result=None, count_result=0, all_result=None):
+        self._first = first_result
+        self._count = count_result
+        self._all = all_result or []
+
+    def filter(self, *args, **kwargs):
+        return self
+
+    def order_by(self, *args, **kwargs):
+        return self
+
+    def first(self):
+        return self._first
+
+    def count(self):
+        return self._count
+
+    def all(self):
+        return self._all
+
+
+class _FakeSession:
+    """Answers the three model queries the provision flow makes, in a fixed
+    per-model mapping; add/flush/commit are no-ops."""
+
+    def __init__(self, results_by_model):
+        self._results = results_by_model
+        self.added = []
+
+    def query(self, model):
+        return self._results.get(model.__name__, _FakeQuery())
+
+    def add(self, obj):
+        self.added.append(obj)
+
+    def flush(self):
+        pass
+
+    def commit(self):
+        pass
+
+
+def _mint_counter(calls):
+    def _fake_create_widget_key(**kwargs):
+        calls.append(kwargs)
+        return {"key": f"ak_pub_test{len(calls)}"}
+
+    return _fake_create_widget_key
+
+
+def test_reprovision_does_not_rotate_existing_key(monkeypatch):
+    from core.models.workspaces import Workspace
+
+    existing_workspace = Workspace(name="HealingBuds", slug="healingbuds")
+    existing_workspace.id = "11111111-1111-1111-1111-111111111111"
+
+    class _ExistingKey:  # only identity matters — presence short-circuits mint
+        pass
+
+    db = _FakeSession(
+        {
+            "Workspace": _FakeQuery(first_result=existing_workspace),
+            "Agent": _FakeQuery(count_result=1),  # roster already seeded
+            "SdkApiKey": _FakeQuery(first_result=_ExistingKey()),
+        }
+    )
+
+    calls: list = []
+    monkeypatch.setattr(
+        "integrations.provisioning._create_widget_key", _mint_counter(calls)
+    )
+
+    result = provision_vertical(
+        db=db,
+        vertical="budstacks",
+        external_id="tenant-1",
+        name="HealingBuds",
+        metadata={"domains": ["healingbuds.budstacks.io"]},
+    )
+
+    assert calls == []  # no rotation
+    assert result["api_key"] is None
+    assert result["key_minted"] is False
+    assert result["is_new"] is False
+
+
+def test_fresh_workspace_still_mints(monkeypatch):
+    db = _FakeSession(
+        {
+            "Workspace": _FakeQuery(first_result=None),
+            "Agent": _FakeQuery(count_result=1),  # skip roster seeding
+            "SdkApiKey": _FakeQuery(first_result=None),
+        }
+    )
+
+    calls: list = []
+    monkeypatch.setattr(
+        "integrations.provisioning._create_widget_key", _mint_counter(calls)
+    )
+
+    result = provision_vertical(
+        db=db,
+        vertical="budstacks",
+        external_id="tenant-2",
+        name="LekkerWeed",
+        metadata={"domains": ["lekkerweed.budstacks.io"]},
+    )
+
+    assert len(calls) == 1
+    assert calls[0]["allowed_domains"] == ["https://lekkerweed.budstacks.io"]
+    assert result["api_key"] == "ak_pub_test1"
+    assert result["key_minted"] is True
+    assert result["is_new"] is True
+
+
+def test_missing_domains_rejects_before_any_key_decision(monkeypatch):
+    from core.models.workspaces import Workspace
+
+    existing_workspace = Workspace(name="HealingBuds", slug="healingbuds")
+    existing_workspace.id = "11111111-1111-1111-1111-111111111111"
+
+    db = _FakeSession(
+        {
+            "Workspace": _FakeQuery(first_result=existing_workspace),
+            "Agent": _FakeQuery(count_result=1),
+        }
+    )
+
+    calls: list = []
+    monkeypatch.setattr(
+        "integrations.provisioning._create_widget_key", _mint_counter(calls)
+    )
+
+    with pytest.raises(VerticalConfigError):
+        provision_vertical(
+            db=db,
+            vertical="budstacks",
+            external_id="tenant-1",
+            name="HealingBuds",
+            metadata={},
+        )
+    assert calls == []
+
+
+# ── per-vertical internal key verifier ──────────────────────────────────
+
+
+def test_vertical_key_verifier_triad(monkeypatch):
+    from config import config as app_config
+    from api.verticals import _verify_vertical_internal_key
+
+    # Unset ⇒ 503 (dark, never open)
+    monkeypatch.setattr(app_config, "BUDSTACKS_INTERNAL_API_KEY", "", raising=False)
+    with pytest.raises(HTTPException) as exc:
+        _verify_vertical_internal_key("budstacks", authorization="Bearer whatever")
+    assert exc.value.status_code == 503
+
+    # Wrong ⇒ 401
+    monkeypatch.setattr(
+        app_config, "BUDSTACKS_INTERNAL_API_KEY", "s3cret", raising=False
+    )
+    with pytest.raises(HTTPException) as exc:
+        _verify_vertical_internal_key("budstacks", authorization="Bearer nope")
+    assert exc.value.status_code == 401
+
+    # Correct ⇒ passes
+    assert (
+        _verify_vertical_internal_key("budstacks", authorization="Bearer s3cret")
+        is None
+    )
+
+    # Unknown vertical ⇒ 503 (no key configured for it)
+    with pytest.raises(HTTPException) as exc:
+        _verify_vertical_internal_key("nonexistent", authorization="Bearer s3cret")
+    assert exc.value.status_code == 503

--- a/orchestrator/tests/test_p2w2_authz_boundary_sweep.py
+++ b/orchestrator/tests/test_p2w2_authz_boundary_sweep.py
@@ -90,6 +90,7 @@ OWN_AUTH_ROUTES = {
     ("POST", "/api/verticals/{vertical}/gdpr/erase"),
     ("POST", "/api/verticals/{vertical}/gdpr/erase-subject"),
     ("POST", "/api/verticals/{vertical}/provision"),
+    ("PATCH", "/api/verticals/{vertical}/provision/domains"),
     ("POST", "/api/shopify/connect"),
     ("POST", "/api/shopify/deactivate"),
     ("POST", "/api/shopify/events"),

--- a/orchestrator/tests/test_prd183_gdpr_seam.py
+++ b/orchestrator/tests/test_prd183_gdpr_seam.py
@@ -91,7 +91,7 @@ SHOP = "demo.myshopify.com"
 
 
 def test_gdpr_endpoints_use_internal_key_dep():
-    """Every GDPR route depends on ``_verify_internal_key`` (the machine key),
+    """Every GDPR route depends on ``_verify_vertical_internal_key`` (the machine key),
     NOT the user-facing GDPR admin guard. Proven structurally: the dependency the
     routes carry is exactly the internal-key verifier the provision/events routes
     use."""
@@ -103,7 +103,7 @@ def test_gdpr_endpoints_use_internal_key_dep():
     ):
         assert path in routes, f"missing route {path}"
         deps = [d.call for d in routes[path].dependant.dependencies]
-        assert verticals._verify_internal_key in deps, f"{path} not internal-key authed"
+        assert verticals._verify_vertical_internal_key in deps, f"{path} not internal-key authed"
 
 
 def test_missing_internal_key_is_rejected():
@@ -114,12 +114,12 @@ def test_missing_internal_key_is_rejected():
     if not (config.SHOPIFY_INTERNAL_API_KEY or "").strip():
         # Key unset in the test env → dep fail-closes with 503 for any token.
         with pytest.raises(HTTPException) as ei:
-            verticals._verify_internal_key(authorization="Bearer whatever")
+            verticals._verify_vertical_internal_key("shopify", authorization="Bearer whatever")
         assert ei.value.status_code in (401, 403, 503)
     else:
         # Key set → a wrong token is rejected 401.
         with pytest.raises(HTTPException) as ei:
-            verticals._verify_internal_key(authorization="Bearer definitely-wrong-key")
+            verticals._verify_vertical_internal_key("shopify", authorization="Bearer definitely-wrong-key")
         assert ei.value.status_code == 401
 
 


### PR DESCRIPTION
BudStacks (multi-tenant cannabis-storefront SaaS — budstacks.io) becomes vertical #2 on the generic provisioning plane (PRD-183 S5). Extends the seam; Shopify behaviour unchanged.

- **Per-vertical internal keys**: `api/verticals.py` resolves the server-to-server secret from the path's `{vertical}` (`SHOPIFY_INTERNAL_API_KEY` / new `BUDSTACKS_INTERNAL_API_KEY` in config.py), same fail-closed 503/401 posture, request-time check only (per the 2026-08-01 boot-guard outage note). One app's key can no longer provision another vertical's workspaces.
- **`reuse_existing_key` (opt-in, budstacks only)**: re-provision returns the existing active public key un-rotated (`api_key: null`, `key_minted: false`). The BudStacks app persists the key against its tenant row, so rotation would kill a live storefront widget; Shopify keeps rotate-on-reprovision as its documented recovery path — hence per-vertical, not global.
- **`VerticalConfigError` → 422**: budstacks REQUIRES `metadata.domains` (origin allowlist; no `*.myshopify.com`-style fallback exists for it) — enforced in the provisioner since the service path bypasses the api-keys HTTP validator. Rejects as 422, not a misleading unknown-vertical 404.
- **`PATCH /api/verticals/{v}/provision/domains`**: re-sync the allowlist on active public keys when a tenant's storefront hostname changes (custom-domain moves). Validated through the vertical's own `allowed_domains`. Route-manifest entry added by hand — flag if `scripts.dump_routes` disagrees.
- **Deliberately surfaced, not descoped** (§12): `agent_slugs` is empty — no cannabis-storefront marketplace roster exists, and seeding Shopify-branded agents into a dispensary workspace would be wrong. Question for Gerard: build a budstacks roster, or keep agent assignment manual per tenant?

Tests: `tests/test_budstacks_vertical_provision.py` — allowed-domains normalization/required, reuse-not-rotate + fresh-mint via fake Session with `_create_widget_key` patched (the S5 seams), config-error before any key decision, and the 503/401/pass triad on the per-vertical verifier.

Consumer: budstack-saas PR #237+ (`tasks/prd-automatos-core-integration.md` Phase 2).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added BudStacks workspace provisioning with domain validation, normalized origins, and reusable public chat keys.
  * Added an endpoint to update allowed widget domains for active keys.
  * Provisioning responses now indicate whether a new API key was created.
* **Security**
  * Added per-vertical authentication for provisioning and GDPR operations, failing closed when credentials are missing or invalid.
* **Bug Fixes**
  * Invalid vertical configuration now returns a clear HTTP 422 response.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->