### PR TITLE
fix(prd-230): a deliberate STOP reaches Auto as its reason, not 'Unknown error'

### DIFF
--- a/orchestrator/modules/tools/tool_router.py
+++ b/orchestrator/modules/tools/tool_router.py
@@ -73,6 +73,41 @@ def _summarize_args(args: Any) -> str:
     return f"{type(args).__name__}"
 
 
+# Result keys marking a deliberate STOP rather than a fault. A stop carries its
+# user-facing copy in ``message`` (not ``error``), and that copy is the whole
+# point of the stop — losing it renders the stop as "Unknown error".
+STOP_MARKERS: Tuple[str, ...] = (
+    "requires_confirmation",   # PRD-143 S15 — a confirmation ask
+    "onboarding_restricted",   # PRD-230 D6 — one package during onboarding
+    "over_quota",              # PRD-230 D9 — the honest plan conversation
+)
+
+
+def select_failure_message(result: Dict[str, Any]) -> str:
+    """The message a failed tool result should show the LLM.
+
+    ``error`` wins when present. Otherwise, for a deliberate STOP, the handler's
+    ``message`` is surfaced — gated on an explicit marker so no arbitrary
+    handler text can leak. Everything else stays "Unknown error".
+
+    Live-test 2026-08-29: D6's one-package copy and D9's over-quota plan
+    conversation both live in ``message``, so Auto was handed the literal string
+    "Unknown error" and INVENTED a cause for the user ("I need the Shopify
+    connection active first"). D9's contract is explicitly "never a silent
+    block" — dropping the message made it precisely that.
+    """
+    if not isinstance(result, dict):
+        return "Unknown error"
+    error = result.get("error")
+    if error:
+        return str(error)
+    if any(result.get(marker) for marker in STOP_MARKERS):
+        message = result.get("message")
+        if message:
+            return str(message)
+    return "Unknown error"
+
+
 def _is_fatal_dependency_error(error: Optional[str]) -> bool:
     if not error:
         return False
@@ -1214,9 +1249,18 @@ class ToolRouter:
             # PRD-143 S15: a confirmation stop is not an opaque failure — the
             # executor's message (action + permission level) must reach the
             # LLM so Auto can relay the ask instead of "Unknown error".
