### PR TITLE
fix(tools): entry-point parity for tool priors + make the onboarding prior observable

### DIFF
--- a/orchestrator/modules/tools/tool_router.py
+++ b/orchestrator/modules/tools/tool_router.py
@@ -408,9 +408,21 @@ def _apply_onboarding_prior(
         merged = _apply_page_prior(
             narrowing, ONBOARDING_PRIOR_ACTIONS, is_admin, is_super_admin
         )
+        pinned = [a for a in ONBOARDING_PRIOR_ACTIONS if a in (merged[0] or [])]
+        logger.info(
+            "[tool-router] onboarding prior applied — %d/%d spine actions in enum: %s",
+            len(pinned), len(ONBOARDING_PRIOR_ACTIONS), pinned,
+        )
         return merged[0], "onboarding_prior", merged[2]
     except Exception:
-        logger.debug("[tool-router] onboarding prior failed — narrowing unchanged", exc_info=True)
+        # WARNING, not debug (2026-08-29): this handler was invisible in prod,
+        # so a failing prior looked identical to a prior that correctly no-oped
+        # — and onboarding losing its tools is exactly the symptom we then
+        # cannot explain from logs. Fail-soft behaviour is unchanged.
+        logger.warning(
+            "[tool-router] onboarding prior FAILED — onboarding tools not pinned",
+            exc_info=True,
+        )
         return narrowing
 
 
@@ -842,6 +854,19 @@ def get_tools_for_agent(
         workspace_id = _resolve_workspace_id_from_agent(session_used, agent_id, workspace_id, trace_id)
         is_admin = _resolve_workspace_admin(session_used, workspace_id, is_admin, trace_id)
         narrowing = _narrow_dispatcher_actions_sync(query, is_admin, is_super_admin)
+        # PARITY WITH THE ASYNC TWIN (live-test 2026-08-29). The async entry
+        # applies the page prior (PRD-221 S4) and the onboarding prior
+        # (PRD-222/#647) after narrowing; this sync entry applied NEITHER, so
+        # any caller routed here got an unpinned surface — onboarding's own
+        # tools missing from the dispatcher enum while the section was still
+        # telling Auto to call them by name. Two entry points into one
+        # composition, only one hardened, is the same shape as the stripped
+        # dispatcher (#654). Both priors are gate-filtered and capped inside,
+        # and both no-op when their preconditions are absent.
+        narrowing = _apply_page_prior(narrowing, None, is_admin, is_super_admin)
+        narrowing = _apply_onboarding_prior(
+            narrowing, session_used, workspace_id, is_admin, is_super_admin
+        )
         return _get_tools_for_agent_core(
             agent_id=agent_id,
             session_used=session_used,

--- a/orchestrator/tests/test_tool_prior_entrypoint_parity.py
+++ b/orchestrator/tests/test_tool_prior_entrypoint_parity.py
@@ -1,0 +1,49 @@
+"""Both tool-surface entry points must apply the same priors.
+
+LIVE FINDING (2026-08-29). ``get_tools_for_agent_async`` applied the PRD-221
+page prior AND the PRD-222/#647 onboarding prior after semantic narrowing.
+Its SYNC twin, ``get_tools_for_agent``, applied NEITHER — so any caller routed
+through the sync entry received an unpinned surface: onboarding's own tools
+absent from the dispatcher enum while the OnboardingSection was still
+instructing Auto to call them by name.
+
+That is the same shape as the stripped dispatcher (#654): one composition,
+two entry points, only one hardened. A capability that depends on which
+function a caller happens to reach is a capability that fails intermittently.
+"""
+from __future__ import annotations
+
+import inspect
+
+from modules.tools import tool_router
+
+
+def _src(fn) -> str:
+    return inspect.getsource(fn)
+
+
+def test_sync_entry_applies_both_priors():
+    src = _src(tool_router.get_tools_for_agent)
+    assert "_apply_onboarding_prior" in src, (
+        "sync entry does not apply the onboarding prior — onboarding tools "
+        "would be missing from the dispatcher enum for its callers"
+    )
+    assert "_apply_page_prior" in src, "sync entry does not apply the page prior"
+
+
+def test_async_entry_still_applies_both_priors():
+    src = _src(tool_router.get_tools_for_agent_async)
+    assert "_apply_onboarding_prior" in src
+    assert "_apply_page_prior" in src
+
+
+def test_both_entries_narrow_before_priors():
+    """Priors UNION into a narrowed set; applying them before narrowing would
+    let the ranking drop them again."""
+    for fn in (tool_router.get_tools_for_agent, tool_router.get_tools_for_agent_async):
+        src = _src(fn)
+        narrow_at = max(src.find("_narrow_dispatcher_actions_sync"),
+                        src.find("_narrow_dispatcher_actions_async"))
+        prior_at = src.find("_apply_onboarding_prior")
+        assert narrow_at != -1 and prior_at != -1, fn.__name__
+        assert narrow_at < prior_at, f"{fn.__name__}: prior must run AFTER narrowing"


### PR DESCRIPTION
Both changes came out of a live reproduction (Gerard's own test) where onboarding **recited its script but recorded nothing** — stage stuck at `not_started`, zero `platform_update_onboarding` calls, opener reappearing forever. Indistinguishable from normal chat from the user's side.

Logs confirmed the section loaded and the #646 ATOM pin fired, so Auto had the instruction and simply never called the tool.

## 1. Entry-point parity

`get_tools_for_agent_async` applies the PRD-221 page prior **and** the PRD-222/#647 onboarding prior after narrowing. Its sync twin `get_tools_for_agent` applied **neither**.

Any caller routed through the sync door gets an **unpinned surface** — onboarding's tools missing from the dispatcher enum while the section still tells Auto to call them by name. Sync callers include `modules/tools/__init__` and the agent factory's documented "ONE tool source".

Same shape as the stripped dispatcher (#654): one composition, two entry points, only one hardened. A capability that depends on which function a caller happens to reach fails intermittently by construction.

**Stated honestly:** the chat route uses the **async** door, so this is hardening — **not** proven to be the cure for that specific reproduction. I checked the callers before claiming otherwise.

## 2. Observability — the reason I can't yet answer "why"

`_apply_onboarding_prior` logged its failure at `debug`, invisible in production. So a prior that **failed** looked exactly like one that correctly no-oped, and "onboarding lost its tools" became unexplainable from logs — which is precisely the position I was in.

Now: failure logs a **warning with traceback**; success logs **which spine actions actually landed in the enum**. Fail-soft behaviour is unchanged.

Next reproduction answers the question from logs in seconds instead of inference.

## Tests

3 parity tests: both entries apply both priors, and priors run **after** narrowing (they union into a narrowed set — applying them earlier would let the ranking drop them again).

Full suite: **5034 passed**, one documented no-local-Postgres baseline failure.