### PR TITLE
fix(prd-222): non-dict segment crashed advance-to-proposal — every onboarding stalled at teach

### DIFF
--- a/orchestrator/services/onboarding_state.py
+++ b/orchestrator/services/onboarding_state.py
@@ -144,8 +144,19 @@ def _validate_transition(current: str, target: str) -> None:
 
 
 def _clean_segment(segment: Optional[dict]) -> dict[str, Any]:
-    """Keep only the three known segment keys carrying a non-None value."""
-    if not segment:
+    """Keep only the three known segment keys carrying a non-None value.
+
+    Boundary-hardened (live-test 2026-08-29): ``segment`` is LLM-supplied through
+    the ``platform_update_onboarding`` tool, and the model sometimes passes it as
+    a bare string (a free-text business summary) instead of the
+    ``{business, goal, comfort}`` object the schema asks for. A non-dict value
+    used to reach ``segment.get(k)`` and raise ``'str' object has no attribute
+    'get'`` — which failed the WHOLE advance-to-proposal call and stalled every
+    onboarding at ``teach``. A non-dict segment now cleans to ``{}`` (ignored:
+    the real answers were already captured on the question turns), so the stage
+    advance still lands.
+    """
+    if not isinstance(segment, dict):
         return {}
     return {k: segment[k] for k in SEGMENT_KEYS if segment.get(k) is not None}
 

--- a/orchestrator/services/plan_tiers.py
+++ b/orchestrator/services/plan_tiers.py
@@ -320,7 +320,7 @@ def recommend_plan(segment: Optional[dict], team_size=None, tiers: Optional[dict
     which both pass only the segment, always agree (an explicit arg still wins,
     for direct/unit use).
     """
-    seg = segment or {}
+    seg = segment if isinstance(segment, dict) else {}  # LLM may pass a bare string
     text = " ".join(str(seg.get(k) or "") for k in ("business", "goal", "comfort")).lower()
     raw_size = team_size if team_size is not None else seg.get("team_size")
     size = raw_size if isinstance(raw_size, int) and not isinstance(raw_size, bool) and raw_size > 0 else None

--- a/orchestrator/tests/test_prd222_onboarding_state.py
+++ b/orchestrator/tests/test_prd222_onboarding_state.py
@@ -253,6 +253,40 @@ def test_set_segment_merges_and_ignores_unknown_keys():
     assert ws.onboarding["segment"] == {"business": "cafe", "goal": "invoicing"}
 
 
+# --------------------------------------------------------------------------- #
+# Boundary hardening (live-test 2026-08-29): the LLM sometimes passes `segment`
+# as a bare STRING through platform_update_onboarding instead of the object the
+# schema asks for. A string used to reach `segment.get(k)` and raise
+# "'str' object has no attribute 'get'", which failed the WHOLE advance and
+# stalled every onboarding at `teach`. A non-dict segment must be IGNORED so the
+# stage advance still lands (the answers were captured on the question turns).
+# --------------------------------------------------------------------------- #
+
+
+def test_advance_to_proposal_with_string_segment_does_not_crash():
+    # The exact live failure: advancing teach -> proposal with a free-text
+    # string segment must succeed, not raise AttributeError.
+    ws = _FakeWorkspace({"stage": "teach", "segment": {"business": "jeweller"}})
+    advance_onboarding_stage(None, ws, "proposal", segment="a jewellery brand on Shopify")
+    assert ws.onboarding["stage"] == "proposal"
+    # The prior real segment is preserved; the junk string contributed nothing.
+    assert ws.onboarding["segment"] == {"business": "jeweller"}
+
+
+@pytest.mark.parametrize("junk", ["a string", 42, ["list"], True])
+def test_clean_segment_ignores_non_dict(junk):
+    from services.onboarding_state import _clean_segment
+
+    assert _clean_segment(junk) == {}
+
+
+def test_recommend_plan_survives_string_segment():
+    from services.plan_tiers import recommend_plan
+
+    plan, _reason = recommend_plan("we're a barber shop")  # bare string, not a dict
+    assert plan in {"basic", "pro", "business"}
+
+
 def test_set_segment_empty_raises():
     ws = _FakeWorkspace(None)
     with pytest.raises(ValueError):


### PR DESCRIPTION
## The wall behind every live stall this week

Found by the **automated persona harness** you asked for — its first substantive run. Two personas (Harbourline via website-scan, Lumen via chat) both reached `teach` and then **never advanced to `proposal`**: no package offered, no plan gate, no completion. The harness captured the cause verbatim from the tool result:

```
Tool platform_update_onboarding failed: 'str' object has no attribute 'get'
```

## Root cause

`platform_update_onboarding`'s `segment` param is **LLM-supplied**. The schema asks for `{business, goal, comfort}`, but on the proposal turn the model frequently passes a **bare string** — a free-text business summary. `_clean_segment` did `segment.get(k)` on it → `AttributeError` → the entire advance rolled back (`success:False`) → stage stuck at `teach`.

- `not_started → teach` advances passed a proper dict, so they worked.
- `teach → proposal` is where the model summarised → passed a string → crash.
- Consequence: **100% of onboardings stalled at teach.** This is the wall behind every live test you ran (Harbourline retests #1–#3, Lumen) — the earlier fixes (#646 engage, #647 tool-narrowing, #648 packages) each peeled a layer and exposed this one underneath.

## Fix

Boundary hardening — matches the house rule "validate all external data at system boundaries":

- `_clean_segment`: a non-dict `segment` cleans to `{}` and is **ignored** — the real answers were already captured on the question turns, so the advance lands and the stage moves to `proposal`. No data lost.
- `recommend_plan`: defense-in-depth `isinstance` guard on the same LLM-supplied value.

3 regression tests, including the exact `teach → proposal`-with-string-segment path that was failing, plus a parametrized non-dict sweep (string / int / list / bool).

## Verification

- New + adjacent onboarding suites (state, tool, plan recommendation): 81 passed.
- Full local suite: 4973 passed at documented baseline (only the no-local-Postgres prd172 failure).
- **Live proof pending deploy:** merge → Railway → I re-run the persona suite; expect `teach → proposal`, a Shopify package offered by name (Harbourline/Lumen), and the flow reaching `building`/`boom`. If anything downstream of proposal is still broken, the harness finds it automatically.

## Harness note

This is the eval harness in action: it reproduced a 100%-reproducible onboarding blocker that manual testing kept hitting but couldn't localize, and pinned it to one line. Full 15-persona suite is built and ready to run against the deploy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved onboarding reliability when unexpected non-object segment data is provided.
  * Preserved existing onboarding segment details during progression.
  * Ensured plan recommendations remain available despite malformed segment input.

* **Tests**
  * Added coverage for string, numeric, list, and boolean segment values.
  * Verified onboarding progression completes without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->