### PR TITLE
PRD-222 test round 1: veteran workspaces read as new + reset 403 for workspace owners

### DIFF
--- a/orchestrator/alembic/versions/prd222_veteran_skip_backfill.py
+++ b/orchestrator/alembic/versions/prd222_veteran_skip_backfill.py
@@ -1,0 +1,60 @@
+"""PRD-222 test-round fix — veteran workspaces read as brand-new (backfill 'skipped').
+
+Found by Gerard's first live test (2026-08-28): the onboarding column arrived
+with PRD-222 and NO backfill marked pre-existing workspaces, while
+``get_onboarding`` defaults a missing/stage-less doc to ``not_started`` — so
+every veteran workspace (including a year-old super-admin account) rendered the
+new-user opener and carried the onboarding spine in Auto's section.
+
+Fix: every workspace WITHOUT a stage at migration time is a veteran (new
+signups race-window excepted — they can re-enter via the dev reset). Mark them
+``skipped`` (the honest terminal state: they never onboarded), preserving any
+other keys in the doc (e.g. ``trial``), stamping ``stages.skipped`` in the same
+shape ``advance_onboarding_stage`` uses, plus a ``veteran: true`` marker so the
+downgrade touches ONLY rows this migration wrote.
+
+Idempotent: the WHERE matches only stage-less docs; a second run matches none.
+
+Revision ID: prd222_veteran_skip_backfill
+Revises: prd222_w2s1_plan_default_basic
+Create Date: 2026-08-28
+"""
+from __future__ import annotations
+
+from alembic import op
+
+revision = "prd222_veteran_skip_backfill"
+down_revision = "prd222_w2s1_plan_default_basic"
+branch_labels = None
+depends_on = None
+
+_UPGRADE_SQL = """
+UPDATE workspaces
+SET onboarding = COALESCE(onboarding, '{}'::jsonb)
+    || jsonb_build_object(
+         'stage', 'skipped',
+         'veteran', true,
+         'stages',
+         COALESCE(onboarding->'stages', '{}'::jsonb)
+           || jsonb_build_object(
+                'skipped',
+                to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD"T"HH24:MI:SS"Z"')
+              )
+       )
+WHERE onboarding IS NULL OR onboarding->>'stage' IS NULL
+"""
+
+_DOWNGRADE_SQL = """
+UPDATE workspaces
+SET onboarding = (onboarding - 'stage' - 'veteran')
+WHERE onboarding->>'veteran' = 'true'
+"""
+
+
+def upgrade() -> None:
+    op.execute(_UPGRADE_SQL)
+
+
+def downgrade() -> None:
+    # Strips ONLY rows this migration marked; their stage becomes unset again.
+    op.execute(_DOWNGRADE_SQL)

--- a/orchestrator/api/workspaces.py
+++ b/orchestrator/api/workspaces.py
@@ -22,7 +22,7 @@ from services.onboarding_state import public_snapshot
 
 from core.auth.hybrid import get_request_context_hybrid
 from core.auth.dependencies import RequestContext
-from core.auth.workspace_permission import require_workspace_permission
+from core.auth.workspace_permission import require_workspace_permission, workspace_permission_granted
 from core.llm.defaults import DEFAULT_LLM_PROVIDER, DEFAULT_LLM_MODEL, get_default_model_config
 from config import config
 
