### PR TITLE
fix(prd-222): onboarding tools survive semantic narrowing

### DIFF
--- a/orchestrator/modules/tools/discovery/actions_onboarding.py
+++ b/orchestrator/modules/tools/discovery/actions_onboarding.py
@@ -9,6 +9,24 @@ the at-least-one rule is stated in the description AND enforced by the handler.
 
 from .action_registry import ActionDefinition, ActionRegistry
 
+# The onboarding spine's tool surface (PRD-222, live-test 2026-08-29): while a
+# workspace is mid-onboarding these actions must SURVIVE semantic narrowing —
+# the OnboardingSection instructs Auto to call them by name, but the top-K
+# ranking keys on the user's latest text, and onboarding turns are exactly the
+# ones with no tool-shaped text ("Yes please."). Ranked out ⇒ Auto narrates the
+# action it cannot take and the flow dead-ends. tool_router folds this list
+# into the dispatcher enum (the PRD-221 page-prior mechanism) while
+# ``onboarding_state.is_onboarding_active`` holds. Every name is guarded
+# against the registry by test_prd222_onboarding_tool_prior.
+ONBOARDING_PRIOR_ACTIONS = [
+    "platform_update_onboarding",      # the spine — every stage advance
+    "platform_scan_business_site",     # teach: site scan
+    "platform_search_packages",        # proposal: match a package (PRD-230)
+    "platform_install_package",        # building: install the accepted package
+    "platform_install_marketplace_agent",  # building: custom-design staffing
+    "platform_submit_report",          # powerup: the onboarding summary Deliverable
+]
+
 # Stages Auto may advance TO. Deliberately excludes ``not_started`` (the initial
 # state — you never advance back to it); mirrors services.onboarding_state.
 _ADVANCE_TARGETS = [

--- a/orchestrator/modules/tools/tool_router.py
+++ b/orchestrator/modules/tools/tool_router.py
@@ -342,6 +342,43 @@ def _apply_page_prior(
     return merged, (reason or "page_prior"), from_pins
 
 
+def _apply_onboarding_prior(
+    narrowing: Tuple[Optional[List[str]], Optional[str], bool],
+    session,
+    workspace_id: Optional[Any],
+    is_admin: bool,
+    is_super_admin: bool,
+) -> Tuple[Optional[List[str]], Optional[str], bool]:
+    """Union the onboarding spine's actions into the narrowed enum while the
+    workspace is mid-onboarding (PRD-222, live-test 2026-08-29).
+
+    The OnboardingSection instructs Auto to call these actions by name, but the
+    semantic ranking keys on the user's latest text — and onboarding turns are
+    exactly the ones with no tool-shaped text ("Yes please."). Same fold, gate
+    filter, and cap as the PRD-221 page prior. Fail-soft: any load error leaves
+    the narrowing untouched.
+    """
+    allowed, _reason, _from_pins = narrowing
+    if allowed is None or not workspace_id or session is None:
+        return narrowing
+    try:
+        from core.models.workspaces import Workspace
+        from services import onboarding_state
+
+        ws = session.query(Workspace).filter(Workspace.id == workspace_id).first()
+        if ws is None or not onboarding_state.is_onboarding_active(ws):
+            return narrowing
+        from modules.tools.discovery.actions_onboarding import ONBOARDING_PRIOR_ACTIONS
+
+        merged = _apply_page_prior(
+            narrowing, ONBOARDING_PRIOR_ACTIONS, is_admin, is_super_admin
+        )
+        return merged[0], "onboarding_prior", merged[2]
+    except Exception:
+        logger.debug("[tool-router] onboarding prior failed — narrowing unchanged", exc_info=True)
+        return narrowing
+
+
 def _dispatcher_always_include() -> List[str]:
     """Action names the dispatcher_only surface (the heartbeat orchestrator)
     must keep reachable regardless of the semantic top-K ranking (P228-RVW-4).
@@ -861,6 +898,11 @@ async def get_tools_for_agent_async(
         # Gate-filtered by the SAME predicate as ranking — a manifest can never
         # expose an admin/su tool to an unauthorized principal.
         narrowing = _apply_page_prior(narrowing, page_actions, is_admin, is_super_admin)
+        # PRD-222: while onboarding is active, the spine's actions survive
+        # narrowing — the section instructs Auto to call them by name.
+        narrowing = _apply_onboarding_prior(
+            narrowing, session_used, workspace_id, is_admin, is_super_admin
+        )
         tools = _get_tools_for_agent_core(
             agent_id=agent_id,
             session_used=session_used,

--- a/orchestrator/tests/test_prd222_onboarding_tool_prior.py
+++ b/orchestrator/tests/test_prd222_onboarding_tool_prior.py
@@ -1,0 +1,139 @@
+"""PRD-222 — the onboarding spine's tools must survive semantic narrowing.
+
+Live failure (Harbourline retest #2, 2026-08-29, after the #646 ATOM fix): the
+flow engaged, Auto collected the segment, said "I'll update our system with
+your preferences" — and stopped. The turn's user text was "Yes please.", the
+semantic top-K ranked the dispatcher enum on that text, and
+``platform_update_onboarding`` fell out of the surface. The section instructs
+Auto to call tools by name; a surface that doesn't carry them dead-ends the
+model (the blueprint-rules wall class).
+
+Fix: ``_apply_onboarding_prior`` in tool_router — while the workspace is
+mid-onboarding, ``ONBOARDING_PRIOR_ACTIONS`` is folded into the narrowed enum
+through the same gate filter and cap as the PRD-221 page prior.
+"""
+from __future__ import annotations
+
+import pytest
+
+from modules.tools.discovery.actions_onboarding import ONBOARDING_PRIOR_ACTIONS
+from modules.tools.tool_router import _apply_onboarding_prior
+
+WS_ID = "11111111-1111-1111-1111-111111111111"
+
+
+class _WS:
+    def __init__(self, stage):
+        self.onboarding = {"stage": stage, "stages": {}, "segment": {}}
+
+
+class _FakeQuery:
+    def __init__(self, ws):
+        self._ws = ws
+
+    def filter(self, *_a, **_k):
+        return self
+
+    def first(self):
+        return self._ws
+
+
+class _FakeSession:
+    def __init__(self, ws):
+        self._ws = ws
+
+    def query(self, _model):
+        return _FakeQuery(self._ws)
+
+
+class _BoomSession:
+    def query(self, _model):
+        raise RuntimeError("db down")
+
+
+_NARROWED = (["platform_list_agents"], "semantic_top_k", False)
+
+
+# --------------------------------------------------------------------------- #
+# The registry guard — a renamed tool must fail THIS test, not dead-end Auto
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("name", ONBOARDING_PRIOR_ACTIONS)
+def test_every_prior_action_is_registered(name):
+    from modules.tools.discovery.action_registry import get_action_registry
+
+    assert get_action_registry().get(name) is not None, (
+        f"{name} is pinned for onboarding but not registered — the section "
+        "instructs Auto to call it by name"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# The fold — active onboarding unions the spine's actions into the enum
+# --------------------------------------------------------------------------- #
+
+
+def test_active_onboarding_folds_spine_actions_into_enum():
+    allowed, reason, _ = _apply_onboarding_prior(
+        _NARROWED, _FakeSession(_WS("questions")), WS_ID,
+        is_admin=False, is_super_admin=False,
+    )
+    assert "platform_list_agents" in allowed  # ranked set survives, order-stable
+    for name in ONBOARDING_PRIOR_ACTIONS:
+        assert name in allowed
+    assert reason == "onboarding_prior"
+
+
+def test_plain_user_gets_the_spine_actions():
+    # The gate filter must clear every spine action for a non-admin principal —
+    # onboarding is a plain-user flow.
+    allowed, _, _ = _apply_onboarding_prior(
+        _NARROWED, _FakeSession(_WS("building")), WS_ID,
+        is_admin=False, is_super_admin=False,
+    )
+    assert set(ONBOARDING_PRIOR_ACTIONS) <= set(allowed)
+
+
+# --------------------------------------------------------------------------- #
+# No-op set — terminal, full-enum, missing, and error paths stay untouched
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("stage", ["completed", "skipped"])
+def test_terminal_stage_leaves_narrowing_untouched(stage):
+    out = _apply_onboarding_prior(
+        _NARROWED, _FakeSession(_WS(stage)), WS_ID,
+        is_admin=False, is_super_admin=False,
+    )
+    assert out == _NARROWED
+
+
+def test_full_enum_needs_no_prior():
+    # allowed is None → every action already exposed; nothing to fold.
+    full = (None, "flag SEMANTIC_TOOL_ROUTING=False", False)
+    out = _apply_onboarding_prior(
+        full, _FakeSession(_WS("questions")), WS_ID,
+        is_admin=False, is_super_admin=False,
+    )
+    assert out == full
+
+
+def test_missing_workspace_or_session_untouched():
+    assert _apply_onboarding_prior(
+        _NARROWED, _FakeSession(None), WS_ID, is_admin=False, is_super_admin=False
+    ) == _NARROWED
+    assert _apply_onboarding_prior(
+        _NARROWED, None, WS_ID, is_admin=False, is_super_admin=False
+    ) == _NARROWED
+    assert _apply_onboarding_prior(
+        _NARROWED, _FakeSession(_WS("questions")), None,
+        is_admin=False, is_super_admin=False,
+    ) == _NARROWED
+
+
+def test_load_error_fails_soft_to_unchanged_narrowing():
+    out = _apply_onboarding_prior(
+        _NARROWED, _BoomSession(), WS_ID, is_admin=False, is_super_admin=False
+    )
+    assert out == _NARROWED


### PR DESCRIPTION
## The next layer (Harbourline retest #2, on the #646 deploy)

#646 worked — the flow engaged: three questions one at a time, segment captured, comfort adapted. It died at the conversation's **first tool-calling moment**: Auto said *"I'll update our system with your preferences"* and stopped. Nothing was created (correct — nothing should be before proposal-yes); the stage never advanced.

**Why:** the turn's user text was **"Yes please."** — and `SEMANTIC_TOOL_ROUTING` (default ON) ranks the `platform_execute` dispatcher enum on exactly that text. `platform_update_onboarding` fell out of the top-K. The OnboardingSection instructs Auto to call tools **by name**, so the model narrated the action it couldn't take and dead-ended — the blueprint-rules wall class. Onboarding turns are structurally the worst case for semantic narrowing: the user's text is "yes please" / "basic" / a business intro, while the tools are named by the *section*.

## Fix

`_apply_onboarding_prior` in tool_router, applied right after the PRD-221 page prior: while `onboarding_state.is_onboarding_active` holds, `ONBOARDING_PRIOR_ACTIONS` folds into the narrowed enum through the **same gate-filtered union + cap** (third member of that idiom family, after page-prior and the P228 heartbeat always-include). The list lives with the spine in `actions_onboarding.py`: stage advance, site scan, package search/install, marketplace-agent install, onboarding report.

- Fail-soft: any load error leaves narrowing untouched.
- Terminal stages / full-enum narrowing: byte-identical behaviour.
- ATOM lane needs no change — #646 guarantees active-onboarding turns never take it.

## Tests

13 new (`test_prd222_onboarding_tool_prior.py`), including a **registry guard**: renaming a pinned tool fails the test instead of silently dead-ending Auto. Narrowing-path suites (semantic router, page context/manifest, fleet tool, selection-at-scale) 115 passed; full local suite 4965 passed at documented baseline.

## Retest (after merge + deploy)

Resume the stalled Harbourline chat with **"carry on"** (no reset needed — the pin reads live stage) — Auto should now actually call the tool: stage pill moves to `teach`/`proposal`, and the package proposal follows. Fresh-reset run works too.

## Also observed this session (not in this PR — flagging)

Auto's chat brain is `google/gemini-2.5-flash` via `core/llm/defaults` — chat model resolution reads the **agent's model_config → system settings**, and never the workspace primary #645 seeds into `workspaces.settings.orchestrator.model`. The seeded primary currently drives the Settings page but not Auto's chair. Whether the workspace primary should win over the agent seed (and whether seeding should write Auto's model_config) is a design call — your call, one obvious small PR either way.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved onboarding workflows by keeping essential onboarding actions available during active onboarding, even when search-based tool selection narrows available options.
  * Preserved existing access controls and behavior for completed onboarding, full tool listings, missing information, and system errors.

* **Tests**
  * Added regression coverage for onboarding action availability, permissions, completion states, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->