### PR TITLE
fix(prd-230): package install has never worked — a slug reached a UUID column

### DIFF
--- a/orchestrator/services/package_installer.py
+++ b/orchestrator/services/package_installer.py
@@ -143,16 +143,53 @@ def _absorb_cascade(manifest: InstallManifest, cascade: Any) -> None:
 # --------------------------------------------------------------------------- #
 
 
+def _is_uuid(value: Any) -> bool:
+    """True when ``value`` parses as a UUID.
+
+    ``Agent.public_id`` is a UUID column: comparing it to a non-UUID string
+    makes Postgres raise ``InvalidTextRepresentation`` at execute time — an
+    error no Python-level guard around the cast can catch, because it happens
+    in the database, not in Python.
+    """
+    try:
+        UUID(str(value))
+        return True
+    except (ValueError, TypeError, AttributeError):
+        return False
+
+
 def _find_marketplace_agent(db: Any, ref: str) -> Any:
+    """Resolve a marketplace agent by integer id, public_id (UUID), slug or name.
+
+    LIVE FAILURE (2026-08-29): package members reference agents by SLUG — the
+    seed builds them that way on purpose — and this fell through the ``int()``
+    guard into a filter that compared ``Agent.public_id`` (uuid) against
+    "shopify-ops". Postgres raised
+
+        invalid input syntax for type uuid: "shopify-ops"
+
+    which escaped as an unhandled exception, so EVERY package install failed.
+    The ``except (ValueError, TypeError)`` above it only ever caught the int
+    cast; the UUID comparison blew up later, inside the driver.
+
+    Each candidate column is now only compared when ``ref`` is the right shape
+    for it.
+    """
     from core.models.core import Agent
 
     q = db.query(Agent).filter(Agent.owner_type == "marketplace")
+
+    # Integer primary key.
     try:
         return q.filter(Agent.id == int(ref)).first()
     except (ValueError, TypeError):
-        return (
-            q.filter((Agent.public_id == ref) | (Agent.slug == ref) | (Agent.name == ref)).first()
-        )
+        pass
+
+    # Text columns are always safe to compare; public_id only when ref IS a UUID.
+    predicate = (Agent.slug == ref) | (Agent.name == ref)
+    if _is_uuid(ref):
+        predicate = predicate | (Agent.public_id == ref)
+    return q.filter(predicate).first()
 
 
 def _existing_workspace_clone(db: Any, workspace_id: UUID, marketplace_agent: Any) -> Any:

--- a/orchestrator/tests/test_package_installer_ref_resolution.py
+++ b/orchestrator/tests/test_package_installer_ref_resolution.py
@@ -1,0 +1,124 @@
+"""Resolving a marketplace agent by SLUG must not blow up on a UUID column.
+
+LIVE FAILURE (2026-08-29, persona harness → Railway logs). Every package
+install failed. The traceback:
+
+    File "services/package_installer.py", line 151, in _find_marketplace_agent
+    psycopg2.errors.InvalidTextRepresentation:
+        invalid input syntax for type uuid: "shopify-ops"
+
+Package members reference agents by SLUG — ``seed_packages`` builds them that
+way deliberately, citing the real roster. ``_find_marketplace_agent`` tried an
+``int()`` cast first (ValueError, caught), then fell into a filter comparing
+``Agent.public_id`` — a UUID column — against "shopify-ops". Postgres raised at
+execute time, INSIDE the driver, where the Python-level ``except (ValueError,
+TypeError)`` could never reach it. The exception escaped the installer, escaped
+the handler, and surfaced to Auto as the opaque "Action 'platform_install_package'
+failed".
+
+Net effect: the seeded Shopify packages could be searched and offered, but
+NEVER installed. The fix compares each column only when ``ref`` has the right
+shape for it.
+"""
+from __future__ import annotations
+
+import pytest
+
+from services.package_installer import _find_marketplace_agent, _is_uuid
+
+
+# --------------------------------------------------------------------------- #
+# _is_uuid — the shape test that decides whether public_id is safe to compare
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("good", [
+    "3f2504e0-4f89-11d3-9a0c-0305e82c3301",
+    "00000000-0000-0000-0000-000000000000",
+])
+def test_is_uuid_accepts_uuids(good):
+    assert _is_uuid(good) is True
+
+
+@pytest.mark.parametrize("bad", [
+    "shopify-ops",                    # the exact prod ref that broke it
+    "shopify-business-analyst",
+    "", None, 42, [], "not-a-uuid",
+])
+def test_is_uuid_rejects_everything_else(bad):
+    assert _is_uuid(bad) is False
+
+
+# --------------------------------------------------------------------------- #
+# The resolver: a slug must never reach the UUID column
+# --------------------------------------------------------------------------- #
+
+
+class _Recorder:
+    """Query stand-in that records how many filters were applied and returns a
+    sentinel — enough to assert WHICH predicate path was taken, with no DB."""
+
+    def __init__(self, store):
+        self._store = store
+
+    def filter(self, *criteria):
+        self._store.append(criteria)
+        return self
+
+    def first(self):
+        return "AGENT" if len(self._store) > 1 else None
+
+
+class _Session:
+    def __init__(self):
+        self.filters = []
+
+    def query(self, _model):
+        return _Recorder(self.filters)
+
+
+def _predicate_sql(session) -> str:
+    """The text of the last predicate applied — used to prove public_id is
+    absent for a slug lookup and present for a UUID lookup."""
+    return " ".join(str(c) for crit in session.filters for c in crit)
+
+
+def test_slug_lookup_never_references_public_id():
+    # THE REGRESSION. A slug must not produce a public_id comparison, or
+    # Postgres raises InvalidTextRepresentation and the whole install dies.
+    s = _Session()
+    _find_marketplace_agent(s, "shopify-ops")
+    sql = _predicate_sql(s)
+    assert "slug" in sql
+    assert "public_id" not in sql, (
+        "a slug reached the public_id (uuid) column — this is the exact "
+        "comparison that made every package install fail in production"
+    )
+
+
+def test_uuid_lookup_does_reference_public_id():
+    s = _Session()
+    _find_marketplace_agent(s, "3f2504e0-4f89-11d3-9a0c-0305e82c3301")
+    assert "public_id" in _predicate_sql(s)
+
+
+def test_numeric_ref_uses_the_id_column():
+    s = _Session()
+    _find_marketplace_agent(s, "123")
+    sql = _predicate_sql(s)
+    assert "agents.id" in sql or ".id" in sql
+    assert "public_id" not in sql
+
+
+def test_seeded_package_refs_all_resolve_by_slug_path():
+    """Every ref in the shipped packages is a slug, so every one of them takes
+    the path that used to explode."""
+    from core.seeds.seed_packages import PACKAGES
+
+    refs = [m["ref"] for p in PACKAGES for m in p["members"] if m["type"] == "agent"]
+    assert refs, "seed carries no agent members — this guard would be vacuous"
+    for ref in refs:
+        assert not _is_uuid(ref)          # all slugs, none UUIDs
+        s = _Session()
+        _find_marketplace_agent(s, ref)
+        assert "public_id" not in _predicate_sql(s)


### PR DESCRIPTION
## Package installation has been dead since PRD-230 shipped

Root-caused from Railway logs, once #659 removed the outer mask:

```
psycopg2.errors.InvalidTextRepresentation: invalid input syntax for type uuid: "shopify-ops"
  File "services/package_installer.py", line 151, in _find_marketplace_agent
```

Package members reference agents by **slug** — `seed_packages` builds them that way deliberately, citing the real roster. `_find_marketplace_agent` tries an `int()` cast (ValueError, caught), then falls into a filter comparing `Agent.public_id` — a **UUID column** — against `"shopify-ops"`. Postgres raises at execute time, **inside the driver**, where the surrounding `except (ValueError, TypeError)` can never reach it.

## Why it survived a full build, a review, and a night of testing

Three layers, each hiding the next:

1. **#648** seeded the packages — they exist and list correctly.
2. **#653** taught Auto to search and offer them by name — the proposal looks perfect.
3. The install underneath threw every time, surfaced first as `Unknown error` (the `message`-vs-`error` drop, fixed in #659) and beneath that as `Action 'platform_install_package' failed` (the executor's blanket catch).

Auto, given no reason, invented one for users: *"I can't proceed without the Shopify connection being active first."* Nobody could see past the mask — including me, until logs became available.

## Fix

Compare each candidate column only when `ref` has the right shape for it: `slug`/`name` always, `public_id` **only when `ref` parses as a UUID**. Integer ids unchanged.

## Tests (13)

`_is_uuid` shape tests including the exact prod ref; slug lookups asserted to **never** reference `public_id`; UUID lookups asserted to still use it; numeric refs still hit `id`. Plus a guard that walks **every agent ref in the shipped packages** and asserts none can reach the uuid column — so a future seed written with slugs (the documented convention) cannot silently reopen this.

Full suite: **5024 passed**, one documented no-local-Postgres baseline failure.

## Pattern worth noting

Third bug tonight in one family: a value of one shape reaching code expecting another, with the real reason swallowed at a boundary — the segment-string crash (#649), the `message`-vs-`error` drop (#659), and now slug-vs-UUID. Worth a design conversation once the queue clears.