@@ -124,10 +124,19 @@ async def get_current_workspace(
 # ── Onboarding reset (PRD-222 W1·S10 / D9) — DEV/OPS ONLY, TEMPORARY ──────────
 
 
-def _require_admin(ctx: RequestContext) -> None:
-    """Workspace-admin gate — same bucket as ``api/onboarding_agents._require_admin``."""
-    if not ctx.user or ctx.user.system_role not in ("admin", "super_admin"):
-        raise HTTPException(status_code=403, detail="Admin access required")
+def _require_admin(ctx: RequestContext, db) -> None:
+    """Workspace-admin gate for the dev reset.
+
+    FIX (2026-08-28 test round 1, su-lock class 3rd sighting): the original check
+    read the PLATFORM ``system_role`` only, so a normal user could never reset a
+    workspace they own/administer — Gerard's alias got 403 on its own workspace.
+    Correct contract: the caller holds ``workspace:manage`` on the CURRENT
+    workspace (roles matrix), with platform admins passing through."""
+    if ctx.user and getattr(ctx.user, "system_role", None) in ("admin", "super_admin"):
+        return
+    if ctx.user and workspace_permission_granted(db, ctx, "workspace:manage"):
+        return
+    raise HTTPException(status_code=403, detail="Admin access required")
 
 
 class OnboardingResetRequest(BaseModel):
@@ -153,7 +162,7 @@ async def reset_current_onboarding(
     """
     if not config.ONBOARDING_RESET_ENABLED:
         raise HTTPException(status_code=404, detail="Not Found")
-    _require_admin(ctx)
+    _require_admin(ctx, db)
 
     workspace = db.query(Workspace).get(ctx.workspace_id)
     if not workspace:

--- a/orchestrator/tests/test_prd222_onboarding_reset.py
+++ b/orchestrator/tests/test_prd222_onboarding_reset.py
@@ -372,13 +372,28 @@ def test_endpoint_404_when_reset_disabled(monkeypatch):
     assert exc.value.status_code == 404   # unadvertised, NOT 403
 
 
-def test_endpoint_403_for_non_admin_when_enabled(monkeypatch):
+def test_endpoint_403_for_non_member_when_enabled(monkeypatch):
+    from api import workspaces as wsmod
     from api.workspaces import reset_current_onboarding, OnboardingResetRequest
 
     monkeypatch.setattr(config, "ONBOARDING_RESET_ENABLED", True)
+    # A plain user whose workspace role does NOT grant workspace:manage.
+    monkeypatch.setattr(wsmod, "workspace_permission_granted", lambda *_a, **_k: False)
     with pytest.raises(HTTPException) as exc:
         _run(reset_current_onboarding(OnboardingResetRequest(), _Ctx("user"), object()))
     assert exc.value.status_code == 403
+
+
+def test_endpoint_workspace_admin_passes_without_platform_role(monkeypatch):
+    """The su-lock regression guard: a NORMAL user who administers the current
+    workspace (matrix grants workspace:manage) must pass the gate — the original
+    platform-role-only check 403'd every workspace owner."""
+    from api import workspaces as wsmod
+
+    monkeypatch.setattr(config, "ONBOARDING_RESET_ENABLED", True)
+    monkeypatch.setattr(wsmod, "workspace_permission_granted", lambda *_a, **_k: True)
+    # Must NOT raise:
+    wsmod._require_admin(_Ctx("user"), object())
 
 
 def test_endpoint_admin_success_returns_report(monkeypatch):


### PR DESCRIPTION
Two blockers from Gerard's first live onboarding tests.

**1. Veteran workspaces read as brand-new (backfill migration).** The onboarding column arrived with PRD-222 and nothing backfilled pre-existing workspaces; the reader defaults a doc-less workspace to not_started — so every veteran account (including a year-old super-admin) rendered the new-user opener and carried the onboarding spine in Auto's context. Fix: one idempotent migration marking every stage-less workspace 'skipped' (veteran marker for clean downgrade; trial keys preserved).

**2. Reset endpoint 403 for the workspace's own admin (su-lock class, 3rd sighting).** The dev-reset gate checked platform system_role only — a normal user could never reset a workspace they administer. Fix: workspace:manage via the roles matrix, platform admins pass through, in-handler shape preserved for the authz sweep. Regression test added.

Merge → Railway deploys → the alias test loop unblocks at /dev/reset-onboarding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Workspace administrators can now reset onboarding without requiring a platform-wide administrator role.
  - Existing onboarding records are preserved while completed legacy records are marked as skipped.

- **Bug Fixes**
  - Users without workspace management permission continue to receive access-denied responses.
  - Onboarding status updates now include a skip timestamp and veteran marker for eligible records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->