### PR TITLE
fix: route-manifest count 770→773 (concurrent merge hand-bump collision)

### DIFF
--- a/orchestrator/reports/route-manifest.json
+++ b/orchestrator/reports/route-manifest.json
@@ -1,5 +1,5 @@
 {
-  "route_count": 770,
+  "route_count": 773,
   "routes": [
     {
       "method": "GET",


### PR DESCRIPTION
Main's tip CI fails on the manifest count-consistency test: this morning's parallel merges each hand-bumped route_count from the same base, so the merged union has 773 rows against a 770 count. Recounted. Test green locally. Merge and main goes green (barring anything new in the currently-running CI on the latest tip).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three newly registered routes to the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->