### PR TITLE
fix(prd-230): packages seed runs at boot — prod marketplace had zero packages

### DIFF
--- a/orchestrator/core/seeds/seed_packages.py
+++ b/orchestrator/core/seeds/seed_packages.py
@@ -227,10 +227,15 @@ PACKAGES: list[dict] = [MANAGEMENT_PACKAGE, DEVELOPMENT_PACKAGE]
 _JSONB_FIELDS = ("vertical_tags", "matching", "members", "setup_manifest")
 
 
-def seed_packages(db=None) -> tuple[int, int]:
+def seed_packages(db=None, create_only: bool = False) -> tuple[int, int]:
     """Idempotently upsert the Shopify packages into ``marketplace_packages``
     (keyed by slug). Re-running is a no-op create-wise: existing rows are
-    refreshed, never duplicated. Returns ``(created, updated)``."""
+    refreshed, never duplicated. Returns ``(created, updated)``.
+
+    ``create_only=True`` (the BOOT posture): missing packages are created,
+    existing rows are left byte-untouched — live curation of package content
+    survives every redeploy. Full refresh stays a deliberate manual run of
+    this script (the skills-repo lesson: seed-vs-row sync is explicit)."""
     from core.models.marketplace_packages import MarketplacePackage
 
     own_session = db is None
@@ -258,6 +263,8 @@ def seed_packages(db=None) -> tuple[int, int]:
                 }))
                 created += 1
                 logger.info("✅ Created package %s", pkg_def["slug"])
+            elif create_only:
+                logger.info("⏭️  Package %s exists — boot posture leaves it untouched", pkg_def["slug"])
             else:
                 # Rebuild JSONB (assign fresh objects — never mutate in place).
                 existing.name = pkg_def["name"]

--- a/orchestrator/main.py
+++ b/orchestrator/main.py
@@ -264,6 +264,22 @@ async def _boot_phase_1_core():
         except Exception as e:
             logger.warning("Auto persona doctrine backfill: %s", e)
 
+        # PRD-230 (live-test 2026-08-29): the packages seed existed only as a
+        # manual script, so prod carried ZERO packages — the Packages tab was
+        # empty and onboarding's proposal silently fell back to custom-design
+        # (D10 masked the gap). CREATE-only here: missing packages land on the
+        # next deploy; existing rows are never touched, so live curation of
+        # package content survives redeploys. Full refresh stays a deliberate
+        # manual run of core/seeds/seed_packages.py.
+        try:
+            from core.seeds.seed_packages import seed_packages
+            with get_db_session() as db:
+                pkg_created, _ = seed_packages(db, create_only=True)
+            if pkg_created:
+                logger.info("Marketplace packages seeded: %d created", pkg_created)
+        except Exception as e:
+            logger.warning("Marketplace packages seed: %s", e)
+
         logger.info("Boot seeds completed (leader worker)")
 
         # ── Orphaned-run reaper (PRD-142 Wave 1 · WS-C · W1-S6) ──

--- a/orchestrator/tests/test_prd230_packages_seed.py
+++ b/orchestrator/tests/test_prd230_packages_seed.py
@@ -189,3 +189,35 @@ def test_seed_is_idempotent_no_duplicates():
     created2, updated2 = seed_packages(db)
     assert (created2, updated2) == (0, 2)
     assert len(db.store) == 2  # no dupes
+
+
+# --------------------------------------------------------------------------- #
+# Boot posture (live-test 2026-08-29: prod had ZERO packages — the seed was a
+# manual script nobody ran; the proposal silently fell back to custom-design)
+# --------------------------------------------------------------------------- #
+
+
+def test_create_only_seeds_missing_and_never_touches_existing_rows():
+    db = _FakeSession()
+
+    created, updated = seed_packages(db, create_only=True)
+    assert (created, updated) == (2, 0)
+
+    # Simulate Gerard's live curation of a row, then a redeploy's boot seed:
+    # the curated row must survive byte-identical.
+    db.store["shopify-management"].description = "hand-tuned copy"
+    created2, updated2 = seed_packages(db, create_only=True)
+    assert (created2, updated2) == (0, 0)
+    assert db.store["shopify-management"].description == "hand-tuned copy"
+    assert len(db.store) == 2
+
+
+def test_boot_lane_runs_the_packages_seed_create_only():
+    # The seed only exists in prod if something calls it — the boot leader
+    # block must carry it, in the create-only posture (grep-proof, the
+    # established wiring-test style).
+    from pathlib import Path
+
+    src = (Path(__file__).resolve().parents[1] / "main.py").read_text()
+    assert "from core.seeds.seed_packages import seed_packages" in src
+    assert "seed_packages(db, create_only=True)" in src


### PR DESCRIPTION
## What you saw

Marketplace → Packages: empty. Correct observation — **prod has zero package rows**, and there's no UI to author them (by design for v1: packages are data, curated in the seed).

## Why

US-008's seed (`core/seeds/seed_packages.py` — Shopify Management + Shopify Development, curated from the 12 live Shopify agents) shipped as a **manual script with no caller**, following the `seed_shopify_agents` convention. Nothing on boot, no migration, nobody ran it → zero rows. Worse: with zero packages, `platform_search_packages` returns nothing and the proposal stage silently falls back to custom-design (D10) — your next retest would have LOOKED fine while never exercising the package flow at all.

## Fix

The boot leader block (same lane as system prompts / settings / persona backfill) now runs `seed_packages(create_only=True)`:

- Missing packages are created on deploy — **merging this puts both Shopify packages in prod, no manual step**.
- Existing rows are **never touched** — when you tune package content later, a redeploy can't clobber it (the skills-repo lesson). Full refresh remains a deliberate manual run of the script.
- Same fail-soft posture as the sibling seeds — a seed error warns, never blocks boot.

## Answering the question behind the question

- **First batch:** Shopify Management (4 agents: Ops, Support, Inventory Watchdog, Business Analyst + weekly-numbers report + store connect) and Shopify Development (App Architect, Storefront Dev, Extension Builder + GitHub connect) — both showcased. That's the deliberate v1 scope from the PRD (no verticals beyond Shopify until the machinery is proven).
- **Authoring packages:** for now = editing `seed_packages.py` (a package is one dict: members, matching signals, setup manifest) or editing rows directly once seeded. A packages admin UI is a real candidate story — your call whether it makes the next wave or waits until after Harbourline proves the machinery.

## Tests

59 PRD-230 tests green including the new ones: create-only seeds missing rows, a hand-tuned row survives a boot-seed byte-identical, boot wiring grep-locked. Full suite 4954 at documented baseline.

## Merge order

Independent of #647 — merge both, one deploy: #647 un-stalls the Harbourline chat, this one gives the proposal stage real packages to offer.