### PR TITLE
fix(prd-222): onboarding never rides the ATOM bypass (+ heal main's route-count drift)

### DIFF
--- a/orchestrator/consumers/chatbot/auto.py
+++ b/orchestrator/consumers/chatbot/auto.py
@@ -815,6 +815,24 @@ class AutoBrain:
 
         msg_lower = message.lower().strip()
 
+        # ── Tier 0: onboarding pin (PRD-222) ──
+        # The onboarding spine lives ONLY in the full ContextService path (the
+        # OnboardingSection + the platform tools that advance the stage). The
+        # ATOM lane bypasses both, and every tier below is onboarding-blind —
+        # the Tier-3 rubric reads a business intro ("We're X, we sell Y…") as
+        # a greeting and says atom, then Tier 1 caches that verdict for 24h.
+        # While THIS workspace is mid-onboarding, Auto owns the turn with full
+        # context: forced ≥ MOLECULE, RESPOND (never delegate/assign away the
+        # spine), "platform" hint so the onboarding tools survive narrowing.
+        # Checked BEFORE the cache and never cached itself — the stage moves.
+        if self._onboarding_active():
+            return ComplexityAssessment(
+                complexity=Complexity.MOLECULE, action=Action.RESPOND,
+                reasoning="Onboarding active — full context path (spine + platform tools)",
+                confidence=1.0, needs_memory=False, tool_hints=["platform"],
+                needs_multi_agent=False,
+            )
+
         # ── Tier 1: Redis cache lookup (<5ms) ──
         cached = self._cache_lookup(msg_lower)
         if cached:
@@ -830,6 +848,39 @@ class AutoBrain:
         llm_result = await self._llm_classify(message, conversation_length)
         self._cache_store(msg_lower, llm_result)
         return llm_result
+
+    def _onboarding_active(self) -> bool:
+        """True while this workspace's onboarding stage is non-terminal.
+
+        One PK lookup on the already-open session (the OnboardingSection loads
+        the same row later on the full path). Fail-soft False — a load error
+        must never break classification, it just classifies normally.
+        """
+        try:
+            from core.models.workspaces import Workspace
+            from services import onboarding_state
+
+            ws = (
+                self._db.query(Workspace)
+                .filter(Workspace.id == self._workspace_id)
+                .first()
+            )
+            if ws is None:
+                return False
+            # Strict: only a KNOWN non-terminal stage string pins the turn — a
+            # corrupt doc (or a non-Workspace object) classifies normally.
+            stage = onboarding_state.current_stage(ws)
+            return (
+                isinstance(stage, str)
+                and stage in onboarding_state.ALL_STAGES
+                and stage not in onboarding_state.TERMINAL_STAGES
+            )
+        except Exception:
+            logger.debug(
+                "[AutoBrain] onboarding check failed — classifying normally",
+                exc_info=True,
+            )
+            return False
 
     # ------------------------------------------------------------------
     # Tier 2: Fast heuristics

--- a/orchestrator/reports/route-manifest.json
+++ b/orchestrator/reports/route-manifest.json
@@ -1,5 +1,5 @@
 {
-  "route_count": 770,
+  "route_count": 773,
   "routes": [
     {
       "method": "GET",

--- a/orchestrator/tests/test_prd222_atom_bypass.py
+++ b/orchestrator/tests/test_prd222_atom_bypass.py
@@ -1,0 +1,164 @@
+"""PRD-222 — the onboarding spine must never ride the ATOM bypass.
+
+The spine lives ONLY in the full ContextService path: the OnboardingSection
+(mode CHATBOT) plus the platform tools that advance the stage
+(``platform_update_onboarding``, the site scan, the package search). The ATOM
+lane bypasses ContextService AND strips those tools — and every classifier
+tier is onboarding-blind: the Tier-3 rubric reads a business intro ("We're
+Harbourline Coffee Roasters, we sell…") as a greeting ("when in doubt, choose
+atom"), and Tier 1 then caches that verdict per exact message text for 24h.
+Live result (2026-08-29): a mid-onboarding workspace greeted its intro like
+small talk and the flow never engaged.
+
+The fix is Tier 0 in ``AutoBrain.assess``: while the workspace's onboarding
+stage is non-terminal, the turn is pinned to MOLECULE / RESPOND with the
+"platform" hint — before the cache, never cached, fail-soft on any load error.
+
+These are PURE tests: ``AutoBrain`` over a fake session; cache and LLM tiers
+are stubbed to explode if consulted.
+"""
+from __future__ import annotations
+
+import pytest
+
+from consumers.chatbot.auto import Action, AutoBrain, Complexity
+from services import onboarding_state
+
+WS_ID = "11111111-1111-1111-1111-111111111111"
+
+INTRO = (
+    "We're Harbourline Coffee Roasters — a small-batch specialty coffee "
+    "roaster in Bristol. We sell whole bean and ground coffee direct to "
+    "consumers on Shopify, run a subscription club, and wholesale to about "
+    "30 cafés around the South West."
+)
+
+ACTIVE_STAGES = [
+    s for s in onboarding_state.STAGE_ORDER
+    if s not in onboarding_state.TERMINAL_STAGES
+]
+
+
+# --------------------------------------------------------------------------- #
+# Fakes — a Workspace row carrying an onboarding doc + a session that returns
+# it from ``.query(Workspace).filter(...).first()`` (all the pin reads).
+# --------------------------------------------------------------------------- #
+
+
+class _WS:
+    def __init__(self, stage):
+        self.onboarding = (
+            None if stage is None else {"stage": stage, "stages": {}, "segment": {}}
+        )
+
+
+class _FakeQuery:
+    def __init__(self, ws):
+        self._ws = ws
+
+    def filter(self, *_a, **_k):
+        return self
+
+    def first(self):
+        return self._ws
+
+
+class _FakeSession:
+    def __init__(self, ws):
+        self._ws = ws
+
+    def query(self, _model):
+        return _FakeQuery(self._ws)
+
+
+class _BoomSession:
+    def query(self, _model):
+        raise RuntimeError("db down")
+
+
+def _brain(session, monkeypatch=None, *, cache=None):
+    brain = AutoBrain(session, WS_ID)
+    brain._redis = None  # Tier 1 off unless a test stubs the lookup itself
+    if monkeypatch is not None:
+        monkeypatch.setattr(
+            brain,
+            "_cache_lookup",
+            cache if cache is not None else _explode("cache consulted"),
+        )
+        monkeypatch.setattr(brain, "_cache_store", _explode("pin was cached"))
+        monkeypatch.setattr(brain, "_llm_classify", _explode("LLM tier consulted"))
+    return brain
+
+
+def _explode(why):
+    def _boom(*_a, **_k):
+        raise AssertionError(why)
+
+    return _boom
+
+
+# --------------------------------------------------------------------------- #
+# The pin — every non-terminal stage forces the full path
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stage", ACTIVE_STAGES)
+async def test_active_onboarding_pins_full_path_before_cache_and_llm(
+    monkeypatch, stage
+):
+    # Cache, cache-store and LLM stubs all raise — the pin must return before
+    # ANY other tier runs and must never be cached (the stage moves).
+    brain = _brain(_FakeSession(_WS(stage)), monkeypatch)
+    result = await brain.assess(INTRO)
+    assert result.complexity == Complexity.MOLECULE
+    assert result.action == Action.RESPOND
+    assert "platform" in result.tool_hints
+
+
+@pytest.mark.asyncio
+async def test_poisoned_cached_atom_cannot_strip_the_spine(monkeypatch):
+    # The live failure: yesterday's run cached atom for this exact intro text.
+    # The pin sits ABOVE Tier 1, so the poisoned entry is never even read.
+    def _cached_atom(_msg):
+        raise AssertionError("Tier 1 ran — the pin must precede the cache")
+
+    brain = _brain(_FakeSession(_WS("questions")), monkeypatch, cache=_cached_atom)
+    result = await brain.assess(INTRO)
+    assert result.complexity == Complexity.MOLECULE
+
+
+@pytest.mark.asyncio
+async def test_doc_less_workspace_reads_active_and_pins(monkeypatch):
+    # A NULL onboarding column reads as not_started (new-workspace posture —
+    # veterans were backfilled to 'skipped' by prd222_veteran_skip_backfill).
+    brain = _brain(_FakeSession(_WS(None)), monkeypatch)
+    result = await brain.assess(INTRO)
+    assert result.complexity == Complexity.MOLECULE
+
+
+# --------------------------------------------------------------------------- #
+# No-op set — terminal stages and failures classify exactly as before
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stage", sorted(onboarding_state.TERMINAL_STAGES))
+async def test_terminal_stage_classifies_normally(stage):
+    brain = _brain(_FakeSession(_WS(stage)))
+    result = await brain.assess("hello")
+    assert result.complexity == Complexity.ATOM  # Tier-2 greeting, untouched
+
+
+@pytest.mark.asyncio
+async def test_missing_workspace_classifies_normally():
+    brain = _brain(_FakeSession(None))
+    result = await brain.assess("hello")
+    assert result.complexity == Complexity.ATOM
+
+
+@pytest.mark.asyncio
+async def test_workspace_load_error_fails_soft_to_normal_classification():
+    brain = _brain(_BoomSession())
+    result = await brain.assess("hello")
+    assert result.complexity == Complexity.ATOM


### PR DESCRIPTION
## What broke (Harbourline retest, this morning)

Auto answered the business intro like small talk — no three questions, no stage awareness. #645 fixed the LLM layer (Auto now *answers*), which exposed the next layer down:

**The onboarding spine lives ONLY in the full ContextService path** — the `OnboardingSection` (mode CHATBOT) plus the platform tools that drive the flow (`platform_update_onboarding`, site scan, package search). The PRD-68 **ATOM fast-lane bypasses both**, and every classifier tier is onboarding-blind:

- Tier-3's rubric literally says *"Greetings, chitchat… when in doubt, choose atom"* — a business intro ("We're Harbourline Coffee Roasters, we sell…") has no ask, so it reads as a greeting.
- Tier 1 then **caches the verdict per exact message text for 24h** (workspace-scoped). Yesterday's crashed run classified + cached the intro before dying at the factory; today's retest re-pasted the same text → sticky ATOM → ContextService bypassed → generic Auto.

PRD-222 never pinned the spine to the full path; whether onboarding engaged was a classifier coin-flip on exactly the kind of message onboarding starts with. (Lumen & Lark happened to classify higher — that's why it engaged.)

## Fix

**Tier 0 in `AutoBrain.assess`**: while the workspace's onboarding stage is a known non-terminal stage, the turn is pinned `MOLECULE / RESPOND` with the `platform` tool hint —

- **before the cache** (a poisoned entry can never strip the spine), **never cached** (the stage moves),
- `RESPOND` + platform hint keeps Auto owning the turn (no delegate/assign lane can carry the intro off-thread),
- strict stage validation + fail-soft on any load error → mocks, corrupt docs, or a DB hiccup classify exactly as before,
- terminal stages (`completed`/`skipped`): zero behaviour change; cost while active = one PK lookup on the open session.

13 new pure tests (`test_prd222_atom_bypass.py`): every active stage pins before cache/LLM, the poisoned-cache scenario, doc-less reads as active, terminal/missing/error paths untouched.

## Second commit — heals main CI

Main has been red since #642/#640 merged: the manifest carries **773 rows but `route_count: 770`** — a parallel branch's older count line clobbered the #644 recount (second sighting of this collision class). One-line fix, rows untouched, never regenerated.

## Verification

- New suite 13/13; auto.py-adjacent suites (assign lane, trust gate, reasoning entry, planning pack, golden journeys) 188 passed.
- Full local suite: 4951 passed — remaining failures are the documented no-local-Postgres baseline (prd172 + psycopg2 connection-refused).
- Manifest guard `test_p2w2_tasks_lane_deleted` 5/5 locally (was the only real CI failure on main).

## Retest script (after merge + Railway deploy)

1. `/dev/reset-onboarding` on the alias workspace.
2. Same Harbourline intro — **word-for-word is now fine** (the pin sits above the cache).
3. Expect: Auto greets in one line and asks question 1 of 3; stage pill moves as you answer; proposal offers the Shopify package by name.