-            error = result.get("error") or (
-                result.get("message") if result.get("requires_confirmation") else None
-            ) or "Unknown error"
+            #
+            # PRD-230 (live-test 2026-08-29): the same is true of the two
+            # package STOPS, which carry their copy in ``message`` and were
+            # therefore rendered to Auto as literally "Unknown error":
+            #   * onboarding_restricted — D6, one package during onboarding
+            #   * over_quota           — D9, the honest plan conversation
+            # D9's whole contract is "never a silent block, always the honest
+            # conversation"; losing the message made it exactly the silent
+            # block it forbids, and Auto — given no reason — invented one for
+            # the user ("I need the Shopify connection active first").
+            # Gated on explicit markers, so no arbitrary handler text leaks.
+            error = select_failure_message(result)
             error_type = result.get("error_type")
             fatal_error = bool(result.get("fatal")) or _is_fatal_dependency_error(error)
             llm_error = (

--- a/orchestrator/tests/test_package_stop_messages.py
+++ b/orchestrator/tests/test_package_stop_messages.py
@@ -1,0 +1,110 @@
+"""A deliberate STOP must reach Auto as its reason, never as "Unknown error".
+
+FOUND IN PRODUCTION (2026-08-29, persona harness + Railway logs). Auto called
+``platform_install_package`` and the tool came back:
+
+    Tool platform_install_package failed: Unknown error
+
+The server had returned a perfectly good reason — the D6 one-package-during-
+onboarding copy — but under the ``message`` key, while the router reads only
+``error``. So the reason was discarded, and Auto, handed nothing, INVENTED a
+cause for the user: "I can't proceed without the Shopify connection being
+active first." It had no evidence for that.
+
+Two PRD-230 stops were affected, and the second one matters most:
+  * ``onboarding_restricted`` — D6, one package during onboarding
+  * ``over_quota``            — D9, the honest plan conversation, whose stated
+    contract is "NEVER a silent block". Losing its message made it exactly the
+    silent block D9 forbids.
+
+PRD-143 S15 had already fixed this class for ``requires_confirmation``; this
+generalises that precedent to the marker set instead of one hard-coded key.
+"""
+from __future__ import annotations
+
+import pytest
+
+from modules.tools.tool_router import STOP_MARKERS, select_failure_message
+
+
+# --------------------------------------------------------------------------- #
+# The regression: each STOP surfaces its own copy
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("marker", STOP_MARKERS)
+def test_every_stop_marker_surfaces_its_message(marker):
+    result = {"success": False, marker: True, "message": "the honest reason"}
+    assert select_failure_message(result) == "the honest reason"
+
+
+def test_d6_one_package_copy_reaches_auto():
+    # The exact prod shape from handlers_packages.install_package_tool.
+    result = {
+        "success": False,
+        "onboarding_restricted": True,
+        "message": "You can install one package during onboarding.",
+    }
+    out = select_failure_message(result)
+    assert out == "You can install one package during onboarding."
+    assert out != "Unknown error"
+
+
+def test_d9_over_quota_is_never_a_silent_block():
+    # D9's contract: over-quota is an honest plan conversation, never a silent
+    # block. If this returns "Unknown error", D9 is violated at the seam.
+    result = {
+        "success": False,
+        "over_quota": True,
+        "message": "That package needs 6 agents; your plan allows 5. Upgrade?",
+    }
+    assert "Upgrade?" in select_failure_message(result)
+
+
+# --------------------------------------------------------------------------- #
+# The gate: no arbitrary handler text leaks
+# --------------------------------------------------------------------------- #
+
+
+def test_message_without_a_stop_marker_is_not_surfaced():
+    # An ordinary failure carrying an incidental 'message' must NOT have it
+    # promoted — the marker gate is what keeps internals out of the LLM.
+    result = {"success": False, "message": "internal detail nobody vetted"}
+    assert select_failure_message(result) == "Unknown error"
+
+
+def test_error_key_always_wins():
+    result = {
+        "success": False,
+        "error": "Package not found: nope",
+        "over_quota": True,
+        "message": "should not be chosen",
+    }
+    assert select_failure_message(result) == "Package not found: nope"
+
+
+# --------------------------------------------------------------------------- #
+# Degenerate shapes never raise
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("junk", [None, "a string", 42, []])
+def test_non_dict_results_degrade(junk):
+    assert select_failure_message(junk) == "Unknown error"
+
+
+def test_stop_marker_with_no_message_degrades():
+    assert select_failure_message({"over_quota": True}) == "Unknown error"
+
+
+def test_handler_shapes_still_carry_their_markers():
+    """The router's markers must match what the package handlers actually emit —
+    a renamed key would silently reopen the bug."""
+    from pathlib import Path
+
+    src = (
+        Path(__file__).resolve().parents[1]
+        / "modules" / "tools" / "discovery" / "handlers_packages.py"
+    ).read_text()
+    assert '"onboarding_restricted": True' in src
+    assert '"over_quota": True' in src


### PR DESCRIPTION
## Found in production, root-caused from Railway logs

The persona harness caught `platform_install_package` failing. The verbatim tool result Auto received:

```
Tool platform_install_package failed: Unknown error
```

The server trail shows it was never an exception — `Platform action platform_install_package success=False`, a **returned** stop. The handler produced a perfectly good reason and put it in `message`; the router reads only `error`. So the reason was discarded, and Auto — given nothing — **invented a cause for the user**: *"I can't proceed without the Shopify connection being active first."* No evidence for that claim.

## Two stops affected, and the second is the serious one

| Marker | Decision | Was shown as |
|---|---|---|
| `onboarding_restricted` | D6 — one package during onboarding | "Unknown error" |
| `over_quota` | **D9 — the honest plan conversation** | "Unknown error" |

D9's contract is explicit: an over-quota install is an honest plan conversation, **never a silent block**. Losing the message made it exactly the silent block D9 forbids — a user hitting their agent quota got "Unknown error" instead of the upgrade conversation. **That decision has been non-functional since PRD-230 shipped.**

## Fix — generalising an existing precedent, not inventing one

PRD-143 S15 already solved this class for `requires_confirmation` with a hard-coded key check. This promotes that to a `STOP_MARKERS` set and extracts the logic as `select_failure_message()`, a pure helper that can be tested directly instead of only through a large orchestration function.

Still **gated on explicit markers** — an ordinary failure carrying an incidental `message` is not promoted, so no unvetted handler text reaches the LLM (the no-internals-in-errors rule holds).

## Tests (13)

Every marker surfaces its copy; D6 and D9 asserted by their **real prod shapes**; `error` always wins; degenerate inputs (None/str/int/list, marker-without-message) degrade rather than raise; and a guard asserting `handlers_packages.py` still emits the marker keys the router looks for — a rename would otherwise silently reopen this.

Full suite: **5011 passed**, one documented no-local-Postgres baseline failure.

## Separate finding, not in this PR

The same logs show `EntityExtractor` instantiating a raw `AsyncOpenAI()` and dying on **every document ingestion** — `Missing credentials … set the OPENAI_API_KEY` — while the platform runs on OpenRouter. It's caught and logged as a warning, so ingestion continues with entity extraction **silently disabled**, quietly degrading the knowledge graph. Same class as the #645 Harbourline failure (demanding a key that doesn't exist). Flagged for its own PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool-stop error messages so users receive the intended explanation for confirmation, onboarding restrictions, and quota limits.
  * Preserved existing error messages when available and provided a consistent fallback for unknown or incomplete errors.
  * Prevented malformed responses from causing additional failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->