### PR TITLE
fix: restore config.py + route-manifest clobbered by #652's squash (prod reset endpoint 500s)

### DIFF
--- a/orchestrator/config.py
+++ b/orchestrator/config.py
@@ -1388,6 +1388,14 @@ class Config:
     TRIAL_GLOBAL_DAILY_USD: float = float(os.getenv("TRIAL_GLOBAL_DAILY_USD", "25.00"))
     # Models a trial workspace may use on the platform key. Reuses the platform's
 
+    # PRD-222 W1·S10 (D9) — DEV/OPS ONLY, TEMPORARY. Arms
+    # POST /api/workspaces/current/onboarding/reset so the operator can re-run
+    # onboarding in ONE workspace with a single alias account, instead of
+    # provisioning and hard-deleting a workspace per attempt. Default OFF: when
+    # false the endpoint 404s (unadvertised — never 403). This flag is
+    # TEMPORARY: remove once onboarding QA moves to a seeded fixture flow (W2+).
+    ONBOARDING_RESET_ENABLED: bool = os.getenv("ONBOARDING_RESET_ENABLED", "false").lower() == "true"
+
     # PRD-207 S4: Auto Live tuning constants. These are NUMERIC dials only —
     # the ON-switch (`voice.live_enabled`) and the Retell credentials live in
     # DB system_settings (category 'voice', masked; see

--- a/orchestrator/reports/route-manifest.json
+++ b/orchestrator/reports/route-manifest.json
@@ -1,5 +1,5 @@
 {
-  "route_count": 766,
+  "route_count": 773,
   "routes": [
     {
       "method": "GET",
@@ -2440,6 +2440,10 @@
     {
       "method": "POST",
       "path": "/api/verticals/{vertical}/provision"
+    },
+    {
+      "method": "PATCH",
+      "path": "/api/verticals/{vertical}/provision/domains"
     },
     {
       "method": "POST",


### PR DESCRIPTION
**Prod-impacting**: #652's squash accidentally regressed the two perpetual-conflict files to a stale state — `config.py` lost `ONBOARDING_RESET_ENABLED` (the onboarding dev-reset endpoint now 500s on AttributeError, breaking the live persona harness which resets between runs) and `route-manifest.json` lost the verticals provision row + correct count (766 vs 772 actual).

Root cause: the e2e branch was silently cut from a stale local main (failed `checkout -b ... origin/main` fell back to `checkout -b` from HEAD); the GitHub branch-update merge resolved both files to the stale side; the squash carried it to main.

Fix: both files restored byte-for-byte to the #655-era state (`1268152c2`) — nothing else merged in between, so that is current-correct. e2e/ payload untouched.

**27 passed, 3 skipped** locally across all seven previously-red tests. Merge-freely in force; merging on push — every minute costs the onboarding pod's harness.