### PR TITLE
hotfix: platform_execute survives semantic routing — onboarding tools actually reach Auto

### DIFF
--- a/orchestrator/config.py
+++ b/orchestrator/config.py
@@ -987,6 +987,14 @@ class Config:
     COORDINATOR_ARCHIVE_AFTER_DAYS: int = int(os.getenv("COORDINATOR_ARCHIVE_AFTER_DAYS", "30"))
     COORDINATOR_ARCHIVE_BATCH_SIZE: int = int(os.getenv("COORDINATOR_ARCHIVE_BATCH_SIZE", "50"))
     CHANNELS_ENABLED: bool = os.getenv("CHANNELS_ENABLED", "true").lower() == "true"
+    # SEMANTIC_TOOL_ROUTING (default ON) and TOOL_ROUTING_GRAPH (default OFF, below)
+    # gate DIFFERENT surfaces — PRD-232 US-002 split them after C2 found the
+    # inversion. SEMANTIC_TOOL_ROUTING gates EMBEDDING narrowing everywhere:
+    # the platform_execute dispatcher's action-enum narrowing (tool_router.py
+    # _semantic_routing_enabled) and PlatformActionsSection's embedding catalog
+    # (_build_filtered). It does NOT gate the learned tool-routing GRAPH reads —
+    # those are TOOL_ROUTING_GRAPH's job. A graph-off turn still narrows
+    # semantically; it just never queries GraphRouter.rank_chains.
     SEMANTIC_TOOL_ROUTING: bool = os.getenv("SEMANTIC_TOOL_ROUTING", "true").lower() == "true"
     SEMANTIC_TOOL_ROUTING_TOP_K: int = int(os.getenv("SEMANTIC_TOOL_ROUTING_TOP_K", "15"))
     # PRD-221 S4: ceiling on the narrowed dispatcher enum after the current
@@ -1039,6 +1047,15 @@ class Config:
     PLAYBOOK_CONTEXT_MAX_TOKENS: int = int(os.getenv("PLAYBOOK_CONTEXT_MAX_TOKENS", "2000"))
     MEMORY_SECTION_MAX_TOKENS: int = int(os.getenv("MEMORY_SECTION_MAX_TOKENS", "1500"))
     COMPOSIO_SECTION_MAX_TOKENS: int = int(os.getenv("COMPOSIO_SECTION_MAX_TOKENS", "1000"))
+    # TOOL_ROUTING_GRAPH (default OFF) gates the learned tool-routing GRAPH reads
+    # — GraphRouter.rank_chains on BOTH surfaces: the schema path
+    # (SmartToolRouter.route, PRD-232 US-002) and the prompt catalog
+    # (PlatformActionsSection._build_graph_filtered). OFF = zero GraphRouter
+    # queries anywhere (the PRD-177 S4/S6 governance posture Gerard holds until
+    # the uplift number clears the flip gate). ON = both surfaces consult the
+    # graph. Distinct from SEMANTIC_TOOL_ROUTING (above), which gates embedding
+    # narrowing and stays ON independently. The flip is a POST-MERGE HUMAN step
+    # (PRD-232 US-013), never toggled by the build loop.
     TOOL_ROUTING_GRAPH: bool = os.getenv("TOOL_ROUTING_GRAPH", "false").lower() == "true"
     TOOL_ROUTING_GRAPH_MIN_CONFIDENCE: float = float(os.getenv("TOOL_ROUTING_GRAPH_MIN_CONFIDENCE", "0.6"))
     TOOL_ROUTING_GRAPH_AGENT_SAMPLE_FLOOR: int = int(os.getenv("TOOL_ROUTING_GRAPH_AGENT_SAMPLE_FLOOR", "50"))

--- a/orchestrator/consumers/chatbot/smart_tool_router.py
+++ b/orchestrator/consumers/chatbot/smart_tool_router.py
@@ -246,8 +246,19 @@ class SmartToolRouter:
         # is empty. An empty result or any failure drops through to category
         # filtering below. CORE_TOOLS / always-include pins / classifier-suggested
         # tools are always kept so the graph path never strips a tool the agent needs.
+        #
+        # PRD-232 US-002: this GraphRouter read is gated on TOOL_ROUTING_GRAPH
+        # (default OFF), NOT SEMANTIC_TOOL_ROUTING (default ON). C2 found the
+        # inversion — the graph read Gerard held dark for PRD-177 S4/S6 governance
+        # ran on every turn under the always-on flag, while TOOL_ROUTING_GRAPH
+        # (its intended gate) only reached the prompt catalog. Now: graph OFF =
+        # zero GraphRouter queries on either surface; graph ON = both the schema
+        # path (here) and the catalog path (PlatformActionsSection) consult it.
+        # SEMANTIC_TOOL_ROUTING continues to gate the embedding narrowing of the
+        # dispatcher enum (modules/tools/tool_router.py) and the catalog embedding
+        # path — a graph-off turn still narrows semantically.
         from config import config
