### PR TITLE
fix(prd-222): onboarding searches packages before proposing — stop inventing agents & guessing slugs

### DIFF
--- a/orchestrator/modules/context/sections/onboarding.py
+++ b/orchestrator/modules/context/sections/onboarding.py
@@ -118,7 +118,11 @@ Offer three ways — their choice:
 - Upload documents.
 - Just tell you in chat.
 When the reading finishes, play back what you learned in plain words and ask them \
-to correct you — corrections matter. Then advance_to `proposal`.
+to correct you — corrections matter. Then, BEFORE you compose any proposal, call \
+`platform_search_packages` (their business + goal) to find a prebuilt package — you \
+staff their team from the marketplace, NEVER by inventing agents or guessing tool/\
+plugin names. In the SAME turn, advance_to `proposal` and present what the search \
+returned (a matched package by name, or a custom team only if it returned nothing).
 """
 
 _NO_SCAN_NOTE = (
@@ -144,9 +148,11 @@ Plan: {plan_recommendation}
 
 _STAGE_BUILDING = """\
 ### Now: build it — narrate every step
-If they accepted a package, install it with `platform_install_package` (its slug) \
-and narrate the manifest — the agents, skills, tools and Playbooks now registered \
-to THEIR workspace, theirs to edit. Otherwise create the pieces directly. Then \
+If they accepted a package, install it with `platform_install_package` (the slug \
+from your package search) and narrate the manifest — the agents, skills, tools and \
+Playbooks now registered to THEIR workspace, theirs to edit. If there was NO package, \
+build from REAL marketplace ids only: search first, then install what the search \
+returned — NEVER invent a plugin/tool/agent slug, a guessed id 404s. Then \
 request the connections the setup needs through the chat connect card (never \
 auto-connect); for Shopify, the two-step honestly — connect now for store data, \
 then the Automatos app adds a Site under Settings → Widget SDK → sync. Narrate as \


### PR DESCRIPTION
## Found by the persona harness (iteration 3)

The functional wall behind the `building` stall. Auto **never called `platform_search_packages`**: at proposal it invented a custom team (agents named after the business — "Lumen/Spark/Forge"), and in building tried to install a guessed plugin slug `shopify-tools` that 404s. Your seeded #648 packages were never used, and the custom path can't install real artifacts either.

## Root cause — guidance timing

The onboarding section injects **the current stage's** guidance at turn start. Auto advances `teach → proposal` **and composes the proposal in that same turn** — still under `teach` guidance. So the proposal block's "call `platform_search_packages` first" instruction never drove the turn that actually built the proposal. It was always one turn too late.

## Fix

- **teach block:** fold the package search into the advance step — search *before* composing any proposal, in the same turn as the advance, and present what it returned (matched package by name, or a custom team only if nothing matched).
- **building block:** install the accepted package by its searched slug; in the no-package path, build from **real marketplace ids only** (search first) — never a guessed slug, since a guessed id 404s.

## Verification

- Section budget + content tests, 230 integration, atom-bypass, tool-prior: **97 passed**.
- **Prompt-behaviour change → verified live on the deploy** via the persona harness (does Auto now call `platform_search_packages` and offer the real Shopify package?). Not unit-testable; live-verified per the agreed loop.

## Loop context

Iteration 3 of the autonomous test→fix→merge loop. Rides on #649 (segment crash, merged) and #651 (same-stage idempotent, in CI). Independent file (the section) — merges cleanly alongside #651. After both deploy I re-run the harness to confirm Harbourline/Lumen reach the real Shopify package and the flow gets to `boom`.