### PR TITLE
fix(tests): tool-router stub always shadows config — heals the two #654 CI reds

### DIFF
--- a/orchestrator/tests/test_tool_router_semantic.py
+++ b/orchestrator/tests/test_tool_router_semantic.py
@@ -152,15 +152,24 @@ def _install_low_level_stubs():
     # config — singleton with the PRD-138 flags. tool_router reads via
     # `from config import config` lazily, so a module called "config"
     # exposing a `config` attribute is enough.
-    if "config" not in sys.modules or not hasattr(sys.modules["config"], "config"):
-        config_mod = types.ModuleType("config")
+    #
+    # Always shadow with OUR fake — the snapshot above preserves any prior (real)
+    # config for restore. A `not in sys.modules` guard here would bind
+    # _FAKE_CONFIG_CLS to the REAL Config class whenever an earlier-collected
+    # test already imported config (e.g. anything importing a context section);
+    # a later `_FAKE_CONFIG_CLS.SEMANTIC_TOOL_ROUTING = ...` toggle would then set
+    # an attribute that `from config import config` never reads back, and the
+    # flag-off tests would see stale values. Same class of leak the
+    # modules.tools.execution stub above documents; fixed the same way.
+    config_mod = types.ModuleType("config")
 
-        class _FakeConfig:
-            SEMANTIC_TOOL_ROUTING = False
-            SEMANTIC_TOOL_ROUTING_TOP_K = 15
+    class _FakeConfig:
+        SEMANTIC_TOOL_ROUTING = False
+        SEMANTIC_TOOL_ROUTING_TOP_K = 15
+        TOOL_ROUTING_GRAPH = False
 
-        config_mod.config = _FakeConfig()
-        sys.modules["config"] = config_mod
+    config_mod.config = _FakeConfig()
+    sys.modules["config"] = config_mod
     global _FAKE_CONFIG_MOD
     _FAKE_CONFIG_MOD = sys.modules["config"]
     fake_config_cls = type(sys.modules["config"].config)


### PR DESCRIPTION
Main went red on #654's merge: two tests in `test_tool_router_semantic.py` failed because the file's fake-config stub only installs when no real config was imported by an earlier-collected test — its flag toggles then no-op against the real Config class. #654's `TOOL_ROUTING_GRAPH` read shifted timing enough for CI's collection order to expose the latent leak.

Fix = the 232 branch's stub hardening (always-shadow + the new flag attr on the fake), WITHOUT its US-014-era assertions (promotion-as-prior isn't on main yet — importing the full file diff was attempted and correctly failed a third test).

31 passed locally (full file + both prd232 hotfix suites). Fix-forward for red main; merge-freely in force.