-        if config.SEMANTIC_TOOL_ROUTING:
+        if config.TOOL_ROUTING_GRAPH:
             try:
                 from modules.tools.discovery.graph_router import get_graph_router
 

--- a/orchestrator/consumers/chatbot/smart_tool_router.py
+++ b/orchestrator/consumers/chatbot/smart_tool_router.py
@@ -119,22 +119,48 @@ class SmartToolRouter:
         "platform_field_inject",
     })
 
+    # The platform_execute dispatcher — the single door to every non-promoted
+    # platform action via its (narrowed) action enum (~136 actions).
+    # It is NOT an ActionDefinition, NOT registry-``promoted``, and NOT a
+    # CORE_TOOL, so before PRD-232 US-001 route()'s graph and category keep-sets
+    # silently stripped it (C1): a turn whose phrasing missed AutoBrain's phrase
+    # map got no ``tool_hints=["platform"]`` substring rescue, so the graph
+    # branch removed the dispatcher and the capability became unreachable — the
+    # 2026-08-28 VECTOR "close the blocked tickets" failure. Pinning it into the
+    # ONE always-include set (`_always_include_names`) keeps it reachable on
+    # every branch that ships tools — whenever the agent actually carries it.
+    _DISPATCHER_PINS = frozenset({
+        "platform_execute",
+    })
+
     def __init__(self):
         self.classifier = get_intent_classifier()
 
     def _always_include_names(self) -> Set[str]:
         """Tool names that bypass intent filtering.
 
-        Signal pins + core platform pins + every registry-``promoted`` action.
-        Reading ``promoted`` here is what makes a tool marked ``promoted=True``
-        surface in chat with no edit to this router (PRD-122 US-010) — e.g. the
-        full-autonomy dial (``platform_set/get_autonomy_level``), whose
-        ``settings`` category is intentionally unmapped.
+        Dispatcher pin + signal pins + core platform pins + every
+        registry-``promoted`` action. This is the SINGLE always-include
+        mechanism — every ``route()`` branch that ships tools (hint, graph,
+        category fallback) unions this set into its keep-set, so a name added
+        here survives on all of them with no per-branch edit (PRD-232 US-001).
+
+        The ``platform_execute`` dispatcher (`_DISPATCHER_PINS`) is folded in
+        here rather than via a second pins pass so there is exactly one door
+        list to reason about. Reading ``promoted`` here is what makes a tool
+        marked ``promoted=True`` surface in chat with no edit to this router
+        (PRD-122 US-010) — e.g. the full-autonomy dial
+        (``platform_set/get_autonomy_level``), whose ``settings`` category is
+        intentionally unmapped.
 
         Fail-safe: a registry import/lookup error degrades to the static pins,
         never crashes routing.
         """
-        names: Set[str] = set(self._SIGNAL_TOOL_PINS) | set(self._CORE_PLATFORM_PINS)
+        names: Set[str] = (
+            set(self._DISPATCHER_PINS)
+            | set(self._SIGNAL_TOOL_PINS)
+            | set(self._CORE_PLATFORM_PINS)
+        )
         try:
             from modules.tools.discovery.action_registry import get_action_registry
 

