### PR TITLE
HOTFIX: deploy crash-loop — drop prod-legacy workspaces_plan_check before plan backfill

### DIFF
--- a/orchestrator/alembic/versions/prd222_w2s1_plan_default_basic.py
+++ b/orchestrator/alembic/versions/prd222_w2s1_plan_default_basic.py
@@ -46,6 +46,17 @@ def upgrade() -> None:
         existing_type=sa.String(length=50),
         server_default=_NEW_DEFAULT,
     )
+    # HOTFIX (2026-08-28 deploy crash-loop): production carries a LEGACY
+    # value-list check constraint `workspaces_plan_check` that predates the tier
+    # rename and exists in NO migration (prod-only schema drift — CI schemas are
+    # built from the chain and never had it, so every test lane was green while
+    # the deploy loop failed). It rejects 'basic'; drop it before the backfill.
+    # Deliberately NOT recreated: plan validity is enforced in code against
+    # config.PLAN_TIERS (the US-025 assignable set) — a DB value-list would
+    # re-drift on the next config tier change. IF EXISTS keeps this a no-op on
+    # databases that never had the constraint (CI, fresh installs).
+    op.execute("ALTER TABLE workspaces DROP CONSTRAINT IF EXISTS workspaces_plan_check")
+
     # Bring existing rows onto the renamed tier (idempotent; only 'starter').
     op.execute(_BACKFILL_SQL)
 


### PR DESCRIPTION
Prod is crash-looping on boot: the #631 tier migration's starter→basic backfill violates a value-list CHECK constraint (workspaces_plan_check) that exists ONLY in production — it's in no migration and no model, so CI schemas never had it and every test lane was green. Transactional DDL = DB consistent, app down until this lands. Fix: DROP CONSTRAINT IF EXISTS before the backfill; not recreated (plan validity is code-enforced via PLAN_TIERS — a DB value list would re-drift on config changes). MERGE IMMEDIATELY — Railway redeploys automatically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default workspace plan from Starter to Basic.
  * Existing workspaces using the Starter plan are now transitioned to Basic.
  * Removed a legacy validation restriction that prevented the Basic plan from being applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->