### PR TITLE
fix(rag): entity extraction has been silently OFF — it demanded an OpenAI key

### DIFF
--- a/orchestrator/modules/search/services/entity_extractor.py
+++ b/orchestrator/modules/search/services/entity_extractor.py
@@ -9,7 +9,6 @@ import json
 from typing import List, Dict, Optional, Tuple
 from dataclasses import dataclass
 import asyncio
-from openai import AsyncOpenAI
 import logging
 
 logger = logging.getLogger(__name__)
@@ -41,8 +40,39 @@ class EntityExtractor:
     """Extract entities and relationships from text"""
     
     def __init__(self):
-        """Initialize entity extractor with LLM client"""
-        self.openai_client = AsyncOpenAI()
+        """Initialize entity extractor.
+
+        Deliberately constructs NO LLM client here. ``AsyncOpenAI()`` raises
+        ``OpenAIError: Missing credentials`` at construction when
+        ``OPENAI_API_KEY`` is unset — and this platform runs on OpenRouter, so
+        that raise fired on EVERY document ingestion (2026-08-29). The caller
+        catches it and logs a warning, so ingestion appeared to succeed while
+        entity extraction was silently disabled and the knowledge graph
+        quietly degraded. Same class as the #645 Harbourline failure: never
+        demand a vendor key that may not exist.
+
+        The manager is built lazily on first use and resolves provider, model
+        and key through the platform's own routing (workspace key first,
+        OpenRouter fallback), so no vendor is hard-coded here.
+        """
+        self._llm_manager = None
+
+    def _manager(self):
+        """The shared LLM manager, created on first use."""
+        if self._llm_manager is None:
+            from core.llm import create_llm_manager
+
+            self._llm_manager = create_llm_manager(
+                service_name="entity_extraction",
+                request_type="entity_extraction",
+            )
+        return self._llm_manager
+
+    @staticmethod
+    def _content_of(response) -> str:
+        """Text of an LLMManager response, whatever shape it arrives in."""
+        content = getattr(response, "content", None)
+        return (content if content is not None else str(response)).strip()
         
     async def extract_entities(
         self, 
@@ -146,15 +176,11 @@ Text to analyze:
 Return ONLY the JSON array, no other text."""
 
         try:
-            from config import config
-            response = await self.openai_client.chat.completions.create(
-                model=config.LLM_MODEL or "gpt-4o-mini",
-                messages=[{"role": "user", "content": prompt}],
-                temperature=0.1,  # Low temperature for consistency
-                max_tokens=2000
+            response = await self._manager().generate_response(
+                messages=[{"role": "user", "content": prompt}]
             )
-            
-            content = response.choices[0].message.content.strip()
+
+            content = self._content_of(response)
             
             # Extract JSON from response (in case LLM adds extra text)
             json_match = re.search(r'\[.*\]', content, re.DOTALL)
@@ -232,15 +258,11 @@ Text:
 Return ONLY the JSON array, no other text."""
 
         try:
-            from config import config
-            response = await self.openai_client.chat.completions.create(
-                model=config.LLM_MODEL or "gpt-4o-mini",
-                messages=[{"role": "user", "content": prompt}],
-                temperature=0.1,
-                max_tokens=1500
+            response = await self._manager().generate_response(
+                messages=[{"role": "user", "content": prompt}]
             )
-            
-            content = response.choices[0].message.content.strip()
+
+            content = self._content_of(response)
             
             # Extract JSON from response
             json_match = re.search(r'\[.*\]', content, re.DOTALL)

--- a/orchestrator/tests/test_entity_extractor_no_vendor_key.py
+++ b/orchestrator/tests/test_entity_extractor_no_vendor_key.py
@@ -1,0 +1,99 @@
+"""EntityExtractor must construct without a vendor key.
+
+FOUND IN PRODUCTION (2026-08-29, Railway logs during onboarding testing):
+
+    Entity extraction failed for document 69991: Missing credentials. Please
+    pass an `api_key` ... or set the `OPENAI_API_KEY` environment variable.
+      File "modules/search/services/entity_extractor.py", line 45, in __init__
+        self.openai_client = AsyncOpenAI()
+      openai.OpenAIError: Missing credentials
+
+``AsyncOpenAI()`` raises at CONSTRUCTION when ``OPENAI_API_KEY`` is unset, and
+this platform runs on OpenRouter. So the raise fired on EVERY document
+ingestion. The caller catches it and logs a warning, so ingestion appeared to
+succeed while entity extraction was silently disabled — every ingested
+document since has contributed no entities to the knowledge graph.
+
+Same class as the #645 Harbourline failure: never demand a vendor key that may
+not exist. The extractor now builds its LLM lazily through the platform's own
+``create_llm_manager``, which resolves provider/model/key (workspace key first,
+OpenRouter fallback) instead of hard-coding a vendor.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+MODULE = (
+    Path(__file__).resolve().parents[1]
+    / "modules" / "search" / "services" / "entity_extractor.py"
+)
+
+
+# --------------------------------------------------------------------------- #
+# The regression: construction must not need a vendor key
+# --------------------------------------------------------------------------- #
+
+
+def test_constructs_with_no_openai_key_present(monkeypatch):
+    """THE PROD FAILURE. With OPENAI_API_KEY absent, construction must still succeed."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_ADMIN_KEY", raising=False)
+
+    from modules.search.services.entity_extractor import EntityExtractor
+
+    extractor = EntityExtractor()  # must not raise
+    assert extractor is not None
+
+
+def test_no_llm_client_is_built_eagerly(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    from modules.search.services.entity_extractor import EntityExtractor
+
+    extractor = EntityExtractor()
+    # The manager is created on first USE, never at construction.
+    assert getattr(extractor, "_llm_manager", "missing") is None
+    assert not hasattr(extractor, "openai_client")
+
+
+def test_module_never_constructs_a_vendor_client_at_import_or_init():
+    """Source guard: reintroducing `AsyncOpenAI()` reopens the outage."""
+    src = MODULE.read_text()
+    code = "\n".join(
+        line for line in src.splitlines()
+        if not line.strip().startswith("#")
+    )
+    # The only surviving mention is inside the docstring explaining the bug.
+    assert "AsyncOpenAI()" not in code.split('"""')[0]
+    assert "self.openai_client" not in code
+    assert "from openai import AsyncOpenAI" not in code
+
+
+def test_routes_through_the_platform_llm_manager():
+    src = MODULE.read_text()
+    assert "create_llm_manager" in src, (
+        "must resolve provider/model/key through platform routing, not a vendor SDK"
+    )
+    # The hard-coded vendor default is gone with it.
+    assert 'or "gpt-4o-mini"' not in src
+
+
+# --------------------------------------------------------------------------- #
+# Response shape handling
+# --------------------------------------------------------------------------- #
+
+
+class _Resp:
+    def __init__(self, content):
+        self.content = content
+
+
+@pytest.mark.parametrize(
+    "response,expected",
+    [(_Resp("  hello  "), "hello"), (_Resp("[]"), "[]"), ("raw string", "raw string")],
+)
+def test_content_of_handles_shapes(response, expected):
+    from modules.search.services.entity_extractor import EntityExtractor
+
+    assert EntityExtractor._content_of(response) == expected


### PR DESCRIPTION
## Found in Railway logs while root-causing something else

```
Entity extraction failed for document 69991: Missing credentials. Please pass an
api_key ... or set the `OPENAI_API_KEY` environment variable
  File "modules/search/services/entity_extractor.py", line 45, in __init__
    self.openai_client = AsyncOpenAI()
  openai.OpenAIError: Missing credentials
```

`AsyncOpenAI()` raises at **construction** when `OPENAI_API_KEY` is unset — and this platform runs on OpenRouter. So the raise fired on **every document ingestion**.

The caller catches it and logs a warning, so **ingestion reported success the whole time**. Every document ingested since this shipped has contributed **zero entities to the knowledge graph**, with no visible failure anywhere in the system.

Same class as the #645 Harbourline failure: never demand a vendor key that may not exist.

## Fix

Build the LLM **lazily**, through the platform's own `create_llm_manager` — which already resolves provider/model/key with workspace-key-first and OpenRouter fallback.

Also removes `config.LLM_MODEL or "gpt-4o-mini"` from both call sites: a literal OpenAI model hard-coded as the fallback in a codebase running on OpenRouter — the same assumption one layer down. **No vendor is named in the file any more.**

## Swept, not spot-fixed

This was the **only** eager `AsyncOpenAI()` in the orchestrator. Remaining `OPENAI_API_KEY` references are legitimate (the config declaration and the provider→env-var map). The class is closed.

## Tests (7)

Construction with no key present (the exact prod failure), no eager client attribute, response-shape handling, and a **source guard** — reintroducing `AsyncOpenAI()` or `self.openai_client` fails CI. That guard matters because the failure is invisible at runtime: caught, warned, ingestion "succeeds".

Full suite: **5031 passed**, one documented no-local-Postgres baseline failure.

## Follow-up worth considering

New documents will extract correctly once deployed, but **everything already ingested has no entities**. A backfill re-ingest is likely wanted — scale-dependent, so flagging rather than assuming.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Entity and relationship extraction now uses the platform’s configured language-model service, improving compatibility across supported providers.
  * The extractor can be initialized without vendor-specific credentials and establishes its language-model connection only when needed.
  * Responses are handled consistently across supported response formats.

* **Bug Fixes**
  * Improved startup reliability by avoiding unnecessary language-model client creation.

* **Tests**
  * Added coverage for credential-free initialization, deferred setup, provider routing, and response handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->