--- a/orchestrator/tests/test_prd232_us001_dispatcher_survives_route.py
+++ b/orchestrator/tests/test_prd232_us001_dispatcher_survives_route.py
@@ -1,0 +1,341 @@
+"""
+PRD-232 US-001 — the ``platform_execute`` dispatcher survives every route() branch.
+===================================================================================
+
+The 2026-08-29 deep review found C1: ``SmartToolRouter.route()`` built its
+graph- and category-branch keep-sets from chain names ∪ CORE_TOOLS ∪
+always-include ∪ suggested, and ``platform_execute`` was in *none* of them.
+The dispatcher — the single door to ~136 non-promoted platform actions — was
+silently stripped on every graph-branch turn whose phrasing missed AutoBrain's
+phrase map (no ``tool_hints=["platform"]`` substring rescue). That is the
+2026-08-28 VECTOR failure: "close all the blocked tickets from vector" reached
+Auto with the board-write route absent.
+
+US-001 folds the dispatcher into the ONE always-include mechanism
+(``_always_include_names``) so it is preserved on the hint, graph, and category
+branches alike — with the intent-requires-no-tools branch the sole legitimate
+exception (no tools at all is a valid surface).
+
+These tests are hermetic: ``intent_classifier`` + ``smart_tool_router`` + ``auto``
+are leaf-loaded under a synthetic package (stdlib/light imports only, no
+DB-backed chat service), and the GraphRouter / ActionRegistry / telemetry
+imports inside ``route()`` are faked in ``sys.modules`` — so no heavy
+transformers/DB chain is ever touched.
+"""
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+_orchestrator_root = Path(__file__).resolve().parent.parent
+if str(_orchestrator_root) not in sys.path:
+    sys.path.insert(0, str(_orchestrator_root))
+
+_chatbot_dir = _orchestrator_root / "consumers" / "chatbot"
+_PKG = "_prd232_us001_chatbot"
+
+VECTOR_SENTENCE = "close all the blocked tickets from vector"
+
+
+def _load_modules():
+    """Leaf-load intent_classifier + smart_tool_router + auto under a synthetic
+    package so ``consumers.chatbot.__init__`` (DB-backed chat service) is never run."""
+    if _PKG not in sys.modules:
+        pkg = types.ModuleType(_PKG)
+        pkg.__path__ = [str(_chatbot_dir)]
+        sys.modules[_PKG] = pkg
+
+    def _leaf(mod_name):
+        full = f"{_PKG}.{mod_name}"
+        if full in sys.modules:
+            return sys.modules[full]
+        spec = importlib.util.spec_from_file_location(full, _chatbot_dir / f"{mod_name}.py")
+        module = importlib.util.module_from_spec(spec)
+        module.__package__ = _PKG
+        sys.modules[full] = module
+        spec.loader.exec_module(module)
+        return module
+
+    intent_mod = _leaf("intent_classifier")
+    router_mod = _leaf("smart_tool_router")
+    auto_mod = _leaf("auto")  # top-level imports are stdlib + dispatch_contract (a string const)
+    return router_mod, intent_mod, auto_mod
+
+
+_router_mod, _intent_mod, _auto_mod = _load_modules()
+SmartToolRouter = _router_mod.SmartToolRouter
+ToolRoutingResult = _router_mod.ToolRoutingResult
+Intent = _intent_mod.Intent
+IntentResult = _intent_mod.IntentResult
+AutoBrain = _auto_mod.AutoBrain
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _intent_result(primary=Intent.SEARCH, requires_tools=True, suggested=None,
+                   reasoning="stub intent"):
+    return IntentResult(
+        primary_intent=primary,
+        confidence=0.9,
+        requires_tools=requires_tools,
+        requires_memory=False,
+        suggested_tools=suggested or [],
+        reasoning=reasoning,
+        is_simple=False,
+    )
+
+
+class _FakeClassifier:
+    def __init__(self, result):
+        self._result = result
+
+    def classify(self, query, conversation_context=None):
+        return self._result
+
+
+def _tool(name, description=None):
+    return {"type": "function", "function": {"name": name, "description": description or f"{name} desc"}}
+
+
+def _dispatcher_tool(enum_actions):
+    """The realistic ``platform_execute`` dispatcher, shaped exactly as
+    ``ActionRegistry.to_dispatcher_schema`` builds it — the door whose action
+    enum makes each non-promoted platform action callable."""
+    return {
+        "type": "function",
+        "function": {
+            "name": "platform_execute",
+            "description": "Execute an internal Automatos platform action.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "action": {"type": "string", "enum": list(enum_actions)},
+                    "params": {"type": "object"},
+                },
+                "required": ["action", "params"],
+            },
+        },
+    }
+
+
+def _realistic_surface():
+    """dispatcher + promoted first-class + core, as ``_get_tools_for_agent_core``
+    assembles a full-path turn. The dispatcher's enum carries the board tools
+    (incl. ``platform_update_task_status``) that the VECTOR turn needed."""
+    return [
+        _dispatcher_tool([
+            "platform_list_tasks",
+            "platform_update_task_status",
+            "platform_create_task",
+            "platform_get_board",
+        ]),
+        _tool("platform_find_tools"),      # promoted → first-class schema
+        _tool("platform_list_agents"),     # core platform pin → first-class schema
+        _tool("search_knowledge"),         # CORE_TOOLS
+        _tool("composio_execute"),         # CORE_TOOLS
+        _tool("generate_document"),        # CORE_TOOLS
+        _tool("send_email", "send an email message to a recipient"),  # hint target
+        _tool("totally_unrelated_tool"),   # droppable
+    ]
+
+
+def _dispatcher_from(result: ToolRoutingResult):
+    hits = [t for t in result.filtered_tools if t.get("function", {}).get("name") == "platform_execute"]
+    return hits[0] if hits else None
+
+
+def _names(result: ToolRoutingResult):
+    return {t.get("function", {}).get("name", "") for t in result.filtered_tools}
+
+
+@pytest.fixture
+def routing_env(monkeypatch):
+    """Both routing flags ON (forward-compatible across US-002's flag split) and
+    fake GraphRouter + ActionRegistry + telemetry injected into sys.modules."""
+    from config import config as real_config
+    # US-001: graph branch is gated on SEMANTIC_TOOL_ROUTING today; US-002 moves
+    # it behind TOOL_ROUTING_GRAPH. Setting BOTH keeps this suite valid across
+    # that split — the graph branch fires either way.
+    monkeypatch.setattr(real_config, "SEMANTIC_TOOL_ROUTING", True, raising=False)
+    monkeypatch.setattr(real_config, "TOOL_ROUTING_GRAPH", True, raising=False)
+
+    state = {"errors": [], "rank_calls": []}
+
+    def install_rank_chains(fn):
+        fake_router = SimpleNamespace(rank_chains=fn)
+        fake_mod = types.ModuleType("modules.tools.discovery.graph_router")
+        fake_mod.get_graph_router = lambda: fake_router
+        monkeypatch.setitem(sys.modules, "modules.tools.discovery.graph_router", fake_mod)
+
+    def install_registry(promoted=("platform_find_tools",), by_category=None):
+        by_category = by_category or {}
+        reg = SimpleNamespace(
+            get_promoted=lambda: [SimpleNamespace(name=n) for n in promoted],
+            get_by_category=lambda cat: [SimpleNamespace(name=n) for n in by_category.get(cat, [])],
+            get=lambda name: SimpleNamespace(
+                name=name, promoted=False, admin_only=False, super_admin_only=False
+            ),
+        )
+        fake_mod = types.ModuleType("modules.tools.discovery.action_registry")
+        fake_mod.get_action_registry = lambda: reg
+        monkeypatch.setitem(sys.modules, "modules.tools.discovery.action_registry", fake_mod)
+        return reg
+
+    fake_tel = types.ModuleType("core.utils.exception_telemetry")
+    fake_tel.record_error = lambda **kw: state["errors"].append(kw)
+    monkeypatch.setitem(sys.modules, "core.utils.exception_telemetry", fake_tel)
+
+    state["install_rank_chains"] = install_rank_chains
+    state["install_registry"] = install_registry
+    return state
+
+
+# ---------------------------------------------------------------------------
+# AC1 — dispatcher present in filtered_tools on graph / hint / category branches
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_dispatcher_survives_graph_branch(routing_env):
+    """Graph branch: rank_chains returns real chains, none of which is the
+    dispatcher (it is not an ActionDefinition) — yet ``platform_execute`` is
+    kept via the single always-include set."""
+    routing_env["install_registry"]()
+
+    async def ok_rank(query, agent_id=None, top_k=15, **kw):
+        routing_env["rank_calls"].append((query, agent_id, top_k))
+        return [
+            ("platform_list_tasks", 0.9, ["platform_list_tasks"]),
+            ("platform_get_board", 0.8, ["platform_get_board"]),
+        ]
+
+    routing_env["install_rank_chains"](ok_rank)
+
+    r = SmartToolRouter()
+    r.classifier = _FakeClassifier(_intent_result(primary=Intent.DATA_QUERY))
+    result = await r.route(query="how's the board looking", available_tools=_realistic_surface(), agent_id=7)
+
+    assert result.reasoning.startswith("Graph routing"), "must have taken the graph branch"
+    assert "platform_execute" in _names(result), "dispatcher stripped on the graph branch (C1 regression)"
+    # ...and it was NOT rescued by ranking — the dispatcher is never a chain node.
+    assert "platform_execute" not in {"platform_list_tasks", "platform_get_board"}
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_survives_hint_branch(routing_env):
+    """Hint branch: a NON-platform hint ("email") matches a real tool, and the
+    dispatcher rides in via the always-include set — the deliberate keep, not
+    the old accidental ``"platform" in "platform_execute"`` substring rescue."""
+    routing_env["install_registry"]()
+    # rank_chains must never be consulted on the hint branch.
+    async def boom(query, **kw):
+        raise AssertionError("graph must not run on the hint branch")
+
+    routing_env["install_rank_chains"](boom)
+
+    r = SmartToolRouter()
+    r.classifier = _FakeClassifier(_intent_result())
+    result = await r.route(
+        query="send an email to the team",
+        available_tools=_realistic_surface(),
+        tool_hints=["email"],  # deliberately NOT "platform"
+        agent_id=7,
+    )
+
+    assert result.reasoning.startswith("Tool hints"), "must have taken the hint branch"
+    names = _names(result)
+    assert "send_email" in names, "hint target must be present"
+    assert "platform_execute" in names, "dispatcher stripped on the hint branch (C1 regression)"
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_survives_category_fallback(routing_env):
+    """Category fallback: rank_chains returns nothing → route() drops through to
+    ``_filter_tools_by_intent``, and the dispatcher survives the category filter."""
+    routing_env["install_registry"](by_category={"tasks": ["platform_list_tasks", "platform_update_task_status"]})
+
+    async def empty_rank(query, agent_id=None, top_k=15, **kw):
+        return []  # no chains → fall through to category filtering
+
+    routing_env["install_rank_chains"](empty_rank)
+
+    r = SmartToolRouter()
+    r.classifier = _FakeClassifier(_intent_result(primary=Intent.MULTI_STEP))
+    result = await r.route(query="do a few things on the board", available_tools=_realistic_surface(), agent_id=7)
+
+    assert not result.reasoning.startswith("Graph routing"), "must have fallen through to category filtering"
+    assert "platform_execute" in _names(result), "dispatcher stripped on the category fallback branch (C1 regression)"
+
+
+# ---------------------------------------------------------------------------
+# AC2 — the VECTOR replay: phrase-map miss + dispatcher callable to the action
+# ---------------------------------------------------------------------------
+
+def test_vector_sentence_misses_phrase_map():
+    """The VECTOR write sentence does NOT hit AutoBrain's phrase map, so it never
+    earns the accidental ``tool_hints=["platform"]`` rescue — the exact C1
+    trigger condition the dispatcher fix must cover."""
+    assert AutoBrain._match_platform_query(VECTOR_SENTENCE) is None
+
+
+@pytest.mark.asyncio
+async def test_vector_replay_dispatcher_makes_update_task_callable(routing_env):
+    """Replay: the VECTOR sentence with NO platform hint (the honest post-miss
+    state) still yields a surface whose ``platform_execute`` enum makes
+    ``platform_update_task_status`` callable."""
+    assert AutoBrain._match_platform_query(VECTOR_SENTENCE) is None  # no hint rescue
+    routing_env["install_registry"]()
+
+    async def ok_rank(query, agent_id=None, top_k=15, **kw):
+        # The graph ranks board reads; the dispatcher is never a chain node.
+        return [("platform_list_tasks", 0.9, ["platform_list_tasks"])]
+
+    routing_env["install_rank_chains"](ok_rank)
+
+    r = SmartToolRouter()
+    r.classifier = _FakeClassifier(_intent_result(primary=Intent.EXTERNAL_ACTION))
+    result = await r.route(query=VECTOR_SENTENCE, available_tools=_realistic_surface(), tool_hints=[], agent_id=7)
+
+    dispatcher = _dispatcher_from(result)
+    assert dispatcher is not None, "VECTOR turn lost the dispatcher — the 2026-08-28 failure"
+    enum = dispatcher["function"]["parameters"]["properties"]["action"].get("enum", [])
+    assert "platform_update_task_status" in enum, "the board-write action is not callable via the dispatcher"
+
+
+# ---------------------------------------------------------------------------
+# AC3 — exactly one always-include mechanism
+# ---------------------------------------------------------------------------
+
+def test_dispatcher_folded_into_single_always_include_mechanism(routing_env):
+    """One door list: ``platform_execute`` is a member of ``_always_include_names``
+    (the single mechanism every branch unions in), not a second parallel pins pass."""
+    import inspect
+
+    routing_env["install_registry"]()
+    r = SmartToolRouter()
+    assert "platform_execute" in r._always_include_names()
+
+    src = inspect.getsource(SmartToolRouter)
+    # Exactly one producer of the always-include set.
+    assert src.count("def _always_include_names") == 1
+    # The dispatcher pin is folded INTO that one producer (not a rival pass).
+    ai_src = inspect.getsource(SmartToolRouter._always_include_names)
+    assert "_DISPATCHER_PINS" in ai_src
+    # Every tool-shipping branch consults the same set: def + hint + graph + 2× category.
+    assert src.count("_always_include_names()") >= 4
+
+
+@pytest.mark.asyncio
+async def test_no_tools_branch_ships_no_dispatcher(routing_env):
+    """The sole legitimate exception: an intent that requires no tools returns an
+    empty surface — the dispatcher is correctly absent."""
+    routing_env["install_registry"]()
+    r = SmartToolRouter()
+    r.classifier = _FakeClassifier(_intent_result(requires_tools=False))
+    result = await r.route(query="hello there", available_tools=_realistic_surface(), agent_id=7)
+    assert result.should_include_tools is False
+    assert result.filtered_tools == []

