### PR TITLE
Workspace LLM foundation: seeded base models, key-availability routing, cap-only trial

### DIFF
--- a/orchestrator/alembic/versions/prd_workspace_models_backfill.py
+++ b/orchestrator/alembic/versions/prd_workspace_models_backfill.py
@@ -1,0 +1,87 @@
+"""Backfill base models into every zero-model workspace (Harbourline fix).
+
+2026-08-29 (Gerard): a workspace with ZERO ``workspace_models`` rows breaks
+Settings → Orchestrator ("Failed to load LLM settings") and leaves chat with no
+sane default. New workspaces are seeded at provisioning from this deploy on
+(``services/workspace_model_seeding.py``); this migration brings every EXISTING
+zero-model workspace to the same floor: up to 4 active OpenRouter-served base
+models (defaults first, then featured by popularity), ``source='default'``,
+``approval_status='approved'``, plus ``settings.orchestrator.model`` set to the
+top pick where no primary exists.
+
+Idempotent (NOT EXISTS guards; second run matches nothing). Additive DML only —
+no DDL, no constraint assumptions (the ``workspaces_plan_check`` lesson).
+
+Revision ID: prd_workspace_models_backfill
+Revises: prd230_marketplace_packages
+Create Date: 2026-08-29
+"""
+from __future__ import annotations
+
+from alembic import op
+
+revision = "prd_workspace_models_backfill"
+down_revision = "prd230_marketplace_packages"
+branch_labels = None
+depends_on = None
+
+_BASE_PICKS = """
+CREATE TEMPORARY TABLE _base_model_picks ON COMMIT DROP AS
+SELECT id, model_id,
+       ROW_NUMBER() OVER (
+         ORDER BY is_default DESC, is_featured DESC,
+                  COALESCE(popularity_score, 0) DESC, id ASC
+       ) AS rank
+FROM llm_models
+WHERE status = 'active'
+  AND (provider = 'openrouter' OR tier = 'openrouter' OR model_id LIKE '%/%')
+LIMIT 50
+"""
+
+_BACKFILL_ROWS = """
+INSERT INTO workspace_models (workspace_id, model_id, is_active, source, approval_status)
+SELECT w.id, p.id, TRUE, 'default', 'approved'
+FROM workspaces w
+CROSS JOIN _base_model_picks p
+WHERE p.rank <= 4
+  AND NOT EXISTS (
+    SELECT 1 FROM workspace_models wm WHERE wm.workspace_id = w.id
+  )
+"""
+
+_SET_PRIMARY = """
+UPDATE workspaces w
+SET settings = jsonb_set(
+      COALESCE(w.settings, '{}'::jsonb),
+      '{orchestrator}',
+      COALESCE(w.settings->'orchestrator', '{}'::jsonb)
+        || jsonb_build_object(
+             'model',
+             (SELECT p.model_id FROM _base_model_picks p WHERE p.rank = 1)
+           ),
+      true
+    )
+WHERE (w.settings->'orchestrator'->>'model') IS NULL
+  AND EXISTS (SELECT 1 FROM _base_model_picks)
+"""
+
+
+def upgrade() -> None:
+    op.execute(_BASE_PICKS)
+    op.execute(_BACKFILL_ROWS)
+    op.execute(_SET_PRIMARY)
+
+
+def downgrade() -> None:
+    # Remove only rows this backfill could have created (source='default') from
+    # workspaces whose ONLY rows are defaults — hand-installed rows untouched.
+    op.execute(
+        """
+        DELETE FROM workspace_models wm
+        WHERE wm.source = 'default'
+          AND NOT EXISTS (
+            SELECT 1 FROM workspace_models o
+            WHERE o.workspace_id = wm.workspace_id AND o.source <> 'default'
+          )
+        """
+    )

--- a/orchestrator/config.py
+++ b/orchestrator/config.py
@@ -1370,8 +1370,6 @@ class Config:
     # today's accumulated trial spend reaches this (US-005's daily counter feeds it).
     TRIAL_GLOBAL_DAILY_USD: float = float(os.getenv("TRIAL_GLOBAL_DAILY_USD", "25.00"))
     # Models a trial workspace may use on the platform key. Reuses the platform's
-    # existing economical model comma-list (BUDGET_MODELS, PRD-54) — no new id invented.
-    TRIAL_MODEL_ALLOWLIST: str = os.getenv("TRIAL_MODEL_ALLOWLIST", BUDGET_MODELS)
 
     # PRD-222 W1·S10 (D9) — DEV/OPS ONLY, TEMPORARY. Arms
     # POST /api/workspaces/current/onboarding/reset so the operator can re-run

