### PR TITLE
fix(ci): heal main's two wave-merge drift failures (222 head test + authz sweep)

### DIFF
--- a/orchestrator/tests/authz_sweep_probe.py
+++ b/orchestrator/tests/authz_sweep_probe.py
@@ -10,7 +10,8 @@ served route+method with the authorization facts the sweep asserts on:
 - ``wsadmin``  — ``require_workspace_admin`` present (PRD-185 S12)
 - ``perm``     — the ``require_workspace_permission`` marker string, if gated
 - ``admin_in_handler`` — the endpoint body asserts the shared admin check
-  (``assert_admin(ctx)`` / ``_assert_admin(ctx)`` / ``_require_admin(ctx)``)
+  (``assert_admin(ctx)`` / ``_assert_admin(ctx)`` / ``_require_admin(ctx)``
+  / ``_require_admin(ctx, db)``)
 - ``own_gate_in_handler`` — the endpoint body carries its own explicit
   auth-type gate (today: credentials resolve)
 
@@ -83,6 +84,9 @@ def main() -> None:
                     "admin_in_handler": (
                         "assert_admin(ctx)" in src
                         or "_require_admin(ctx)" in src
+                        # PRD-222 W1b dev-reset gate — db-aware since the
+                        # roles-matrix fix (workspace:manage check needs db).
+                        or "_require_admin(ctx, db)" in src
                         # api/gdpr.py's hand-rolled gate — PRD-196 S7 owns its
                         # consolidation; classified, not touched (PRD-195).
                         or "_require_workspace_admin(ctx)" in src

--- a/orchestrator/tests/test_prd222_w2s1_plan_tiers.py
+++ b/orchestrator/tests/test_prd222_w2s1_plan_tiers.py
@@ -256,9 +256,14 @@ def test_migration_chains_onto_current_head():
 
 
 def test_exactly_one_head_after_this_migration():
-    heads = _script_dir().get_heads()
+    sd = _script_dir()
+    heads = sd.get_heads()
     assert len(heads) == 1, f"expected exactly one alembic head, got {heads}"
-    assert heads[0] == NEW_REVISION
+    # Later PRDs legitimately stack on top of this revision (PRD-225 already
+    # does) — the invariant is a single head WITH this revision in its
+    # lineage, not that this revision stays the head forever.
+    chain = {rev.revision for rev in sd.walk_revisions(base="base", head=heads[0])}
+    assert NEW_REVISION in chain, f"{NEW_REVISION} missing from head lineage"
 
 
 def test_backfill_sql_is_scoped_to_starter():


### PR DESCRIPTION
## What

Main's `test` workflow has been red since the PRD-226 merge (~21:17 on 08-28) — every wave merge after it pushed red. Two failures, both **integration drift**, zero production code involved:

| Test | Why it broke | Fix |
|---|---|---|
| `test_prd222_w2s1_plan_tiers::test_exactly_one_head_after_this_migration` | Asserted `heads[0] ==` its own revision; PRD-225's migration now stacks on top (down_revision re-pointed at merge) | Intent-based, mirroring 225's twin: single head **and** the 222 revision in the head's lineage |
| `test_p2w2_authz_boundary_sweep::test_manifest_sweep_no_unclassified_mutating_routes` | 222 W1b's roles-matrix fix changed the reset gate to `_require_admin(ctx, db)`; the probe's literal match `_require_admin(ctx)` stopped hitting | Probe recognises the db-aware variant (+ docstring) |

**The onboarding/reset route was verified properly gated** — flag-404 when `ONBOARDING_RESET_ENABLED` is off, then `_require_admin(ctx, db)` (platform admin OR `workspace:manage` via the roles matrix). This was a detection gap, not an authz gap.

## Why merge FIRST

`feat/auto-skill-seed-sync` (#640) and the overnight PRD-231 branch both inherit exactly these two failures — nothing else fails on either (`2 failed, 5001 passed`). Green main un-blocks the whole morning chain: **this → skills#37 → skills#38 → #640 → PRD-231**.

## Test plan

- Both tests pass locally against this branch (2 passed).
- CI on this PR is the real gate — full suite vs assembled main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved automated checks for administrative access safeguards, including database-aware validation scenarios.
  * Updated migration verification to support valid follow-on migrations while preserving a single consistent migration path.
  * These updates strengthen release quality and reduce the risk of authorization or database upgrade issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->