--- a/orchestrator/tests/test_prd232_us002_flag_split.py
+++ b/orchestrator/tests/test_prd232_us002_flag_split.py
@@ -1,0 +1,237 @@
+"""
+PRD-232 US-002 — each flag gates its own surface (the C2 inversion fix).
+=======================================================================
+
+C2 (deep review 2026-08-29): the GraphRouter read in ``SmartToolRouter.route()``
+was gated on ``SEMANTIC_TOOL_ROUTING`` (default ON), so the learned graph — held
+dark for PRD-177 S4/S6 governance — ran on effectively every turn, while
+``TOOL_ROUTING_GRAPH`` (default OFF, its intended gate) reached only the prompt
+catalog. The flag was inverted across surfaces.
+
+US-002 moves the schema-path graph read behind ``TOOL_ROUTING_GRAPH`` so:
+- graph OFF  → zero GraphRouter queries on EITHER surface (schema + catalog);
+- graph ON   → BOTH the schema path (SmartToolRouter.route) and the catalog path
+  (PlatformActionsSection) consult the graph;
+- ``SEMANTIC_TOOL_ROUTING`` keeps gating embedding narrowing everywhere (the
+  dispatcher enum narrowing in tool_router + the embedding catalog path), so a
+  graph-off turn still narrows semantically.
+
+``smart_tool_router`` is leaf-loaded (light); the catalog + narrowing gates come
+from the real ``PlatformActionsSection`` / ``tool_router`` (the split lives
+across those modules). The GraphRouter is faked in ``sys.modules`` so no learned
+graph / DB is ever touched.
+"""
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+_root = Path(__file__).resolve().parent.parent
+if str(_root) not in sys.path:
+    sys.path.insert(0, str(_root))
+
+_chatbot_dir = _root / "consumers" / "chatbot"
+_PKG = "_prd232_us002_chatbot"
+
+
+def _leaf_load_router():
+    if _PKG not in sys.modules:
+        pkg = types.ModuleType(_PKG)
+        pkg.__path__ = [str(_chatbot_dir)]
+        sys.modules[_PKG] = pkg
+
+    def _leaf(name):
+        full = f"{_PKG}.{name}"
+        if full in sys.modules:
+            return sys.modules[full]
+        spec = importlib.util.spec_from_file_location(full, _chatbot_dir / f"{name}.py")
+        module = importlib.util.module_from_spec(spec)
+        module.__package__ = _PKG
+        sys.modules[full] = module
+        spec.loader.exec_module(module)
+        return module
+
+    _leaf("intent_classifier")
+    return _leaf("smart_tool_router")
+
+
+_router_mod = _leaf_load_router()
+SmartToolRouter = _router_mod.SmartToolRouter
+_intent_mod = sys.modules[f"{_PKG}.intent_classifier"]
+Intent = _intent_mod.Intent
+IntentResult = _intent_mod.IntentResult
+
+# Real catalog + narrowing surfaces — the other half of the split.
+from modules.context.sections.platform_actions import PlatformActionsSection
+from modules.tools.tool_router import (
+    _semantic_routing_enabled,
+    _narrow_dispatcher_actions_async_inputs,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _intent_result(primary=Intent.MULTI_STEP, requires_tools=True, suggested=None):
+    return IntentResult(
+        primary_intent=primary,
+        confidence=0.9,
+        requires_tools=requires_tools,
+        requires_memory=False,
+        suggested_tools=suggested or [],
+        reasoning="stub intent",
+        is_simple=False,
+    )
+
+
+class _FakeClassifier:
+    def __init__(self, result):
+        self._result = result
+
+    def classify(self, query, conversation_context=None):
+        return self._result
+
+
+def _tool(name, description=None):
+    return {"type": "function", "function": {"name": name, "description": description or f"{name} desc"}}
+
+
+@pytest.fixture
+def flags_and_spy(monkeypatch):
+    """Fake GraphRouter (records every rank_chains call, returns []) + telemetry,
+    and expose the real config singleton for per-test flag setting."""
+    from config import config as real_config
+
+    calls = []
+
+    async def spy_rank(query, workspace_id=None, agent_id=None, top_k=15, **kw):
+        calls.append({"query": query, "workspace_id": workspace_id, "agent_id": agent_id})
+        return []  # empty is enough: the call itself proves the surface consulted the graph
+
+    fake_router = SimpleNamespace(rank_chains=spy_rank)
+    fake_gr = types.ModuleType("modules.tools.discovery.graph_router")
+    fake_gr.get_graph_router = lambda: fake_router
+    monkeypatch.setitem(sys.modules, "modules.tools.discovery.graph_router", fake_gr)
+
+    fake_tel = types.ModuleType("core.utils.exception_telemetry")
+    fake_tel.record_error = lambda **kw: None
+    monkeypatch.setitem(sys.modules, "core.utils.exception_telemetry", fake_tel)
+
+    return SimpleNamespace(config=real_config, calls=calls, mp=monkeypatch)
+
+
+# ---------------------------------------------------------------------------
+# AC1 — graph OFF + semantic ON: route() never calls rank_chains; narrowing runs
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_graph_off_no_rank_chains_but_embedding_narrowing_runs(flags_and_spy):
+    cfg = flags_and_spy.config
+    flags_and_spy.mp.setattr(cfg, "TOOL_ROUTING_GRAPH", False)
+    flags_and_spy.mp.setattr(cfg, "SEMANTIC_TOOL_ROUTING", True)
+
+    r = SmartToolRouter()
+    r.classifier = _FakeClassifier(_intent_result())
+    tools = [_tool("search_knowledge"), _tool("platform_execute"), _tool("composio_execute")]
+    result = await r.route(query="close the blocked tickets", available_tools=tools, agent_id=9)
+
+    # The learned graph is dark on the schema path.
+    assert flags_and_spy.calls == [], "route() consulted the graph with TOOL_ROUTING_GRAPH off"
+    assert not result.reasoning.startswith("Graph routing")
+
+    # Embedding narrowing is unaffected — it keys off SEMANTIC, which is still ON.
+    assert _semantic_routing_enabled() is True
+    # None == "no skip reason" == narrowing proceeds (would run rank_actions).
+    assert _narrow_dispatcher_actions_async_inputs("close the blocked tickets") is None
+
+    # Catalog surface: embedding path live, graph path dark.
+    section = PlatformActionsSection()
+    assert section._semantic_routing_enabled() is True
+    assert section._graph_routing_enabled() is False
+
+
+@pytest.mark.asyncio
+async def test_semantic_off_disables_narrowing_gate_only(flags_and_spy):
+    """Symmetry check: turning SEMANTIC off skips embedding narrowing, and the
+    graph read remains independently controlled by TOOL_ROUTING_GRAPH."""
+    cfg = flags_and_spy.config
+    flags_and_spy.mp.setattr(cfg, "SEMANTIC_TOOL_ROUTING", False)
+    flags_and_spy.mp.setattr(cfg, "TOOL_ROUTING_GRAPH", False)
+
+    assert _semantic_routing_enabled() is False
+    skip = _narrow_dispatcher_actions_async_inputs("anything")
+    assert skip is not None and skip.startswith("flag SEMANTIC_TOOL_ROUTING")
+    assert PlatformActionsSection()._semantic_routing_enabled() is False
+
+
+# ---------------------------------------------------------------------------
+# AC2 — graph ON: BOTH the schema path and the catalog path consult the graph
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_graph_on_both_surfaces_consult_graph(flags_and_spy):
+    cfg = flags_and_spy.config
+    flags_and_spy.mp.setattr(cfg, "TOOL_ROUTING_GRAPH", True)
+    flags_and_spy.mp.setattr(cfg, "SEMANTIC_TOOL_ROUTING", True)
+
+    # ── schema path: SmartToolRouter.route() ──
+    r = SmartToolRouter()
+    r.classifier = _FakeClassifier(_intent_result(primary=Intent.DATA_QUERY))
+    tools = [_tool("search_knowledge"), _tool("platform_execute")]
+    await r.route(query="how's the board looking", available_tools=tools, agent_id=9)
+    schema_calls = len(flags_and_spy.calls)
+    assert schema_calls >= 1, "SmartToolRouter.route() did not consult the graph with the flag on"
+    assert flags_and_spy.calls[-1]["workspace_id"] is None  # threaded through (no ws in this call)
+
+    # ── catalog path: PlatformActionsSection ──
+    section = PlatformActionsSection()
+    assert section._graph_routing_enabled() is True  # render() routes into the graph method
+    ctx = SimpleNamespace(kwargs={"agent_id": 9}, workspace_id="ws-42")
+    out = await section._build_graph_filtered("how's the board looking", ctx)
+    assert out is None  # empty chains → None, but the graph WAS consulted
+    assert len(flags_and_spy.calls) > schema_calls, "PlatformActionsSection did not consult the graph"
+    # per-tenant scoping (PRD-177 S5) threaded on the catalog call
+    assert flags_and_spy.calls[-1]["workspace_id"] == "ws-42"
+    assert flags_and_spy.calls[-1]["agent_id"] == 9
+
+
+# ---------------------------------------------------------------------------
+# AC3 — config.py documents the split; no os.getenv outside config.py for the flags
+# ---------------------------------------------------------------------------
+
+def test_config_docstrings_state_the_split():
+    import inspect
+    import config as config_mod
+
+    src = inspect.getsource(config_mod)
+    # Both flag lines carry the split rationale nearby (PRD-232 US-002 anchor).
+    assert "PRD-232 US-002" in src
+    assert "SEMANTIC_TOOL_ROUTING gates EMBEDDING narrowing" in src
+    assert "TOOL_ROUTING_GRAPH (default OFF) gates the learned tool-routing GRAPH" in src
+
+
+def test_no_os_getenv_for_routing_flags_outside_config():
+    """The two routing flags are read via the config singleton only — the raw
+    env read lives solely in config.py (the canonical-config rule). Production
+    code (everything but config.py and the test tree) must be clean."""
+    import subprocess
+
+    root = str(_root)
+    proc = subprocess.run(
+        ["grep", "-rn", "-E", r'os\.getenv\(\s*["\'](SEMANTIC_TOOL_ROUTING|TOOL_ROUTING_GRAPH)["\']',
+         "--include=*.py", root],
+        capture_output=True, text=True,
+    )
+    offending = []
+    for ln in proc.stdout.splitlines():
+        if not ln.strip():
+            continue
+        path = ln.split(":", 1)[0]
+        if path.endswith("/config.py") or "/tests/" in path:
+            continue  # config.py is the canonical read; test files may document/set flags
+        offending.append(ln)
+    assert offending == [], f"os.getenv for routing flags outside config.py: {offending}"

--- a/orchestrator/tests/test_us014_graph_router_delegation.py
+++ b/orchestrator/tests/test_us014_graph_router_delegation.py
@@ -93,9 +93,15 @@ def _tool(name):
 
 @pytest.fixture
 def graph_env(monkeypatch):
-    """Force semantic routing on and inject fake GraphRouter + telemetry modules."""
+    """Force graph routing on and inject fake GraphRouter + telemetry modules.
+
+    PRD-232 US-002: route()'s GraphRouter read moved from SEMANTIC_TOOL_ROUTING
+    (default on) to TOOL_ROUTING_GRAPH (default off). The graph-branch tests here
+    therefore set TOOL_ROUTING_GRAPH; SEMANTIC stays on too (it still gates the
+    embedding narrowing on the other surface)."""
     from config import config as real_config
     monkeypatch.setattr(real_config, "SEMANTIC_TOOL_ROUTING", True)
+    monkeypatch.setattr(real_config, "TOOL_ROUTING_GRAPH", True)
 
     recorder = {"errors": [], "rank_calls": []}
 
@@ -275,10 +281,12 @@ async def test_graph_router_fallback_on_failure(graph_env):
 
 
 @pytest.mark.asyncio
-async def test_semantic_off_skips_graph_router(graph_env, monkeypatch):
-    """With SEMANTIC_TOOL_ROUTING off, GraphRouter is never called."""
+async def test_graph_flag_off_skips_graph_router(graph_env, monkeypatch):
+    """With TOOL_ROUTING_GRAPH off, GraphRouter is never called — PRD-232 US-002
+    moved the gate here from SEMANTIC_TOOL_ROUTING. SEMANTIC stays ON (via the
+    fixture) to prove the graph read is gated ONLY by the graph flag now."""
     from config import config as real_config
-    monkeypatch.setattr(real_config, "SEMANTIC_TOOL_ROUTING", False)
+    monkeypatch.setattr(real_config, "TOOL_ROUTING_GRAPH", False)
 
     called = {"n": 0}
 
@@ -294,5 +302,5 @@ async def test_semantic_off_skips_graph_router(graph_env, monkeypatch):
 
     result = await r.route(query="anything", available_tools=tools, agent_id=3)
 
-    assert called["n"] == 0  # delegation gated off → straight to category filtering
+    assert called["n"] == 0  # graph gated off → straight to category filtering
     assert result.should_include_tools is True


### PR DESCRIPTION
## Why now

The live onboarding test loop is seeing Auto **narrate tool calls it cannot make**. Root cause (PRD-232 deep review, C1+C2): `SmartToolRouter.route()`'s graph branch strips the `platform_execute` dispatcher from the tool surface — and it fires on exactly the turns with no tool-shaped text ("Yes please."), because the phrase-map hint that would rescue the dispatcher never triggers. **#647's onboarding pin lands inside the dispatcher's enum, so the pin sinks with the boat.**

## What (2 commits cherry-picked from `ralph/prd-232-intent-graph`)

1. **US-001** — `platform_execute` is preserved through every `route()` branch (graph/hint/category), via the existing reserved-slot mechanism. Includes the missing dispatcher-survival test + a replay test.
2. **US-002** — the GraphRouter call moves behind its own flag (`TOOL_ROUTING_GRAPH`, default false) instead of running under `SEMANTIC_TOOL_ROUTING` (default true). The learned-graph read-side goes genuinely dark until the PRD-177 uplift gate passes — as designed.

Net effect on prod: semantic narrowing keeps working; the graph branch stops firing; the dispatcher (with #647's onboarding pins inside) reaches Auto on every tool-requiring turn.

## Test plan

- Both new test files green locally (branch-scoped); full suite = CI.
- The rest of PRD-232 (utterance seeding, learning loop, promotion diet) follows on its own branch — these two commits rebase-out cleanly there.

Merge-freely policy in force (Gerard, 2026-08-29) — auto-merge on green.