### PR TITLE
fix(prd-222): redundant same-stage advance is idempotent, not a user-visible error

### DIFF
--- a/orchestrator/modules/tools/discovery/handlers_onboarding.py
+++ b/orchestrator/modules/tools/discovery/handlers_onboarding.py
@@ -15,6 +15,7 @@ from core.models.workspaces import Workspace
 from services.onboarding_state import (
     InvalidStageTransition,
     advance_onboarding_stage,
+    current_stage,
     get_onboarding,
     public_snapshot,
     record_plan_event,
@@ -51,6 +52,23 @@ async def update_onboarding(
     )
     if not workspace:
         return {"success": False, "error": "workspace not found"}
+
+    # Idempotent same-stage advance (live-test 2026-08-29): the LLM routinely
+    # re-asserts the stage it is already in — e.g. calling advance_to="building"
+    # while building — and the strict monotonic validator raised
+    # "non-forward transition 'building' -> 'building'", which the tool surfaced
+    # as an error. Auto then apologised to the user for a "hiccup" and looped.
+    # Re-asserting the current stage is a benign no-op, not an error: drop the
+    # redundant advance (segment/plan writes below still run). BACKWARD and
+    # UNKNOWN targets are untouched — they still validate-and-error.
+    if advance_to and advance_to == current_stage(workspace):
+        logger.info(
+            "[update_onboarding] advance_to=%s equals current stage — idempotent no-op",
+            advance_to,
+        )
+        advance_to = None
+        if not segment and not plan:
+            return {"success": True, "data": public_snapshot(workspace)}
 
     # Reject a non-assignable plan BEFORE any write — honest coming-soon copy.
     if plan is not None:

--- a/orchestrator/tests/test_prd222_onboarding_tool.py
+++ b/orchestrator/tests/test_prd222_onboarding_tool.py
@@ -105,6 +105,30 @@ def test_handler_backward_transition_returns_clean_error():
     assert ws.onboarding["stage"] == "proposal"
 
 
+def test_handler_same_stage_advance_is_idempotent_success():
+    # Live-test 2026-08-29: the LLM re-asserts the stage it's already in (e.g.
+    # advance_to="building" while building). That must be a benign no-op success,
+    # NOT the "non-forward transition X -> X" error Auto used to surface + loop on.
+    ws = _FakeWorkspace({"stage": "building", "stages": {"building": "t"}, "segment": {}})
+    res = _run(update_onboarding(_db_returning(ws), uuid4(), {"advance_to": "building"}))
+    assert res["success"] is True
+    assert res["data"]["stage"] == "building"
+    assert ws.onboarding["stage"] == "building"  # unchanged, no error
+
+
+def test_handler_same_stage_advance_still_records_segment():
+    # A redundant advance paired with real segment answers: drop the no-op
+    # advance but still persist the segment (and report success).
+    ws = _FakeWorkspace({"stage": "teach", "stages": {"teach": "t"}, "segment": {}})
+    res = _run(update_onboarding(
+        _db_returning(ws), uuid4(),
+        {"advance_to": "teach", "segment": {"goal": "book appts"}},
+    ))
+    assert res["success"] is True
+    assert ws.onboarding["stage"] == "teach"
+    assert ws.onboarding["segment"] == {"goal": "book appts"}
+
+
 def test_handler_records_segment_only():
     ws = _FakeWorkspace({"stage": "questions", "stages": {}, "segment": {}})
     res = _run(


### PR DESCRIPTION
## Found by the persona harness (Lumen, building stage)

Iteration 2 of the autonomous test→fix→merge loop. #649 unblocked `teach → proposal → building`; the harness then caught Auto looping in `building`:

```
Tool platform_execute failed: non-forward onboarding transition 'building' -> 'building'
```

Auto surfaced it to the user as *"a slight hiccup"* / *"a bit of a loop"* and burned turns apologising.

## Cause

The LLM routinely re-asserts the stage it's already in (`advance_to='building'` while building). The strict monotonic validator correctly rejects same-stage transitions — but the tool turned that rejection into a user-visible error.

## Fix

Re-asserting the **current** stage is a benign no-op. The handler drops the redundant advance (segment/plan writes in the same call still run) and returns the current snapshot as `success`. **Backward and unknown targets are untouched** — still validate-and-error through the monotonic guard. Only the LLM-facing tool became tolerant of redundancy. 2 regression tests.

## Verification

- Onboarding tool + state suites: 59 passed.
- Full local suite: 4975 passed at documented baseline (only the no-local-Postgres prd172 failure).

## Note — deeper building blocker (separate, next iteration)

This removes the *noise*, not the functional wall. The harness also found Auto **never calls `platform_search_packages`** at proposal — it custom-designs a team and tries to install guessed plugin slugs (`shopify-tools`) that 404, so #648's packages are never used. That's prompt-adherence in the proposal/building guidance, not a code bug — diagnosing next, will flag the intended fix before changing Auto's behaviour.