### PR TITLE
fix: repair the two #633-stale CI guards (main red since yesterday evening)

### DIFF
--- a/orchestrator/tests/authz_sweep_probe.py
+++ b/orchestrator/tests/authz_sweep_probe.py
@@ -10,7 +10,7 @@ served route+method with the authorization facts the sweep asserts on:
 - ``wsadmin``  — ``require_workspace_admin`` present (PRD-185 S12)
 - ``perm``     — the ``require_workspace_permission`` marker string, if gated
 - ``admin_in_handler`` — the endpoint body asserts the shared admin check
-  (``assert_admin(ctx)`` / ``_assert_admin(ctx)`` / ``_require_admin(ctx)``)
+  (``assert_admin(ctx)`` / ``_assert_admin(ctx)`` / ``_require_admin(ctx…)``)
 - ``own_gate_in_handler`` — the endpoint body carries its own explicit
   auth-type gate (today: credentials resolve)
 
@@ -82,7 +82,7 @@ def main() -> None:
                     "perm": perm,
                     "admin_in_handler": (
                         "assert_admin(ctx)" in src
-                        or "_require_admin(ctx)" in src
+                        or "_require_admin(ctx" in src
                         # api/gdpr.py's hand-rolled gate — PRD-196 S7 owns its
                         # consolidation; classified, not touched (PRD-195).
                         or "_require_workspace_admin(ctx)" in src

--- a/orchestrator/tests/test_prd222_w2s1_plan_tiers.py
+++ b/orchestrator/tests/test_prd222_w2s1_plan_tiers.py
@@ -258,7 +258,27 @@ def test_migration_chains_onto_current_head():
 def test_exactly_one_head_after_this_migration():
     heads = _script_dir().get_heads()
     assert len(heads) == 1, f"expected exactly one alembic head, got {heads}"
-    assert heads[0] == NEW_REVISION
+    # FIX (2026-08-29): pinning heads[0] to THIS revision broke the moment the
+    # next migration (prd222_veteran_skip_backfill, PR #633) chained on top —
+    # a guard that fails on every future migration guards nothing. The intent
+    # ("our revision is properly chained into the single-headed graph") is the
+    # ancestry property:
+    sd = _script_dir()
+    chain = set()
+    cursor = [heads[0]]
+    while cursor:
+        rev_id = cursor.pop()
+        if rev_id in chain:
+            continue
+        chain.add(rev_id)
+        rev = sd.get_revision(rev_id)
+        down = rev.down_revision
+        if down is None:
+            continue
+        cursor.extend([down] if isinstance(down, str) else list(down))
+    assert NEW_REVISION in chain, (
+        f"{NEW_REVISION} is not an ancestor of the single head {heads[0]}"
+    )
 
 
 def test_backfill_sql_is_scoped_to_starter():


### PR DESCRIPTION
Main's required orchestrator-tests job has been red since #633 merged — two guard tests with stale EXPECTATIONS (behavior was always correct): the authz probe's literal `_require_admin(ctx)` marker missed the new `(ctx, db)` signature, and the w2s1 migration test pinned the chain head to its own revision (breaks on every future migration by design — rewritten to the ancestry property). Both green locally; the PRD-230 branch's CI confirms these are the only 2 failures (4966 passed, +119 vs main). Merge before or with the PRD-230 PR and main goes green again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved authorization checks to recognize administrator requirements with additional arguments.
  * Updated migration validation to remain reliable as newer migrations are added.
  * Expanded migration ancestry verification while preserving existing safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->