--- a/orchestrator/core/auth/hybrid.py
+++ b/orchestrator/core/auth/hybrid.py
@@ -380,6 +380,17 @@ def _provision_new_user_workspace(
     except Exception:
         logger.exception("Failed to seed document templates for workspace %s — non-fatal", ws_id)
 
+    # 5.5) 2026-08-29 (the Harbourline failure): every workspace starts with
+    # WORKING models — base OpenRouter set in workspace_models + the primary in
+    # settings.orchestrator. Zero-model workspaces broke Settings → Orchestrator
+    # ("Failed to load LLM settings") and left chat with no sane default.
+    try:
+        from services.workspace_model_seeding import seed_workspace_models
+        if seed_workspace_models(db, ws_id) is not None:
+            db.commit()
+    except Exception:
+        logger.exception("Base-model seed failed for workspace %s — non-fatal", ws_id)
+
     # 6) PRD-222 US-004 (W1·S9): grant the one-time $5 onboarding trial credit so
     # the value moment lands before the BYOK ask. One per Clerk user; paused by
     # the global daily cap or the TRIAL_ENABLED kill switch (all config-driven).

--- a/orchestrator/modules/agents/factory/agent_factory.py
+++ b/orchestrator/modules/agents/factory/agent_factory.py
@@ -341,6 +341,20 @@ class AgentFactory:
                 self.logger.warning(f"max_output_tokens lookup failed for {model_id}: {e}")
         return DEFAULT_MAX_OUTPUT_TOKENS
 
+    _OPENROUTER_VENDOR_PREFIX = {
+        "openai": "openai/",
+        "anthropic": "anthropic/",
+        "google": "google/",
+        "grok": "x-ai/",
+    }
+
+    def _openrouter_model_id(self, vendor_provider: str, model_id: str) -> str:
+        """Vendor model id -> its OpenRouter form (no-op when already prefixed)."""
+        if "/" in model_id:
+            return model_id
+        prefix = self._OPENROUTER_VENDOR_PREFIX.get(vendor_provider)
+        return f"{prefix}{model_id}" if prefix else model_id
+
     def _resolve_provider_for_model(self, provider_str: str, model_id: str) -> tuple[str, str]:
         """Auto-detect and correct provider-model mismatches.
 
@@ -504,24 +518,21 @@ class AgentFactory:
 
         return None
 
-    def _resolve_trial_decision(self, workspace_id, model_id: str, is_byok: bool) -> Tuple[bool, Optional[str]]:
+    def _resolve_trial_decision(self, workspace_id, model_id: str, is_byok: bool) -> bool:
         """PRD-222 US-005 / PRD-230 US-001 — the trial routing decision at the
         LLM key-resolution choke point, shared by BOTH the mission factory path
         (``_create_llm_manager``) and the chat path (``activate_agent``). One gate,
         no drift.
 
-        Returns ``(trial_routed, pinned_model)``:
-          * ``trial_routed`` — tag the LLMManager so spend accrues to the trial
-            ledger (``manager.py`` gates ``record_trial_spend`` on this flag).
-          * ``pinned_model`` — a ``TRIAL_MODEL_ALLOWLIST`` model to substitute for
-            an off-list request, else ``None``.
+        Returns ``trial_routed`` — tag the LLMManager so spend accrues to the
+        trial ledger (``manager.py`` gates ``record_trial_spend`` on this flag).
 
-        Raises ``TrialExhaustedError`` when the trial is spent. No-op
-        (``(False, None)``) for BYOK, non-trial, and system calls (``workspace_id``
-        None) — so neither surface can run unmetered or off-allowlist.
+        2026-08-29 (Gerard): model pinning DELETED — the trial is a spend cap,
+        not a model gate. Raises ``TrialExhaustedError`` when the trial is
+        spent. No-op (``False``) for BYOK, non-trial, and system calls.
         """
         if not workspace_id or is_byok:
-            return False, None
+            return False
         from services.trial_ledger import (
             resolve_trial_routing, TrialExhaustedError,
             ACTION_BLOCKED, ACTION_PLATFORM_TRIAL,
@@ -534,9 +545,8 @@ class AgentFactory:
             self.logger.info(f"[Trial] Blocking exhausted trial workspace {workspace_id}")
             raise TrialExhaustedError()
         if routing.action == ACTION_PLATFORM_TRIAL:
-            pinned = routing.model if (routing.model and routing.model != model_id) else None
-            return True, pinned
-        return False, None
+            return True
+        return False
 
     async def _create_llm_manager(self, model_config: ModelConfiguration, agent_name: str = "", workspace_id=None) -> Tuple[LLMManager, ResolvedKey]:
         """Create LLM manager with API key resolution (PRD-15, PRD-54)."""
@@ -563,6 +573,22 @@ class AgentFactory:
 
         provider = provider_map[effective_provider]
         resolved = await self._resolve_api_key(effective_provider, agent_name, workspace_id=workspace_id)
+        if not resolved and effective_provider != "openrouter":
+            # 2026-08-29 (Gerard, the Harbourline failure): provider resolution is
+            # KEY-AVAILABILITY-DRIVEN. A vendor model with no direct vendor key
+            # must route via OpenRouter when that key exists — never error while
+            # a capable key sits in the chain. Direct vendor keys, when a user
+            # adds them, still win (this branch only runs when they are absent).
+            or_resolved = await self._resolve_api_key("openrouter", agent_name, workspace_id=workspace_id)
+            if or_resolved:
+                effective_model_id = self._openrouter_model_id(effective_provider, effective_model_id)
+                self.logger.info(
+                    f"[KeyRouting] no {effective_provider} key — routing {effective_model_id} "
+                    f"via OpenRouter (source={or_resolved.source})"
+                )
+                effective_provider = "openrouter"
+                provider = provider_map["openrouter"]
+                resolved = or_resolved
         if not resolved:
             raise ValueError(
                 f"No API key available for {effective_provider}. "
@@ -576,27 +602,9 @@ class AgentFactory:
         # else route on the platform key and PIN the model to the trial allowlist.
         # No-op for non-trial workspaces and system calls (workspace_id None).
         # Shared with the chat path (activate_agent) via _resolve_trial_decision.
-        trial_routed, pinned_model = self._resolve_trial_decision(
+        trial_routed = self._resolve_trial_decision(
             workspace_id, effective_model_id, resolved.is_byok
         )
-        if pinned_model:
-            self.logger.info(
-                f"[Trial] Pinning off-allowlist model {effective_model_id} -> "
-                f"{pinned_model} for workspace {workspace_id}"
-            )
-            effective_provider, effective_model_id = self._resolve_provider_for_model(
-                model_config.provider, pinned_model
-            )
-            if effective_provider not in provider_map:
-                raise ValueError(f"Unsupported trial provider: {effective_provider}")
-            provider = provider_map[effective_provider]
-            resolved = await self._resolve_api_key(
-                effective_provider, agent_name, workspace_id=workspace_id
-            )
-            if not resolved:
-                raise ValueError(
-                    f"No platform key available for trial model {effective_model_id}."
-                )
 
         llm_config = LLMConfig(
             provider=provider,
@@ -918,39 +926,14 @@ class AgentFactory:
                 provider = LLMProvider(provider_str)
                 resolved = await self._resolve_api_key(provider_str, db_agent.name, workspace_id=effective_ws_id)
 
-            # PRD-230 US-001 — apply the SAME trial gate the mission factory uses,
-            # on the chat path. Without this Auto ran unmetered/unpinned: the gate
-            # lived only in _create_llm_manager, which activate_agent never calls.
-            # BYOK bypasses (resolved.is_byok); exhausted trials raise the typed
-            # error; active trials pin off-list models to TRIAL_MODEL_ALLOWLIST and
-            # tag the manager so spend accrues.
-            trial_routed, pinned_model = self._resolve_trial_decision(
+            # PRD-230 US-001 — the SAME trial gate the mission factory uses, on
+            # the chat path (without it Auto ran unmetered). 2026-08-29: model
+            # pinning DELETED (Gerard — the trial is a spend cap, not a model
+            # gate). BYOK bypasses; exhausted trials raise the typed error;
+            # active trials tag the manager so spend accrues.
+            trial_routed = self._resolve_trial_decision(
                 effective_ws_id, model_id_str, resolved.is_byok if resolved else False
             )
-            if pinned_model:
-                self.logger.info(
-                    f"[Trial] Pinning off-allowlist model {model_id_str} -> "
-                    f"{pinned_model} for workspace {effective_ws_id}"
-                )
-                provider_str, model_id_str = self._resolve_provider_for_model(
-                    llm_config_dict.get("provider") or provider_str, pinned_model
-                )
-                try:
-                    provider = LLMProvider(provider_str)
-                except ValueError:
-                    provider_str = "openrouter"
-                    provider = LLMProvider(provider_str)
-                resolved = await self._resolve_api_key(
-                    provider_str, db_agent.name, workspace_id=effective_ws_id
-                )
-                if (not resolved or not resolved.api_key) and provider_str != "openrouter":
-                    provider_str = "openrouter"
-                    if "/" not in model_id_str:
-                        model_id_str = f"{(llm_config_dict.get('provider') or '').lower()}/{model_id_str}"
-                    provider = LLMProvider(provider_str)
-                    resolved = await self._resolve_api_key(
-                        provider_str, db_agent.name, workspace_id=effective_ws_id
-                    )
 
             llm_config = LLMConfig(
                 provider=provider,

--- a/orchestrator/services/trial_ledger.py
+++ b/orchestrator/services/trial_ledger.py
@@ -258,11 +258,6 @@ class TrialRouting:
     reason: str = ""
 
 
-def _allowlist() -> list[str]:
-    """Parse ``config.TRIAL_MODEL_ALLOWLIST`` into a clean model-id list."""
-    return [m.strip() for m in (config.TRIAL_MODEL_ALLOWLIST or "").split(",") if m.strip()]
-
-
 def _trial_of(workspace: Any) -> Optional[dict[str, Any]]:
     if workspace is None:
         return None
@@ -293,8 +288,8 @@ def resolve_trial_routing(
        ``passthrough``: existing resolution is left exactly as today.
     3. trial ``exhausted`` → ``blocked`` with ``error_code='trial_exhausted'``.
     4. trial ``active``/``warned`` → ``platform_trial``: the request pins to the
-       ``TRIAL_MODEL_ALLOWLIST`` — an off-list model is SUBSTITUTED for the first
-       allowlisted model (chosen behavior: substitute, not error, so a trial
+       requested model passes through unchanged — the trial is a spend cap,
+       not a model gate (2026-08-29).
        never dead-ends on model choice).
     """
     if is_byok:
@@ -309,9 +304,11 @@ def resolve_trial_routing(
             ACTION_BLOCKED, error_code=TRIAL_EXHAUSTED_CODE, reason="trial_exhausted"
         )
 
-    allow = _allowlist()
-    model = requested_model if (not allow or requested_model in allow) else allow[0]
-    return TrialRouting(ACTION_PLATFORM_TRIAL, model=model, reason="trial_active")
+    # 2026-08-29 (Gerard): the trial is a SPEND CAP, not a model gate — "$5 is
+    # $5 no matter what model they choose." Model pinning + TRIAL_MODEL_ALLOWLIST
+    # deleted; an expensive model simply exhausts the credit sooner. Metering,
+    # the 80% warn, the hard stop, and the global daily cap are the controls.
+    return TrialRouting(ACTION_PLATFORM_TRIAL, model=requested_model, reason="trial_active")
 
 
 def compute_trial_state(spent_usd: float, granted_usd: float, *, warn_ratio: float = WARN_THRESHOLD) -> str:

--- a/orchestrator/services/workspace_model_seeding.py
+++ b/orchestrator/services/workspace_model_seeding.py
@@ -1,0 +1,123 @@
+"""Workspace base-model seeding — every workspace starts with working models.
+
+Gerard's 2026-08-29 design call (the Harbourline test): a new workspace must
+never start with ZERO rows in ``workspace_models`` — that empty mapping is why
+Settings → Orchestrator failed with "Failed to load LLM settings" and why no
+sane default existed for chat. Provisioning now seeds a small set of
+OpenRouter-served base models (the platform key everyone has), marks one
+primary in ``workspaces.settings.orchestrator``, and the marketplace remains
+the "add more" path (PRD-230 D1 registers those to the workspace too).
+
+Selection: active ``llm_models`` rows served via OpenRouter — ``is_default``
+rows first, then featured OpenRouter-tier rows — capped at ``_SEED_CAP``.
+Rows are inserted with ``source='default'`` (the enum value the schema always
+anticipated) and ``approval_status='approved'`` (they are the platform's own
+vetted picks; PRD-223 governance still quarantines them like any model later).
+
+Idempotent: the (workspace_id, model_id) unique constraint + existence checks
+make re-runs no-ops. Never raises into provisioning — a workspace without
+seeded models is degraded, not broken, and the failure is logged loudly.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+from sqlalchemy import or_
+from sqlalchemy.orm import Session
+
+from core.models.core import LLMModel, WorkspaceModel
+from core.models.workspaces import Workspace
+
+logger = logging.getLogger(__name__)
+
+_SEED_CAP = 4
+
+
+def _openrouter_served(q):
+    """Filter llm_models to rows the platform OpenRouter key can serve."""
+    return q.filter(
+        or_(
+            LLMModel.provider == "openrouter",
+            LLMModel.tier == "openrouter",
+            LLMModel.model_id.contains("/"),
+        )
+    )
+
+
+def pick_base_models(db: Session) -> list[LLMModel]:
+    """The platform's base set: defaults first, then featured, OpenRouter-served."""
+    base = _openrouter_served(
+        db.query(LLMModel).filter(LLMModel.status == "active")
+    )
+    defaults = base.filter(LLMModel.is_default.is_(True)).all()
+    picked = list(defaults[:_SEED_CAP])
+    if len(picked) < _SEED_CAP:
+        seen = {m.id for m in picked}
+        featured = (
+            base.filter(LLMModel.is_featured.is_(True))
+            .order_by(LLMModel.popularity_score.desc())
+            .limit(_SEED_CAP * 2)
+            .all()
+        )
+        for m in featured:
+            if m.id not in seen:
+                picked.append(m)
+                seen.add(m.id)
+            if len(picked) >= _SEED_CAP:
+                break
+    return picked
+
+
+def seed_workspace_models(db: Session, ws_id: Any) -> Optional[str]:
+    """Seed base models into ``workspace_models`` + set the primary.
+
+    Takes the workspace id (the provisioning site's currency). Returns the
+    primary model id string when seeding produced/confirmed one, else None.
+    Caller owns the commit. Never raises.
+    """
+    try:
+        workspace = db.query(Workspace).get(ws_id)
+        if workspace is None:
+            logger.error("[ModelSeed] workspace %s not found", ws_id)
+            return None
+        existing = {
+            wm.model_id
+            for wm in db.query(WorkspaceModel.model_id)
+            .filter(WorkspaceModel.workspace_id == ws_id)
+            .all()
+        }
+        base = pick_base_models(db)
+        if not base and not existing:
+            logger.error(
+                "[ModelSeed] no OpenRouter-served base models in llm_models — "
+                "workspace %s starts with an empty model mapping", ws_id
+            )
+            return None
+        for m in base:
+            if m.id in existing:
+                continue
+            db.add(
+                WorkspaceModel(
+                    workspace_id=ws_id,
+                    model_id=m.id,
+                    is_active=True,
+                    source="default",
+                    approval_status="approved",
+                )
+            )
+        # Primary: first default pick (or keep an already-set choice).
+        # PRD-220: rebuild the settings doc, never mutate in place.
+        settings = dict(workspace.settings or {})
+        orch = dict(settings.get("orchestrator", {}))
+        primary = orch.get("model")
+        if not primary and base:
+            primary = base[0].model_id
+            orch["model"] = primary
+            settings["orchestrator"] = orch
+            workspace.settings = settings
+            db.add(workspace)
+        return str(primary) if primary else None
+    except Exception:  # pragma: no cover — degraded, not broken
+        logger.exception("[ModelSeed] seeding failed for workspace %s", getattr(workspace, "id", "?"))
+        return None

--- a/orchestrator/tests/test_prd222_trial_enforcement.py
+++ b/orchestrator/tests/test_prd222_trial_enforcement.py
@@ -69,18 +69,18 @@ def test_converted_trial_passes_through():
 
 
 def test_active_trial_routes_to_platform(monkeypatch):
-    monkeypatch.setattr(config, "TRIAL_MODEL_ALLOWLIST", "modelA,modelB")
     r = resolve_trial_routing(_WS(_trial(TRIAL_ACTIVE)), "modelA", is_byok=False)
     assert r.action == ACTION_PLATFORM_TRIAL
-    assert r.model == "modelA"  # allowlisted request kept as-is
+    assert r.model == "modelA"  # requested model kept as-is (cap-only trial)
 
 
-def test_offlist_model_is_substituted(monkeypatch):
-    monkeypatch.setattr(config, "TRIAL_MODEL_ALLOWLIST", "modelA,modelB")
-    r = resolve_trial_routing(_WS(_trial(TRIAL_WARNED)), "expensive-gpt", is_byok=False)
+def test_active_trial_any_model_passes_through(monkeypatch):
+    """2026-08-29 (Gerard): the trial is a SPEND CAP, not a model gate — any
+    requested model rides the platform key unchanged; an expensive model just
+    exhausts the credit sooner."""
+    r = resolve_trial_routing(_WS(_trial(TRIAL_ACTIVE)), "any-expensive-model", is_byok=False)
     assert r.action == ACTION_PLATFORM_TRIAL
-    assert r.model == "modelA"  # off-list → substituted to the first allowlisted
-
+    assert r.model == "any-expensive-model"
 
 def test_exhausted_trial_is_blocked_with_typed_code():
     r = resolve_trial_routing(_WS(_trial(TRIAL_EXHAUSTED)), "m", is_byok=False)

--- a/orchestrator/tests/test_prd222_trial_ledger.py
+++ b/orchestrator/tests/test_prd222_trial_ledger.py
@@ -84,15 +84,7 @@ def test_trial_config_defaults():
     assert isinstance(config.TRIAL_ENABLED, bool)
     assert isinstance(config.TRIAL_CREDIT_USD, float)
     assert isinstance(config.TRIAL_GLOBAL_DAILY_USD, float)
-    assert isinstance(config.TRIAL_MODEL_ALLOWLIST, str)
 
-
-def test_trial_model_allowlist_reuses_budget_models():
-    # Reuse the platform's existing economical model comma-list — no new id.
-    if not os.getenv("TRIAL_MODEL_ALLOWLIST"):
-        assert config.TRIAL_MODEL_ALLOWLIST == config.BUDGET_MODELS
-    assert config.TRIAL_MODEL_ALLOWLIST  # non-empty
-    assert "," in config.TRIAL_MODEL_ALLOWLIST or config.TRIAL_MODEL_ALLOWLIST.strip()
 
 
 def test_trial_ledger_uses_no_os_getenv():

--- a/orchestrator/tests/test_prd230_chat_trial_metering.py
+++ b/orchestrator/tests/test_prd230_chat_trial_metering.py
@@ -79,26 +79,22 @@ def _factory(ws):
 def test_active_trial_chat_turn_meters_and_pins_offlist_model(monkeypatch):
     # An active-trial workspace: the request is trial-routed (so record_trial_spend
     # fires at the usage seam) and an off-allowlist model is substituted.
-    monkeypatch.setattr(config, "TRIAL_MODEL_ALLOWLIST", "trial-cheap-a,trial-cheap-b")
     f = _factory(_WS(_trial(TRIAL_ACTIVE)))
-    trial_routed, pinned = f._resolve_trial_decision(WS_ID, "expensive-gpt", is_byok=False)
+    trial_routed = f._resolve_trial_decision(WS_ID, "expensive-gpt", is_byok=False)
     assert trial_routed is True
-    assert pinned == "trial-cheap-a"  # off-list → pinned to TRIAL_MODEL_ALLOWLIST[0]
+    # 2026-08-29: pinning deleted — cap-only trial; routing flag is the contract.
 
 
 def test_active_trial_allowlisted_model_is_not_repinned(monkeypatch):
-    monkeypatch.setattr(config, "TRIAL_MODEL_ALLOWLIST", "trial-cheap-a,trial-cheap-b")
     f = _factory(_WS(_trial(TRIAL_ACTIVE)))
-    trial_routed, pinned = f._resolve_trial_decision(WS_ID, "trial-cheap-a", is_byok=False)
+    trial_routed = f._resolve_trial_decision(WS_ID, "trial-cheap-a", is_byok=False)
     assert trial_routed is True  # still metered
-    assert pinned is None        # already allowlisted → no substitution
 
 
-def test_warned_trial_still_meters(monkeypatch):
-    monkeypatch.setattr(config, "TRIAL_MODEL_ALLOWLIST", "trial-cheap-a")
+def test_warned_trial_still_meters():
     f = _factory(_WS(_trial(TRIAL_WARNED)))
-    trial_routed, pinned = f._resolve_trial_decision(WS_ID, "expensive-gpt", is_byok=False)
-    assert trial_routed is True and pinned == "trial-cheap-a"
+    trial_routed = f._resolve_trial_decision(WS_ID, "expensive-gpt", is_byok=False)
+    assert trial_routed is True  # warned still meters; no pinning (cap-only trial)
 
 
 # --------------------------------------------------------------------------- #
@@ -115,7 +111,7 @@ def test_byok_chat_turn_bypasses_trial_untouched():
     from modules.agents.factory.agent_factory import AgentFactory
 
     f = AgentFactory(db_session=_Boom())
-    assert f._resolve_trial_decision(WS_ID, "any-model", is_byok=True) == (False, None)
+    assert f._resolve_trial_decision(WS_ID, "any-model", is_byok=True) is False
 
 
 # --------------------------------------------------------------------------- #
@@ -136,17 +132,17 @@ def test_exhausted_trial_raises_typed_error_on_chat_path():
 
 
 def test_no_trial_workspace_passes_through():
-    assert _factory(_WS(None))._resolve_trial_decision(WS_ID, "m", is_byok=False) == (False, None)
+    assert _factory(_WS(None))._resolve_trial_decision(WS_ID, "m", is_byok=False) is False
 
 
 def test_converted_trial_passes_through():
     f = _factory(_WS(_trial(TRIAL_CONVERTED)))
-    assert f._resolve_trial_decision(WS_ID, "m", is_byok=False) == (False, None)
+    assert f._resolve_trial_decision(WS_ID, "m", is_byok=False) is False
 
 
 def test_system_call_without_workspace_is_noop():
     # workspace_id None (a system/non-chat call) → no read, no metering.
-    assert _factory(None)._resolve_trial_decision(None, "m", is_byok=False) == (False, None)
+    assert _factory(None)._resolve_trial_decision(None, "m", is_byok=False) is False
 
 
 # --------------------------------------------------------------------------- #

--- a/orchestrator/tests/test_workspace_model_seeding.py
+++ b/orchestrator/tests/test_workspace_model_seeding.py
@@ -1,0 +1,177 @@
+"""Harbourline fixes — workspace base-model seeding + key-availability routing.
+
+2026-08-29 (Gerard's design): every workspace starts with working models; the
+factory routes vendor models via OpenRouter when no vendor key exists; the
+trial is a spend cap (pinning deleted — covered in the trial test files).
+"""
+from __future__ import annotations
+
+import pytest
+
+
+# --------------------------------------------------------------------------- #
+# _openrouter_model_id — vendor id -> OpenRouter form (pure)
+# --------------------------------------------------------------------------- #
+
+def _factory():
+    from modules.agents.factory.agent_factory import AgentFactory
+    return AgentFactory(db_session=None)
+
+
+def test_vendor_model_gains_openrouter_prefix():
+    f = _factory()
+    assert f._openrouter_model_id("openai", "gpt-4o-mini") == "openai/gpt-4o-mini"
+    assert f._openrouter_model_id("anthropic", "claude-haiku-4-5") == "anthropic/claude-haiku-4-5"
+
+
+def test_prefixed_model_untouched():
+    f = _factory()
+    assert f._openrouter_model_id("openai", "openai/gpt-4o-mini") == "openai/gpt-4o-mini"
+
+
+def test_unknown_vendor_passes_through():
+    f = _factory()
+    assert f._openrouter_model_id("huggingface", "some-model") == "some-model"
+
+
+# --------------------------------------------------------------------------- #
+# seed_workspace_models — selection, idempotency, primary (fake session)
+# --------------------------------------------------------------------------- #
+
+class _Model:
+    def __init__(self, id, model_id, default=False, featured=False, pop=0):
+        self.id = id
+        self.model_id = model_id
+        self.is_default = default
+        self.is_featured = featured
+        self.popularity_score = pop
+
+
+class _Q:
+    """Chainable fake for the service's two query shapes."""
+    def __init__(self, rows):
+        self._rows = rows
+
+    def filter(self, *_a, **_k):
+        return self
+
+    def order_by(self, *_a):
+        return self
+
+    def limit(self, _n):
+        return self
+
+    def all(self):
+        return list(self._rows)
+
+
+class _DB:
+    def __init__(self, models, existing_ids=(), workspace=None):
+        self._models = models
+        self._existing = [type("R", (), {"model_id": i})() for i in existing_ids]
+        self._ws = workspace
+        self.added = []
+
+    def query(self, target):
+        from core.models.core import LLMModel, WorkspaceModel
+        if target is LLMModel:
+            class _BaseQ(_Q):
+                def __init__(qself):
+                    super().__init__([])
+                def filter(qself, *_a, **_k):
+                    return qself
+                def all(qself):
+                    return []
+            # The service filters defaults first, then featured — emulate by
+            # returning defaults for the first .all(), featured for the next.
+            db = self
+
+            class _ModelQ:
+                def __init__(qself):
+                    qself._mode = None
+                def filter(qself, *args, **_k):
+                    return qself
+                def order_by(qself, *_a):
+                    return qself
+                def limit(qself, _n):
+                    return qself
+                def all(qself):
+                    calls = getattr(db, "_model_calls", 0)
+                    db._model_calls = calls + 1
+                    if calls == 0:
+                        return [m for m in db._models if m.is_default]
+                    return [m for m in db._models if m.is_featured]
+            return _ModelQ()
+        if target is WorkspaceModel.model_id or getattr(target, "key", "") == "model_id":
+            return _Q(self._existing)
+        return _Q(self._existing)
+
+    def add(self, obj):
+        self.added.append(obj)
+
+    def get(self, _id):  # pragma: no cover
+        return self._ws
+
+
+class _WS:
+    def __init__(self):
+        self.id = "ws-1"
+        self.settings = None
+
+
+def _run_seed(db, ws):
+    import services.workspace_model_seeding as m
+
+    real_get = db.query
+    # patch Workspace lookup inside the service
+    class _WSQ:
+        def get(self, _id):
+            return ws
+    orig_query = db.query
+    def query(target):
+        from core.models.workspaces import Workspace
+        if target is Workspace:
+            return _WSQ()
+        return orig_query(target)
+    db.query = query
+    return m.seed_workspace_models(db, ws.id)
+
+
+def test_seeds_defaults_then_featured_capped_and_sets_primary():
+    from core.models.core import WorkspaceModel
+
+    models = [
+        _Model(1, "openai/gpt-4o-mini", default=True),
+        _Model(2, "anthropic/claude-haiku-4-5", featured=True, pop=90),
+        _Model(3, "deepseek/deepseek-chat", featured=True, pop=80),
+        _Model(4, "meta-llama/llama-3-70b", featured=True, pop=70),
+        _Model(5, "qwen/qwen-2", featured=True, pop=60),
+    ]
+    db = _DB(models)
+    ws = _WS()
+    primary = _run_seed(db, ws)
+
+    added_models = [a for a in db.added if isinstance(a, WorkspaceModel)]
+    assert len(added_models) == 4  # capped
+    assert all(a.source == "default" and a.approval_status == "approved" for a in added_models)
+    assert primary == "openai/gpt-4o-mini"  # first default pick
+    assert ws.settings["orchestrator"]["model"] == "openai/gpt-4o-mini"
+
+
+def test_existing_rows_not_duplicated_and_primary_kept():
+    from core.models.core import WorkspaceModel
+
+    models = [_Model(1, "openai/gpt-4o-mini", default=True)]
+    db = _DB(models, existing_ids=(1,))
+    ws = _WS()
+    ws.settings = {"orchestrator": {"model": "user-chosen"}}
+    primary = _run_seed(db, ws)
+
+    assert [a for a in db.added if isinstance(a, WorkspaceModel)] == []  # idempotent
+    assert primary == "user-chosen"  # user's choice never overwritten
+
+
+def test_no_base_models_degrades_without_raising():
+    db = _DB([])
+    ws = _WS()
+    assert _run_seed(db, ws) is None  # logged, degraded, never raises


### PR DESCRIPTION
Gerard's three design corrections from the Harbourline onboarding failure. (1) Every workspace now starts with working models: provisioning seeds ~4 OpenRouter-served base models + a primary into workspace_models/settings.orchestrator, and a backfill migration floors every existing zero-model workspace — fixes 'Failed to load LLM settings' and the no-default chat state. (2) Provider resolution is key-availability-driven: vendor models route via OpenRouter when no direct vendor key exists (vendor-prefixed id, loud log); direct keys still win when present — no more 'No API key for openai' while the OpenRouter key sits right there. (3) The trial is a spend cap, not a model gate: TRIAL_MODEL_ALLOWLIST and all pinning deleted (revises PRD-222 D4); metering + 80% warn + hard stop + global daily cap remain. Full suite at documented baseline; 6 new tests; trial suites rewritten cap-only. ONE migration (additive DML backfill, idempotent). After merge+deploy: reset the alias and re-run Harbourline — chat should answer, the pill should move, and Settings→Orchestrator should load.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New workspaces are automatically populated with a curated set of approved base models.
  * A primary model is selected automatically when none has been configured.
  * Existing workspaces without models are backfilled with recommended options.
  * Trial access now supports any requested model while enforcing spending limits.
  * OpenRouter fallback is available when a direct provider key is unavailable.

* **Bug Fixes**
  * Prevented duplicate model assignments and preserved user-selected primary models.
  * Seeding failures no longer block workspace creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->