### PR TITLE
fix(prd-222): an unusable segment no longer fails the whole onboarding tool call

### DIFF
--- a/orchestrator/modules/tools/discovery/handlers_onboarding.py
+++ b/orchestrator/modules/tools/discovery/handlers_onboarding.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import Session
 
 from core.models.workspaces import Workspace
 from services.onboarding_state import (
+    SEGMENT_KEYS,
     InvalidStageTransition,
     advance_onboarding_stage,
     current_stage,
@@ -40,6 +41,26 @@ async def update_onboarding(
     advance_to = params.get("advance_to")
     segment = params.get("segment")
     plan = params.get("plan")
+
+    # Normalize an UNUSABLE segment to absent (live-test 2026-08-29). ``segment``
+    # is LLM-supplied: it arrives as a bare string, or a dict of unrecognized
+    # keys, often enough to matter. ``_clean_segment`` already tolerates that at
+    # the state layer, but ``set_segment`` deliberately RAISES when nothing
+    # recognised survives (so a no-op write can't masquerade as a saved answer) —
+    # and the handler routed such calls straight into it, failing the whole tool
+    # call with "set_segment requires at least one of business/goal/comfort".
+    # Observed in prod paired with a same-stage advance: the advance is dropped
+    # as a no-op, then the junk segment raises, so a benign call errors.
+    # Treating unusable as absent makes each path correct: advance proceeds,
+    # a same-stage no-op returns success, and a call carrying NOTHING usable
+    # gets the honest "at least one is required" message below instead of an
+    # internal function name.
+    if segment is not None and not (
+        isinstance(segment, dict)
+        and any(segment.get(k) is not None for k in SEGMENT_KEYS)
+    ):
+        logger.info("[update_onboarding] segment carries nothing usable — ignoring")
+        segment = None
 
     if not advance_to and not segment and not plan:
         return {

--- a/orchestrator/tests/test_prd222_onboarding_tool.py
+++ b/orchestrator/tests/test_prd222_onboarding_tool.py
@@ -129,6 +129,39 @@ def test_handler_same_stage_advance_still_records_segment():
     assert ws.onboarding["segment"] == {"goal": "book appts"}
 
 
+def test_same_stage_advance_with_unusable_segment_succeeds():
+    # THE PROD FAILURE (2026-08-29, caught by the persona harness):
+    #   "Tool platform_update_onboarding failed: set_segment requires at least
+    #    one of business/goal/comfort"
+    # A same-stage advance drops to a no-op, then a bare-string segment reached
+    # set_segment and raised, failing the whole call. Must be a benign success.
+    ws = _FakeWorkspace({"stage": "teach", "stages": {"teach": "t"}, "segment": {}})
+    res = _run(update_onboarding(
+        _db_returning(ws), uuid4(),
+        {"advance_to": "teach", "segment": "a barber shop in Leeds"},
+    ))
+    assert res["success"] is True
+    assert ws.onboarding["stage"] == "teach"
+
+
+def test_advance_with_unrecognized_segment_keys_still_advances():
+    ws = _FakeWorkspace({"stage": "teach", "stages": {}, "segment": {}})
+    res = _run(update_onboarding(
+        _db_returning(ws), uuid4(),
+        {"advance_to": "proposal", "segment": {"industry": "dental", "notes": "x"}},
+    ))
+    assert res["success"] is True
+    assert ws.onboarding["stage"] == "proposal"
+
+
+def test_unusable_segment_alone_gets_the_honest_error_not_an_internal_one():
+    ws = _FakeWorkspace({"stage": "teach", "stages": {}, "segment": {}})
+    res = _run(update_onboarding(_db_returning(ws), uuid4(), {"segment": "just prose"}))
+    assert res["success"] is False
+    assert "at least one" in res["error"].lower()
+    assert "set_segment" not in res["error"]  # never leak the internal helper
+
+
 def test_handler_records_segment_only():
     ws = _FakeWorkspace({"stage": "questions", "stages": {}, "segment": {}})
     res = _run(


### PR DESCRIPTION
## Caught in prod by the persona harness

Barber persona, teach stage:

```
Tool platform_update_onboarding failed: set_segment requires at least one of business/goal/comfort
```

## Cause — an interaction between two of my own merged fixes

`segment` is LLM-supplied and arrives as a bare string, or a dict of unrecognised keys, often enough to matter. #649 made `_clean_segment` tolerate that at the state layer, but `set_segment` deliberately **raises** when nothing recognised survives (so a no-op write can't masquerade as a saved answer) — and the handler routed those calls straight into it.

The observed pairing is the worst one: #651 drops a same-stage `advance_to` to a no-op, then the junk segment raises, so an entirely benign call returns `success:False` and Auto surfaces an internal helper name to the user. **My #651 test passed only because it used a valid segment dict.**

## Fix

Normalise an unusable segment to absent once, at the top of the handler. Every path then behaves correctly:

- advance + junk segment → the advance proceeds
- same-stage advance + junk segment → benign no-op success (the prod failure)
- nothing usable at all → the honest "at least one is required" message, never a leaked internal function name

`set_segment`'s raise-on-empty contract is untouched.

## Verification

- 3 regression tests; **two fail without this change** — verified by reverting the handler and re-running, not assumed.
- Onboarding tool + state suites: 62 passed.
- Full local suite: 4988 passed against the current main baseline.

## Note on main's CI (not this PR)

Full-suite runs on **clean main** currently show two failures in `test_tool_router_semantic.py` (`test_semantic_routing_disabled_by_default`, `test_get_tools_for_agent_query_with_flag_off_does_not_narrow`). They pass in isolation and fail under full-suite ordering, they arrived with #654, and they are **not** caused by this branch — I verified by stashing this change and running the full suite on clean main. The Munder pod is already healing them (`fix(tests): tool-router stub always shadows config` is in progress on main). Flagging so this PR's CI isn't misread.