### PR TITLE
PRD-233: Open-core Phase 1 — the local edition worth downloading (S1–S7, docs, DCO)

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,49 @@
+name: dco
+
+# PRD-233 S5 — Developer Certificate of Origin check.
+#
+# Every commit in a pull request must carry a `Signed-off-by:` trailer
+# (`git commit -s`). The sign-off is the contributor's certification of the
+# DCO (https://developercertificate.org) — the only rider on top of the
+# repository's Apache-2.0 licence, whose §5 already makes contributions
+# shippable in every edition (local, hosted, commercial). No CLA.
+#
+# Dependency-free on purpose: a plain git log over the PR range, so the lane
+# cannot break when a third-party action is retired. Introduced NON-REQUIRED
+# like the other lanes; flipping it to a required check is the repo admin's
+# call (see CONTRIBUTING.md).
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  dco:
+    name: Signed-off-by on every commit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check sign-offs
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          missing=0
+          while IFS= read -r sha; do
+            [ -z "$sha" ] && continue
+            if ! git log -1 --format=%B "$sha" | grep -qE '^Signed-off-by: .+ <.+@.+>$'; then
+              echo "::error::commit $sha has no Signed-off-by trailer — commit with 'git commit -s' (see CONTRIBUTING.md)"
+              missing=$((missing + 1))
+            fi
+          done < <(git rev-list --no-merges "$BASE_SHA".."$HEAD_SHA")
+          if [ "$missing" -gt 0 ]; then
+            echo "$missing commit(s) missing a DCO sign-off"
+            exit 1
+          fi
+          echo "All commits carry a Signed-off-by trailer."

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -521,6 +521,24 @@ jobs:
               exit 1
             fi
           done
+          echo "Asserting what orphan-root ORDERING used to lose on a fresh path (PRD-233 live-test finding)..."
+          # prd82a (a root) adds agent_reports.orchestration_task_id before agent_reports exists in the
+          # replay; prd133b (another root) builds v_workspace_outputs on it. The generator's
+          # model-column reconciliation + idempotent raw-SQL re-run passes must leave both present.
+          for chk in "v_workspace_outputs" ; do
+            FOUND="$(psql -h 127.0.0.1 -U test -d alembic_zero_db -tAc "SELECT to_regclass('${chk}');" | tr -d ' ')"
+            if [ -z "${FOUND}" ]; then
+              echo "::error::fresh schema is missing '${chk}' — the idempotent raw-SQL (views) pass regressed."
+              exit 1
+            fi
+          done
+          COL="$(psql -h 127.0.0.1 -U test -d alembic_zero_db -tAc "SELECT column_name FROM information_schema.columns WHERE table_name='agent_reports' AND column_name='orchestration_task_id';" | tr -d ' ')"
+          if [ -z "${COL}" ]; then
+            echo "::error::fresh schema is missing agent_reports.orchestration_task_id — the model-column reconciliation pass regressed."
+            exit 1
+          fi
+          ROWS="$(psql -h 127.0.0.1 -U test -d alembic_zero_db -tAc 'SELECT count(*) FROM v_workspace_outputs;' | tr -d ' ')"
+          echo "v_workspace_outputs answers (rows=${ROWS})"
           echo "Fresh-clone boot path succeeded: complete schema + stamp + no-op upgrade."
 
   # PRD-209 S4 (F051 / deployability J4) — the schema-drift net for the "four

--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,10 @@ tests/e2e/.auth/
 # live/ dirs hold real workspace UUIDs + client corpus data (e.g. InBuild UK).
 orchestrator/scripts/eval/**/live/
 *.gold.jsonl
+
+# Workspace-worker host directory (PRD-233 S1): agent deliverables live here on
+# YOUR machine (AUTOMATOS_WORKSPACE_DIR, default ./workspaces). Never tracked.
+/workspaces/
+
+# TypeScript incremental build state (dropped by `tsc --noEmit` runs)
+*.tsbuildinfo

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,20 @@ Welcome! We’re excited you’d like to contribute. This is a concise guide. Fo
 - Fork the repo and create a feature branch from `main`.
 - Write clear commits and include tests where applicable.
 - Open a Pull Request with a descriptive title and context.
+- Sign off every commit (`git commit -s`). The `Signed-off-by:` trailer is your
+  [Developer Certificate of Origin](https://developercertificate.org) attestation;
+  the `dco` check on each pull request verifies it. There is no CLA.
+
+## Where to contribute capability
+The platform is one codebase that ships as two editions: the **local edition**
+you run yourself (`docker compose up`, no accounts) and the **hosted edition**.
+Capability contributions land best where they never conflict with core:
+**skills, tools, MCP integrations, Playbooks and agent packages first, core
+second.** A new skill or tool needs no knowledge of the orchestrator's
+internals and reaches both editions unchanged; a core change needs the
+schema-drift, route-contract and fresh-clone smoke lanes to stay green in
+both. Open an issue first for anything that touches auth, storage, the
+tool router or a migration.
 
 ## Development Setup
 1. Clone via SSH: `git clone git@github.com:AutomatosAI/automatos-ai.git`
@@ -28,7 +42,12 @@ Welcome! We’re excited you’d like to contribute. This is a concise guide. Fo
 Participation is governed by our [Code of Conduct](./CODE_OF_CONDUCT.md). Report unacceptable behavior to support@automatos.ai.
 
 ## License
-By contributing, you agree your contributions are licensed under the repository’s license.
+By contributing, you agree your contributions are licensed under the repository’s
+license (Apache-2.0). Under §5 of that license your contribution may be
+distributed in every edition of the platform — including the hosted and
+commercial editions run by the maintainers — under the same terms, with no
+separate agreement. That is the whole deal: what you contribute stays
+Apache-2.0 for everyone, and it ships everywhere the code ships.
 
 For the detailed guidelines, templates, and examples, please see: `docs/CONTRIBUTING.md`.
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -67,9 +67,15 @@ backend has constructed).
 - **MinIO object storage.** An S3-compatible store (ports 9000 / 9001) holds
   generated outputs so nothing is lost between runs.
 - **The core stack:** Postgres (5432), Redis (6379), backend API (8000),
-  frontend (3000), and MinIO (9000/9001). Optional profiles add more:
-  `docker compose --profile workers up` includes the workspace worker, and
-  `--profile all` adds Gotenberg document rendering (3001) and Adminer (8080).
+  frontend (3000), MinIO (9000/9001) and the **workspace worker** — the Code
+  Canvas runtime that lets agents act on files on *your* machine. It keeps
+  those files in `./workspaces` next to `docker-compose.yml`
+  (`AUTOMATOS_WORKSPACE_DIR` in `.env` points it elsewhere); every tool call
+  is confined to that directory and mutations still need your approval.
+  Canvas sessions need `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN` in
+  `.env` (the SDK subprocess reads env only, not Settings → Credentials).
+  `docker compose --profile all up` adds Gotenberg document rendering (3001)
+  and Adminer (8080).
 
 ## What does *not* work out of the box
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -2,6 +2,9 @@
 
 Clone the repo and bring up the full stack with Docker. The local edition runs
 with **no login** and a single default workspace — no Clerk, no cloud accounts.
+This is the short path; the full reference (every service, every dial,
+troubleshooting, how the editions relate) is
+[docs/getting-started/self-hosting.md](docs/getting-started/self-hosting.md).
 
 ## 1. Set the three required secrets
 
@@ -23,7 +26,7 @@ cp .env.example .env
 ```
 
 That is the whole requirement — everything else (edition, workspace id, storage,
-ports) already has a working default baked into the compose file.
+ports) already has a working default in the compose file and `envs/*.defaults`.
 
 ### Optional: one LLM key for AI features (bring your own key)
 
@@ -36,7 +39,8 @@ OPENAI_API_KEY=sk-...          # or
 ANTHROPIC_API_KEY=sk-ant-...   # or an OpenRouter key for 300+ models
 ```
 
-You can also add keys later through **Settings → Credentials** in the UI.
+You can also add keys later through **Settings → API Keys** in the UI (until
+you do, the chat page shows *"Add an LLM key to bring Auto to life"*).
 
 ## 2. Start the platform
 
@@ -44,10 +48,10 @@ You can also add keys later through **Settings → Credentials** in the UI.
 docker compose up
 ```
 
-First run builds the images and initialises the database. When the backend is
-healthy it serves `http://localhost:8000/health` (liveness) and
-`http://localhost:8000/health/ready` (readiness — true once the local RAG
-backend has constructed).
+First run builds the images, builds the database schema, runs the seeds and
+then serves. `http://localhost:8000/health` answers as soon as the API process
+is up; `http://localhost:8000/health/ready` returns 503 until the full boot has
+finished and 200 once the instance is usable.
 
 ## 3. Open it
 
@@ -61,7 +65,12 @@ backend has constructed).
 ## What you get in the local edition
 
 - **No login.** `AUTH_EDITION=local` — you land straight in a single default
-  workspace, no accounts to create.
+  workspace, no accounts to create. The one operator is you: set your name
+  under **Settings → Profile** and Auto greets you by it.
+- **Something to run on the first boot.** The local edition seeds Auto, a
+  starter roster (Researcher, Writer, Analyst), one Playbook — *Two-minute
+  brief* — and a welcome Deliverable under **Deliverables → Blogs**. Run the
+  Playbook from the Playbooks page with a topic of your own.
 - **Local RAG on pgvector.** Documents are chunked, embedded, and searched in
   Postgres (`S3_VECTORS_ENABLED=false`) — no AWS needed.
 - **MinIO object storage.** An S3-compatible store (ports 9000 / 9001) holds
@@ -73,7 +82,8 @@ backend has constructed).
   (`AUTOMATOS_WORKSPACE_DIR` in `.env` points it elsewhere); every tool call
   is confined to that directory and mutations still need your approval.
   Canvas sessions need `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN` in
-  `.env` (the SDK subprocess reads env only, not Settings → Credentials).
+  `.env` (the SDK subprocess reads env only, not Settings → API Keys). On a
+  Linux host the files there end up owned by uid 1000, the worker's user.
   `docker compose --profile all up` adds Gotenberg document rendering (3001)
   and Adminer (8080).
 
@@ -81,13 +91,16 @@ backend has constructed).
 
 - **AI features need an LLM key** (above) — without one, agents and chat have no
   model to call.
-- **Composio-powered integrations** (the 1,000+ external-tool marketplace) need a
-  Composio API key in `.env` (`COMPOSIO_API_KEY=…`, free tier at app.composio.dev),
-  then `docker compose up -d backend` to apply it, then run the catalogue sync
-  once — the **Sync** action on the Tools page, or
-  `curl -X POST http://localhost:8000/api/tools/sync`. Nothing syncs on boot.
-  Without a key the integrations surface stays empty — an honest
-  "integrations disabled" state and auto-sync-on-first-key are **PRD-233 S2**.
+- **Composio-powered integrations** (Gmail, Slack, GitHub, Shopify and the rest
+  of the third-party app catalogue) need your own Composio key in `.env`
+  (`COMPOSIO_API_KEY=…`, free tier at app.composio.dev; env-only, there is no
+  UI field), then `docker compose up -d backend` to apply it. On that boot the
+  backend syncs the catalogue itself and re-binds the seeded agents to their
+  apps. Without a key the Tools page says *"Integrations are disabled — no
+  Composio API key is configured."*, Composio tools are not offered to agents,
+  and the native platform tools keep working (PRD-233 S2).
+- **Durable memory (mem0) and field memory (Qdrant)** are not in the default
+  stack; the backend degrades cleanly without them.
 
 ## Optional: database GUI
 
@@ -104,6 +117,17 @@ docker compose down            # stop
 docker compose down -v         # stop and delete all data volumes
 ```
 
+`down -v` does not remove the bind-mounted `./workspaces` folder — delete it
+yourself if you want the agents' files gone too.
+
+## Updating
+
+```bash
+git pull && docker compose up -d --build
+```
+
+Database migrations run on every backend boot.
+
 ## Troubleshooting
 
 - **Backend logs:** `docker compose logs -f backend`
@@ -112,8 +136,12 @@ docker compose down -v         # stop and delete all data volumes
 - **"POSTGRES_PASSWORD is required" / "REDIS_PASSWORD is required" /
   "API_KEY is required":** one of the three required secrets is missing from
   `.env` — see step 1.
+- **"password authentication failed" after changing `POSTGRES_PASSWORD`:** the
+  existing Postgres volume keeps the password it was initialised with — reset
+  with `docker compose down -v` or `ALTER USER` it; see the guide.
 - **Database GUI:** Adminer at http://localhost:8080 (with `--profile all`).
 - **API reference:** http://localhost:8000/docs
 
-All keys you add through Settings → Credentials are encrypted in the database and
-available to the platform immediately.
+All keys you add through Settings → API Keys are encrypted in the database and
+available to the platform immediately. More in
+[docs/getting-started/self-hosting.md](docs/getting-started/self-hosting.md).

--- a/README.md
+++ b/README.md
@@ -14,19 +14,27 @@
 
 ---
 
-Automatos AI is an open-source platform for building AI workforces. Create specialised agents, equip them with tools and knowledge, schedule their work, and let them operate autonomously — reporting back through a unified command centre.
+Automatos AI is an open-source (Apache-2.0) platform for running teams of AI agents. You create agents, give them skills, tools and knowledge, run them through Playbooks and Missions, and read what they produced as Deliverables — with Auto, the assistant, as the front door and a Command Center for oversight.
 
-It is not a chatbot wrapper. It is an operating system for AI agents.
+## One codebase, three editions
+
+| Edition | What it is | Status |
+|---|---|---|
+| **Local edition** | Clone the repo, set three secrets, `docker compose up`. No login, one workspace, one operator; Postgres + pgvector, Redis and MinIO in the stack; agents can act on files on your own machine through the workspace-worker. Bring your own LLM key (and, optionally, your own Composio key). | Available — [QUICKSTART.md](QUICKSTART.md) · [self-hosting guide](docs/getting-started/self-hosting.md) |
+| **Hosted edition** | The same code run as a service at [automatos.app](https://automatos.app): accounts, workspaces, teams and plans on top of it. | Available |
+| **Enterprise** | Parked. No separate directory, no license keys, nothing built. | Not started |
+
+The edition is a runtime flag (`AUTH_EDITION=local|saas`). Product capability is not gated: every agent, tool, Playbook, Mission and Deliverable feature in the code runs in the local edition.
 
 <p align="center">
-  <strong>100+ marketplace agents &middot; 1,000+ tool integrations &middot; 300+ LLMs &middot; 150+ skills &middot; Bring-your-own-keys</strong>
+  <strong>Marketplace agents &middot; Composio tool integrations (bring your own key) &middot; 300+ LLMs through OpenRouter or direct keys &middot; Reusable skills</strong>
 </p>
 
 <br>
 
 ## Talk to your agents
 
-A unified chat interface that routes your messages to the right agent automatically. Quick actions let you jump straight into coding, creating agents, managing knowledge, or building recipes.
+A unified chat interface that routes your messages to the right agent automatically. Quick actions let you jump straight into coding, creating agents, managing knowledge, or building Playbooks.
 
 <p align="center">
   <img src="docs/assets/01-Chat.png" alt="Chat Interface" width="800">
@@ -46,7 +54,7 @@ A unified chat interface that routes your messages to the right agent automatica
 
 ## 1,000+ tool integrations
 
-Connect your agents to GitHub, Slack, Jira, Stripe, Shopify, Datadog, Notion, HubSpot, and a thousand more through the community marketplace. Browse, install, and assign integrations to specific agents from a single dashboard — no glue code, no per-tool SDKs.
+Connect your agents to GitHub, Slack, Jira, Stripe, Shopify, Datadog, Notion, HubSpot, and a thousand more through the Composio catalogue. Browse, install, and assign integrations to specific agents from a single dashboard — no glue code, no per-tool SDKs. In the local edition this needs your own `COMPOSIO_API_KEY`; without one the Tools page says so and the native platform tools keep working.
 
 <p align="center">
   <img src="docs/assets/03-Marketplace-tools.png" alt="Community Marketplace" width="800">
@@ -88,7 +96,7 @@ Track every API call across every model. See cost per agent, cost per request, u
 
 ## Knowledge bases with cloud sync
 
-Upload documents, sync folders from Dropbox and cloud storage, and let the platform chunk, embed, and index everything automatically. Your agents get RAG-powered access to your entire knowledge base.
+Upload documents, sync folders from Dropbox and cloud storage (the cloud connectors run through Composio), and let the platform chunk, embed, and index everything automatically. Your agents get RAG-powered access to your entire knowledge base — on pgvector in the local edition, on S3 Vectors in the hosted one.
 
 <p align="center">
   <img src="docs/assets/06-Knowledge.png" alt="Knowledge Bases" width="800">
@@ -101,31 +109,29 @@ Upload documents, sync folders from Dropbox and cloud storage, and let the platf
 | Capability | What it does |
 |---|---|
 | **Universal Router** | Multi-tier routing (cache, rules, semantic, LLM) sends messages to the right agent every time |
-| **Recipes & Workflows** | Multi-step automation with scheduling, triggers, and inter-agent coordination |
+| **Playbooks & Missions** | Multi-step automation with scheduling, triggers, and inter-agent coordination |
 | **Prompt Optimisation** | A/B test and score prompts against live traffic, automatically improve agent performance |
 | **Workspace Execution** | Sandboxed environments where agents run code, manage files, and interact with Git repos |
-| **Multi-Tenancy** | Full workspace isolation — each team gets their own agents, data, and configuration |
+| **Multi-Tenancy** | Full workspace isolation in the hosted edition — each team gets their own agents, data, and configuration |
 | **Plugin System** | Extend agents with skills, plugins, and custom tools from the marketplace or your own repos |
 
 ---
 
-## Quick start
+## Quick start (local edition)
 
 ```bash
 git clone https://github.com/AutomatosAI/automatos-ai.git
 cd automatos-ai
 cp .env.example .env    # set the 3 required secrets: POSTGRES_PASSWORD, REDIS_PASSWORD, API_KEY
-docker compose up
+docker compose up       # first run builds the images and the database schema
 ```
 
-The local edition runs with **no login** and a single default workspace. Compose
-needs only those three secrets set; add an LLM key (`OPENAI_API_KEY` /
-`ANTHROPIC_API_KEY` / OpenRouter) when you want AI features. See
-[QUICKSTART.md](QUICKSTART.md) for the full walkthrough and what does / doesn't
-work out of the box.
-
-- **Frontend**: http://localhost:3000
-- **API Docs**: http://localhost:8000/docs
+Then open http://localhost:3000 (API reference at http://localhost:8000/docs).
+No login. Add one LLM key (`OPENAI_API_KEY` / `ANTHROPIC_API_KEY` /
+`OPENROUTER_API_KEY` in `.env`, or later under Settings → API Keys) and run the
+seeded *Two-minute brief* Playbook. [QUICKSTART.md](QUICKSTART.md) is the short
+walkthrough; [docs/getting-started/self-hosting.md](docs/getting-started/self-hosting.md)
+covers every service, dial, and what the local edition does not include.
 
 ---
 
@@ -133,29 +139,28 @@ work out of the box.
 
 | Layer | Technology |
 |---|---|
-| Frontend | Next.js 14, TypeScript, Tailwind CSS, shadcn/ui |
-| Backend | Python, FastAPI, SQLAlchemy, Alembic |
-| Database | PostgreSQL, Redis |
-| AI | OpenRouter, OpenAI, Anthropic, DeepSeek (multi-provider) |
-| Storage | AWS S3, S3 Vectors |
-| Auth | Clerk |
-| Infra | Docker, Railway |
+| Frontend | Next.js 15, React, TypeScript, Tailwind CSS, shadcn/ui |
+| Backend | Python 3.11, FastAPI, SQLAlchemy, Alembic |
+| Data | PostgreSQL 16 with pgvector, Redis 7 |
+| AI | OpenRouter, OpenAI, Anthropic and other providers through one router; bring your own keys |
+| Object storage | S3 API — MinIO in the local stack, AWS S3 (+ S3 Vectors for RAG) in the hosted edition |
+| Auth | None in the local edition (`AUTH_EDITION=local`); Clerk in the hosted edition |
+| Runtime | Docker Compose (local); Railway (hosted) |
 
 ---
 
 ## Documentation
 
-Full platform documentation is available in [`/docs`](docs/README.md), auto-synced from [DeepWiki](https://deepwiki.com/AutomatosAI/automatos-ai) — 100+ pages covering architecture, APIs, agents, workflows, and deployment.
+Platform documentation lives in [`/docs`](docs/README.md) — architecture, APIs, agents, Playbooks, deployment. Most pages are generated from [DeepWiki](https://deepwiki.com/AutomatosAI/automatos-ai); the self-hosting guide and the contributing guide are maintained by hand.
 
 ---
 
 ## Contributing
 
-We're building the operating system for the agentic future. Contributions welcome.
+See [CONTRIBUTING.md](CONTRIBUTING.md). Two things to know before the first PR:
 
-1. Fork the repo
-2. Create a feature branch
-3. Submit a PR
+- **Sign off every commit** (`git commit -s`). The `Signed-off-by:` trailer is your [Developer Certificate of Origin](https://developercertificate.org) attestation and the `dco` check verifies it on each pull request. There is no CLA; contributions are Apache-2.0 and ship in every edition.
+- **Capability first, core second.** Skills, tools, MCP integrations, Playbooks and agent packages reach both editions unchanged and never conflict with core. Open an issue first for anything touching auth, storage, the tool router or a migration.
 
 ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -176,13 +176,18 @@ services:
       COMPOSIO_API_KEY: ${COMPOSIO_API_KEY:-}
 
       # Object storage — local MinIO via the S3 seam (PRD-176 F089).
-      # S3_ENDPOINT_URL points boto at MinIO; the AWS_* creds are the MinIO
-      # root creds. Prod leaves S3_ENDPOINT_URL unset and uses real AWS S3.
+      # S3_ENDPOINT_URL points boto at MinIO. The store's credentials are mapped
+      # through S3_* names on purpose (PRD-233 S4 finding): a developer's AWS_*
+      # in .env or the shell must never reach the local store — with a real
+      # AWS key in AWS_ACCESS_KEY_ID every server-side call to MinIO failed
+      # InvalidAccessKeyId. To use real S3 locally instead: S3_ENDPOINT_URL=
+      # (empty) + S3_ACCESS_KEY_ID / S3_SECRET_ACCESS_KEY / S3_REGION in .env.
+      # Prod (Railway) never reads this file and keeps its AWS_* env.
       S3_ENDPOINT_URL: ${S3_ENDPOINT_URL:-http://minio:9000}
       S3_DOCUMENTS_BUCKET: ${S3_DOCUMENTS_BUCKET:-automatos-ai}
-      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-${MINIO_ROOT_USER:-minioadmin}}
-      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-${MINIO_ROOT_PASSWORD:-minioadmin}}
-      AWS_REGION: ${AWS_REGION:-us-east-1}
+      AWS_ACCESS_KEY_ID: ${S3_ACCESS_KEY_ID:-${MINIO_ROOT_USER:-minioadmin}}
+      AWS_SECRET_ACCESS_KEY: ${S3_SECRET_ACCESS_KEY:-${MINIO_ROOT_PASSWORD:-minioadmin}}
+      AWS_REGION: ${S3_REGION:-us-east-1}
 
       # Document Generation (PRD-63)
       GOTENBERG_URL: http://gotenberg:3000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,12 +3,14 @@
 # =============================================================================
 # Quick Start:
 #   1. Copy .env.example to .env and set required values (POSTGRES_PASSWORD, REDIS_PASSWORD, API_KEY)
-#   2. Run: docker-compose up --build
+#   2. Run: docker compose up
 #   3. Access: http://localhost:3000
-#   4. Go to Settings > Credentials to add API keys (OpenAI, Anthropic, etc.)
+#   4. Add an LLM key: Settings → API Keys in the UI, or OPENAI_API_KEY /
+#      ANTHROPIC_API_KEY / OPENROUTER_API_KEY in .env (passed through below)
 #
 # A .env file IS REQUIRED with at minimum: POSTGRES_PASSWORD, REDIS_PASSWORD, API_KEY
-# All LLM credentials managed via the Settings UI.
+# LLM keys live in the database (Settings → API Keys) or in .env; the stored key
+# also drives embeddings locally (PLATFORM_KEY_WORKSPACE_ID in envs/api.defaults).
 #
 # Profiles:
 #   - Default: postgres, redis, minio (+ minio-init), backend, frontend and the
@@ -171,6 +173,9 @@ services:
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
       OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:-}
+      # Optional: pin the credential-encryption key instead of the auto-generated
+      # one on the backend_data volume (CREDENTIAL_KEY_FILE in envs/api.defaults).
+      CREDENTIAL_ENCRYPTION_KEY: ${CREDENTIAL_ENCRYPTION_KEY:-}
       # Composio (hosted tool integrations) — bring your own key; without it the
       # integrations surface stays empty (PRD-233 makes that honest in the UI).
       COMPOSIO_API_KEY: ${COMPOSIO_API_KEY:-}
@@ -183,7 +188,10 @@ services:
       # InvalidAccessKeyId. To use real S3 locally instead: S3_ENDPOINT_URL=
       # (empty) + S3_ACCESS_KEY_ID / S3_SECRET_ACCESS_KEY / S3_REGION in .env.
       # Prod (Railway) never reads this file and keeps its AWS_* env.
-      S3_ENDPOINT_URL: ${S3_ENDPOINT_URL:-http://minio:9000}
+      # `-` (no colon) on purpose: an EMPTY S3_ENDPOINT_URL in .env means 'real S3'
+      # (`:-` would silently put MinIO back). Then also override S3_PUBLIC_ENDPOINT_URL=
+      # and S3_USE_PATH_STYLE=false in envs/api.local.
+      S3_ENDPOINT_URL: ${S3_ENDPOINT_URL-http://minio:9000}
       S3_DOCUMENTS_BUCKET: ${S3_DOCUMENTS_BUCKET:-automatos-ai}
       AWS_ACCESS_KEY_ID: ${S3_ACCESS_KEY_ID:-${MINIO_ROOT_USER:-minioadmin}}
       AWS_SECRET_ACCESS_KEY: ${S3_SECRET_ACCESS_KEY:-${MINIO_ROOT_PASSWORD:-minioadmin}}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,11 @@
 # All LLM credentials managed via the Settings UI.
 #
 # Profiles:
-#   - Default: Core services (postgres, redis, backend, frontend)
-#   - All: Add --profile all (includes admin tools)
+#   - Default: postgres, redis, minio (+ minio-init), backend, frontend and the
+#     workspace-worker (Code Canvas runtime). The worker's files live in a host
+#     directory bind-mounted at /workspaces — AUTOMATOS_WORKSPACE_DIR in .env,
+#     default ./workspaces next to this file, created on first boot (PRD-233 S1).
+#   - All: Add --profile all (adminer database GUI, gotenberg document conversion)
 # =============================================================================
 
 services:
@@ -190,6 +193,10 @@ services:
       
       # Security
       API_KEY: ${API_KEY:?API_KEY is required - set in .env file}
+      # Optional shared secret for the workspace-worker's internal HTTP API —
+      # sent as X-Internal-Token; must match the worker's value (empty = none,
+      # the worker port is never published outside the compose network).
+      WORKER_INTERNAL_TOKEN: ${WORKER_INTERNAL_TOKEN:-}
       
       # Clerk Authentication — SaaS-only. `:-` (not `:?`) so their ABSENCE never
       # blocks `docker compose up` in local mode; when set (saas) they resolve
@@ -207,8 +214,11 @@ services:
       # Persists the auto-generated credential-encryption key (see envs/api.defaults).
       - backend_data:/app/data
       - backend_logs:/app/logs
-      # PRD-66: Read-only access to workspace files for code viewer widget
-      - workspace_data:/workspaces:ro
+      # The workspace-worker's host directory, read-only (PRD-233 S1): the
+      # backend's WORKSPACE_VOLUME_PATH view of agent deliverables. The file
+      # browser and Code Canvas go through the worker's HTTP API instead
+      # (WORKER_INTERNAL_URL in envs/api.defaults).
+      - ${AUTOMATOS_WORKSPACE_DIR:-./workspaces}:/workspaces:ro
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
       interval: 30s
@@ -261,10 +271,16 @@ services:
       - automatos
 
   # ===========================================================================
-  # Workspace Worker (PRD-56 Phase 2: Physical Workspaces)
+  # Workspace Worker — the Code Canvas runtime (PRD-56 Phase 2 · PRD-170 · PRD-233 S1)
   # ===========================================================================
-  # Agent task execution in isolated workspace directories.
-  # Enable with: --profile workers
+  # Runs in the DEFAULT profile: agents act on files that live on YOUR machine.
+  # The host directory ${AUTOMATOS_WORKSPACE_DIR:-./workspaces} is bind-mounted
+  # at /workspaces (created on first boot). Each workspace gets
+  # /workspaces/<workspace_id>/; every Code Canvas tool call is confined to it
+  # (canvas_confinement.py) and mutations still need approval
+  # (canvas_approvals.py) — local is not unguarded. AUTOMATOS_WORKSPACE_DIR in
+  # .env is the ONE dial that widens host access. The backend reaches this
+  # service over the compose network at WORKER_INTERNAL_URL (envs/api.defaults).
   # ===========================================================================
   workspace-worker:
     build:
@@ -272,7 +288,6 @@ services:
       dockerfile: Dockerfile
     container_name: automatos_workspace_worker
     restart: unless-stopped
-    profiles: ["workers"]
     depends_on:
       redis:
         condition: service_healthy
@@ -283,7 +298,8 @@ services:
       DATABASE_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-orchestrator_db}
       # Redis
       REDIS_URL: redis://:${REDIS_PASSWORD}@redis:6379/0
-      # Workspace config
+      # Workspace config — the IN-CONTAINER mount root (worker_config.workspace_root);
+      # the host side is the bind mount under `volumes:` below.
       WORKSPACE_VOLUME_PATH: /workspaces
       WORKSPACE_DEFAULT_QUOTA_GB: ${WORKSPACE_DEFAULT_QUOTA_GB:-5}
       WORKER_CONCURRENCY: ${WORKER_CONCURRENCY:-3}
@@ -293,11 +309,15 @@ services:
       # Set the same value on the Railway workspace-worker service.
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
       CLAUDE_CODE_OAUTH_TOKEN: ${CLAUDE_CODE_OAUTH_TOKEN:-}
+      # Optional shared secret for this service's internal HTTP API (the
+      # backend sends the same value as X-Internal-Token; empty = no token).
+      WORKER_INTERNAL_TOKEN: ${WORKER_INTERNAL_TOKEN:-}
       # Environment
       ENVIRONMENT: ${ENVIRONMENT:-development}
       LOG_LEVEL: ${LOG_LEVEL:-INFO}
     volumes:
-      - workspace_data:/workspaces
+      # Host directory (bind mount, read-write) — the ONE host-access dial.
+      - ${AUTOMATOS_WORKSPACE_DIR:-./workspaces}:/workspaces
     deploy:
       resources:
         limits:
@@ -365,9 +385,6 @@ volumes:
   backend_logs:
     driver: local
     name: automatos_backend_logs
-  workspace_data:
-    driver: local
-    name: automatos_workspace_data
 
 # =============================================================================
 # Networks

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -320,6 +320,10 @@ services:
       # Environment
       ENVIRONMENT: ${ENVIRONMENT:-development}
       LOG_LEVEL: ${LOG_LEVEL:-INFO}
+      # The worker's log relay targets Railway's internal Loki push endpoint by
+      # default (automatos_logging.py); off locally, like the backend.
+      LOG_RELAY_ENABLED: "false"
+      SERVICE_NAME: workspace-worker
     volumes:
       # Host directory (bind mount, read-write) — the ONE host-access dial.
       - ${AUTOMATOS_WORKSPACE_DIR:-./workspaces}:/workspaces

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,105 +1,143 @@
-# 🤝 Contributing to Automatos AI
+# Contributing to Automatos AI
 
-> **"We're building the operating system for AI agents. We need your help."**
-
-First off, thank you for considering contributing to Automatos AI! It's people like you that make open source such a powerful force.
-
----
-
-## 🌟 Ways to Contribute
-
-You don't need to be an AI expert to help out. Here are high-impact ways to contribute:
-
-### 1. 🛠️ Build Tools (Best for Beginners)
-The easiest way to add value is to add a new tool to the registry.
-- **Idea:** Add a tool for Jira, Trello, GitHub, or your favorite API.
-- **Guide:** See [Developer Guide > Adding a Tool](DEVELOPER_GUIDE.md#tutorial-1-adding-a-new-tool).
-
-### 2. 🐛 Fix Bugs
-Find a bug? Fix it!
-- Look for issues labeled `good first issue`.
-- Check `FIXME` or `TODO` comments in the code.
-
-### 3. 📝 Improve Documentation
-Docs are never perfect.
-- Fix typos.
-- Add examples.
-- Write tutorials.
-- Translate docs.
-
-### 4. 🧠 Enhance Core Modules
-Ready for a challenge?
-- Improve the RAG pipeline.
-- Optimize the memory system.
-- Add new agent coordination patterns.
+This is the full contributor guide. The short version lives in the repository
+root, [CONTRIBUTING.md](../CONTRIBUTING.md); where the two overlap, they say
+the same thing.
 
 ---
 
-## 🚀 Pull Request Process
+## The deal, in three lines
 
-### 1. Fork & Clone
-Fork the repo to your account and clone it locally.
+1. **Licence.** The repository is Apache-2.0. Under §5 of that licence your
+   contribution may be distributed in every edition of the platform — the
+   local edition you run yourself, and the hosted and commercial editions run
+   by the maintainers — under the same terms, with no separate agreement.
+   What you contribute stays Apache-2.0 for everyone, and it ships everywhere
+   the code ships.
+2. **Sign-off, not CLA.** Every commit carries a `Signed-off-by:` trailer
+   (`git commit -s`), your [Developer Certificate of Origin](https://developercertificate.org)
+   attestation. The `dco` check on each pull request verifies it and fails on
+   any commit without one. There is no CLA to sign.
+3. **One codebase, two shipped editions.** The local edition
+   (`AUTH_EDITION=local`, `docker compose up`, no accounts) and the hosted
+   edition (`saas`, automatos.app) are the same code behind one runtime flag.
+   A change must keep both working; CI gates both.
 
-### 2. Create a Branch
-Use a descriptive name:
+---
+
+## Where to contribute capability
+
+Capability lands best where it never conflicts with core, in this order:
+
+| First | Second |
+|---|---|
+| **Skills, tools, MCP integrations, Playbooks, agent packages.** A new skill or platform action needs no knowledge of the orchestrator's internals and reaches both editions unchanged. | **Core** — auth, storage, the tool router, migrations, the boot lifecycle. A core change needs the schema-drift, route-contract and fresh-clone smoke lanes to stay green in both editions. |
+
+Open an issue first for anything that touches auth, storage, the tool router
+or a migration. For the mechanics of adding a platform action, read
+[`orchestrator/modules/tools/README.md`](../orchestrator/modules/tools/README.md).
+
+Other welcome contributions: bug fixes (look for `good first issue`),
+documentation (this directory — most pages are DeepWiki-generated, a few are
+hand-maintained and listed in [docs/README.md](README.md)), and tests.
+
+---
+
+## Development environment
+
+The compose stack **is** the development environment — there is no separate
+bare-metal setup:
+
 ```bash
-git checkout -b feat/add-jira-tool
-# or
-git checkout -b fix/memory-leak-in-stream
+git clone https://github.com/<you>/automatos-ai.git
+cd automatos-ai
+cp .env.example .env        # POSTGRES_PASSWORD, REDIS_PASSWORD, API_KEY + one LLM key
+docker compose up
 ```
 
-### 3. Make Changes
-- Follow the [Developer Guide](DEVELOPER_GUIDE.md).
-- Keep changes focused (one feature per PR).
-- Add tests for new code.
-
-### 4. Test & Lint
-Before pushing, ensure everything is green:
-```bash
-# Run tests
-pytest
-
-# Check style
-ruff check .
-```
-
-### 5. Push & Open PR
-Push to your fork and open a Pull Request against `main`.
-- **Title**: Clear and descriptive (e.g., "feat: Add Jira integration tool").
-- **Description**: Explain *what* you did and *why*.
-- **Screenshots**: If you changed the UI, show us!
+- The backend and frontend containers bind-mount their source directories
+  (`./orchestrator` → `/app`, `./frontend` → `/app`) and run in reload mode
+  (`uvicorn --reload`, `npm run dev`), so edits are picked up without a
+  rebuild. Dependency changes need `docker compose up -d --build`.
+- For frontend-only work you can run the UI on the host instead
+  (`cd frontend && npm install && npm run dev`) against the containerised API
+  at `http://localhost:8000`.
+- Database migrations run on every backend boot (`alembic upgrade heads`);
+  a fresh, empty database is built by `python -m scripts.init_fresh_db` first.
+- Everything else — services, ports, dials, troubleshooting — is in the
+  [self-hosting guide](getting-started/self-hosting.md).
 
 ---
 
-## 🎨 Style Guidelines
+## Pull request process
 
-- **Python**: We follow PEP 8. Use `ruff` to format.
-- **Types**: All function arguments and return values must have type hints.
-- **Docstrings**: Every public function/class needs a docstring.
-- **Async**: Use `async/await` for all I/O operations.
+1. **Fork and branch** from `main` with a descriptive name
+   (`feat/…`, `fix/…`, `docs/…`).
+2. **Keep it focused** — one change per PR. Add or extend tests with the
+   change: features and bug fixes ship with the test that proves them.
+3. **Sign off every commit**: `git commit -s -m "feat: …"`. Amend a missed
+   one with `git commit --amend -s --no-edit` (or `git rebase --signoff`
+   for a range).
+4. **Open the PR against `main`** with a clear title, what changed and why,
+   and screenshots for UI changes. Link the issue if there is one.
+5. **CI is the gate.** Every lane runs on the PR; fix what it reports. The
+   lanes and what each one proves:
+
+| Workflow · job | What it checks |
+|---|---|
+| `test` · `orchestrator-tests` | The backend suite (`pytest tests`) against an ephemeral Postgres, in the local edition, with a coverage ratchet. **Required.** |
+| `test` · `alembic-from-zero` | Exactly one Alembic head, and the fresh-clone boot path (`init_fresh_db`, then `upgrade heads`). |
+| `test` · `schema-drift` | No table is `ALTER`-ed by a migration without some writer `CREATE`-ing it (`scripts/ci/schema_drift_check.py`). |
+| `test` · `frontend-ci` | vitest, baselined `tsc`, eslint report, and the route contract (every backend path the frontend calls exists in the route manifest). |
+| `test` · eval lanes | NL2SQL, retrieval-recall, memory-recall and graph-uplift harness self-tests (informational). |
+| `smoke-fresh-clone` | `docker compose up` from an empty checkout with only the three secrets reaches a green `/health` and `/health/ready`. |
+| `import-linter` | Module-boundary contracts (`orchestrator/.importlinter`). |
+| `dco` | A `Signed-off-by:` trailer on every commit. |
+| `gitleaks`, `CodeQL`, `malware-scan`, `check-shopify-isolation` | Secrets, static analysis, dependency hygiene, Shopify-package isolation. |
+
+Lanes marked non-required in their workflow file still run and still report;
+treat red as red.
 
 ---
 
-## 📜 Code of Conduct
+## Conventions the code enforces
 
-**Be kind. Be respectful. Be constructive.**
-
-We are committed to providing a friendly, safe, and welcoming environment for all, regardless of gender, sexual orientation, disability, ethnicity, religion, or similar personal characteristic.
-
-Harassment of any kind will not be tolerated.
+- **`orchestrator/config.py` is the only module that reads the environment.**
+  No `os.getenv` elsewhere; add a config attribute and read it through
+  `config`.
+- **Canonical terms** in user-facing copy and identifiers: *Playbook* (not
+  recipe), *Mission* (not workflow or job), *Deliverable* (not output or
+  artifact), *Knowledge Graph*, *Command Center*, and *Auto* is a name.
+- **Replace, don't shim.** When a path is superseded, the old one is deleted
+  in the same PR — no `_legacy` suffixes, no compatibility branches.
+- **Data lives in the database.** Personas, agent definitions and seed
+  content are seeded into tables (`orchestrator/core/seeds/`), never read from
+  files at runtime.
+- **Python**: PEP 8, type hints on public functions, docstrings on public
+  classes and functions, `async`/`await` for I/O. **TypeScript**: the
+  project's ESLint/Prettier configuration.
+- **Editions.** Anything hosted-only is gated by `AUTH_EDITION` /
+  `isSaaS`, never by role; anything compose-only lives in `docker-compose.yml`
+  and `envs/*.defaults`, which the hosted deployment never reads.
 
 ---
 
-## 🏆 Recognition
+## Pull request checklist
 
-We love our contributors!
-- **All contributors** are listed in the repository.
-- **Major contributors** get shout-outs in our release notes.
-- **Consistent contributors** may be invited to join the core team.
+- [ ] Linked issue (if applicable)
+- [ ] Clear description of the change and the reason for it
+- [ ] Tests added or updated
+- [ ] Docs updated (`README.md`, `QUICKSTART.md` or `docs/` as needed)
+- [ ] Every commit signed off (`git commit -s`)
+- [ ] No linter or build errors; CI green
 
 ---
 
-**Questions?**
-Join our [Discord](https://discord.gg/automatos) and ask in the `#dev-chat` channel.
+## Code of Conduct
 
-**Happy Hacking!** 💻
+Participation is governed by the [Code of Conduct](../CODE_OF_CONDUCT.md).
+Report unacceptable behaviour to support@automatos.ai.
+
+## Questions
+
+Open an issue on the repository.

--- a/docs/PRDS/PRD-151-STORAGE-DECOUPLING-MINIO-DEFAULT.md
+++ b/docs/PRDS/PRD-151-STORAGE-DECOUPLING-MINIO-DEFAULT.md
@@ -1,6 +1,6 @@
 # PRD-151: Storage Decoupling — One S3 Code Path, MinIO as the Local Default
 
-**Status:** Draft
+**Status:** Draft — **ABSORBED 2026-08-29 into PRD-233 S4** (open-core wave; see `PRD-WAVE-OPEN-CORE.md`). The endpoint seam (`S3_ENDPOINT_URL`) landed via PRD-176 F089; the factory consolidation + deletion of the three bespoke fallbacks builds under PRD-233. Do not build from this doc — the §2 boto3 census remains the reference list (re-verify at build; #625 removed the voice entries).
 **Author:** Gerard Kavanagh (with Auto)
 **Date:** 2026-06-09
 **Type:** Refactor / Consolidation (centralize a scattered dependency; delete bespoke fallbacks)

--- a/docs/PRDS/PRD-153-ONE-COMMAND-LOCAL-RUN.md
+++ b/docs/PRDS/PRD-153-ONE-COMMAND-LOCAL-RUN.md
@@ -1,6 +1,6 @@
 # PRD-153: One-Command Local Run — Compose Consolidation & Schema Lifecycle
 
-**Status:** Superseded — its compose-consolidation slice (delete the six `infrastructure/docker-compose*.yml`) was absorbed and executed by **PRD-209 S9 (US-008, 2026-08-29)**; the local-defaults consumer by PRD-209 S7. This doc's G1/M2 compose-deletion goals are now met on the fresh-clone-boot branch.
+**Status:** Draft — **ABSORBED 2026-08-29 into PRD-209 S2/S7/S8/S9** (open-core Phase 0; see `PRD-WAVE-OPEN-CORE.md`): schema lifecycle → S2, `envs/*.defaults` consumer → S7, honest QUICKSTART (M1) → S8, deletion of the six drifted compose files → S9. Do not build from this doc — §10's program table is superseded by the wave doc.
 **Author:** Gerard Kavanagh (with Auto)
 **Date:** 2026-06-09
 **Type:** Refactor / Consolidation (one canonical compose; one schema lifecycle; delete six drifted compose files)

--- a/docs/PRDS/PRD-233-OPEN-CORE-LOCAL-EDITION.md
+++ b/docs/PRDS/PRD-233-OPEN-CORE-LOCAL-EDITION.md
@@ -1,0 +1,110 @@
+# PRD-233: Open-Core Local Edition — Basic becomes worth downloading
+
+> **Status:** BUILT 2026-08-29/30 on `ralph/prd-233-local-edition` (stacked on PRD-209's branch; S4 on its own stacked branch `ralph/prd-233-s4-storage-factory` per Q3). Local test pass green (see §Build log). Awaiting push → CI → owner merge. Grounded @ `origin/main 182cd6739` (2026-08-29); `file:line` refs may drift — confirm by grep at build. **Program:** Open-Core **Phase 1** (see `PRD-WAVE-OPEN-CORE.md`; owner decisions locked 2026-08-29: single codebase FINAL, enterprise PARKED, Basic + SaaS co-exist). **Depends on:** PRD-209 (Phase 0 — fresh-clone boot + compose local defaults; **must merge first**, shares `docker-compose.yml`). Reuses PRD-175 (`AUTH_EDITION`), PRD-176 (MinIO seam), PRD-197 S5 (pgvector-local RAG, landed `9cfbf9005`). **Absorbs PRD-151** (storage-client consolidation — S4 here; PRD-151 header updated).
+
+---
+
+## Framing (CLAUDE.md §3)
+
+**Extension + consolidation — no new subsystem.** Every story extends something that already runs in SaaS (workspace-worker, tool router, seeds, boto3 call sites) or consolidates a duplication PRD-151 already enumerated. Net-new surface: one tool-routing degrade seam and one docs page. **Build size:** M overall (S4 is the only mechanical sweep). **Risk:** Low-Medium — the tool seam touches the router (fail-open history, see S2); everything else is additive or deletion.
+
+## Overview
+
+After PRD-209, a stranger can boot the platform. This PRD makes the booted thing **worth keeping**: agents that can act on the user's own machine (the thing SaaS structurally cannot offer), a tool surface that degrades honestly instead of dying silently without a Composio platform key, a seeded first-run that demonstrates the product in two minutes, storage that works fully against MinIO, and the intake scaffolding that points community energy at skills/tools where it never conflicts with core. North-Star: this is the contributor-acquisition wave — the local edition is the funnel into everything else.
+
+**Non-goals (owner decisions, recorded — not deferrals):** no capability gating in Basic (paid tiers gate organizational features and hosting, never product capability); no `ee/` directory or license keys (enterprise PARKED 2026-08-29); teams-connecting-local-workspaces-via-SaaS = future funnel, out of this PRD by owner call; **session mode (subscription runtime) = PRD-234**, not here.
+
+---
+
+## Current reality (grounded @ `origin/main 182cd6739`)
+
+- **Composio is woven with no seam and no fallback**: ~164 backend files; `orchestrator/core/composio/` (client, tool_executor, tool_router_manager, entity_manager), `orchestrator/modules/tools/composio_tool_router.py`, `orchestrator/modules/tools/tool_router.py`, ~18 API routers; config keys at `orchestrator/config.py:516-526, 984-998`. Without `COMPOSIO_API_KEY` the integration surface is dead and nothing tells the user why. Router history: F018 fail-open (`modules/tools/tool_router.py` ~960-996) — this codebase's disease class is *fail-open-wider*; the degrade seam must fail **honest**, not open.
+- **workspace-worker exists, containerized, off by default locally**: `services/workspace-worker/` (executor, workspace_manager, canvas_session_service, canvas_confinement, canvas_approvals) — the Code Canvas runtime; compose gates it behind `profiles: ["workers"]`.
+- **Storage is half-seamed**: the RAG/document leg honors `S3_ENDPOINT_URL` (PRD-176 F089), but PRD-151 §2's enumerated **12+ independent `boto3.client()` sites** remain (e.g. `orchestrator/api/documents.py:296`, `api/document_generation.py:389`, `api/recipe_executor.py:795`, `services/checkpoint_service.py:26`, `services/tool_manifest_service.py:26`, `services/workspace_purge.py:29` — re-verify list at build; #625 may have deleted the voice entries), plus **three bespoke local fallbacks** PRD-151 marked for deletion: `core/services/marketplace_s3.py:268`, `core/services/image_store.py:205`, `modules/attachments/store.py:82`.
+- **Seeds exist** (`orchestrator/core/seeds/`, entrypoint wait→migrate→seed step from PRD-176) but there is no curated local first-run: no demo agents/playbook bound to the `DEFAULT_WORKSPACE_ID` workspace.
+- **Community intake is generic**: `CONTRIBUTING.md` exists; nothing states the commercial-shipping deal, nothing routes capability contributions to skills/tools, no DCO check.
+
+---
+
+## Stories (test-first; CI is the only gate — no local runs, no servers)
+
+### S1 · Workspace-worker joins the local profile — agents act on the user's machine — S/M
+**Files:** `docker-compose.yml` (worker moves into the default/local profile **after PRD-209 S7 merges** — sequence-sensitive shared file); `services/workspace-worker/worker_config.py` + `canvas_confinement.py` (a host-access dial: confinement root defaults to a designated host directory bind-mounted into the worker, e.g. `${AUTOMATOS_WORKSPACE_DIR:-./workspaces}`); `envs/api.defaults` (worker URL default).
+**Test:** worker config unit tests for the confinement-root resolution (designated-dir default; escape attempts rejected — extend existing `canvas_confinement` tests); a compose source-guard asserts the worker service is in the local profile and the bind-mount matches the config default.
+**Notes:** This ships the *existing* runtime to the laptop — no new execution paths. Scope of host access is **Q1** (designated directory vs wider). The approval layer (`canvas_approvals.py`) stays on — local ≠ unguarded.
+
+### S2 · Tool-routing degrade seam — honest without Composio — M
+**Files:** `orchestrator/core/composio/client.py` (one availability predicate: key present + client constructible — config-read only, no `os.getenv` outside `config.py`); `orchestrator/modules/tools/tool_router.py` + `modules/tools/composio_tool_router.py` (routing consults availability ONCE, at a single seam: absent ⇒ Composio tools are **not offered** — excluded from discovery/schemas — rather than offered-then-erroring); frontend tools surface shows an "integrations disabled — no Composio key" state, not an empty lie.
+**Test:** router tests: with key configured, Composio tools present (today's behaviour, unchanged); with key absent, (a) discovery excludes Composio tools, (b) native platform tools + agent-native tools still route, (c) a direct Composio call returns an explicit `integrations_unavailable` error — **never** a silent success or a fail-open pass-through. Regression: the F018 gate stays fail-closed.
+**Notes:** Degrade order in Basic: platform-native tools → (PRD-234's session tools when that lands) → BYO `COMPOSIO_API_KEY` if the user sets one (document it, **Q2**). This story is the D2 seam from the program doc; it deliberately does NOT abstract Composio behind a provider interface — one predicate, one exclusion point, honest UI.
+
+### S3 · First-run seed — the two-minute demo — S
+**Files:** `orchestrator/core/seeds/` (an idempotent local-edition seed: the `DEFAULT_WORKSPACE_ID` workspace + a small named agent roster + one demo Playbook + a welcome Deliverable, gated on `AUTH_EDITION=local`; runs in the existing entrypoint seed step — no new lifecycle); reuse `seed_auto_agent.py` patterns (note its skip-existing behaviour at `:110` — the local seed must be idempotent-refresh, not skip-forever).
+**Test:** seed unit test against a fresh schema: run twice ⇒ identical state (idempotent); assert workspace id == config `DEFAULT_WORKSPACE_ID`; assert the roster/playbook rows exist and are workspace-scoped. The PRD-209 S5 smoke probe may additionally assert the seed ran (coordinate, don't duplicate).
+**Notes:** Content stays minimal and useful (a real Playbook a stranger can run with only their LLM key). No file-hacks: seed content lives in the seed module, DB is the runtime source (CLAUDE.md §4).
+
+### S4 · One storage-client factory — absorbs PRD-151 — M
+**Files:** one factory in `orchestrator/core/` honoring `S3_ENDPOINT_URL` + per-bucket config (PRD-151's design: "S3's API *is* the interface — no StorageProvider abstraction"); migrate the enumerated `boto3.client()` sites to it; **DELETE the three bespoke local fallbacks** (`marketplace_s3.py` local path, `image_store.py` local path, `modules/attachments/store.py` local path) in the same PR — MinIO is the local answer, one code path both editions.
+**Test:** factory unit tests (endpoint/credential resolution: MinIO defaults locally, AWS in SaaS); a source guard asserts zero direct `boto3.client(` calls outside the factory module (today: 12+); existing attachment/marketplace/image tests keep passing against the factory.
+**Notes:** Mechanical but wide — **Q3** asks whether this rides this wave or lands as its own PR lane inside it (same PRD either way; no scope loss). Re-verify PRD-151's site list at build (#625 removed voice).
+
+### S5 · Self-host docs + community intake — S
+**Files:** `docs/getting-started/self-hosting.md` (the real guide: 3 secrets + 1 LLM key, what runs where, MinIO/pgvector notes, worker host-access dial, BYO-Composio, troubleshooting — supersedes the scattered `docs/deployment-infrastructure/` compose pages, which get pointers, not duplicates); `CONTRIBUTING.md` (+2 paragraphs: the commercial-shipping deal — contributions may ship in hosted/commercial editions under Apache-2.0 §5 — and "where to contribute capability": skills/tools/MCP first, core second); `.github/workflows/` DCO check (probot/dco or equivalent lane).
+**Test:** doc guard: every `${VAR:?}` in compose appears in the self-hosting guide (same shape as PRD-209 S8's guard — share the checker); DCO lane proves itself on the PR (sign-offs present).
+**Notes:** Keep the tone factual — what things do, no pitch. The **PRD-210 history scrub remains the promotion gate**: docs can merge, but no launch push until 210 runs (program-level gate, owner-scheduled).
+
+### S6 · Local profile — Auto knows who it is talking to — S
+**Context (owner ask, 2026-08-29 live test):** "no login on local also means I can't add a profile, means Auto doesn't know me — make it feel more real: *Hello Gerard*." The local edition has exactly one operator; the anonymous session currently carries no identity, so every greeting, attribution, and `created_by` is faceless.
+**Files:** the local-edition seed (S3) creates ONE `users` row for the operator (well-known id alongside `DEFAULT_WORKSPACE_ID`, e.g. `DEFAULT_LOCAL_USER_ID` in `envs/api.defaults`; `name`/`email` start as placeholders); `core/auth/hybrid.py` anonymous lane binds `UserContext(id=<that row>, name, email, system_role="super_admin")` in local mode (today it carries only the role); **Settings → Profile** in local mode becomes a plain form (name, role/title, email) writing that row — replacing the Clerk-managed profile surface that has nothing to show locally; the Auto context pack / greeting reads `ctx.user.name` (it already renders names for SaaS users — reuse, do not add a second greeting path).
+**Test:** hybrid unit test: local anonymous ctx carries the seeded user id + name; profile API round-trip test in local mode (PUT name → GET reflects; saas untouched); context-section test asserts the operator's name appears in Auto's greeting/context when set and falls back gracefully when blank.
+**Backbone already shipped by PRD-209 (live-test finding 2026-08-29: chat 500'd "No users found"):** the entrypoint seeds `users` id 1 (`LOCAL_OPERATOR_EMAIL`, config + `envs/api.defaults`), and `hybrid.py`'s anonymous local lane carries that email + `super_admin`. S6's remaining scope = the Settings → Profile form (name/role/email writing that row), the greeting/context threading, and attribution polish.
+**Notes:** No accounts, no passwords, no login — a profile, not an identity system. Seed is idempotent-refresh only on placeholder values (never overwrite a name the operator typed). This also fixes the faceless `created_by`/attribution on locally created agents, Playbooks and Deliverables.
+
+---
+
+## Sequencing
+
+- **After PRD-209 merges** (shared `docker-compose.yml`; the boot must be true before any of this matters).
+- S1 ∥ S2 ∥ S4 are file-disjoint and parallel-safe; S3 after S1 (worker profile defines what the demo can show); S6 with S3 (same seed + hybrid lane); S5 last (documents reality).
+- **Delivered early by PRD-209's live-test fixes (2026-08-29):** the marketplace catalog seeders (agents v2, Shopify agents, packages, personas, plugin categories) now run idempotently at every boot via `core/database/load_seed_data`, and the local session is the instance super-admin. S3's remaining scope is the curated first-run *content* (demo Playbook, welcome Deliverable, the prod-curated catalog refresh) and the Settings→Credentials nudge — not the seeding plumbing.
+
+## Verification (CI only)
+
+No local servers, no `docker compose` runs on the dev machine. Every behavioural story carries pure unit tests (confinement resolution, router degrade, seed idempotency, factory resolution) + source guards (compose profile, zero stray `boto3.client(`, doc-var coverage, DCO lane presence). The de-masked PRD-209 smoke lane is the end-to-end proof surface for anything boot-visible.
+
+## Success metrics
+
+- With `COMPOSIO_API_KEY` unset: tool discovery excludes Composio, native tools work, the UI says why. Today: silent dead surface.
+- Worker runs in the local profile against a designated host directory with approvals on. Today: off by default, container-confined only.
+- Fresh local boot lands in a seeded workspace with a runnable demo Playbook. Today: empty.
+- Zero `boto3.client(` outside the factory; the three bespoke local fallbacks deleted. Today: 12+ and 3.
+- A stranger can go clone → running → first Playbook executed with only the documented steps. Today: impossible.
+
+## Decisions recorded 2026-08-29 (owner, during the live local test)
+
+- **Marketplace = two things.** The seeded **local catalog** (agents, packages, playbooks, personas) is the product's content library — offline, no auth, stays. The **community hub** (share/pull other people's work) is a network service: **pulling needs no account and nothing is ever paywalled** (n8n community nodes / HACS / Grafana catalog model — "more people sharing makes the platform stronger"); **publishing needs a free Automatos account, and pushes are monitored and approved** (moderation + a verified tier). Subscription stays where it is: hosted workspaces + teams. Hub v1 form (GitHub-repo-backed registry first vs SaaS-hosted) = still open (Q5). Portable package manifest export/import = the primitive both need.
+- **SaaS-only surfaces hidden in local by an explicit allowlist**, not by role (the local session is super_admin): Workspace Admin, Team, plan/trial pills, invitations, sign-in/up. (→ S7)
+- **Composio in the local edition = bring your own key in `.env`** (`COMPOSIO_API_KEY`, env-only — `config.py`; compose passthrough added by PRD-209). Nuance for S2/S3: the catalog seeders bind agents to Composio apps via `composio_apps_cache`; on a keyless first boot those bindings are skipped ("Tool 'SLACK' not found"), and the by-name/by-slug idempotency means they are **not** re-bound when a key is added later — S2 must re-resolve seeded agents' app bindings once the cache populates (or bind lazily by intended slug). Also: nothing syncs the catalogue on boot — the only triggers are `POST /api/tools/sync` (Tools page **Sync**, `workspace:manage`) and two manual scripts (`scripts/run_tools_sync.py`, `scripts/sync_composio_metadata.py`); S2 acceptance = a boot with a key and an empty `composio_apps_cache` runs the sync itself, then re-binds the seeded agents.
+
+### S7 · Edition-aware navigation — SaaS-only surfaces hidden in local — S
+**Files:** the nav/route registry (sidebar + `app/` routes for Team, Workspace Admin, billing/plan, invitations, sign-in/up) gated on `isSaaS` via one explicit list in `lib/auth-edition.ts` (no per-page ad-hoc checks); local Settings shows Profile (S6) + Credentials + system settings only.
+**Test:** a component test renders the nav in local mode and asserts none of the listed surfaces appear; saas mode unchanged.
+**Notes:** role-based hiding is wrong here — the local operator is super_admin by design.
+
+## Open questions — Gerard's call (§12)
+
+1. **Host-access default scope (S1).** Designated directory (`./workspaces` bind-mount; recommended — safe default, one dial to widen) vs home-directory access out of the box. Confirm.
+2. **BYO-Composio placement (S2/S5).** Documented-but-secondary (recommended) vs promoted as the primary local tool path?
+3. **S4 lane (storage sweep).** Ride the main wave PR or its own PR inside the wave (wide mechanical diff; separate PR eases review)? Recommendation: separate PR, same wave.
+4. **Local MCP surface (S2 notes).** v1 = user-configured MCP servers documented for the session runtime (PRD-234) only, or does the platform tool router also learn MCP discovery here? Recommendation: defer MCP-in-router to PRD-234's session lane — one seam at a time. Confirm (this is a scope call, not a silent deferral).
+
+---
+
+*Traceability: program doc `PRD-WAVE-OPEN-CORE.md` (owner decisions 2026-08-29); `reports/dossiers/deployability-open-core.md` (EXTEND verdict); `reports/dossiers/thesis-T2-repo-topology.md` (monolith-in-compose is the self-host shape); PRD-151 §2 (boto3 census — absorbed here as S4); PRD-153 §5/§10 (program framing — Phase-0 pieces absorbed by PRD-209 S7-S9); coupling census from the 2026-08-29 open-core sweep (Composio 164 files; Clerk 83/30 — untouched here; identity work remains optional hygiene, not a Basic blocker).*
+5. **Hub v1 form.** GitHub-repo-backed registry (`automatos-packages`, PRs as the publish path — zero infra, matches the skills-repo doctrine; recommended) vs SaaS-hosted registry with accounts first. Browsing on by default with a visible switch + env var (recommended) vs opt-in.
+
+## Build log (2026-08-29/30)
+
+All seven stories built and proven on the live local stack: S1 worker in the default profile against `./workspaces`; S2 availability seam + boot catalogue sync + honest Tools card; S3 first-run seed (Auto, roster, 'Two-minute brief', welcome Deliverable) idempotent-refresh; S4 storage factory (own PR — 12 SaaS-reaching behaviour changes enumerated for the owner); S5 self-hosting guide + DCO lane + every README/doc page; S6 local profile ("I'm talking to you, <name>!" proven through the frontend proxy); S7 edition-aware nav + unrestricted local exposure profile. Findings fixed on the way: fresh databases were missing `v_workspace_outputs` (orphan-root ordering — generator gained model-column + idempotent raw-SQL passes; CI Gate 2 asserts it); every local upload had ended `status: failed` behind an "uploaded successfully" message (embeddings never saw the operator's key — `PLATFORM_KEY_WORKSPACE_ID` now points at the local workspace; message honest); the seed loader's `sys.path` hack, the dead skills seeder and the v2 marketplace seeder's id churn; a developer's `AWS_*` hijacking MinIO; uvicorn dev reloads wedging on open SSE streams; the postgres data volume keeping its initdb password across recreates.
+
+**Owner decisions still open after the build:** Q1 host-access default = designated directory (built as recommended); Q2 BYO-Composio documented-but-secondary (built as recommended); Q3 S4 = separate PR (done); Q4 MCP-in-router deferred to PRD-234 (as recommended — confirm); Q5 hub v1 form; the `role/title` profile field (no column; add via a later migration or drop); `TASK_RUNNER_BACKEND=queued` locally (needed for clone-a-repo; diverts workflow execution to the worker — Railway's value unknown); uploaded originals stay in the container's `/tmp` (pre-existing upload-path behaviour; MinIO holds only pipeline outputs) — durability gap for the local edition.

--- a/docs/PRDS/PRD-234-SESSION-MODE-SUBSCRIPTION-RUNTIME.md
+++ b/docs/PRDS/PRD-234-SESSION-MODE-SUBSCRIPTION-RUNTIME.md
@@ -1,0 +1,83 @@
+# PRD-234: Session Mode — agents on your Claude subscription, zero API keys
+
+> **Status:** DRAFT — spec only, no build yet. Grounded @ `origin/main 182cd6739` (2026-08-29); `file:line` refs may drift — confirm by grep at build. **Program:** Open-Core **Phase 3** (see `PRD-WAVE-OPEN-CORE.md`). **Depends on:** PRD-209 (boot), PRD-233 (local worker profile + tool seam). Reuses the Code Canvas session runtime (`services/workspace-worker/canvas_session_service.py`), the merged Auto-Manager wave (PRD-224 ticket lane · PRD-225/229 questions · PRD-226 dispatch doctrine · PRD-227 board events · PRD-228 fleet state), and `AUTH_EDITION` (PRD-175).
+
+---
+
+## Framing (CLAUDE.md §3)
+
+**Extension — the runtime exists, the manager exists; this PRD connects them and makes the connection selectable.** `canvas_session_service.py` already drives Claude Agent SDK sessions with per-workspace config, permission callbacks, and confinement. The ticket lane already dispatches work to named agents. Net-new: a runtime selector on agent execution, the session-side prompt/result contract, and honest failure states. **Build size:** M-L (S1/S2 are the substance). **Risk:** Medium — a second execution runtime beside the API path; contained by local-only gating and no-silent-fallback rules.
+
+## Overview
+
+**The Basic edition's headline feature.** Today every agent turn is an LLM API call (BYOK or platform key). Session mode adds a second runtime: an agent's work executes as a **Claude Code session on the user's own machine, authenticated by the user's own Claude subscription login — no API key anywhere**. Automatos is the layer above: Auto assigns tickets, writes the dispatch contract, tracks the board, keeps memory and context; sessions do the work. The lane is proven in-house: the Ralph overnight runner launches headless sessions with `ANTHROPIC_API_KEY` deliberately unset and bills the owner's Max subscription — supported Agent SDK path, user's own machine, user's own subscription. Session mode is **structurally local-only** (the login lives on the user's machine), which is exactly why it belongs to Basic: it is the thing the SaaS cannot offer, and the reason a contributor installs the open edition.
+
+**Non-goals (owner decisions, recorded):** SaaS-side session mode (structurally impossible — not built around); **teams connecting local Automatos workspaces via the SaaS subscription = future funnel** (owner-flagged 2026-08-29 as later + nice-to-have; nothing here precludes it — the runtime contract is workspace-scoped, which is the seam a future team-connect would use); no scraping or reverse-engineering of subscription auth — the supported `claude_agent_sdk` / Claude Code login path only; Auto's own orchestrator brain stays on the API path in v1 (**Q3**).
+
+---
+
+## Current reality (grounded @ `origin/main 182cd6739`)
+
+- **The session runtime exists for one caller.** `services/workspace-worker/canvas_session_service.py`: lazy `claude_agent_sdk` import (`:129` — `ClaudeAgentOptions`, `ClaudeSDKClient`), per-workspace `CLAUDE_CONFIG_DIR` (`/workspaces/{workspace_id}/.canvas/claude/`, `:12,68`), permission callbacks (`PermissionResultAllow/Deny`, `:185`), confinement (`canvas_confinement.py`), approvals (`canvas_approvals.py`), events (`canvas_events.py`). Built for Code Canvas; nothing else can reach it.
+- **Agent execution is API-only.** AgentFactory → LLM manager → provider clients (`core/llm/`), key resolution workspace-first (`core/llm/workspace_keys.py`). No runtime selector exists on agents or dispatch.
+- **The manager plane is merged and waiting.** Ticket lane: `platform_create_task(assigned_agent_name=…)`, `platform_assign_task`, status→`in_progress` triggers execution (PRD-224). Dispatch doctrine: `DISPATCH_CONTRACT_FRAGMENT` — OBJECTIVE·OUTPUT·TOOLS·BOUNDARIES (PRD-226). Agent moves emit board SSE (PRD-227). Fleet state + `platform_fleet_status` (PRD-228). Questions/clarifications ride `approval_grants` (PRD-225/229, incl. the answered-resume loop US-005).
+- **The subscription lane is proven.** Operational precedent 2026-08-27: headless sessions launched `env -u ANTHROPIC_API_KEY` bill the Max subscription; nested/headless launch works.
+
+---
+
+## Stories (test-first; CI is the only gate — no live Claude sessions in CI)
+
+### S1 · SessionRuntime — generalize the canvas service into a selectable agent runtime — M/L
+**Files:** `services/workspace-worker/` (extract the session-drive core of `canvas_session_service.py` into a runtime module both canvas and agent-dispatch consume — refactor, not fork; canvas keeps working byte-identically); agent model + dispatch path gain `runtime: api | session` (default `api`; **no new table** — extend the existing agent definition per CLAUDE.md §4); `orchestrator/config.py` (`SESSION_RUNTIME_ENABLED`, default false; boot guard: enabling it requires `AUTH_EDITION=local` — extend `validate_auth_edition()`); session env construction **explicitly strips `ANTHROPIC_API_KEY`** (subscription billing is the contract, mixed billing is a bug).
+**Test:** runtime-module contract tests against a fake SDK client (the lazy-import seam at `:129` is the injection point — same pattern the canvas tests use); guard: `SESSION_RUNTIME_ENABLED=true` + `AUTH_EDITION=saas` ⇒ boot abort; env-construction test asserts the key-strip; canvas regression suite unchanged.
+**Notes:** Per-workspace `CLAUDE_CONFIG_DIR` already gives sessions isolated auth/config; reuse it unchanged. Session concurrency cap = **Q1** (config dial, small default).
+
+### S2 · Dispatch to sessions — the ticket lane drives real work — M
+**Files:** the execution trigger behind status→`in_progress` (PRD-224's path) branches on the agent's runtime: `session` ⇒ enqueue to the worker's session runtime with a prompt built from the **PRD-226 dispatch contract** (OBJECTIVE·OUTPUT·TOOLS·BOUNDARIES) + agent soul/skills + workspace context pack; session result (final output + artifacts under the confinement root) flows back through the **existing** task-completion path so board events (227), watches, and Deliverable promotion (#611 lineage) all fire unchanged.
+**Test:** dispatch-branch unit tests (api agents unchanged — regression; session agents enqueue with the composed contract); completion-path test: a fake-session result lands as task completion + board event + Deliverable exactly like an API agent's would (assert no parallel result path was invented).
+**Notes:** Missions can target session agents too via the same AgentMatcher/dispatch seam — but the ticket lane is the v1 proof surface (single named agents, Gerard's stated management model). Mission-wide session staffing = **Q5**.
+
+### S3 · Honest failure, no silent fallback — S
+**Files:** session runtime preflight (login/config present? SDK importable?); on failure the task goes **blocked** with a question through the PRD-225 ask lane ("Claude login not found for session agent X — run `claude login` on this machine or switch the agent to API runtime"), resuming via the 229 answered-resume loop. **Never** silently fall back to the API path (that would bill keys the user chose not to use — the fail-open disease class, PRD-223 lineage).
+**Test:** preflight-failure test asserts blocked-task + ask emission and **zero** API-client invocation; resume test: answer ⇒ task resumes on the corrected runtime.
+**Notes:** This is where 225/229's machinery pays for itself — reuse, don't invent a second question surface.
+
+### S4 · Sessions on the board and in the fleet — S
+**Files:** session lifecycle (started / tool-permission-asked / finished / died) emits through `canvas_events.py` → `notify_board_event` (227) and surfaces in fleet state / `platform_fleet_status` (228) with `runtime: session` visible; permission asks route through the existing approvals surface (`canvas_approvals.py` → the approvals UI), not a new modal.
+**Test:** event-mapping unit tests (each lifecycle event → the existing board-event type it reuses); fleet-state test shows the session agent with runtime tag.
+**Notes:** Visibility is what makes "Automatos manages all my Claude sessions" true rather than vibes — the fleet page is the management console for sessions.
+
+### S5 · OpenAI lane — Codex CLI sessions behind the same runtime interface — M
+**Files:** a second implementation of S1's runtime interface driving OpenAI's Codex CLI headless sessions (subscription-authenticated, same preflight/honest-failure/fleet contracts); config dial per agent (`runtime: session` + `session_provider: claude | codex`).
+**Test:** same contract-test suite run against the codex fake; preflight distinguishes "no codex login" from "no claude login" in the ask text.
+**Notes:** **Q4 — in-wave or follow-on:** the interface (S1) is built for two implementations either way; the owner call is only *when* the second lands. Surfaced, not deferred.
+
+---
+
+## Sequencing
+
+S1 → S2 → {S3 ∥ S4} → S5 (if in-wave). All after PRD-233 (worker in local profile is the substrate). The canvas refactor inside S1 is the one regression-sensitive step — land it first with the canvas suite as the gate.
+
+## Verification (CI only — sessions cannot run in CI)
+
+Real subscription sessions are unrunnable in CI by design (no login, and billing someone's subscription from CI would be wrong). The proof stack: contract tests against fake SDK clients at the lazy-import seam (canvas precedent), pure unit tests for dispatch branching / env-strip / preflight / event mapping, source guards for the boot-gate and no-fallback invariants, and the canvas regression suite for the refactor. First real-session validation is an owner smoke on the owner's machine — scripted (`scripts/` one-shot: create ticket → assign session agent → observe board), run by Gerard, not CI.
+
+## Success metrics
+
+- A zero-API-key local install (subscription login only) takes a ticket from `platform_create_task` → assigned session agent → completed task + board event + Deliverable. Today: impossible without keys.
+- Missing login ⇒ blocked task + actionable question; **zero** silent API fallback. 
+- Fleet view shows live session agents with runtime tags; permission asks land in the existing approvals surface.
+- Canvas suite green before/after the S1 refactor (byte-identical canvas behaviour).
+
+## Open questions — Gerard's call (§12)
+
+1. **Concurrency cap (S1).** Sessions are heavyweight and share one subscription's limits. Default cap 2 concurrent sessions, config dial? Confirm a number.
+2. **Session lifetime (S1/S2).** Per-task ephemeral sessions (recommended v1 — clean, resumable via dispatch contract) vs long-lived per-agent sessions with resume. Confirm.
+3. **Auto itself on session runtime?** v1 keeps Auto (orchestrator brain) on the API path — chat latency and tool-loop shape fit the API client; sessions fit *task work*. Flip later if desired. Confirm v1 boundary.
+4. **Codex lane timing (S5).** In this wave or the first follow-on? (Interface built for it either way.)
+5. **Mission staffing on sessions (S2).** v1 = ticket lane only (recommended), missions follow once ticket-lane telemetry looks right. Confirm.
+6. **UI surface for runtime selection.** Agent settings page gains the `runtime`/`session_provider` fields (recommended: yes, it's one field group) — or config-only for v1?
+
+---
+
+*Traceability: program doc `PRD-WAVE-OPEN-CORE.md` (owner decisions 2026-08-29 — session mode = Basic headline; teams-later funnel note); munder-difflin review 2026-08-27 (the operating model: manager above CLI sessions; artifact f31677a8) and its merged wave PRD-224–229; Code Canvas lineage (PRD-170/184 → `canvas_session_service.py`); subscription-lane precedent (Ralph runner, `env -u ANTHROPIC_API_KEY`, 2026-08-27 ops notes); PRD-223 (fail-open = disease class → S3's no-silent-fallback rule); PRD-175 (`AUTH_EDITION` boot guard being extended).*

--- a/docs/PRDS/PRD-WAVE-OPEN-CORE.md
+++ b/docs/PRDS/PRD-WAVE-OPEN-CORE.md
@@ -15,8 +15,8 @@
 
 | Phase | Goal | PRD | State | Blocks |
 |---|---|---|---|---|
-| **0** | `docker compose up` true; smoke lane armed; SaaS provably untouched | **PRD-209** (S1–S9) | Drafted, build-ready | everything |
-| **1** | Basic worth downloading: worker on the laptop, honest tool degrade, seeded first-run, one storage factory, self-host docs + DCO | **PRD-233** | Drafted, build-ready after 209 | Phase 3 |
+| **0** | `docker compose up` true; smoke lane armed; SaaS provably untouched | **PRD-209** (S1–S9) | BUILT — local edition proven 2026-08-29; PR #650 (rebase + CI pending) | everything |
+| **1** | Basic worth downloading: worker on the laptop, honest tool degrade, seeded first-run, one storage factory, self-host docs + DCO | **PRD-233** | BUILT 2026-08-30 (stacked on 209; S4 = own PR) — awaiting push/CI/merge | Phase 3 |
 | **2** | Promotion safety: git-history secrets scrub + branch-protection arming | **PRD-210** (exists) | Drafted | any public promotion of Basic |
 | **3** | Session mode: tickets execute as subscription sessions; fleet = the session console; Codex lane | **PRD-234** | Drafted, build-ready after 233 | — |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,12 @@
-# DeepWiki Documentation
+# Documentation
 
-Auto-synced from [DeepWiki](https://deepwiki.com/AutomatosAI/automatos-ai)
+Most pages here are generated from [DeepWiki](https://deepwiki.com/AutomatosAI/automatos-ai)
+(last sync: 2026-05-08 23:55:45 UTC) and carry a "Relevant source files" block.
+A few are maintained by hand and take precedence where they overlap:
 
-Last synced: 2026-05-08 23:55:45 UTC
+- [Self-hosting — the local edition](getting-started/self-hosting.md): services, ports, dials, troubleshooting, how the editions relate.
+- [Contributing](CONTRIBUTING.md): DCO sign-off, where capability contributions go, the CI lanes.
+- [QUICKSTART.md](../QUICKSTART.md) (repo root): the short install path.
 
 ## Table of Contents
 
@@ -10,6 +14,7 @@ Last synced: 2026-05-08 23:55:45 UTC
   - [Key Concepts](overview/key-concepts.md)
   - [System Architecture](overview/system-architecture.md)
 - [Getting Started](getting-started/_index.md)
+  - [Self-hosting — the local edition](getting-started/self-hosting.md)
   - [Installation & Setup](getting-started/installation-setup.md)
   - [Configuration Guide](getting-started/configuration-guide.md)
   - [Quick Start Tutorial](getting-started/quick-start-tutorial.md)

--- a/docs/agents/agent-plugins-skills.md
+++ b/docs/agents/agent-plugins-skills.md
@@ -126,8 +126,8 @@ graph TD
 
 ## Data Model & Storage
 
-### Plugin Storage (S3/Local)
-Plugins are stored in S3 (production) or the local filesystem (development). The `MarketplaceS3Service` handles the extraction of ZIP contents into a structured directory: `plugins/{slug}/{version}/` [orchestrator/core/services/marketplace_s3.py:61-91]().
+### Plugin Storage (S3 API)
+Plugins are stored in an S3-compatible object store through the platform's single S3 client factory (`orchestrator/core/storage/s3.py`): AWS S3 in the hosted edition, the MinIO container in the local edition (`S3_ENDPOINT_URL`, bucket `MARKETPLACE_S3_BUCKET`). There is no filesystem fallback — the former local-directory path was deleted (PRD-233 S4). The `MarketplaceS3Service` handles the extraction of ZIP contents into a structured key prefix: `plugins/{slug}/{version}/` [orchestrator/core/services/marketplace_s3.py]().
 
 ### Database Schema
 

--- a/docs/community-marketplace/browsing-installing-items.md
+++ b/docs/community-marketplace/browsing-installing-items.md
@@ -22,7 +22,6 @@ The following files were used as context for generating this wiki page:
 - [orchestrator/api/llm_marketplace.py](orchestrator/api/llm_marketplace.py)
 - [orchestrator/api/marketplace_plugins.py](orchestrator/api/marketplace_plugins.py)
 - [orchestrator/api/openrouter_marketplace.py](orchestrator/api/openrouter_marketplace.py)
-- [orchestrator/core/database/init_complete_schema.sql](orchestrator/core/database/init_complete_schema.sql)
 - [orchestrator/core/database/migrations/042_openrouter_models_cache.sql](orchestrator/core/database/migrations/042_openrouter_models_cache.sql)
 - [orchestrator/scripts/seed_llm_marketplace.py](orchestrator/scripts/seed_llm_marketplace.py)
 - [orchestrator/scripts/seed_recipes_marketplace.py](orchestrator/scripts/seed_recipes_marketplace.py)

--- a/docs/deployment-infrastructure/_index.md
+++ b/docs/deployment-infrastructure/_index.md
@@ -21,24 +21,26 @@ The following files were used as context for generating this wiki page:
 
 ## Purpose and Scope
 
-This document covers the containerization, orchestration, and deployment infrastructure for Automatos AI. It explains the Docker multi-stage build process, the modular Docker Compose architecture mirroring a 19-service production topology, environment variable configuration, and production deployment strategies on platforms like Railway.
+This document covers the containerization, orchestration, and deployment infrastructure for Automatos AI. It explains the Docker multi-stage build process, the Docker Compose stack that is the local edition, environment variable configuration, and the hosted deployment on Railway.
+
+> **Running it yourself?** [Self-hosting — the local edition](../getting-started/self-hosting.md) is the reference for the compose stack: services and ports, the three required secrets, the worker's host directory, object storage, the optional Composio key, updating, resetting and troubleshooting. The pages under this section describe the containers and the hosted topology; they point at the guide rather than repeating it.
 
 **Related Pages:**
-- For Dockerfiles of specific components, see [Docker Containerization](#20.1)
-- For modular service definitions and health checks, see [Docker Compose Setup](#20.2)
-- For required secrets and API keys, see [Environment Variables](#20.3)
-- For pgvector and migrations, see [Database Setup](#20.4)
-- For pub/sub and session storage, see [Redis Configuration](#20.5)
-- For scaling and monitoring, see [Production Deployment](#20.6)
+- For Dockerfiles of specific components, see [Docker Containerization](docker-containerization.md)
+- For the compose services, volumes and profiles, see [Docker Compose Setup](docker-compose-setup.md)
+- For where configuration lives and what each variable does, see [Environment Variables](environment-variables.md)
+- For pgvector and migrations, see [Database Setup](database-setup.md)
+- For pub/sub and session storage, see [Redis Configuration](redis-configuration.md)
+- For the hosted (Railway) deployment, see [Production Deployment](production-deployment.md)
 
 ---
 
 ## System Overview
 
-Automatos AI uses a highly modular, containerized architecture. While a single `docker-compose.yml` exists for quick starts, the production infrastructure is divided into functional groups to allow independent scaling. The backend services utilize a `boot_leader_lock` via PostgreSQL advisory locks to coordinate database migrations across multiple worker replicas [orchestrator/core/database/boot_lock.py:25-34]().
+One codebase ships as two editions behind a runtime flag: the **local edition** (`AUTH_EDITION=local` — the `docker-compose.yml` stack: no login, one workspace, MinIO + pgvector) and the **hosted edition** (`AUTH_EDITION=saas` on Railway — Clerk accounts, AWS S3 + S3 Vectors, mem0/Qdrant memory, telemetry). The hosted deployment sets each service's environment itself and never reads the compose file or `envs/*.defaults`; the compose defaults therefore cost it nothing. The backend services utilize a `boot_leader_lock` via PostgreSQL advisory locks to coordinate database migrations across multiple worker replicas [orchestrator/core/database/boot_lock.py:25-34]().
 
 ### Infrastructure Topology
-The following diagram maps the production service groups to their respective code entities and data stores.
+The following diagram maps the **hosted** service groups to their respective code entities and data stores. Locally, `agent-opt-worker`, Qdrant and S3 Vectors are absent (MinIO stands in for S3; RAG runs on pgvector) and Composio is only reachable with your own key.
 
 ```mermaid
 graph TB
@@ -102,35 +104,37 @@ For details, see [Docker Containerization](#20.1).
 
 ## Docker Compose Setup
 
-The system provides a unified `docker-compose.yml` for local development.
+The unified `docker-compose.yml` is the local edition and the development environment.
 
-- **Service Orchestration**: It defines `postgres`, `redis`, `backend`, and `frontend` as core services [docker-compose.yml:18-170]().
-- **Profiles**: Services like `workspace-worker` are gated behind the `workers` profile to save resources during standard development [docker-compose.yml:184]().
-- **Health Checks**: All services include robust health checks (e.g., `pg_isready` for Postgres [docker-compose.yml:36-41](), `redis-cli ping` for Redis [docker-compose.yml:66-71]()).
-- **Volume Mounting**: The backend mounts the `orchestrator/` directory for hot-reloading and has read-only access to `workspace_data` for the code viewer widget [docker-compose.yml:126-130]().
+- **Default profile**: `postgres` (pgvector), `redis`, `minio` (+ the one-shot `minio-init`), `backend`, `frontend` and `workspace-worker` [docker-compose.yml]().
+- **`--profile all`**: adds `adminer` (database GUI, :8080) and `gotenberg` (document conversion, :3001). There is no `workers` profile any more — the workspace-worker runs by default.
+- **Health Checks**: every long-running service has one (`pg_isready`, `redis-cli ping`, `mc ready`, `curl /health`); the frontend starts only after the backend is healthy.
+- **Mounts**: the backend and frontend bind-mount their source directories for hot reload. The worker's files live in the host directory `AUTOMATOS_WORKSPACE_DIR` (default `./workspaces`), bind-mounted at `/workspaces` — read-write for the worker, read-only for the backend. This is a bind mount, not a named volume.
 
-For details, see [Docker Compose Setup](#20.2).
+For details, see [Docker Compose Setup](docker-compose-setup.md).
 
-**Sources:** [docker-compose.yml:1-190]()
+**Sources:** [docker-compose.yml]()
 
 ---
 
 ## Environment Variables
 
-Configuration is driven by environment variables. A template is provided in `.env.example`.
+Configuration is layered: `.env` (from `.env.example`) holds the secrets and is read by compose for substitution only; `envs/api.defaults` and `envs/frontend.defaults` carry the committed local topology; `envs/*.local` are gitignored overrides; `orchestrator/config.py` holds every code default and is the only module that reads the environment.
 
 ### Variable Categories
 | Category | Key Variables |
 | :--- | :--- |
-| **Databases** | `DATABASE_URL`, `POSTGRES_PASSWORD`, `REDIS_PASSWORD` [docker-compose.yml:94-102]() |
-| **Auth** | `CLERK_SECRET_KEY`, `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` [docker-compose.yml:118-121]() |
-| **Security** | `API_KEY` (Required for backend/worker communication) [docker-compose.yml:116]() |
-| **LLM Providers** | `OPENAI_API_KEY`, `ANTHROPIC_API_KEY` [docker-compose.yml:105-106]() |
-| **Integrations** | `GOTENBERG_URL` (PDF Generation) [docker-compose.yml:109]() |
+| **Required (compose refuses to start without them)** | `POSTGRES_PASSWORD`, `REDIS_PASSWORD`, `API_KEY` [docker-compose.yml]() |
+| **Edition** | `AUTH_EDITION` (`local` / `saas`) and its frontend mirror `NEXT_PUBLIC_AUTH_EDITION` [envs/api.defaults](), [envs/frontend.defaults]() |
+| **LLM Providers** | `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `OPENROUTER_API_KEY` — or keys stored under Settings → API Keys [docker-compose.yml]() |
+| **Object storage** | `S3_ENDPOINT_URL` (MinIO locally), `S3_ACCESS_KEY_ID` / `S3_SECRET_ACCESS_KEY` / `S3_REGION` (mapped to the backend's `AWS_*`), `S3_PUBLIC_ENDPOINT_URL` [docker-compose.yml](), [envs/api.defaults]() |
+| **Workspace worker** | `AUTOMATOS_WORKSPACE_DIR`, `ANTHROPIC_API_KEY` / `CLAUDE_CODE_OAUTH_TOKEN` (Canvas sessions), `WORKER_CONCURRENCY`, `WORKER_INTERNAL_TOKEN` [docker-compose.yml]() |
+| **Integrations** | `COMPOSIO_API_KEY` (bring your own; optional), `GOTENBERG_URL` [docker-compose.yml]() |
+| **Auth (hosted edition only)** | `CLERK_SECRET_KEY`, `CLERK_JWKS_URL`, `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` — `:-` defaults in compose, so their absence never blocks a local boot [docker-compose.yml]() |
 
-For details, see [Environment Variables](#20.3).
+For details, see [Environment Variables](environment-variables.md).
 
-**Sources:** [docker-compose.yml:26-121]()
+**Sources:** [docker-compose.yml](), [envs/api.defaults](), [envs/frontend.defaults]()
 
 ---
 
@@ -139,8 +143,8 @@ For details, see [Environment Variables](#20.3).
 The platform is optimized for cloud deployment with a focus on reliability and security.
 
 - **Railway Deployment**: The `railway.json` file configures the production build target and restart policies [railway.json:1-13]().
-- **Database Migrations**: The production command `alembic upgrade heads && uvicorn ...` ensures that the schema is always synchronized with the code before the server starts [orchestrator/Dockerfile:140]().
-- **Redis Hardening**: Production Redis is configured to rename/disable dangerous commands like `FLUSHDB` and `FLUSHALL` [docker-compose.yml:59-60]().
+- **Database Migrations**: The entrypoint runs `alembic upgrade heads` before `uvicorn` on every boot, in both editions; a failing migration stops the boot [docker-entrypoint.sh](), [orchestrator/Dockerfile:140]().
+- **Redis Hardening**: The compose Redis is configured to rename/disable dangerous commands like `FLUSHDB` and `FLUSHALL` [docker-compose.yml]().
 - **Real-time Events**: The `RedisClient` manages workflow event publishing to channels like `workflow:{id}:execution:{id}` for frontend streaming [orchestrator/core/redis/client.py:110-119]().
 
 For details, see [Production Deployment](#20.6).

--- a/docs/deployment-infrastructure/database-setup.md
+++ b/docs/deployment-infrastructure/database-setup.md
@@ -58,6 +58,8 @@ Automatos AI uses **PostgreSQL** as its primary relational store, augmented with
 
 The system initializes in three phases: structural creation, version control via Alembic, and comprehensive seeding of platform defaults.
 
+**Fresh databases (compose, CI).** An empty database has no `alembic_version` table, and the migration history cannot replay from empty on its own. The backend entrypoint (`docker-entrypoint.sh`) therefore runs `python -m scripts.init_fresh_db` first: it builds the schema from the SQLAlchemy models plus a tolerant replay of the migration forest and stamps Alembic at heads, after which `alembic upgrade heads` is a no-op. No SQL snapshot is committed — the former `init_complete_schema.sql` is retired. Existing databases (anything with an `alembic_version` row) skip straight to incremental migrations. The `schema-drift` CI lane (`scripts/ci/schema_drift_check.py`) fails when a migration alters a table no writer creates. See [Self-hosting](../getting-started/self-hosting.md#4-first-boot--what-happens-and-how-long-it-takes) for the full boot order.
+
 ```mermaid
 flowchart TD
     subgraph "Phase 1: Engine & Tables"

--- a/docs/deployment-infrastructure/docker-compose-setup.md
+++ b/docs/deployment-infrastructure/docker-compose-setup.md
@@ -17,35 +17,38 @@ The following files were used as context for generating this wiki page:
 
 
 
-This page documents the Docker Compose orchestration for Automatos AI, covering service definitions, dependencies, health checks, volumes, networks, and deployment profiles. The setup mirrors a 19-service production topology used in Railway deployments, organized into modular functional groups.
+This page documents the Docker Compose orchestration for Automatos AI — the stack that **is** the local edition and the development environment: service definitions, dependencies, health checks, volumes, networks and the one optional profile. The hosted (Railway) topology is separate and described in [Production Deployment](production-deployment.md); Railway never reads this file.
+
+> The operator-facing walkthrough — secrets, first boot, the worker's host directory, object storage, Composio, updating, resetting, troubleshooting — is [Self-hosting — the local edition](../getting-started/self-hosting.md). This page describes the compose file itself.
 
 ## Purpose and Scope
 
 The Docker Compose configuration orchestrates all services required to run Automatos AI in a containerized environment. It defines:
 
-- **Core Services**: PostgreSQL, Redis, FastAPI backend, Next.js frontend [docker-compose.yml:18-170]().
-- **Data Infrastructure**: Dedicated pgvector and Redis instances [docker-compose.yml:22-73]().
-- **Worker Services**: `workspace-worker` for isolated task execution and `agent-opt-worker` for prompt optimization [docker-compose.yml:178-217]().
-- **Support Services**: Gotenberg for document generation (PRD-63) [docker-compose.yml:109]().
+- **Data services**: PostgreSQL with `pgvector`, Redis, MinIO (S3-compatible object storage) with a one-shot bucket initialiser [docker-compose.yml]().
+- **Application services**: the FastAPI backend and the Next.js frontend, built from source with their `development` targets [docker-compose.yml]().
+- **The workspace-worker**: the Code Canvas runtime, in the default profile, acting on a host directory [docker-compose.yml]().
+- **`--profile all`**: Adminer (database GUI) and Gotenberg (DOCX/XLSX → PDF, PRD-63) [docker-compose.yml]().
 
-Sources: [docker-compose.yml:1-217](), [orchestrator/Dockerfile:1-141](), [frontend/Dockerfile:1-115]()
+The `agent-opt-worker` (prompt optimisation), mem0, Qdrant and the observability stack are not part of the compose file; they belong to the hosted deployment.
+
+Sources: [docker-compose.yml](), [orchestrator/Dockerfile:1-141](), [frontend/Dockerfile:1-115]()
 
 ---
 
-## Modular Architecture
+## Services
 
-The system uses a unified `docker-compose.yml` with profiles to manage service groups, allowing for both minimal local development and full-scale worker deployments.
-
-### Service Grouping
-
-| Group | Service Name | Role |
-|-------|--------------|------|
-| **Database** | `postgres` | Primary storage with `pgvector` [docker-compose.yml:22-43]() |
-| **Cache** | `redis` | Pub/Sub hub and session store [docker-compose.yml:48-73]() |
-| **API** | `backend` | FastAPI orchestrator [docker-compose.yml:78-138]() |
-| **UI** | `frontend` | Next.js dashboard [docker-compose.yml:146-170]() |
-| **Workers** | `workspace-worker` | Isolated agent task execution [docker-compose.yml:178-202]() |
-| **Optimization**| `agent-opt-worker` | FutureAGI prompt scoring/optimization [docker-compose.yml:204-217]() |
+| Service | Container | Image / build | Host port (variable) | Role |
+|---|---|---|---|---|
+| `postgres` | `automatos_postgres` | `pgvector/pgvector:pg16` | 5432 (`POSTGRES_PORT`) | Relational data and the pgvector chunk store (local RAG) [docker-compose.yml]() |
+| `redis` | `automatos_redis` | `redis:7-alpine` | 6379 (`REDIS_PORT`) | Cache, pub/sub, queues; `FLUSHDB`/`FLUSHALL`/`DEBUG` disabled, 256 MB `allkeys-lru` [docker-compose.yml]() |
+| `minio` | `automatos_minio` | `minio/minio` | 9000 API (`MINIO_PORT`), 9001 console (`MINIO_CONSOLE_PORT`) | S3-compatible object store; the backend reaches it via `S3_ENDPOINT_URL=http://minio:9000` [docker-compose.yml]() |
+| `minio-init` | `automatos_minio_init` | `minio/mc` | — | One-shot: creates `S3_DOCUMENTS_BUCKET` (default `automatos-ai`), then exits [docker-compose.yml]() |
+| `backend` | `automatos_backend` | `./orchestrator`, target `development` | 8000 (`API_PORT`) | FastAPI API; `uvicorn --reload` over the bind-mounted source; entrypoint `docker-entrypoint.sh` [docker-compose.yml]() |
+| `frontend` | `automatos_frontend` | `./frontend`, target `development` | 3000 (`FRONTEND_PORT`) | Next.js UI (`npm run dev`); starts after the backend is healthy [docker-compose.yml]() |
+| `workspace-worker` | `automatos_workspace_worker` | `./services/workspace-worker` | none (8081 internal only) | Code Canvas runtime; 2 CPU / 2 GB limits; `WORKER_CONCURRENCY` default 3 [docker-compose.yml]() |
+| `adminer` (`--profile all`) | `automatos_adminer` | `adminer` | 8080 (`ADMINER_PORT`) | Database GUI pre-pointed at `postgres` [docker-compose.yml]() |
+| `gotenberg` (`--profile all`) | `automatos_gotenberg` | `gotenberg/gotenberg:8` | 3001 (`GOTENBERG_PORT`) | Document conversion at `http://gotenberg:3000` for the backend [docker-compose.yml]() |
 
 **System Data Flow & Networking**
 
@@ -54,34 +57,36 @@ graph TB
     subgraph "Public Entrypoints"
         LB_API["localhost:8000"]
         LB_UI["localhost:3000"]
+        LB_MINIO["localhost:9000 / 9001"]
     end
 
-    subgraph "Core Group"
+    subgraph "Application"
         API["automatos_backend<br/>(FastAPI)"]
         UI["automatos_frontend<br/>(Next.js)"]
+        WS_WORKER["automatos_workspace_worker<br/>(Code Canvas runtime, default profile)"]
     end
 
-    subgraph "Worker Group (Profile: workers)"
-        WS_WORKER["workspace_worker<br/>(ARQ/Redis)"]
-        OPT_WORKER["agent_opt_worker<br/>(FutureAGI)"]
-    end
-
-    subgraph "Data Group"
+    subgraph "Data"
         PG["postgres<br/>(pgvector)"]
         RD["redis<br/>(Cache/PubSub)"]
+        MN["minio<br/>(S3 API)"]
     end
 
     LB_API --> API
     LB_UI --> UI
+    LB_MINIO --> MN
     
     API --> PG
     API --> RD
+    API --> MN
+    API -- "WORKER_INTERNAL_URL" --> WS_WORKER
     WS_WORKER --> RD
     WS_WORKER --> PG
-    OPT_WORKER --> API
 ```
 
-Sources: [docker-compose.yml:18-217](), [orchestrator/core/redis/client.py:141-197]()
+All services share the `automatos` bridge network (`automatos_network`) [docker-compose.yml]().
+
+Sources: [docker-compose.yml](), [envs/api.defaults](), [orchestrator/core/redis/client.py:141-197]()
 
 ---
 
@@ -90,8 +95,13 @@ Sources: [docker-compose.yml:18-217](), [orchestrator/core/redis/client.py:141-1
 ### Backend (FastAPI)
 The backend service is built using a multi-stage `Dockerfile` targeting `python:3.11-slim` [orchestrator/Dockerfile:13](). It includes system dependencies for OCR (`tesseract-ocr`), document processing (`ghostscript`), and PDF generation (`libpango`) [orchestrator/Dockerfile:18-32]().
 
-- **Entrypoint**: Runs `alembic upgrade heads` before starting `uvicorn` to ensure schema synchronization [orchestrator/Dockerfile:140]().
-- **Hot Reload**: In development mode, the `./orchestrator` directory is mounted to `/app` [docker-compose.yml:126]().
+- **Entrypoint**: `docker-entrypoint.sh` (bind-mounted from the repo root) waits for Postgres, builds the schema on an empty database (`python -m scripts.init_fresh_db`), runs `alembic upgrade heads` (fail-closed), loads the idempotent seeds, ensures the local workspace and operator exist, then starts `uvicorn` [docker-entrypoint.sh]().
+- **Configuration**: `env_file: envs/api.defaults` (committed local topology, `AUTH_EDITION=local`) then the optional gitignored `envs/api.local`; the `environment:` block carries the secrets substituted from `.env` and wins over both [docker-compose.yml]().
+- **Hot Reload**: In development mode, the `./orchestrator` directory is mounted to `/app` and `uvicorn` runs with `--reload` [docker-compose.yml](), [orchestrator/Dockerfile:93]().
+- **Object storage**: `S3_ENDPOINT_URL=http://minio:9000`; the backend's `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_REGION` are set from `S3_ACCESS_KEY_ID` / `S3_SECRET_ACCESS_KEY` / `S3_REGION` (defaulting to the MinIO root credentials), so a developer's `AWS_*` variables never reach the local store [docker-compose.yml]().
+
+### Workspace worker
+Built from `services/workspace-worker`. The host directory `${AUTOMATOS_WORKSPACE_DIR:-./workspaces}` is bind-mounted at `/workspaces` (read-write here, read-only in the backend); each workspace gets `/workspaces/<workspace_id>/`, every Code Canvas tool call is confined to it and mutations need approval. The process runs as uid 1000 (`worker`) and its entrypoint takes ownership of the mounted directory. Canvas sessions need `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN` in `.env`. The backend reaches the worker at `WORKER_INTERNAL_URL=http://workspace-worker:8081` (`envs/api.defaults`); the port is not published on the host [docker-compose.yml](), [services/workspace-worker/entrypoint.sh](), [services/workspace-worker/worker_config.py]().
 
 ### Frontend (Next.js)
 The frontend uses a multi-stage build that outputs a standalone Node.js server for production efficiency [frontend/Dockerfile:83-114]().
@@ -140,35 +150,39 @@ Sources: [orchestrator/main.py:1-50](), [orchestrator/core/redis/client.py:14-31
 
 ## Data Persistence & Volumes
 
-The setup uses named volumes to ensure state is preserved across container lifecycles.
+The setup uses named volumes to ensure state is preserved across container lifecycles, plus one host bind mount.
 
-| Volume Name | Service | Mount Path | Purpose |
+| Volume / mount | Service | Mount Path | Purpose |
 |-------------|---------|------------|---------|
-| `postgres_data` | `postgres` | `/var/lib/postgresql/data` | Persistent SQL & Vector data [docker-compose.yml:34]() |
-| `redis_data` | `redis` | `/data` | Cache and session persistence [docker-compose.yml:65]() |
-| `workspace_data` | `backend`, `worker` | `/workspaces` | Shared agent filesystems (RO for API, RW for Worker) [docker-compose.yml:130]() |
-| `backend_logs` | `backend` | `/app/logs` | Centralized application logs [docker-compose.yml:128]() |
+| `postgres_data` (`automatos_postgres_data`) | `postgres` | `/var/lib/postgresql/data` | Persistent SQL & vector data. Keeps the password it was initialised with — changing `POSTGRES_PASSWORD` later needs a reset or `ALTER USER` [docker-compose.yml]() |
+| `redis_data` (`automatos_redis_data`) | `redis` | `/data` | Cache and session persistence [docker-compose.yml]() |
+| `minio_data` (`automatos_minio_data`) | `minio` | `/data` | Object storage (documents, generated outputs, plugin packages, images) [docker-compose.yml]() |
+| `backend_data` | `backend` | `/app/data` | The auto-generated credential-encryption key (`CREDENTIAL_KEY_FILE`); losing it makes stored API keys undecryptable [docker-compose.yml](), [envs/api.defaults]() |
+| `backend_logs` (`automatos_backend_logs`) | `backend` | `/app/logs` | Application logs [docker-compose.yml]() |
+| **bind mount** `${AUTOMATOS_WORKSPACE_DIR:-./workspaces}` | `workspace-worker` (rw), `backend` (ro) | `/workspaces` | The agents' files, on the host. Not a named volume: `docker compose down -v` leaves it in place [docker-compose.yml]() |
 
-Sources: [docker-compose.yml:34](), [docker-compose.yml:65](), [docker-compose.yml:128-130]()
+Sources: [docker-compose.yml](), [envs/api.defaults]()
 
 ---
 
 ## Environment Configuration
 
-A `.env` file is mandatory for initialization. Key required variables include:
+A `.env` file is mandatory for initialization. Compose reads it for variable substitution only; the committed topology lives in `envs/api.defaults` and `envs/frontend.defaults`, with `envs/api.local` / `envs/frontend.local` as gitignored overrides.
 
-- **Database**: `POSTGRES_PASSWORD` [docker-compose.yml:29]().
-- **Redis**: `REDIS_PASSWORD` [docker-compose.yml:56]().
-- **Security**: `API_KEY` for backend authentication [docker-compose.yml:116]().
-- **Auth**: `CLERK_SECRET_KEY` and `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` [docker-compose.yml:119-121]().
-- **LLM Keys**: Optional at startup; can be configured via the UI [docker-compose.yml:105-106]().
+- **Required** (`${VAR:?…}` — compose refuses to start without them): `POSTGRES_PASSWORD`, `REDIS_PASSWORD`, `API_KEY` [docker-compose.yml]().
+- **LLM keys**: optional at startup (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `OPENROUTER_API_KEY`); can also be stored under Settings → API Keys [docker-compose.yml]().
+- **Integrations**: `COMPOSIO_API_KEY` — bring your own; without it integrations are disabled and native tools keep working [docker-compose.yml]().
+- **Worker**: `AUTOMATOS_WORKSPACE_DIR`, `ANTHROPIC_API_KEY` / `CLAUDE_CODE_OAUTH_TOKEN`, `WORKER_CONCURRENCY`, `WORKSPACE_DEFAULT_QUOTA_GB`, `WORKER_INTERNAL_TOKEN` [docker-compose.yml]().
+- **Auth**: Clerk variables are hosted-edition only and use `:-` defaults, so their absence never blocks a local boot; `AUTH_EDITION=local` comes from `envs/api.defaults` [docker-compose.yml](), [envs/api.defaults]().
 
 ### Launching the Stack
 
-- **Standard Development**: `docker-compose up --build` [docker-compose.yml:6]().
-- **With Workers**: `docker-compose --profile workers up --build` [docker-compose.yml:184]().
-- **Production Mode**: Build using the `production` target in Dockerfiles to exclude dev dependencies like `pytest`, `black`, and `isort` [orchestrator/Dockerfile:110-114]().
+- **Default**: `docker compose up` (add `--build` after dependency or Dockerfile changes) [docker-compose.yml]().
+- **With admin tools**: `docker compose --profile all up` — Adminer and Gotenberg [docker-compose.yml]().
+- **Updating**: `git pull && docker compose up -d --build`; migrations run on every backend boot.
+- **Reset**: `docker compose down -v` removes the named volumes; delete `AUTOMATOS_WORKSPACE_DIR` by hand.
+- **Production Mode**: the `production` targets in the Dockerfiles exclude dev dependencies like `pytest`, `black`, and `isort` and are what the hosted deployment builds; the compose file uses the `development` targets [orchestrator/Dockerfile:98-146](), [frontend/Dockerfile:92-121]().
 
-Sources: [docker-compose.yml:1-16](), [orchestrator/Dockerfile:95-141](), [frontend/Dockerfile:85-115]()
+Sources: [docker-compose.yml](), [orchestrator/Dockerfile](), [frontend/Dockerfile]()
 
 ---

--- a/docs/deployment-infrastructure/docker-containerization.md
+++ b/docs/deployment-infrastructure/docker-containerization.md
@@ -141,7 +141,7 @@ graph TD
 
     subgraph "Backend_Services"
         BACK["backend (FastAPI)"]
-        WSW["workspace-worker (Profile: workers)"]
+        WSW["workspace-worker (default profile; host bind mount AUTOMATOS_WORKSPACE_DIR)"]
     end
 
     subgraph "UI_Layer"

--- a/docs/deployment-infrastructure/environment-variables.md
+++ b/docs/deployment-infrastructure/environment-variables.md
@@ -18,25 +18,29 @@ The following files were used as context for generating this wiki page:
 
 
 
-This document describes the environment variable configuration system used across all Automatos AI services. Environment variables control database connections, external service credentials, feature flags, and service-specific settings across the 19-service production topology.
+This document describes the environment variable configuration system used across all Automatos AI services. Environment variables control database connections, external service credentials, feature flags, and service-specific settings in both editions.
 
-For deployment infrastructure, see [Production Deployment](20.6). For credential management in the UI, see [Credentials Management](17.5).
+For the compose stack end to end, see [Self-hosting — the local edition](../getting-started/self-hosting.md). For deployment infrastructure, see [Production Deployment](production-deployment.md). For credential management in the UI, see [Credentials Management](../authentication-multi-tenancy/credentials-management.md).
 
 ---
 
 ## Overview
 
-Automatos AI uses environment variables for all external configuration to support multiple deployment targets (Docker Compose, Railway, Kubernetes) without code changes. Variables are loaded from `.env` files in local development and from platform-provided environment in production.
+Automatos AI uses environment variables for all external configuration to support multiple deployment targets (Docker Compose locally, Railway for the hosted edition) without code changes. `orchestrator/config.py` is the only module that reads the environment; everything else reads `config`.
 
-The system follows a three-tier loading strategy:
+In the compose stack the layers are:
 
-1.  **Environment variables** (highest priority) — set by hosting platform or shell.
-2.  **`.env` file** — loaded via `python-dotenv` in the backend application lifecycle.
-3.  **Hardcoded defaults** — fallback values in centralized config.
+| Layer | What it holds | Precedence (backend container) |
+| :--- | :--- | :--- |
+| `.env` (from the root `.env.example`) | Secrets and the few values only you choose. **Read by compose for substitution only** — a variable reaches a container only if `docker-compose.yml` references it. | — |
+| `docker-compose.yml` `environment:` block | The substituted secrets and explicit wiring (`DATABASE_URL`, `S3_ENDPOINT_URL`, the `S3_*` → `AWS_*` mapping, Composio and LLM keys). | Highest |
+| `envs/api.local` (gitignored, optional) | Personal overrides for any backend variable — the deep-override lane. | Middle |
+| `envs/api.defaults` (committed) | The local topology: `AUTH_EDITION=local`, `DEFAULT_WORKSPACE_ID`, `LOCAL_OPERATOR_EMAIL`, `PLATFORM_KEY_WORKSPACE_ID`, `WORKER_INTERNAL_URL`, `S3_PUBLIC_ENDPOINT_URL`, `S3_VECTORS_ENABLED=false`, observability off. No secrets. | Lowest env file |
+| `orchestrator/config.py` | Code defaults for every remaining dial. | Fallback |
 
-The codebase includes an service-specific `orchestrator/.env.example` for the core API and a global `.gitignore` that protects sensitive environment files.
+The frontend has the same shape (`envs/frontend.defaults`, `envs/frontend.local`). The hosted deployment sets each service's environment itself and never reads the compose file or `envs/*`. `orchestrator/.env.example` is a template for running the backend process outside compose; it is not the supported local path and its values (for example `REQUIRE_AUTH`) predate the edition flag.
 
-**Sources:** [orchestrator/.env.example:1-65](), [.gitignore:102-109]()
+**Sources:** [docker-compose.yml](), [envs/api.defaults](), [envs/frontend.defaults](), [orchestrator/config.py](), [.gitignore]()
 
 ---
 
@@ -84,19 +88,41 @@ graph TB
 
 ## Required Environment Variables
 
-These variables **must** be set for the system to function. Missing required variables will cause startup failures in production.
+These are the only variables the compose stack **refuses to start without** — declared as `${VAR:?message}` in `docker-compose.yml`, so an unset or empty value stops `docker compose up` with the message shown.
 
 ### Core Infrastructure
 
-| Variable | Purpose | Example | Used By |
+| Variable | Purpose | Error when missing | Used By |
 | :--- | :--- | :--- | :--- |
-| `POSTGRES_PASSWORD` | PostgreSQL admin password | `secure_db_pass_123` | `pgvector` container, `backend` |
-| `REDIS_PASSWORD` | Redis authentication | `secure_redis_pass` | `redis` container, `backend` |
-| `API_KEY` | Internal API authentication | `your_secure_api_key_here` | `backend` |
-| `API_HOST` | Host binding for the API | `0.0.0.0` | `backend` |
-| `API_PORT` | Port binding for the API | `8000` | `backend` |
+| `POSTGRES_PASSWORD` | PostgreSQL password (applied when the data volume is first initialised) | `POSTGRES_PASSWORD is required - set in .env file` | `postgres`, `backend`, `workspace-worker` |
+| `REDIS_PASSWORD` | Redis authentication | `REDIS_PASSWORD is required - set in .env file` | `redis`, `backend`, `workspace-worker` |
+| `API_KEY` | The backend's own API-key principal | `API_KEY is required - set in .env file` | `backend` |
 
-**Sources:** [orchestrator/.env.example:6,11,14-16]()
+In the hosted edition (`AUTH_EDITION=saas`) the boot guard additionally requires `CLERK_JWKS_URL` and `CLERK_SECRET_KEY` and fails fast without them (`config.validate_auth_edition`); in the local edition it requires `DEFAULT_WORKSPACE_ID`, which `envs/api.defaults` provides.
+
+**Sources:** [docker-compose.yml](), [orchestrator/config.py]()
+
+---
+
+## Edition and Local-Edition Variables
+
+| Variable | Default (compose) | Purpose |
+| :--- | :--- | :--- |
+| `AUTH_EDITION` | `local` (`envs/api.defaults`; code default `saas`) | The one edition flag. `local` forces `REQUIRE_AUTH=false` (no login, one operator); `saas` requires Clerk. |
+| `NEXT_PUBLIC_AUTH_EDITION` | `local` (`envs/frontend.defaults`) | Frontend mirror, read by `frontend/lib/auth-edition.ts`; hides the hosted-only surfaces locally. |
+| `DEFAULT_WORKSPACE_ID` | `00000000-0000-0000-0000-0000000000c1` | The single local workspace every anonymous request resolves to. |
+| `LOCAL_OPERATOR_EMAIL` | `local@automatos.local` | The operator's `users` row (the session's lookup key; name editable under Settings → Profile). |
+| `PLATFORM_KEY_WORKSPACE_ID` | the local workspace id | Whose stored API key acts as the platform key for embeddings and system LLM calls. |
+| `AUTOMATOS_WORKSPACE_DIR` | `./workspaces` | Host directory bind-mounted at `/workspaces` — the workspace-worker's host-access dial. |
+| `WORKER_INTERNAL_URL` / `WORKER_INTERNAL_TOKEN` | `http://workspace-worker:8081` / empty | Where the backend reaches the worker; optional shared secret. |
+| `COMPOSIO_API_KEY` | unset | Bring-your-own Composio key (env-only). Absent ⇒ Composio tools are not offered and the Tools page says integrations are disabled; native tools keep working. |
+| `S3_ENDPOINT_URL` | `http://minio:9000` | Points the single S3 client factory at MinIO. |
+| `S3_ACCESS_KEY_ID` / `S3_SECRET_ACCESS_KEY` / `S3_REGION` | MinIO root credentials / `us-east-1` | The object store's credentials as the backend sees them (compose maps them onto the backend's `AWS_*`); your own `AWS_*` variables are deliberately not read by the local store. |
+| `S3_PUBLIC_ENDPOINT_URL` | `http://localhost:9000` | Host the browser can reach for presigned links; change with `MINIO_PORT`. |
+| `S3_VECTORS_ENABLED` | `false` | Local RAG runs on pgvector; S3 Vectors is hosted-only. |
+| `CREDENTIAL_KEY_FILE` | `/app/data/.credential_key` | Where the auto-generated credential-encryption key persists (the `backend_data` volume). |
+
+**Sources:** [docker-compose.yml](), [envs/api.defaults](), [envs/frontend.defaults](), [orchestrator/config.py]()
 
 ---
 
@@ -105,24 +131,25 @@ These variables **must** be set for the system to function. Missing required var
 ### PostgreSQL with pgvector
 The system uses `pgvector` for semantic search and `orchestrator_db` for relational data.
 
-| Variable | Default | Purpose |
+| Variable | Default (compose) | Purpose |
 | :--- | :--- | :--- |
-| `POSTGRES_HOST` | `localhost` | PostgreSQL server hostname |
+| `POSTGRES_HOST` | `postgres` | PostgreSQL server hostname (the compose service) |
 | `POSTGRES_PORT` | `5432` | PostgreSQL port |
 | `POSTGRES_DB` | `orchestrator_db` | Database name |
 | `POSTGRES_USER` | `postgres` | Database user |
+| `DATABASE_URL` | assembled by compose | The SQLAlchemy connection string |
 
-**Sources:** [orchestrator/.env.example:1-5]()
+**Sources:** [docker-compose.yml](), [envs/api.defaults]()
 
 ### Redis Configuration
 Redis serves as the L1 memory tier, Pub/Sub broker, and task queue.
 
-| Variable | Default | Purpose |
+| Variable | Default (compose) | Purpose |
 | :--- | :--- | :--- |
-| `REDIS_HOST` | `localhost` | Redis server hostname |
+| `REDIS_HOST` | `redis` | Redis server hostname (the compose service) |
 | `REDIS_PORT` | `6379` | Redis port |
 
-**Sources:** [orchestrator/.env.example:9-11]()
+**Sources:** [docker-compose.yml](), [envs/api.defaults]()
 
 ---
 
@@ -151,16 +178,16 @@ graph TD
 
 | Variable | Purpose |
 | :--- | :--- |
-| `OPENAI_API_KEY` | Key for OpenAI models |
-| `ANTHROPIC_API_KEY` | Key for Anthropic models |
-| `LLM_PROVIDER` | Default provider (e.g., `openai`) |
-| `LLM_MODEL` | Default model (e.g., `gpt-4`) |
-| `LLM_MAX_TOKENS` | Token limit per request |
-| `LLM_TEMPERATURE` | Default model temperature |
+| `OPENAI_API_KEY` | Key for OpenAI models (passed through by compose) |
+| `ANTHROPIC_API_KEY` | Key for Anthropic models — also the credential the workspace-worker's Canvas sessions read |
+| `OPENROUTER_API_KEY` | Key for OpenRouter (many providers behind one key) |
+| `CLAUDE_CODE_OAUTH_TOKEN` | Alternative Canvas-session credential (Claude subscription token), worker only |
 
-**Encryption:** Credentials stored in the database are encrypted using `encryption_service.encrypt_dict()` before being persisted in the `credentials` table [orchestrator/core/credentials/service.py:146-150](). The `Credential` model stores this as `encrypted_data` [orchestrator/core/models/credentials.py:74]().
+Any one of the first three is enough for chat, agents and embeddings; keys can also be added in the UI under Settings → API Keys, where they are stored encrypted.
 
-**Sources:** [orchestrator/.env.example:18-26](), [orchestrator/core/credentials/service.py:146-150](), [orchestrator/core/models/credentials.py:60-75]()
+**Encryption:** Credentials stored in the database are encrypted using `encryption_service.encrypt_dict()` before being persisted in the `credentials` table [orchestrator/core/credentials/service.py:146-150](). The `Credential` model stores this as `encrypted_data` [orchestrator/core/models/credentials.py:74](). The encryption key is generated on first boot and persisted at `CREDENTIAL_KEY_FILE` (the `backend_data` volume) unless `CREDENTIAL_ENCRYPTION_KEY` is set — note that compose does not pass `CREDENTIAL_ENCRYPTION_KEY` from `.env`; set it in `envs/api.local` if you want to pin it.
+
+**Sources:** [docker-compose.yml](), [envs/api.defaults](), [orchestrator/core/credentials/service.py:146-150](), [orchestrator/core/models/credentials.py:60-75]()
 
 ---
 
@@ -187,29 +214,29 @@ Controls the marketplace caching and storage.
 
 **Sources:** [orchestrator/.env.example:38-40]()
 
-### AWS and Cloud Integration
-Used for S3-backed storage and PRD-42 Cloud Document Sync.
+### Object storage (S3 API) — hosted edition
+Every S3 client in the backend is built by one factory (`orchestrator/core/storage/s3.py`). With `S3_ENDPOINT_URL` unset it targets AWS S3 with the credentials below; with it set (the compose default, `http://minio:9000`) it targets MinIO with path-style addressing. The hosted deployment sets these itself.
 
 | Variable | Purpose |
 | :--- | :--- |
-| `AWS_ACCESS_KEY_ID` | AWS authentication ID |
-| `AWS_SECRET_ACCESS_KEY` | AWS authentication secret |
-| `AWS_REGION` | Target AWS region |
-| `S3_VECTORS_ENABLED` | Toggle for cloud vector sync |
+| `AWS_ACCESS_KEY_ID` | AWS authentication ID (locally set by compose from `S3_ACCESS_KEY_ID`) |
+| `AWS_SECRET_ACCESS_KEY` | AWS authentication secret (locally from `S3_SECRET_ACCESS_KEY`) |
+| `AWS_REGION` | Target AWS region (locally from `S3_REGION`) |
+| `S3_DOCUMENTS_BUCKET`, `MARKETPLACE_S3_BUCKET`, `RECIPE_LOG_S3_BUCKET` | Bucket names; against MinIO they self-create on first use, on AWS they must exist |
+| `S3_VECTORS_ENABLED` | S3 Vectors for RAG — hosted only; never enable against MinIO |
 
-**Sources:** [orchestrator/.env.example:49-51,61-64]()
+**Sources:** [orchestrator/config.py](), [orchestrator/core/storage/s3.py](), [docker-compose.yml]()
 
 ---
 
 ## System and Logging
-| Variable | Purpose | Default |
+| Variable | Purpose | Default (compose) |
 | :--- | :--- | :--- |
-| `ENVIRONMENT` | Deployment stage (`development`, `production`) | `production` |
+| `ENVIRONMENT` | Deployment stage (`development`, `production`) | `development` |
 | `LOG_LEVEL` | Verbosity of backend logs (`DEBUG`, `INFO`, `ERROR`) | `INFO` |
-| `LOG_FILE` | Path to log output | `logs/orchestrator.log` |
-| `DEBUG` | Toggle for FastAPI debug mode | `false` |
-| `REQUIRE_AUTH` | Toggle for authentication enforcement | `false` (local dev) |
+| `LOG_RELAY_ENABLED`, `LOG_RELAY_URL`, `LOKI_URL`, `PROMETHEUS_URL`, `AGENT_OPT_WORKER_URL` | Hosted telemetry and the prompt-optimisation worker; an empty URL disables the feature with a log line | `false` / empty |
+| `REQUIRE_AUTH` | Authentication enforcement — **derived**: forced `false` when `AUTH_EDITION=local`, read from the environment (default `true`) in `saas` | derived |
 
-**Sources:** [orchestrator/.env.example:29-30,33,57-58]()
+**Sources:** [envs/api.defaults](), [orchestrator/config.py]()
 
 ---

--- a/docs/getting-started/_index.md
+++ b/docs/getting-started/_index.md
@@ -29,33 +29,33 @@ The following files were used as context for generating this wiki page:
 
 This guide provides a high-level roadmap for installing and running Automatos AI. It covers the essential prerequisites, environment setup, and the **Business Intake Wizard**—the primary entry point for configuring a new workspace and seeding system-level intelligence.
 
-For detailed installation procedures, see [Installation & Setup](#2.1). For comprehensive configuration options, see [Configuration Guide](#2.2). For hands-on tutorials creating agents and workflows, see [Quick Start Tutorial](#2.3). For the automated onboarding flow, see [Business Intake Wizard](#2.4).
+> **The reference for running the platform yourself is [Self-hosting — the local edition](self-hosting.md).** It covers every service and port, the three required secrets, the worker's host-access directory, object storage, the optional Composio key, what the local edition does not include, updating, resetting and troubleshooting. This page and its siblings summarise; the guide is authoritative where they differ.
+
+For detailed installation procedures, see [Installation & Setup](installation-setup.md). For comprehensive configuration options, see [Configuration Guide](configuration-guide.md). For hands-on tutorials creating agents and Playbooks, see [Quick Start Tutorial](quick-start-tutorial.md). For the automated onboarding flow, see [Business Intake Wizard](business-intake-wizard.md).
 
 ---
 
 ## Prerequisites
 
-Before installing Automatos AI, ensure you have the following installed on your system:
+| Requirement | Purpose |
+|------------|---------|
+| **Docker** with the **Compose v2** plugin (`docker compose`) | Runs the whole stack; the compose file uses v2 syntax |
+| **Git** | Cloning and updates |
+| ~10 GB disk | Images (the workspace-worker image is the largest) and data volumes |
 
-| Requirement | Version | Purpose |
-|------------|---------|---------|
-| **Docker** | 20.10+ | Container orchestration |
-| **Docker Compose** | 2.0+ | Multi-service management |
-| **Node.js** | 20+ | Frontend development (optional) |
-| **Python** | 3.11 | Backend development (optional) |
+**Required values** (the only ones compose refuses to start without): `POSTGRES_PASSWORD`, `REDIS_PASSWORD`, `API_KEY` in `.env` [docker-compose.yml]().
 
-**Required API Keys**:
-- **LLM Provider Key**: At least one key (OpenAI, Anthropic, or OpenRouter) is required for agent execution [orchestrator/requirements.txt:71-75]().
-- **Clerk Authentication**: Required for multi-tenant identity and workspace isolation [docker-compose.yml:118-121]().
-- **Platform API Key**: A secure `API_KEY` must be set for internal service communication [docker-compose.yml:116-116]().
+**Recommended**: one LLM key — `OPENAI_API_KEY`, `ANTHROPIC_API_KEY` or `OPENROUTER_API_KEY` in `.env`, or added later under Settings → API Keys. Agents, chat and embeddings have no model to call until one exists.
 
-Sources: [docker-compose.yml:4-16](), [orchestrator/Dockerfile:13-13](), [frontend/Dockerfile:14-14](), [orchestrator/requirements.txt:1-117]()
+**Not required locally**: Clerk. The local edition runs with `AUTH_EDITION=local` (set in `envs/api.defaults`) — no login, one operator, one workspace. Clerk is the hosted edition's identity provider and is only required when `AUTH_EDITION=saas` [orchestrator/config.py]() (`validate_auth_edition`).
+
+Sources: [docker-compose.yml](), [envs/api.defaults](), [orchestrator/config.py]()
 
 ---
 
 ## System Architecture Overview
 
-Automatos AI follows a containerized multi-tier architecture. The system bridges user intent to autonomous execution through specialized services including a dedicated `workspace-worker` for file-system isolation and an `agent-opt-worker` for prompt engineering.
+Automatos AI follows a containerized multi-tier architecture. The local compose stack runs Postgres (with pgvector), Redis, MinIO (S3-compatible object storage), the FastAPI backend, the Next.js frontend and the `workspace-worker` — the Code Canvas runtime, which acts on files in a host directory (`AUTOMATOS_WORKSPACE_DIR`, default `./workspaces`) bind-mounted into the container. The `agent-opt-worker` (prompt optimisation) is part of the hosted deployment only.
 
 ### System Entity Map
 
@@ -79,7 +79,7 @@ graph TB
         Cache["redis:6379<br/>Redis_PubSub<br/>Session_Store"]
     end
     
-    UI -->|"Clerk_JWT"| API
+    UI -->|"anonymous session (local) / Clerk_JWT (saas)"| API
     Chat -->|"POST /api/chat"| API
     API -->|"get_system_setting"| DB
     API -->|"publish_event"| Cache
@@ -88,11 +88,11 @@ graph TB
 ```
 
 **Service Dependencies:**
-- **Backend**: Requires a healthy `postgres` (with `pgvector`) and `redis` instance to initialize connection pools [docker-compose.yml:85-89]().
+- **Backend**: Requires a healthy `postgres` (with `pgvector`), `redis` and `minio` instance before it starts [docker-compose.yml]().
 - **LLM Management**: The `LLMManager` resolves configurations via `SystemSetting` entries, mapping services like `orchestrator` or `chatbot` to specific LLM tiers [orchestrator/core/llm/manager.py:33-53]().
-- **Workspace Worker**: Operates as a background consumer for agent tasks, mounted to `workspace_data` for physical file isolation [docker-compose.yml:178-184]().
+- **Workspace Worker**: Runs in the default compose profile. The host directory `AUTOMATOS_WORKSPACE_DIR` (default `./workspaces`) is bind-mounted at `/workspaces` — read-write in the worker, read-only in the backend; every Code Canvas tool call is confined to the workspace's subdirectory and mutations need approval [docker-compose.yml](), [services/workspace-worker/worker_config.py]().
 
-Sources: [docker-compose.yml:18-200](), [orchestrator/core/llm/manager.py:33-53](), [orchestrator/api/chatbot_llm.py:37-52]()
+Sources: [docker-compose.yml](), [orchestrator/core/llm/manager.py:33-53](), [orchestrator/api/chatbot_llm.py:37-52]()
 
 ---
 
@@ -106,59 +106,62 @@ cp .env.example .env
 ```
 
 ### 2. Configure Environment
-Edit the `.env` file. You must set `POSTGRES_PASSWORD`, `REDIS_PASSWORD`, and `API_KEY` [docker-compose.yml:29-116](). 
+Edit the `.env` file. You must set `POSTGRES_PASSWORD`, `REDIS_PASSWORD`, and `API_KEY` [docker-compose.yml](); add one LLM key when you want AI features.
 
 ### 3. Start Services
 ```bash
-# Standard startup (Core services)
-docker-compose up --build
+# The default profile: postgres, redis, minio, backend, frontend, workspace-worker
+docker compose up
 
-# Startup with execution workers (Required for physical workspace tasks)
-docker-compose --profile workers up --build
+# Add Adminer (database GUI, :8080) and Gotenberg (document conversion, :3001)
+docker compose --profile all up
 ```
+
+There is no separate workers profile any more — the workspace-worker is part of the default stack.
 
 ### Application Boot Sequence
 
-The sequence below illustrates the transition from container initialization to a ready-to-use system, including the critical `alembic` migration step that prevents schema drift.
+The backend entrypoint (`docker-entrypoint.sh`) owns the schema lifecycle: it waits for Postgres, builds the schema on an empty database (`python -m scripts.init_fresh_db`), applies migrations, seeds, ensures the local workspace and operator exist, and only then starts `uvicorn`.
 
 ```mermaid
 sequenceDiagram
     participant DC as "Docker_Compose"
     participant DB as "Postgres (pgvector)"
     participant BE as "FastAPI (backend:8000)"
-    participant Seed as "seed_system_settings.py"
-    
+    participant Seed as "core.database.load_seed_data"
+
     DC->>DB: "Start_Container"
-    DC->>BE: "Start_Container"
-    BE->>BE: "alembic upgrade heads"
-    Note right of BE: [orchestrator/Dockerfile:90]
-    BE->>Seed: "seed_system_settings(db)"
-    Note right of Seed: [orchestrator/core/seeds/seed_system_settings.py:161]
-    Seed->>DB: "Upsert default LLM tiers"
+    DC->>BE: "Start_Container (after postgres, redis, minio healthy)"
+    BE->>DB: "empty? python -m scripts.init_fresh_db (models + migration replay, stamp heads)"
+    BE->>DB: "alembic upgrade heads (fail-closed)"
+    BE->>Seed: "python -m core.database.load_seed_data (idempotent)"
+    Seed->>DB: "system settings, models, skills, personas, catalogue, local first-run content"
+    BE->>DB: "ensure local workspace + operator user"
     BE->>BE: "uvicorn main:app"
-    BE-->>DC: "Health_Check_Pass"
+    BE-->>DC: "Health_Check_Pass (/health); /health/ready 200 after full boot"
 ```
 
-Sources: [docker-compose.yml:22-138](), [orchestrator/Dockerfile:90-90](), [orchestrator/core/seeds/seed_system_settings.py:161-175]()
+Sources: [docker-entrypoint.sh](), [orchestrator/scripts/init_fresh_db.py](), [orchestrator/core/database/load_seed_data.py]()
 
 ---
 
 ## Verification
 
 ### 1. Check Service Health
-The platform uses Docker health checks to ensure availability across core services [docker-compose.yml:36-41]().
+The platform uses Docker health checks to ensure availability across core services [docker-compose.yml]().
 ```bash
-docker-compose ps
+docker compose ps
 ```
 
 ### 2. Backend API
-- **Health Check**: `http://localhost:8000/health` [orchestrator/Dockerfile:78-79]().
+- **Liveness**: `http://localhost:8000/health` — 200 as soon as the API process answers.
+- **Readiness**: `http://localhost:8000/health/ready` — 503 until the full boot has finished, then 200 [orchestrator/main.py]().
 - **Swagger Docs**: `http://localhost:8000/docs`
 
 ### 3. Frontend Access
-The primary user interface is available at `http://localhost:3000` [docker-compose.yml:162]().
+The primary user interface is available at `http://localhost:3000` [docker-compose.yml](). No login: the local edition lands in its single workspace, seeded with Auto, a starter roster (Researcher, Writer, Analyst), the *Two-minute brief* Playbook and a welcome Deliverable. Set the operator's name under Settings → Profile.
 
-Sources: [docker-compose.yml:131-138](), [frontend/Dockerfile:107-108]()
+Sources: [docker-compose.yml](), [orchestrator/main.py](), [orchestrator/core/seeds/seed_local_first_run.py]()
 
 ---
 
@@ -182,9 +185,10 @@ Sources: [orchestrator/core/llm/manager.py:29-53](), [frontend/components/settin
 
 ## Next Steps
 
-1. **[Installation & Setup](#2.1)** — Detailed Docker configurations and multi-stage build logic.
-2. **[Configuration Guide](#2.2)** — Environment variables, Clerk auth, and LLM tier tuning.
-3. **[Quick Start Tutorial](#2.3)** — Create your first agent and connect tools via Composio.
-4. **[Business Intake Wizard](#2.4)** — Deep dive into the 7-step onboarding flow.
+1. **[Self-hosting — the local edition](self-hosting.md)** — the full reference: services, dials, storage, the worker, Composio, troubleshooting, editions.
+2. **[Installation & Setup](installation-setup.md)** — Docker configurations and multi-stage build logic.
+3. **[Configuration Guide](configuration-guide.md)** — Where configuration lives, LLM tier tuning, memory parameters.
+4. **[Quick Start Tutorial](quick-start-tutorial.md)** — Create your first agent, connect tools, run a Playbook.
+5. **[Business Intake Wizard](business-intake-wizard.md)** — Deep dive into the 7-step onboarding flow.
 
 ---

--- a/docs/getting-started/configuration-guide.md
+++ b/docs/getting-started/configuration-guide.md
@@ -29,13 +29,30 @@ The following files were used as context for generating this wiki page:
 
 
 
-This document covers the technical configuration of Automatos AI, including environment variables, service-specific settings (LLM, Redis, Postgres), memory layer parameters, and the database-backed system settings architecture that replaces traditional `.env` files for runtime configuration.
+This document covers the technical configuration of Automatos AI, including environment variables, service-specific settings (LLM, Redis, Postgres), memory layer parameters, and the database-backed system settings architecture that holds runtime configuration.
+
+---
+
+## Where configuration lives
+
+For a compose (local-edition) install the layers are, in order of precedence for the backend container:
+
+| Layer | Role |
+|---|---|
+| `docker-compose.yml` `environment:` block | Explicit values and the three required secrets (`POSTGRES_PASSWORD`, `REDIS_PASSWORD`, `API_KEY`), substituted from `.env`. Wins over the env files. |
+| `envs/api.local` (gitignored, optional) | Personal overrides for **any** backend variable — the deep-override lane. |
+| `envs/api.defaults` (committed) | The local topology: `AUTH_EDITION=local`, `DEFAULT_WORKSPACE_ID`, `LOCAL_OPERATOR_EMAIL`, MinIO wiring (`S3_ENDPOINT_URL`, `S3_PUBLIC_ENDPOINT_URL`), `WORKER_INTERNAL_URL`, observability off. |
+| `orchestrator/config.py` | Code defaults for every remaining dial; the only module that reads the environment. |
+
+`.env` itself only feeds compose substitution — a variable reaches a container only if `docker-compose.yml` references it. The frontend has the same shape with `envs/frontend.defaults` / `envs/frontend.local`. LLM tiers, the Auto/System/Embeddings model choices and feature flags are then edited in the database through the Settings UI, not in files. The hosted deployment sets each service's environment itself and never reads the compose file or `envs/*`.
+
+Full walkthrough: [Self-hosting — the local edition](self-hosting.md). Variable reference: [Environment Variables](../deployment-infrastructure/environment-variables.md).
 
 ---
 
 ## Configuration Architecture
 
-Automatos AI has migrated from a static environment-based configuration to a dynamic, database-backed system. While core infrastructure (DB/Redis) still uses environment variables for bootstrapping, LLM tiers and feature flags are managed via the `SystemSetting` model.
+Automatos AI keeps infrastructure wiring (DB/Redis/storage/edition) in environment variables for bootstrapping, while LLM tiers and feature flags are managed via the `SystemSetting` model.
 
 ### Configuration Loading Flow
 

--- a/docs/getting-started/installation-setup.md
+++ b/docs/getting-started/installation-setup.md
@@ -19,7 +19,9 @@ The following files were used as context for generating this wiki page:
 
 
 
-This page guides you through installing and running Automatos AI using Docker Compose. It covers cloning the repository, configuring environment variables, starting services, and verifying the installation. The setup utilizes a multi-tier architecture, including specialized workers for code execution and prompt optimization, and supports both local development and production-ready deployments.
+This page guides you through installing and running Automatos AI using Docker Compose. It covers cloning the repository, configuring environment variables, starting services, and verifying the installation.
+
+> **[Self-hosting — the local edition](self-hosting.md) is the full reference** (every service and port, the worker's host directory, object storage, the optional Composio key, updating, resetting, troubleshooting). This page keeps to the install steps and the build details.
 
 ---
 
@@ -27,11 +29,10 @@ This page guides you through installing and running Automatos AI using Docker Co
 
 Before installing Automatos AI, ensure your system has:
 
-- **Docker** (20.10+) and **Docker Compose** (2.0+)
+- **Docker** with the **Compose v2** plugin (`docker compose`)
 - **Git** for repository cloning
-- **Minimum 8GB RAM** (16GB recommended)
-- **10GB disk space** for Docker images and persistent volumes
-- **Port availability**: 3000 (frontend), 8000 (backend), 5432 (PostgreSQL), 6379 (Redis)
+- **~10 GB disk space** for Docker images and persistent volumes
+- **Port availability**: 3000 (frontend), 8000 (backend), 5432 (PostgreSQL), 6379 (Redis), 9000/9001 (MinIO API/console) — all overridable through `*_PORT` variables in `.env`
 
 ---
 
@@ -46,35 +47,37 @@ cd automatos-ai
 
 ### 2. Configure Environment Variables
 
-A `.env` file is required for the stack to boot correctly [docker-compose.yml:10](). Copy the example file:
+A `.env` file is required for the stack to boot correctly [docker-compose.yml](). Copy the example file:
 
 ```bash
 cp .env.example .env
 ```
 
-Edit `.env` and set the following **required** variables:
+Edit `.env` and set the following **required** variables — compose declares them as `${VAR:?…}` and refuses to start while any is unset or empty:
 
 | Variable | Description | Source |
 |----------|-------------|--------|
-| `POSTGRES_PASSWORD` | PostgreSQL root password | [docker-compose.yml:29]() |
-| `REDIS_PASSWORD` | Redis authentication password | [docker-compose.yml:56]() |
-| `API_KEY` | Backend API authentication key | [docker-compose.yml:116]() |
+| `POSTGRES_PASSWORD` | PostgreSQL password (applied when the data volume is first initialised) | [docker-compose.yml]() |
+| `REDIS_PASSWORD` | Redis authentication password | [docker-compose.yml]() |
+| `API_KEY` | Backend API authentication key | [docker-compose.yml]() |
 
-**Sources:** [docker-compose.yml:5-11](), [orchestrator/Dockerfile:112-116]()
+Optional but recommended: one LLM key (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY` or `OPENROUTER_API_KEY`), or add one later under Settings → API Keys. `.env` is read by compose for substitution only; the committed local topology lives in `envs/api.defaults` and `envs/frontend.defaults` (`AUTH_EDITION=local`, MinIO wiring, worker URL), with `envs/api.local` as the gitignored override lane.
+
+**Sources:** [docker-compose.yml](), [envs/api.defaults](), [envs/frontend.defaults]()
 
 ### 3. Start Services
 
-Automatos AI uses Docker Compose profiles to manage its extensive service list.
-
 ```bash
-# Start core services (Postgres, Redis, Backend, Frontend)
-docker-compose up --build
+# Default profile: postgres, redis, minio (+ minio-init), backend, frontend, workspace-worker
+docker compose up
 
-# Start with sandboxed code execution workers (PRD-56)
-docker-compose --profile workers up --build
+# Add Adminer (database GUI) and Gotenberg (DOCX/XLSX → PDF)
+docker compose --profile all up
 ```
 
-**Sources:** [docker-compose.yml:13-16](), [docker-compose.yml:178-184]()
+The workspace-worker runs in the default profile; the former `workers` profile no longer exists. Its files live in the host directory `AUTOMATOS_WORKSPACE_DIR` (default `./workspaces`, created on first boot).
+
+**Sources:** [docker-compose.yml]()
 
 ---
 
@@ -89,6 +92,7 @@ graph TB
     subgraph "Data_Layer"
         pg["postgres<br/>(pgvector/pgvector:pg16)"]
         rd["redis<br/>(redis:7-alpine)"]
+        mn["minio<br/>(minio/minio, S3 API :9000, console :9001)"]
     end
     
     subgraph "Core_Application"
@@ -97,24 +101,26 @@ graph TB
     end
     
     subgraph "Execution_Workers"
-        ww["workspace-worker<br/>(automatos_workspace_worker)"]
+        ww["workspace-worker<br/>(automatos_workspace_worker)<br/>host dir AUTOMATOS_WORKSPACE_DIR → /workspaces"]
     end
 
     fe -- "NEXT_PUBLIC_API_URL" --> be
     be -- "DATABASE_URL" --> pg
     be -- "REDIS_HOST" --> rd
-    ww -- "ARQ Redis Queue" --> rd
+    be -- "S3_ENDPOINT_URL" --> mn
+    be -- "WORKER_INTERNAL_URL" --> ww
+    ww -- "Redis queue" --> rd
     
     classDef default stroke:#333,stroke-width:2px;
 ```
 
-**Sources:** [docker-compose.yml:22-171](), [docker-compose.yml:178-182](), [frontend/Dockerfile:111-115]()
+**Sources:** [docker-compose.yml](), [envs/api.defaults](), [frontend/Dockerfile:111-115]()
 
 ---
 
 ## Service Initialization Sequence
 
-The following diagram details the internal function calls and health checks that occur during the `docker-compose up` lifecycle, including database migration handling.
+The following diagram details the internal function calls and health checks that occur during the `docker compose up` lifecycle, including database migration handling.
 
 ### Startup & Code Logic Flow
 
@@ -126,51 +132,61 @@ sequenceDiagram
     participant BE as "Backend (FastAPI)"
     
     DC->>PG: "Start Container"
-    API->>PG: "Init Schema (scripts/init_fresh_db.py — create_all + stamp)"
     PG-->>DC: "Health: pg_isready"
     
     DC->>RD: "Start Container"
     Note over RD: "Security: --rename-command FLUSHALL ''"
     RD-->>DC: "Health: redis-cli ping"
     
-    DC->>BE: "Start Container (depends_on healthy)"
+    DC->>BE: "Start Container (depends_on postgres, redis, minio healthy)"
     activate BE
     BE->>BE: "docker-entrypoint.sh"
-    BE->>PG: "alembic upgrade heads"
+    BE->>PG: "empty database? python -m scripts.init_fresh_db"
+    BE->>PG: "alembic upgrade heads (fail-closed)"
+    BE->>PG: "python -m core.database.load_seed_data (idempotent seeds)"
+    BE->>PG: "ensure local workspace + operator user"
     BE->>BE: "init_redis_client() [client.py]"
     BE->>BE: "uvicorn main:app"
-    BE-->>DC: "Health: GET /health"
+    BE-->>DC: "Health: GET /health (then /health/ready after full boot)"
     deactivate BE
 ```
 
 **Key Initialization Logic:**
-1. **Database Schema**: The backend entrypoint initializes empty databases via `scripts/init_fresh_db.py` (create_all + stamp) — automated table creation [docker-compose.yml:35]().
-2. **Migrations**: The backend executes `alembic upgrade heads` before starting `uvicorn` to ensure the schema is current [orchestrator/Dockerfile:90]().
-3. **Boot Locking**: On multi-worker startups, `boot_leader_lock` uses PostgreSQL advisory locks to ensure only one worker runs seed operations [orchestrator/core/database/boot_lock.py:25-40]().
-4. **Redis Security**: Dangerous commands like `FLUSHDB` and `FLUSHALL` are disabled at the command line [docker-compose.yml:59-60]().
-5. **Redis Client**: Initialized via `init_redis_client`, supporting both `REDIS_URL` and discrete host/port variables [orchestrator/core/redis/client.py:141-161]().
+1. **Fresh database**: With no `alembic_version` table present, the entrypoint runs `python -m scripts.init_fresh_db` — the SQLAlchemy models plus a tolerant replay of the migration history, stamped at heads. No SQL snapshot is committed; the generator is the fresh path [docker-entrypoint.sh](), [orchestrator/scripts/init_fresh_db.py]().
+2. **Migrations**: `alembic upgrade heads` runs on every boot and fails closed — a failing migration stops the backend rather than serving a half-built schema [docker-entrypoint.sh]().
+3. **Seeds**: `core.database.load_seed_data` is idempotent (credential types, models, skills, personas, plugin categories, marketplace catalogue, and in the local edition the first-run content: Auto, the Researcher/Writer/Analyst roster, the *Two-minute brief* Playbook and a welcome Deliverable) [orchestrator/core/database/load_seed_data.py](), [orchestrator/core/seeds/seed_local_first_run.py]().
+4. **Boot Locking**: On multi-worker startups, `boot_leader_lock` uses PostgreSQL advisory locks to ensure only one worker runs seed operations [orchestrator/core/database/boot_lock.py:25-40]().
+5. **Redis Security**: Dangerous commands like `FLUSHDB` and `FLUSHALL` are disabled at the command line [docker-compose.yml]().
+6. **Redis Client**: Initialized via `init_redis_client`, supporting both `REDIS_URL` and discrete host/port variables [orchestrator/core/redis/client.py:141-161]().
 
-**Sources:** [docker-compose.yml:35-90](), [orchestrator/Dockerfile:84-90](), [orchestrator/core/database/boot_lock.py:1-21](), [orchestrator/core/redis/client.py:141-161]()
+**Sources:** [docker-entrypoint.sh](), [orchestrator/scripts/init_fresh_db.py](), [orchestrator/core/database/boot_lock.py:1-21](), [orchestrator/core/redis/client.py:141-161]()
 
 ---
 
 ## Environment Variables Reference
 
+The full list, with what each dial does, is in [Self-hosting](self-hosting.md) and [Environment Variables](../deployment-infrastructure/environment-variables.md). The ones an installer meets first:
+
 ### Core Service Variables
 | Variable | Default | Purpose |
 |----------|---------|---------|
-| `DATABASE_URL` | `postgresql://...` | Primary SQLAlchemy connection string [docker-compose.yml:97](). |
-| `REDIS_HOST` | `redis` | Hostname for Redis connection [docker-compose.yml:100](). |
-| `API_KEY` | **Required** | Secures the FastAPI backend routes [docker-compose.yml:116](). |
-| `GOTENBERG_URL` | `http://gotenberg:3000` | PDF generation service for PRD-63 [docker-compose.yml:109](). |
+| `DATABASE_URL` | `postgresql://...` | Primary SQLAlchemy connection string, assembled by compose [docker-compose.yml](). |
+| `REDIS_HOST` | `redis` | Hostname for Redis connection [docker-compose.yml](). |
+| `API_KEY` | **Required** | The backend's own API-key principal [docker-compose.yml](). |
+| `AUTH_EDITION` | `local` (from `envs/api.defaults`) | The edition flag — `local` (no login) or `saas` (Clerk required) [orchestrator/config.py](). |
+| `S3_ENDPOINT_URL` | `http://minio:9000` | Points the S3 client at MinIO; the store's credentials are mapped from `S3_ACCESS_KEY_ID` / `S3_SECRET_ACCESS_KEY` (default: the MinIO root credentials) [docker-compose.yml](). |
+| `AUTOMATOS_WORKSPACE_DIR` | `./workspaces` | Host directory the workspace-worker acts in [docker-compose.yml](). |
+| `COMPOSIO_API_KEY` | unset | Bring-your-own Composio key; without it integrations are disabled and native tools keep working [docker-compose.yml](). |
+| `GOTENBERG_URL` | `http://gotenberg:3000` | PDF generation service for PRD-63 (`--profile all`) [docker-compose.yml](). |
 
 ### Frontend Variables
 | Variable | Default | Purpose |
 |----------|---------|---------|
-| `NEXT_PUBLIC_API_URL` | `http://localhost:8000` | Backend API endpoint for the browser [frontend/Dockerfile:58](). |
+| `NEXT_PUBLIC_API_URL` | `http://localhost:8000` | Backend API endpoint for the browser [envs/frontend.defaults](). |
+| `NEXT_PUBLIC_AUTH_EDITION` | `local` | Frontend mirror of `AUTH_EDITION` [envs/frontend.defaults](). |
 | `NODE_ENV` | `development` | Sets Next.js optimization level [frontend/Dockerfile:111](). |
 
-**Sources:** [docker-compose.yml:91-121](), [frontend/Dockerfile:53-71]()
+**Sources:** [docker-compose.yml](), [envs/api.defaults](), [envs/frontend.defaults](), [frontend/Dockerfile:53-71]()
 
 ---
 
@@ -206,10 +222,12 @@ After deployment, verify the stack is operational:
 2. **Redis Connectivity**:
    The backend logs will show `✅ Redis connection test successful` upon initialization via `test_connection()` [orchestrator/core/redis/client.py:121-145]().
 3. **API Connectivity**:
-   Navigate to `http://localhost:8000/health`. The container `HEALTHCHECK` uses this endpoint to verify availability [orchestrator/Dockerfile:78-79]().
-4. **Cloud Storage**:
-   Verify cloud connection discovery via the `GET /api/cloud-documents/connections` endpoint, which checks for active Composio entities [orchestrator/api/cloud_documents.py:185-203]().
+   Navigate to `http://localhost:8000/health`. The container `HEALTHCHECK` uses this endpoint to verify availability [orchestrator/Dockerfile:78-79](). `http://localhost:8000/health/ready` returns 200 only once the full boot has finished.
+4. **Integrations**:
+   `GET /api/tools/integrations/status` reports whether Composio integrations are available and why not when they are not (no `COMPOSIO_API_KEY` is the expected local answer) [orchestrator/api/tools.py](). Cloud-document connectors (`GET /api/cloud-documents/connections`) also run through Composio [orchestrator/api/cloud_documents.py:185-203]().
 
-**Sources:** [orchestrator/core/redis/client.py:121-145](), [orchestrator/Dockerfile:78-79](), [orchestrator/api/cloud_documents.py:185-203]()
+For "password authentication failed" after changing `POSTGRES_PASSWORD`, the required-variable errors, and the other common faults, see the [troubleshooting section of the self-hosting guide](self-hosting.md#12-troubleshooting).
+
+**Sources:** [orchestrator/core/redis/client.py:121-145](), [orchestrator/Dockerfile:78-79](), [orchestrator/api/tools.py](), [orchestrator/api/cloud_documents.py:185-203]()
 
 ---

--- a/docs/getting-started/quick-start-tutorial.md
+++ b/docs/getting-started/quick-start-tutorial.md
@@ -33,9 +33,11 @@ The following files were used as context for generating this wiki page:
 
 
 
-This document provides a hands-on tutorial for getting started with Automatos AI. You will learn how to create an agent, connect tools, run a streaming chat, and execute a workflow.
+This document provides a hands-on tutorial for getting started with Automatos AI. You will learn how to create an agent, connect tools, run a streaming chat, and execute a Playbook.
 
-**Prerequisites**: This tutorial assumes you have completed the installation described in [Installation & Setup](2.1) and have the application running.
+**Prerequisites**: This tutorial assumes you have completed the installation described in [Self-hosting — the local edition](self-hosting.md) (or [Installation & Setup](installation-setup.md)), have the application running, and have stored one LLM key (`.env` or Settings → API Keys).
+
+**Shortest path in the local edition**: a fresh instance is already seeded with Auto, a starter roster (Researcher, Writer, Analyst) and one Playbook, *Two-minute brief*. Open **Playbooks**, run it with a topic of your own, and follow the execution log — the Analyst's output is the brief. The welcome Deliverable under **Deliverables → Blogs** repeats these steps. The sections below then show how each piece is built.
 
 ---
 
@@ -72,7 +74,7 @@ sequenceDiagram
 
 ## Step 2: Connect Tools and Skills
 
-Tools allow agents to interact with the outside world (e.g., Slack, GitHub, Jira) via Composio.
+Tools allow agents to interact with the outside world (e.g., Slack, GitHub, Jira) via Composio. In the local edition that needs your own `COMPOSIO_API_KEY` in `.env` (then `docker compose up -d backend`; the catalogue syncs itself on that boot). Without one the Tools page says integrations are disabled, Composio tools are not offered to agents, and the native platform tools — the `platform_*` actions Auto uses, documents, Deliverables, Code Canvas — keep working. See [Self-hosting §7](self-hosting.md#7-bring-your-own-composio-key-optional).
 
 ### Tool Assignment Logic
 Tools are assigned to agents through the `agent_app_assignments` table. When an agent is executed, the `ToolRouter` fetches these assignments to build the available toolset for the LLM.
@@ -123,11 +125,11 @@ graph TD
 
 ---
 
-## Step 4: Execute a Workflow (Recipe)
+## Step 4: Execute a Playbook
 
-Workflows (or "Recipes") are sequences of steps executed by one or more agents. For simple automation, the system uses the `RecipeDirectExecutor`.
+Playbooks (`workflow_recipes` in the schema; "recipe" in older code paths) are sequences of steps executed by one or more agents. For simple automation, the system uses the `RecipeDirectExecutor`. The seeded *Two-minute brief* is one: Researcher → Writer → Analyst, three steps, native tools only.
 
-### Workflow Execution Lifecycle
+### Playbook Execution Lifecycle
 1.  **Context Assembly**: Uses `ContextService(RECIPE)` to build a system prompt containing the recipe's goal and current step instructions [orchestrator/api/recipe_executor.py:9-12]().
 2.  **Scratchpad**: Agents use a `RecipeScratchpad` to pass data between steps without bloating the context window [orchestrator/api/recipe_executor.py:15-16]().
 3.  **Notifications**: On completion, the `NotificationDispatcher` sends an event (e.g., `playbook_complete`) to the user's notification bell [orchestrator/api/recipe_executor.py:45-61]().
@@ -148,7 +150,7 @@ Upon finishing a recipe, the `ReportService` generates a Markdown summary includ
 | **Create Agent** | `AgentFactory.create_agent` | [orchestrator/modules/agents/factory/agent_factory.py]() |
 | **Route Chat** | `UniversalRouter.route` | [orchestrator/core/routing/engine.py]() |
 | **Execute Tool** | `UnifiedToolExecutor.execute` | [orchestrator/modules/tools/tool_router.py]() |
-| **Run Workflow** | `execute_recipe_direct` | [orchestrator/api/recipe_executor.py]() |
+| **Run Playbook** | `execute_recipe_direct` | [orchestrator/api/recipe_executor.py]() |
 | **Stream Response** | `StreamingChatService.stream` | [orchestrator/consumers/chatbot/service.py]() |
 
 **Sources**: [orchestrator/api/agents.py:31](), [orchestrator/api/chat.py:30](), [orchestrator/api/recipe_executor.py:1]()

--- a/docs/getting-started/self-hosting.md
+++ b/docs/getting-started/self-hosting.md
@@ -1,0 +1,404 @@
+# Self-hosting Automatos AI — the local edition
+
+This is the reference for running the platform on your own machine with
+`docker compose`. [QUICKSTART.md](../../QUICKSTART.md) is the short path; this
+page is the long one — what runs, where the dials are, what the local edition
+does and does not include, and how to update, reset and debug it.
+
+Everything here is read from the committed sources: `docker-compose.yml`,
+`envs/api.defaults`, `envs/frontend.defaults`, `.env.example`,
+`docker-entrypoint.sh`, `orchestrator/config.py` and
+`services/workspace-worker/worker_config.py`. When a statement and the file
+disagree, the file wins — open an issue.
+
+---
+
+## 1. Prerequisites
+
+| Need | Notes |
+|---|---|
+| Docker Desktop (macOS / Windows) or Docker Engine (Linux) | with the Compose v2 plugin — the `docker compose` subcommand. The compose file uses v2 syntax (`${VAR:?…}` required variables, optional `env_file` entries), so the old `docker-compose` v1 binary is not supported. |
+| Disk | Budget roughly 10 GB for images and data volumes. The workspace-worker image is the largest: it carries Node 20, the Claude Code CLI, Python tooling and a headless Chromium. |
+| Git | to clone and to pull updates. |
+| Free ports | 3000, 8000, 5432, 6379, 9000, 9001 by default — every one is overridable (§4). |
+
+Nothing else. No cloud account, no identity provider, no AWS.
+
+## 2. The three secrets and the one key
+
+Compose refuses to start until three variables are set in a `.env` file next
+to `docker-compose.yml`. They are declared as `${VAR:?message}`, so an unset or
+empty value stops `docker compose up` with the message shown:
+
+| Variable | Error when missing | Used by |
+|---|---|---|
+| `POSTGRES_PASSWORD` | `POSTGRES_PASSWORD is required - set in .env file` | postgres, backend, workspace-worker |
+| `REDIS_PASSWORD` | `REDIS_PASSWORD is required - set in .env file` | redis, backend, workspace-worker |
+| `API_KEY` | `API_KEY is required - set in .env file` | backend (its own API-key principal) |
+
+Any non-empty values work on a private machine. They have no defaults on
+purpose: a public repository must not ship known passwords.
+
+```bash
+git clone https://github.com/AutomatosAI/automatos-ai.git
+cd automatos-ai
+cp .env.example .env      # fill in section 1 (the three secrets)
+docker compose up
+```
+
+**One LLM key** makes the agents think. The platform boots and serves without
+one, but chat, agents and embeddings have no model to call until you set
+exactly one of `OPENAI_API_KEY`, `ANTHROPIC_API_KEY` or `OPENROUTER_API_KEY`
+in `.env` — or add a key later in the UI under **Settings → API Keys**
+(providers: OpenAI, Anthropic, OpenRouter, Azure OpenAI; stored encrypted in
+your local database). While no key is stored the chat page shows a banner,
+*"Add an LLM key to bring Auto to life"*, linking to that tab. The key stored
+there is also what embeddings use (`PLATFORM_KEY_WORKSPACE_ID` in
+`envs/api.defaults` points the platform key slot at the local workspace), so
+document uploads index with it; without any embedding provider an upload is
+accepted but its processing ends `failed`.
+
+## 3. What runs where
+
+`docker compose up` starts the default profile. Nothing in it needs the
+internet after the images are built, except the LLM provider you chose (and
+Composio, if you add a key).
+
+| Service | Container | Image / build | Host port (variable) | What it does |
+|---|---|---|---|---|
+| `postgres` | `automatos_postgres` | `pgvector/pgvector:pg16` | 5432 (`POSTGRES_PORT`) | Relational data and the pgvector chunk store the local RAG leg searches (`S3_VECTORS_ENABLED=false`). |
+| `redis` | `automatos_redis` | `redis:7-alpine` | 6379 (`REDIS_PORT`) | Cache, pub/sub, queues. `FLUSHDB`, `FLUSHALL` and `DEBUG` are disabled; 256 MB `allkeys-lru`. |
+| `minio` | `automatos_minio` | `minio/minio` | 9000 API (`MINIO_PORT`), 9001 console (`MINIO_CONSOLE_PORT`) | S3-compatible object store for documents, generated outputs, plugin packages and images. |
+| `minio-init` | `automatos_minio_init` | `minio/mc` | — | One-shot: creates the documents bucket (`S3_DOCUMENTS_BUCKET`, default `automatos-ai`) and exits. |
+| `backend` | `automatos_backend` | built from `./orchestrator` (`development` target) | 8000 (`API_PORT`) | The FastAPI API. Source is bind-mounted and served by `uvicorn --reload`. |
+| `frontend` | `automatos_frontend` | built from `./frontend` (`development` target) | 3000 (`FRONTEND_PORT`) | The Next.js UI (`npm run dev`, source bind-mounted). Starts once the backend health check passes. |
+| `workspace-worker` | `automatos_workspace_worker` | built from `./services/workspace-worker` | none — port 8081 stays inside the compose network | The Code Canvas runtime: the container in which agents read, write and run things, confined to your workspace directory (§5). |
+
+`docker compose --profile all up` adds two more:
+
+| Service | Host port (variable) | What it does |
+|---|---|---|
+| `adminer` | 8080 (`ADMINER_PORT`) | Database GUI, pre-pointed at `postgres`. |
+| `gotenberg` | 3001 (`GOTENBERG_PORT`) | DOCX/XLSX → PDF conversion. The backend reaches it at `http://gotenberg:3000`; without the profile, document conversions that need it fail, everything else is unaffected. |
+
+Named volumes: `automatos_postgres_data`, `automatos_redis_data`,
+`automatos_minio_data`, `automatos_backend_logs`, and `backend_data`, which
+holds the auto-generated credential-encryption key (`CREDENTIAL_KEY_FILE` in
+`envs/api.defaults`). The workspace directory is a **bind mount** of a host
+folder, not a volume (§5).
+
+### Where configuration lives
+
+| File | Role |
+|---|---|
+| `.env` (from `.env.example`) | Your secrets and the few values only you can choose. Compose reads it for variable substitution **only** — a variable reaches a container only if `docker-compose.yml` references it. |
+| `envs/api.defaults` | The committed local topology for the backend: `AUTH_EDITION=local`, `DEFAULT_WORKSPACE_ID`, MinIO wiring, worker URL, observability off. No secrets. |
+| `envs/frontend.defaults` | The frontend's local wiring: `NEXT_PUBLIC_AUTH_EDITION=local`, localhost API URLs. |
+| `envs/api.local`, `envs/frontend.local` (gitignored, optional) | Personal overrides for **any** backend/frontend variable — the deep-override lane. Listed after the defaults, so they win over them; values set explicitly in the compose `environment:` block still win over both. |
+| `orchestrator/config.py` | Code defaults for every remaining dial. The only module that reads the environment. |
+
+You should not need to open the last three for a standard install.
+
+## 4. First boot — what happens and how long it takes
+
+1. **Image builds.** Backend (Python dependencies plus system libraries for
+   OCR and PDF rendering), frontend (`npm install`), workspace-worker (Node,
+   Claude Code CLI, Python tooling, Chromium). This is the slow part and only
+   happens once per dependency change.
+2. **Data services.** Postgres initialises an empty cluster with
+   `POSTGRES_PASSWORD` — this password is baked into the volume at that moment
+   (see §10). MinIO starts and `minio-init` creates the documents bucket.
+3. **Backend entrypoint** (`docker-entrypoint.sh`), in order, each step
+   fail-closed unless noted:
+   - wait for Postgres, verify the connection;
+   - **empty database?** run `python -m scripts.init_fresh_db` — builds the
+     CI-proven schema (the SQLAlchemy models plus a tolerant replay of the
+     migration history) and stamps Alembic at heads. Nothing is restored from
+     a committed SQL snapshot; the generator is the fresh path;
+   - `alembic upgrade heads` — a no-op on a fresh database, incremental on an
+     existing one;
+   - `python -m core.database.load_seed_data` — idempotent seeds: credential
+     types, model catalogue, skills, personas, plugin categories, the
+     marketplace catalogue (agents, packages) and, in the local edition, the
+     first-run content of §8 (this step logs a warning and continues on
+     failure);
+   - ensure the local workspace (`DEFAULT_WORKSPACE_ID`, named *Local
+     Workspace*) and the operator user exist;
+   - start `uvicorn`. The application then runs its own boot stages,
+     including the Composio catalogue bootstrap (§7).
+4. **Frontend** starts after the backend's health check passes (the check
+   allows 40 s of start-up and probes every 30 s).
+
+Readiness, not liveness, is the signal that it is usable:
+
+| URL | Meaning |
+|---|---|
+| `http://localhost:8000/health` | 200 as soon as the API process answers, with per-component status (database, config, resources). |
+| `http://localhost:8000/health/ready` | 503 `{"status": "starting"}` until the full boot finished, then 200 `{"status": "ready"}`. |
+| `http://localhost:8000/health/bootstrap` | The per-stage boot report with timings. |
+| `http://localhost:8000/docs` | The OpenAPI reference. |
+
+Then open **http://localhost:3000**. There is no login: the local edition has
+exactly one operator and lands straight in the local workspace.
+
+### The operator profile — "Hello, \<your name\>"
+
+The anonymous local session is bound to one `users` row (email
+`LOCAL_OPERATOR_EMAIL`, default `local@automatos.local`, set in
+`envs/api.defaults`; seeded name *Local Operator*). That session is the
+instance's `super_admin` — there is no platform above the operator of a
+self-hosted instance, so system settings, credentials and admin analytics are
+all yours.
+
+Set your name under **Settings → Profile** (or the avatar in the header, which
+links to `/settings/profile`): display name, username and avatar URL. The
+email is read-only — it is the key the session resolves your row by. The name
+you set is what Auto greets you by and what appears as the author of the
+agents, Playbooks and Deliverables you create. Nothing here is an account:
+no password, no login, no second user.
+
+## 5. The workspace-worker and the host-access dial
+
+The worker is the runtime behind **Code Canvas** — the surface where an agent
+edits files and runs commands. In the local edition it runs in the default
+profile and its files live **on your machine**:
+
+- `AUTOMATOS_WORKSPACE_DIR` in `.env` (default `./workspaces`, next to
+  `docker-compose.yml`, created on first boot, gitignored) is bind-mounted at
+  `/workspaces` — read-write in the worker, read-only in the backend. It is
+  the one dial that decides what the agents can touch: point it at a
+  different folder to hand them that folder.
+- Each workspace gets its own subdirectory, `/workspaces/<workspace_id>/`
+  (the local workspace id is the `DEFAULT_WORKSPACE_ID` value in
+  `envs/api.defaults`). Every Canvas tool call is re-bound to that root
+  before it runs: `..` traversal, symlink escapes, null bytes and shell
+  commands that reference paths outside it are rejected
+  (`canvas_confinement.py`).
+- Mutations still need you: a file edit or shell command pauses, the UI
+  shows a permission request (a diff for edits), and the tool runs only after
+  you approve (`canvas_approvals.py`). Read-only navigation is not gated.
+  Local is not unguarded.
+- **Model credential.** Canvas sessions run a headless Claude Agent SDK
+  subprocess inside the worker. It reads only `ANTHROPIC_API_KEY` or
+  `CLAUDE_CODE_OAUTH_TOKEN` (a Claude subscription token) from `.env` — keys
+  stored through the UI, and OpenAI/OpenRouter keys, do not reach it. With
+  neither set, starting a session fails immediately instead of idling.
+- **Linux ownership note.** The worker process runs as uid 1000 (`worker`).
+  Its entrypoint `chown -R`s the mounted directory to that uid whenever it is
+  owned by anyone else, so on a Linux host the files under
+  `AUTOMATOS_WORKSPACE_DIR` end up owned by uid 1000. If that is not your
+  user, expect to need `sudo` to edit or delete them, or pre-create the
+  directory owned by uid 1000.
+- Limits and knobs: the service is capped at 2 CPUs and 2 GB;
+  `WORKER_CONCURRENCY` (default 3) and `WORKSPACE_DEFAULT_QUOTA_GB` (default
+  5) are overridable in `.env`. `WORKER_INTERNAL_TOKEN` is an optional shared
+  secret between backend and worker; the worker port is never published, so
+  it is off by default.
+
+## 6. Object storage — MinIO, and the real-S3 option
+
+The backend talks to **one** S3 code path (`orchestrator/core/storage/s3.py`
+builds every client) and the compose stack points it at MinIO:
+
+- `S3_ENDPOINT_URL=http://minio:9000`; path-style addressing; buckets other
+  than the documents bucket (marketplace packages, recipe logs) self-create
+  on first use against MinIO — never against AWS.
+- The store's credentials are mapped through **`S3_*` names on purpose**:
+  compose sets the backend's `AWS_ACCESS_KEY_ID` from `S3_ACCESS_KEY_ID`
+  (default: `MINIO_ROOT_USER`, `minioadmin`), `AWS_SECRET_ACCESS_KEY` from
+  `S3_SECRET_ACCESS_KEY` (default: `MINIO_ROOT_PASSWORD`, `minioadmin`) and
+  `AWS_REGION` from `S3_REGION` (default `us-east-1`). A developer's `AWS_*`
+  variables in `.env` or the shell are deliberately **not** read by the local
+  store — a real AWS key there used to make every MinIO call fail with
+  `InvalidAccessKeyId`.
+- Links handed to the browser are presigned against
+  `S3_PUBLIC_ENDPOINT_URL=http://localhost:9000` (`envs/api.defaults`). If you
+  change `MINIO_PORT`, set `S3_PUBLIC_ENDPOINT_URL` to the new host port in
+  `envs/api.local`, or those links will not resolve.
+- The MinIO console is at **http://localhost:9001** (`MINIO_ROOT_USER` /
+  `MINIO_ROOT_PASSWORD`). Change both in `.env` before exposing the machine
+  to anyone else.
+
+**Real S3 instead of MinIO.** In `.env` set `S3_ENDPOINT_URL=` (empty — compose
+treats an empty value as "no custom endpoint") plus `S3_ACCESS_KEY_ID`,
+`S3_SECRET_ACCESS_KEY` and `S3_REGION`; then create `envs/api.local` with
+`S3_PUBLIC_ENDPOINT_URL=` and `S3_USE_PATH_STYLE=false` (the MinIO defaults live in
+`envs/api.defaults`, and `api.local` wins). Buckets are not auto-created on AWS —
+create them first. Your shell's `AWS_*` variables are never read by the store.
+
+## 7. Bring your own Composio key (optional)
+
+Third-party app integrations (Gmail, Slack, GitHub, Shopify and the rest of
+the Composio catalogue) run through Composio. In the local edition that is a
+**bring-your-own key, env-only** setting:
+
+1. Put `COMPOSIO_API_KEY=…` in `.env` (free tier at app.composio.dev).
+2. Apply it: `docker compose up -d backend` (the container must be recreated;
+   the key is read from the environment, not from the UI).
+3. On that boot, if the local catalogue (`composio_apps_cache`) is empty, the
+   backend syncs the full Composio catalogue in a background thread and then
+   re-binds the seeded marketplace agents to the apps they were designed for.
+   A later boot with a populated catalogue only re-binds anything still
+   unbound. The Tools page shows *"Integration catalogue is syncing"* while
+   this runs.
+
+Without a key the platform is honest rather than empty:
+
+- the Tools page shows *"Integrations are disabled — no Composio API key is
+  configured."* with the fix;
+- Composio tools are not offered to agents at all (excluded from discovery),
+  and a direct call returns an explicit `integrations_unavailable` error —
+  never a silent success;
+- native platform tools (the `platform_*` actions, Playbooks, documents,
+  Deliverables, Code Canvas) keep working.
+
+`GET /api/tools/integrations/status` reports `available`, `reason`,
+`key_configured`, `apps_cached`, `last_sync` and `sync_status` — the same
+predicate the router uses.
+
+## 8. What a fresh instance contains
+
+Every boot in the local edition runs an idempotent first-run seed
+(`orchestrator/core/seeds/seed_local_first_run.py`), scoped to the local
+workspace:
+
+- **Auto**, the assistant, through the same seeder the hosted edition uses.
+- **A starter roster** on the Agents page — *Researcher* (Research Analyst),
+  *Writer* (Content Writer) and *Analyst* (Business Analyst). They use native
+  platform tools only, so they run with nothing but your LLM key.
+- **One Playbook** — *Two-minute brief*: Researcher → Writer → Analyst produce
+  a reviewed one-page brief on a topic you choose. Run it from the Playbooks
+  page and follow the execution log.
+- **One Deliverable** — *Welcome to Automatos (local edition)*, under
+  **Deliverables → Blogs**, authored by Auto. It repeats these steps inside
+  the product.
+
+The seed refreshes its own content across upgrades but never overwrites
+something you edited, and does not resurrect something you deleted (the
+workspace keeps a ledger of what was seeded). The marketplace catalogue
+(agents, packages, personas, plugin categories) is seeded the same way and is
+fully usable offline.
+
+## 9. What is not in the local edition
+
+One codebase, two shipped editions (§12). These are hosted-edition surfaces,
+hidden locally by an explicit list (`frontend/lib/auth-edition.ts`,
+`SAAS_ONLY_ROUTES`) — not by role, because the local operator is deliberately
+`super_admin`:
+
+| Not present locally | Why |
+|---|---|
+| Accounts, sign-in/up, password reset, SSO | No identity provider. `AUTH_EDITION=local` — one operator, one workspace. |
+| Team, invitations, Workspace Admin, plan/trial pills, plugin moderation | Multi-tenant and commercial machinery of the hosted edition. |
+| Settings → Webhooks, Channels, Widget SDK | Inbound webhooks and channel callbacks need a public URL; the widget embed needs the hosted loader. |
+| The community hub | **Planned, not shipped.** The seeded catalogue is local and offline. The hub — sharing and pulling other people's agents, packages and Playbooks — is a network service: pulling will need no account and nothing will be paywalled; publishing will need a free account and pass moderation. |
+| Durable memory (mem0) and field memory (Qdrant) | Neither ships in the default stack. `MEM0_API_URL` / `QDRANT_URL` in `envs/api.defaults` point at names that do not resolve, and the backend degrades cleanly. Point them at your own instances via `envs/api.local` and the features light up. |
+| S3 Vectors RAG | Hosted-only; local RAG runs on pgvector (`S3_VECTORS_ENABLED=false`). Never enable it against MinIO. |
+| Auto Live voice (Retell) | The switch and the Retell credentials live in the hosted edition's system settings; nothing in the local stack configures them. |
+| Loki / Prometheus / log relay, the agent-opt worker | Hosted telemetry and prompt-optimisation services — silenced by empty URLs in `envs/api.defaults`. |
+
+Product capability is not gated: every agent, tool, Playbook, Mission and
+Deliverable feature that exists in the code runs locally.
+
+## 10. Updating
+
+```bash
+git pull
+docker compose up -d --build
+```
+
+Source directories are bind-mounted, so most code changes are picked up by
+the running containers; `--build` matters when dependencies or Dockerfiles
+changed. Database migrations run on every backend boot
+(`alembic upgrade heads`, fail-closed — a failing migration stops the backend
+rather than serving a half-built schema), and the seeds are idempotent.
+Changing a value in `.env` or `envs/*` needs the container recreated
+(`docker compose up -d`), not just restarted.
+
+## 11. Stopping and resetting
+
+```bash
+docker compose down          # stop; data stays in the named volumes
+docker compose down -v       # stop and delete every named volume
+```
+
+`down -v` removes Postgres, Redis, MinIO, backend logs and `backend_data`
+(the credential-encryption key). It does **not** touch the bind-mounted
+`AUTOMATOS_WORKSPACE_DIR` — delete that folder yourself if you want the
+agents' files gone too. Removing `backend_data` alone, while keeping the
+database, makes every API key stored through the UI undecryptable; keep the
+two together.
+
+## 12. Troubleshooting
+
+**`POSTGRES_PASSWORD is required - set in .env file`** (or the same for
+`REDIS_PASSWORD` / `API_KEY`). Compose refused to start: the variable is
+missing or empty. `.env` must sit next to `docker-compose.yml`; a value of
+nothing counts as unset.
+
+**Logs.** `docker compose logs -f backend` (boot steps, migrations, seeds),
+`docker compose logs -f workspace-worker`, `docker compose logs -f frontend`.
+`docker compose ps` shows health.
+
+**`password authentication failed for user "postgres"` after changing
+`POSTGRES_PASSWORD`.** Postgres applies the password only when it initialises
+an empty volume; an existing `automatos_postgres_data` keeps the old one, so
+the backend and worker now present a password the database does not know.
+Either reset the data (`docker compose down -v`) or change the stored password
+to match `.env` — the command runs inside the container over its local
+socket:
+
+```bash
+docker compose exec postgres psql -U postgres -d orchestrator_db \
+  -c "ALTER USER postgres PASSWORD '<the value now in .env>';"
+docker compose up -d backend workspace-worker
+```
+
+**Backend shows `unhealthy` or `starting` for a long time.** A first boot
+builds the schema, replays migrations and seeds the catalogue before serving;
+`/health/ready` stays 503 the whole time. Watch the backend log for the
+`Starting Backend Application` banner; a red `❌` line names the step that
+failed (a bad migration or a missing local workspace stops the boot on
+purpose).
+
+**Chat answers nothing; banner "Add an LLM key to bring Auto to life".** No
+model key is stored. Settings → API Keys, or one of the keys in §2.
+
+**Tools page: "Integrations are disabled".** No `COMPOSIO_API_KEY` (§7). Native
+tools keep working.
+
+**Code Canvas session fails as soon as it starts.** The worker has no model
+credential: set `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN` in `.env`
+and `docker compose up -d workspace-worker`.
+
+**Port already in use.** Override the `*_PORT` variable in `.env` (§3). After
+changing `MINIO_PORT`, also set `S3_PUBLIC_ENDPOINT_URL` (§6).
+
+**Files under `./workspaces` owned by another user (Linux).** Expected — the
+worker runs as uid 1000 (§5).
+
+**Stored API keys stopped decrypting.** The `backend_data` volume (the
+encryption key) was removed or replaced while the database was kept (§11).
+
+**A saas-mode boot says `AUTH_EDITION=saas requires Clerk to be configured`.**
+You flipped the edition without the identity provider. The local edition is
+`AUTH_EDITION=local` (`envs/api.defaults`); leave it unless you are running
+your own Clerk instance.
+
+## 13. How the editions relate
+
+There is **one codebase**. The edition is a runtime flag:
+
+| | Local edition (this guide) | Hosted edition (automatos.app) | Enterprise |
+|---|---|---|---|
+| Flag | `AUTH_EDITION=local` (backend) / `NEXT_PUBLIC_AUTH_EDITION=local` (frontend), set by `envs/*.defaults` | `AUTH_EDITION=saas` — the code default; the boot guard then **requires** Clerk (`CLERK_JWKS_URL`, `CLERK_SECRET_KEY`) and fails fast without it, so a hosted boot can never fall through to the anonymous local identity | Parked. No `ee/` directory, no license keys, nothing built. |
+| Identity | one operator, no login | Clerk accounts, workspaces, teams, plans | — |
+| Configuration | `docker-compose.yml` + `envs/*.defaults` + `.env` | Railway sets each service's environment itself and **never reads** the compose file or `envs/*` — local defaults cost the hosted edition nothing | — |
+| Storage / RAG | MinIO + pgvector | AWS S3 + S3 Vectors | — |
+| Tools | native tools; Composio with your own key | native tools; Composio with the platform key | — |
+
+The same CI gates both: every change is compose-only, fresh-clone-only, or
+guarded by `AUTH_EDITION`, and the fresh-clone smoke lane boots this exact
+stack from an empty checkout. Contributions land in every edition under the
+repository's Apache-2.0 licence with a DCO sign-off — see
+[CONTRIBUTING.md](../../CONTRIBUTING.md).

--- a/docs/runbooks/DR-postgres.md
+++ b/docs/runbooks/DR-postgres.md
@@ -36,9 +36,11 @@ the PITR decision in §5.
 
 - All SQLAlchemy-modelled tables.
 - **Raw-DDL tables** that `create_all()` cannot build (e.g. `document_chunks`,
-  the pgvector chunk store created in prod via `init_complete_schema.sql`).
-  These live in the database, so the dump contains them — the restore rebuilds
-  them from the dump, not from `create_all()`.
+  the pgvector chunk store — on a fresh database it is built by the raw-DDL
+  extras in `scripts/init_fresh_db.py` / `scripts/init_test_db.py`; the old
+  `init_complete_schema.sql` snapshot is retired). These live in the database,
+  so the dump contains them — the restore rebuilds them from the dump, not
+  from `create_all()`.
 
 Two things the restore must handle that a naive `pg_restore` misses:
 

--- a/envs/api.defaults
+++ b/envs/api.defaults
@@ -64,6 +64,23 @@ DEFAULT_WORKSPACE_ID=00000000-0000-0000-0000-0000000000c1
 LOCAL_OPERATOR_EMAIL=local@automatos.local
 
 # -----------------------------------------------------------------------------
+# Workspace worker — the Code Canvas runtime, in the default compose profile
+# -----------------------------------------------------------------------------
+# [ACTIVE] Where the backend reaches the worker's internal HTTP API (file
+# browser, Code Canvas sessions, sandboxed exec — core/workspace_client.py).
+# config.py's code default is http://localhost:8081, which inside the backend
+# container reaches nothing; the compose service name is the answer (PRD-233 S1).
+WORKER_INTERNAL_URL=http://workspace-worker:8081
+# WORKER_INTERNAL_TOKEN -> root .env (optional; compose passes it to both services)
+
+# [ACTIVE] The worker's files live on YOUR machine: compose bind-mounts the host
+# directory ${AUTOMATOS_WORKSPACE_DIR:-./workspaces} (root .env dial) at
+# /workspaces in both containers — read-write for the worker, read-only here.
+# This is the in-container path; it stays fixed when you move the host directory.
+# The worker reads the same variable through worker_config.workspace_root().
+WORKSPACE_VOLUME_PATH=/workspaces
+
+# -----------------------------------------------------------------------------
 # Object storage — MinIO (S3-compatible, ships in the compose stack)
 # -----------------------------------------------------------------------------
 # [PRD-151] One S3 code path; these point it at the local MinIO container.

--- a/envs/api.defaults
+++ b/envs/api.defaults
@@ -63,6 +63,14 @@ DEFAULT_WORKSPACE_ID=00000000-0000-0000-0000-0000000000c1
 # a real user. Editable profile = PRD-233 S6.
 LOCAL_OPERATOR_EMAIL=local@automatos.local
 
+# [ACTIVE] Embeddings (RAG, memory, semantic routing) resolve their provider key
+# from the PLATFORM key slot — core/llm/workspace_keys.py reads the key row of
+# THIS workspace (the PR #610 'read the key where it lives' seam). Locally that
+# is the single default workspace, so the OpenRouter/OpenAI key you add in
+# Settings → API Keys powers embeddings too. Unset, every document upload ends
+# 'failed' (no embedding provider) while the API still says 'uploaded'.
+PLATFORM_KEY_WORKSPACE_ID=00000000-0000-0000-0000-0000000000c1
+
 # -----------------------------------------------------------------------------
 # Workspace worker — the Code Canvas runtime, in the default compose profile
 # -----------------------------------------------------------------------------

--- a/envs/api.defaults
+++ b/envs/api.defaults
@@ -33,7 +33,7 @@ REDIS_PORT=6379
 ENVIRONMENT=development
 LOG_LEVEL=INFO
 
-# Document conversion sidecar (compose profile: tools) [ACTIVE]
+# Document conversion sidecar (compose profile: all) [ACTIVE]
 GOTENBERG_URL=http://gotenberg:3000
 
 # -----------------------------------------------------------------------------
@@ -98,8 +98,9 @@ S3_PUBLIC_ENDPOINT_URL=http://localhost:9000
 S3_USE_PATH_STYLE=true
 # MinIO ignores region; kept for AWS-API compatibility. [ACTIVE]
 AWS_REGION=us-east-1
-# AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY -> root .env
-# (locally these are the MinIO root credentials)
+# The store's credentials arrive as AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY, which
+# compose maps FROM S3_ACCESS_KEY_ID / S3_SECRET_ACCESS_KEY / S3_REGION in .env
+# (MinIO root creds by default) — a developer's own AWS_* never reaches the store.
 
 # [ACTIVE] Vector store: pgvector in the main Postgres is the default.
 # AWS S3 Vectors is a SaaS-only opt-in; never enable it against MinIO.
@@ -120,7 +121,8 @@ S3_VECTORS_ENABLED=false
 # both as optional compose profiles is PRD-233 territory. If you run your own
 # instances, point these at them and the features light up.
 MEM0_API_URL=http://mem0-server:8765
-# MEM0_API_KEY -> root .env
+# MEM0_API_KEY: set it in envs/api.local if you run your own mem0 (.env values are
+# substitution-only; compose does not pass MEM0_API_KEY through)
 QDRANT_URL=http://qdrant:6333
 
 # -----------------------------------------------------------------------------
@@ -133,5 +135,5 @@ LOG_RELAY_URL=
 LOKI_URL=
 PROMETHEUS_URL=
 AGENT_OPT_WORKER_URL=
-# Enable observability locally via:  docker compose --profile observability up
-# plus envs/observability.defaults (see that file).
+# Observability (Loki/Prometheus/Grafana) is not part of this compose file — see the
+# automatos-monitoring repo; envs/observability.defaults documents the variables.

--- a/frontend/app/__tests__/saas-only-pages.test.tsx
+++ b/frontend/app/__tests__/saas-only-pages.test.tsx
@@ -1,0 +1,244 @@
+/**
+ * PRD-233 S7 — the SaaS-only route pages in each edition.
+ *
+ * `local`: Team, Workspace Admin and Invitations render the shared notice
+ * (the route still resolves — hidden ≠ deleted); the Clerk sign-in sub-flows
+ * (reset-password, sso-callback) send visitors home like sign-in/up do.
+ * `saas`: every page renders its hosted UI exactly as today.
+ *
+ * The real seam is exercised (env stubbed, module graph reset per test). Heavy
+ * children, the layout shell, Clerk and the API client are stubbed.
+ */
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
+import { render, screen, cleanup, waitFor, act } from '@testing-library/react'
+import React from 'react'
+
+// Each case dynamically imports a page (and its tree) after stubbing the
+// edition; the first transform can exceed vitest's 5s default under load.
+vi.setConfig({ testTimeout: 30_000 })
+
+const redirectMock = vi.hoisted(() =>
+  vi.fn((to: string) => {
+    throw new Error(`NEXT_REDIRECT:${to}`)
+  }),
+)
+
+vi.mock('next/navigation', () => ({
+  redirect: redirectMock,
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(''),
+  usePathname: () => '/',
+}))
+vi.mock('next/image', () => ({
+  default: (props: { alt?: string; src?: unknown }) =>
+    React.createElement('img', { alt: props.alt ?? '', src: typeof props.src === 'string' ? props.src : '' }),
+}))
+vi.mock('@/components/layout/main-layout', () => ({
+  MainLayout: ({ children }: { children: React.ReactNode }) => <div data-testid="main-layout">{children}</div>,
+}))
+vi.mock('@/hooks/use-page-api', () => ({ usePageAPI: () => {} }))
+vi.mock('@/components/team/team-management', () => ({
+  TeamManagement: () => <div data-testid="team-management" />,
+}))
+vi.mock('@/lib/api-client', () => ({
+  apiClient: { request: vi.fn(async () => ({ items: [], total: 0, page: 1, limit: 20 })) },
+}))
+vi.mock('@/components/workspace-provider', () => ({
+  useWorkspace: () => ({ workspace: null, refreshWorkspace: vi.fn(), isLoading: false }),
+}))
+vi.mock('@clerk/nextjs', () => ({
+  useAuth: () => ({ isLoaded: true, isSignedIn: false }),
+  useUser: () => ({ user: null }),
+  useSignIn: () => ({ isLoaded: false, signIn: null, setActive: null }),
+  SignIn: () => <div data-testid="clerk-sign-in" />,
+  SignUp: () => <div data-testid="clerk-sign-up" />,
+  AuthenticateWithRedirectCallback: () => <div data-testid="clerk-sso-callback" />,
+}))
+
+const NOTICE = 'This area is part of the hosted edition; the local edition has no accounts, teams or plans.'
+
+const pages = {
+  team: () => import('@/app/team/page'),
+  admin: () => import('@/app/admin/workspaces/page'),
+  invitation: () => import('@/app/accept-invitation/page'),
+  reset: () => import('@/app/reset-password/page'),
+  sso: () => import('@/app/sso-callback/page'),
+  plugins: () => import('@/app/admin/plugins/page'),
+  devReset: () => import('@/app/dev/reset-onboarding/page'),
+}
+
+async function load(edition: 'local' | 'saas', key: keyof typeof pages) {
+  vi.stubEnv('NEXT_PUBLIC_AUTH_EDITION', edition)
+  const mod = await pages[key]()
+  return mod.default
+}
+
+beforeEach(() => {
+  // accept-invitation looks its token up on mount; keep it off the network.
+  vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, json: async () => ({}) })))
+})
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllEnvs()
+  vi.unstubAllGlobals()
+  vi.resetModules()
+  redirectMock.mockClear()
+})
+
+describe('/team', () => {
+  it('local: renders the notice inside the shell, not TeamManagement', async () => {
+    const TeamPage = await load('local', 'team')
+    render(<TeamPage />)
+
+    expect(screen.getByTestId('main-layout')).toBeInTheDocument()
+    expect(screen.getByTestId('saas-only-notice')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Team' })).toBeInTheDocument()
+    expect(screen.getByText(NOTICE)).toBeInTheDocument()
+    expect(screen.queryByTestId('team-management')).toBeNull()
+  })
+
+  it('saas: renders TeamManagement exactly as today', async () => {
+    const TeamPage = await load('saas', 'team')
+    render(<TeamPage />)
+
+    expect(screen.getByTestId('team-management')).toBeInTheDocument()
+    expect(screen.queryByTestId('saas-only-notice')).toBeNull()
+  })
+})
+
+describe('/admin/workspaces', () => {
+  it('local: renders the notice inside the shell; the admin console never mounts', async () => {
+    const AdminPage = await load('local', 'admin')
+    render(<AdminPage />)
+
+    expect(screen.getByTestId('main-layout')).toBeInTheDocument()
+    expect(screen.getByTestId('saas-only-notice')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Workspace Admin' })).toBeInTheDocument()
+    expect(screen.queryByText(/Manage all workspaces/)).toBeNull()
+    const { apiClient } = await import('@/lib/api-client')
+    expect(apiClient.request).not.toHaveBeenCalled()
+  })
+
+  it('saas: renders the admin console exactly as today', async () => {
+    const AdminPage = await load('saas', 'admin')
+    const { apiClient } = await import('@/lib/api-client')
+    render(<AdminPage />)
+
+    expect(screen.queryByTestId('saas-only-notice')).toBeNull()
+    expect(screen.getByRole('heading', { name: /Workspace Admin/ })).toBeInTheDocument()
+    expect(screen.getByText(/Manage all workspaces/)).toBeInTheDocument()
+    // The console's list fetch runs on mount (the hosted path is live); let its
+    // resolved state update land inside the test instead of after it.
+    await waitFor(() => expect(apiClient.request).toHaveBeenCalled())
+    await act(async () => {
+      await Promise.resolve()
+    })
+  })
+})
+
+describe('/accept-invitation', () => {
+  it('local: renders the notice; no Clerk hook runs', async () => {
+    const AcceptInvitationPage = await load('local', 'invitation')
+    render(<AcceptInvitationPage />)
+
+    expect(screen.getByTestId('saas-only-notice')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Invitations' })).toBeInTheDocument()
+    expect(globalThis.fetch).not.toHaveBeenCalled()
+  })
+
+  it('saas: renders the invitation flow exactly as today', async () => {
+    const AcceptInvitationPage = await load('saas', 'invitation')
+    render(<AcceptInvitationPage />)
+
+    expect(screen.queryByTestId('saas-only-notice')).toBeNull()
+    // No token in the URL ⇒ the flow's own error state.
+    expect(await screen.findByText('Invalid link')).toBeInTheDocument()
+  })
+})
+
+describe('Clerk sign-in sub-flows', () => {
+  let consoleError: ReturnType<typeof vi.spyOn>
+  beforeEach(() => {
+    consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+  afterEach(() => {
+    consoleError.mockRestore()
+  })
+
+  it('/reset-password local: redirects home before any Clerk hook runs', async () => {
+    const ResetPasswordPage = await load('local', 'reset')
+    expect(() => render(<ResetPasswordPage />)).toThrow('NEXT_REDIRECT:/')
+    expect(redirectMock).toHaveBeenCalledWith('/')
+  })
+
+  it('/reset-password saas: renders the reset form, no redirect', async () => {
+    const ResetPasswordPage = await load('saas', 'reset')
+    const { container } = render(<ResetPasswordPage />)
+    expect(redirectMock).not.toHaveBeenCalled()
+    expect(container.querySelector('form')).not.toBeNull()
+  })
+
+  it('/sso-callback local: redirects home', async () => {
+    const SSOCallbackPage = await load('local', 'sso')
+    expect(() => render(<SSOCallbackPage />)).toThrow('NEXT_REDIRECT:/')
+    expect(redirectMock).toHaveBeenCalledWith('/')
+  })
+
+  it('/sso-callback saas: mounts Clerk\'s callback exactly as today', async () => {
+    const SSOCallbackPage = await load('saas', 'sso')
+    render(<SSOCallbackPage />)
+    expect(redirectMock).not.toHaveBeenCalled()
+    expect(screen.getByTestId('clerk-sso-callback')).toBeInTheDocument()
+  })
+})
+
+describe('/admin/plugins (hosted hub moderation queue)', () => {
+  it('local: renders the notice inside the shell; the console never mounts', async () => {
+    const AdminPluginsPage = await load('local', 'plugins')
+    // Mocked-module spies survive vi.resetModules(); start this count clean.
+    const { apiClient } = await import('@/lib/api-client')
+    vi.mocked(apiClient.request).mockClear()
+    render(<AdminPluginsPage />)
+
+    expect(screen.getByTestId('main-layout')).toBeInTheDocument()
+    expect(screen.getByTestId('saas-only-notice')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Plugin moderation' })).toBeInTheDocument()
+    expect(apiClient.request).not.toHaveBeenCalled()
+  })
+
+  it('saas: renders the moderation console exactly as today', async () => {
+    const AdminPluginsPage = await load('saas', 'plugins')
+    const { apiClient } = await import('@/lib/api-client')
+    render(<AdminPluginsPage />)
+
+    expect(screen.queryByTestId('saas-only-notice')).toBeNull()
+    await waitFor(() => expect(apiClient.request).toHaveBeenCalled())
+    await act(async () => {
+      await Promise.resolve()
+    })
+  })
+})
+
+describe('/dev/reset-onboarding (Clerk-only dev page)', () => {
+  let consoleError: ReturnType<typeof vi.spyOn>
+  beforeEach(() => {
+    consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+  afterEach(() => {
+    consoleError.mockRestore()
+  })
+
+  it('local: redirects home before any Clerk hook runs', async () => {
+    const ResetOnboardingPage = await load('local', 'devReset')
+    expect(() => render(<ResetOnboardingPage />)).toThrow('NEXT_REDIRECT:/')
+    expect(redirectMock).toHaveBeenCalledWith('/')
+  })
+
+  it('saas: renders the dev page, no redirect', async () => {
+    const ResetOnboardingPage = await load('saas', 'devReset')
+    const { container } = render(<ResetOnboardingPage />)
+    expect(redirectMock).not.toHaveBeenCalled()
+    expect(container).not.toBeEmptyDOMElement()
+  })
+})

--- a/frontend/app/accept-invitation/page.tsx
+++ b/frontend/app/accept-invitation/page.tsx
@@ -6,6 +6,8 @@ import { useAuth, useUser, SignIn, SignUp } from '@clerk/nextjs'
 import { apiClient } from '@/lib/api-client'
 import { CheckCircle2, AlertCircle, Loader2, Mail } from 'lucide-react'
 import Link from 'next/link'
+import { SaasOnlyNotice } from '@/components/local/saas-only-notice'
+import { isRouteAvailableInEdition } from '@/lib/auth-edition'
 
 interface InvitationInfo {
     email: string
@@ -233,6 +235,15 @@ function ErrorState({ title, detail, cta }: { title: string; detail: string; cta
 }
 
 export default function AcceptInvitationPage() {
+    // PRD-233 S7: invitations are a hosted-edition flow (Clerk-bound). Local
+    // renders the notice; the Clerk hooks inside AcceptInvitationInner never run.
+    if (!isRouteAvailableInEdition('/accept-invitation')) {
+        return (
+            <div className="min-h-screen flex items-center justify-center bg-background">
+                <SaasOnlyNotice surface="Invitations" />
+            </div>
+        )
+    }
     return (
         <Suspense fallback={<Shell><Loader2 className="w-8 h-8 animate-spin text-[hsl(var(--info))] mx-auto" /></Shell>}>
             <AcceptInvitationInner />

--- a/frontend/app/admin/plugins/page.tsx
+++ b/frontend/app/admin/plugins/page.tsx
@@ -18,6 +18,8 @@ import {
   RefreshCw,
 } from 'lucide-react'
 import { MainLayout } from '@/components/layout/main-layout'
+import { SaasOnlyNotice } from '@/components/local/saas-only-notice'
+import { isRouteAvailableInEdition } from '@/lib/auth-edition'
 import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
@@ -152,7 +154,7 @@ function formatDate(dateStr: string | null) {
 // Component
 // ===================================================================
 
-export default function AdminPluginsPendingPage() {
+function AdminPluginsPendingConsole() {
   usePageAPI('admin')
 
   // Data
@@ -891,4 +893,18 @@ export default function AdminPluginsPendingPage() {
       </div>
     </MainLayout>
   )
+}
+
+// PRD-233 S7: plugin moderation is the hosted hub's approval queue (owner
+// decision 2026-08-29: publishing is monitored and approved on the hosted
+// side). The local edition renders the notice; the console never mounts.
+export default function AdminPluginsPendingPage() {
+  if (!isRouteAvailableInEdition('/admin/plugins')) {
+    return (
+      <MainLayout>
+        <SaasOnlyNotice surface="Plugin moderation" />
+      </MainLayout>
+    )
+  }
+  return <AdminPluginsPendingConsole />
 }

--- a/frontend/app/admin/workspaces/page.tsx
+++ b/frontend/app/admin/workspaces/page.tsx
@@ -26,6 +26,8 @@ import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { usePageAPI } from '@/hooks/use-page-api'
 import { apiClient } from '@/lib/api-client'
+import { SaasOnlyNotice } from '@/components/local/saas-only-notice'
+import { isRouteAvailableInEdition } from '@/lib/auth-edition'
 
 // ===================================================================
 // Types
@@ -108,7 +110,7 @@ function stateBadge(w: WorkspaceRow) {
 // Page
 // ===================================================================
 
-export default function AdminWorkspacesPage() {
+function AdminWorkspacesConsole() {
   usePageAPI('admin')
 
   const [workspaces, setWorkspaces] = useState<WorkspaceRow[]>([])
@@ -654,4 +656,20 @@ export default function AdminWorkspacesPage() {
       </div>
     </MainLayout>
   )
+}
+
+// PRD-233 S7: Workspace Admin is a hosted-edition surface (cross-tenant
+// administration). The console above is untouched; in local the route renders
+// the shared notice instead — before any of the console's hooks or admin
+// fetches run. Hidden by the seam's explicit list, not by role (the local
+// operator is super_admin by design).
+export default function AdminWorkspacesPage() {
+  if (!isRouteAvailableInEdition('/admin/workspaces')) {
+    return (
+      <MainLayout>
+        <SaasOnlyNotice surface="Workspace Admin" />
+      </MainLayout>
+    )
+  }
+  return <AdminWorkspacesConsole />
 }

--- a/frontend/app/chat/page.tsx
+++ b/frontend/app/chat/page.tsx
@@ -6,6 +6,7 @@ import { useSearchParams, useRouter } from 'next/navigation'
 import { ArrowLeft } from 'lucide-react'
 import { MainLayout } from '@/components/layout/main-layout'
 import { Chat } from '@/components/chatbot/chat'
+import { FirstRunNudge } from '@/components/local/first-run-nudge'
 import { AppSidebar } from '@/components/chatbot/sidebar'
 import { StudioChatShell } from '@/components/chatbot/studio-chat-shell'
 import { Sheet, SheetContent } from '@/components/ui/sheet'
@@ -100,15 +101,20 @@ export default function ChatPage() {
   }, [chatIdParam, currentChatId, chatLoadAttempted])
 
   const chatBody = (
-    <Chat
-      key={`${currentChatId || 'new'}-${chatInstance}`}
-      id={currentChatId}
-      initialMessages={currentMessages}
-      initialVisibilityType={selectedChat?.visibility || 'private'}
-      isReadonly={false}
-      autoResume={false}
-      initialLastContext={selectedChat?.lastContext}
-    />
+    <>
+      {/* PRD-233 S3: local-edition first-run nudge — renders nothing in saas
+          or once an LLM key exists; a zero-height overlay in both layouts. */}
+      <FirstRunNudge />
+      <Chat
+        key={`${currentChatId || 'new'}-${chatInstance}`}
+        id={currentChatId}
+        initialMessages={currentMessages}
+        initialVisibilityType={selectedChat?.visibility || 'private'}
+        isReadonly={false}
+        autoResume={false}
+        initialLastContext={selectedChat?.lastContext}
+      />
+    </>
   )
 
   // Studio desktop: CD's three-column ledger layout

--- a/frontend/app/dev/reset-onboarding/page.tsx
+++ b/frontend/app/dev/reset-onboarding/page.tsx
@@ -2,7 +2,8 @@
 
 import { useState } from 'react'
 import { useUser } from '@clerk/nextjs'
-import { useRouter } from 'next/navigation'
+import { redirect, useRouter } from 'next/navigation'
+import { isRouteAvailableInEdition } from '@/lib/auth-edition'
 import { RotateCcw, AlertTriangle, Loader2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Switch } from '@/components/ui/switch'
@@ -45,7 +46,7 @@ function clearLegacyOnboardingStorage(userId: string) {
   }
   remove.forEach((k) => localStorage.removeItem(k))
 }
-export default function ResetOnboardingPage() {
+function ResetOnboardingConsole() {
   const { user } = useUser()
   const router = useRouter()
   const { workspace, refreshWorkspace } = useWorkspace()
@@ -219,4 +220,13 @@ export default function ResetOnboardingPage() {
       </Button>
     </div>
   )
+}
+
+// PRD-233 S7: this dev page is built on Clerk's useUser(); in the local edition
+// it would throw without ClerkProvider, so it redirects home like sign-in.
+export default function ResetOnboardingPage() {
+  if (!isRouteAvailableInEdition('/dev/reset-onboarding')) {
+    redirect('/')
+  }
+  return <ResetOnboardingConsole />
 }

--- a/frontend/app/reset-password/page.tsx
+++ b/frontend/app/reset-password/page.tsx
@@ -2,7 +2,8 @@
 
 import { useState } from 'react'
 import { useSignIn } from '@clerk/nextjs'
-import { useRouter } from 'next/navigation'
+import { useRouter, redirect } from 'next/navigation'
+import { isRouteAvailableInEdition } from '@/lib/auth-edition'
 import { motion } from 'framer-motion'
 import { ArrowRight, Loader2, AlertCircle, Lock, KeyRound } from 'lucide-react'
 import { Button } from '@/components/ui/button'
@@ -13,6 +14,11 @@ import { Alert, AlertDescription } from '@/components/ui/alert'
 import Image from 'next/image'
 
 export default function ResetPasswordPage() {
+    // PRD-233 S7: a Clerk sign-in sub-flow — there is no login in the local
+    // edition, so send visitors home before the Clerk hook runs (as sign-in does).
+    if (!isRouteAvailableInEdition('/reset-password')) {
+        redirect('/')
+    }
     const { isLoaded, signIn, setActive } = useSignIn()
     const [code, setCode] = useState('')
     const [newPassword, setNewPassword] = useState('')

--- a/frontend/app/settings/profile/__tests__/page.test.tsx
+++ b/frontend/app/settings/profile/__tests__/page.test.tsx
@@ -1,0 +1,180 @@
+/**
+ * PRD-233 S6 — Settings → Profile, one route, two editions.
+ *
+ *   local → a plain form over GET/PUT /api/profile (name / username / avatar;
+ *           email read-only with the LOCAL_OPERATOR_EMAIL hint). No Clerk hook
+ *           is ever called.
+ *   saas  → the Clerk-managed page renders exactly as before and never touches
+ *           the profile API.
+ *
+ * The edition seam (`@/lib/auth-edition`) is mocked per test; everything else
+ * that reaches the network (api-client, workspace hook, Clerk) is stubbed.
+ */
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+
+const { getProfileMock, updateProfileMock, clerkUseUserMock } = vi.hoisted(() => ({
+  getProfileMock: vi.fn(),
+  updateProfileMock: vi.fn(),
+  clerkUseUserMock: vi.fn(),
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ back: vi.fn(), push: vi.fn() }),
+}))
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...rest }: any) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}))
+
+vi.mock('@/hooks/use-workspace', () => ({
+  useWorkspace: () => ({ workspaceId: '00000000-0000-0000-0000-0000000000aa', loading: false, error: null }),
+}))
+
+vi.mock('@/lib/api-client', () => ({
+  apiClient: { getProfile: getProfileMock, updateProfile: updateProfileMock },
+}))
+
+vi.mock('@/components/shared', () => ({
+  PageHeader: ({ title, titleAccent }: any) => (
+    <h1>
+      {title} {titleAccent}
+    </h1>
+  ),
+}))
+
+// auth-hooks.ts reads every Clerk hook at module evaluation — all must exist.
+vi.mock('@clerk/nextjs', () => ({
+  useUser: clerkUseUserMock,
+  useAuth: vi.fn(),
+  useSession: vi.fn(),
+  useOrganization: vi.fn(),
+  useClerk: vi.fn(),
+  UserButton: () => <div data-testid="clerk-user-button" />,
+}))
+
+const LOCAL_PROFILE = {
+  edition: 'local',
+  editable: true,
+  id: 1,
+  email: 'local@automatos.local',
+  name: 'Local Operator',
+  username: 'local',
+  avatar_url: null,
+  system_role: 'super_admin',
+  email_note:
+    'Email is the operator lookup key — it is set by LOCAL_OPERATOR_EMAIL in .env and cannot be changed here.',
+}
+
+async function loadPage(edition: 'local' | 'saas') {
+  vi.doMock('@/lib/auth-edition', () => ({
+    authEdition: edition,
+    isLocal: edition === 'local',
+    isSaaS: edition === 'saas',
+  }))
+  const mod = await import('../page')
+  return mod.default
+}
+
+beforeEach(() => {
+  getProfileMock.mockReset()
+  updateProfileMock.mockReset()
+  clerkUseUserMock.mockReset()
+})
+
+afterEach(() => {
+  vi.doUnmock('@/lib/auth-edition')
+  vi.resetModules()
+})
+
+describe('Settings → Profile (PRD-233 S6) — local edition', () => {
+  it('renders the operator form from GET /api/profile with a read-only email and never calls Clerk', async () => {
+    getProfileMock.mockResolvedValue(LOCAL_PROFILE)
+    const Page = await loadPage('local')
+    render(<Page />)
+
+    const nameInput = (await screen.findByLabelText('Display name')) as HTMLInputElement
+    expect(nameInput.value).toBe('Local Operator')
+    expect((screen.getByLabelText('Username') as HTMLInputElement).value).toBe('local')
+
+    const emailInput = screen.getByLabelText('Email') as HTMLInputElement
+    expect(emailInput.value).toBe('local@automatos.local')
+    expect(emailInput).toHaveAttribute('readonly')
+    expect(screen.getByText(/LOCAL_OPERATOR_EMAIL/)).toBeInTheDocument()
+
+    // Initials avatar from the seeded name.
+    expect(screen.getByLabelText('Avatar initials')).toHaveTextContent('LO')
+
+    expect(getProfileMock).toHaveBeenCalledTimes(1)
+    expect(clerkUseUserMock).not.toHaveBeenCalled()
+    expect(screen.queryByTestId('clerk-user-button')).not.toBeInTheDocument()
+  })
+
+  it('saves only the changed fields through PUT /api/profile and confirms', async () => {
+    getProfileMock.mockResolvedValue(LOCAL_PROFILE)
+    updateProfileMock.mockResolvedValue({ ...LOCAL_PROFILE, name: 'Test Operator' })
+    const Page = await loadPage('local')
+    render(<Page />)
+
+    const nameInput = (await screen.findByLabelText('Display name')) as HTMLInputElement
+    const save = screen.getByRole('button', { name: /save/i })
+    expect(save).toBeDisabled()
+
+    fireEvent.change(nameInput, { target: { value: 'Test Operator' } })
+    expect(save).toBeEnabled()
+    fireEvent.click(save)
+
+    await waitFor(() => expect(updateProfileMock).toHaveBeenCalledWith({ name: 'Test Operator' }))
+    expect(await screen.findByText('Profile updated.')).toBeInTheDocument()
+    expect((screen.getByLabelText('Display name') as HTMLInputElement).value).toBe('Test Operator')
+  })
+
+  it('shows the backend detail when a save is rejected', async () => {
+    getProfileMock.mockResolvedValue(LOCAL_PROFILE)
+    updateProfileMock.mockRejectedValue(new Error('username is already taken'))
+    const Page = await loadPage('local')
+    render(<Page />)
+
+    fireEvent.change(await screen.findByLabelText('Username'), { target: { value: 'taken' } })
+    fireEvent.click(screen.getByRole('button', { name: /save/i }))
+
+    expect(await screen.findByText('username is already taken')).toBeInTheDocument()
+  })
+
+  it('makes a FastAPI 422 detail readable', async () => {
+    const { readableError } = await import('../local-profile-form')
+    const detail = JSON.stringify([{ loc: ['body', 'avatar_url'], msg: 'Value error, avatar_url must be an http(s) URL' }])
+    expect(readableError(new Error(detail))).toBe('avatar_url: Value error, avatar_url must be an http(s) URL')
+    expect(readableError(new Error('plain message'))).toBe('plain message')
+  })
+})
+
+describe('Settings → Profile (PRD-233 S6) — saas edition', () => {
+  it('renders the Clerk-managed page untouched and never calls the profile API', async () => {
+    clerkUseUserMock.mockReturnValue({
+      isLoaded: true,
+      user: {
+        fullName: 'Sample User',
+        firstName: 'Sample',
+        lastName: 'User',
+        username: 'sample',
+        imageUrl: '',
+        emailAddresses: [{ id: 'e1', emailAddress: 'sample@example.test' }],
+        primaryEmailAddressId: 'e1',
+        primaryEmailAddress: { emailAddress: 'sample@example.test' },
+      },
+    })
+    const Page = await loadPage('saas')
+    render(<Page />)
+
+    expect(await screen.findByText('Edit Profile')).toBeInTheDocument()
+    expect(screen.getByText('Sample User')).toBeInTheDocument()
+    expect(clerkUseUserMock).toHaveBeenCalled()
+    expect(getProfileMock).not.toHaveBeenCalled()
+    expect(screen.queryByLabelText('Display name')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/app/settings/profile/local-profile-form.tsx
+++ b/frontend/app/settings/profile/local-profile-form.tsx
@@ -1,0 +1,365 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import {
+    AlertCircle,
+    ArrowLeft,
+    Briefcase,
+    Check,
+    CheckCircle,
+    Copy,
+    Loader2,
+    Mail,
+    Save,
+    User,
+} from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { PageHeader } from '@/components/shared'
+import { useWorkspace } from '@/hooks/use-workspace'
+import { apiClient, type ProfileResponse, type ProfileUpdateRequest } from '@/lib/api-client'
+import { initialsFor } from '@/components/auth/user-profile-button'
+
+/**
+ * PRD-233 S6 — the local operator's profile.
+ *
+ * The local edition has exactly one operator and no login, so there is no
+ * identity provider to edit a profile in. This form edits the operator's
+ * `users` row through GET/PUT /api/profile: display name (the name Auto greets
+ * you by), username and avatar URL. Email is read-only — it is the lookup key
+ * the anonymous session resolves the row by (`LOCAL_OPERATOR_EMAIL` in .env),
+ * and the backend says so in `email_note`.
+ */
+
+const STATUS_RESET_MS = 3000
+const COPY_RESET_MS = 2000
+const INPUT_CLASS =
+    'w-full px-4 py-2 bg-secondary/50 border border-border rounded-lg text-foreground placeholder:text-muted-foreground focus:border-primary focus:ring-2 focus:ring-primary/20 outline-none'
+const READONLY_CLASS =
+    'w-full px-4 py-2 bg-secondary/30 border border-border rounded-lg text-muted-foreground cursor-not-allowed'
+
+interface FormFields {
+    name: string
+    username: string
+    avatar_url: string
+}
+
+const EMPTY_FORM: FormFields = { name: '', username: '', avatar_url: '' }
+
+function formFrom(profile: ProfileResponse): FormFields {
+    return {
+        name: profile.name ?? '',
+        username: profile.username ?? '',
+        avatar_url: profile.avatar_url ?? '',
+    }
+}
+
+/** Only the fields that differ from the loaded profile — PUT is partial. */
+export function changedFields(profile: ProfileResponse, form: FormFields): ProfileUpdateRequest {
+    const current = formFrom(profile)
+    return (Object.keys(form) as Array<keyof FormFields>).reduce<ProfileUpdateRequest>(
+        (acc, key) => (form[key] === current[key] ? acc : { ...acc, [key]: form[key] }),
+        {},
+    )
+}
+
+/** api-client throws `Error(detail)`; a FastAPI 422 detail arrives JSON-stringified. */
+export function readableError(error: unknown): string {
+    const message = error instanceof Error ? error.message : String(error)
+    if (!message.startsWith('[')) return message
+    try {
+        const items = JSON.parse(message) as Array<{ loc?: unknown[]; msg?: string }>
+        return items
+            .map((item) => {
+                const field = item.loc && item.loc.length > 0 ? String(item.loc[item.loc.length - 1]) : 'field'
+                return `${field}: ${item.msg ?? 'invalid'}`
+            })
+            .join('; ')
+    } catch {
+        return message
+    }
+}
+
+export function LocalProfileForm() {
+    const router = useRouter()
+    const { workspaceId, loading: workspaceLoading } = useWorkspace()
+    const [profile, setProfile] = useState<ProfileResponse | null>(null)
+    const [form, setForm] = useState<FormFields>(EMPTY_FORM)
+    const [loadError, setLoadError] = useState<string | null>(null)
+    const [isSaving, setIsSaving] = useState(false)
+    const [saveStatus, setSaveStatus] = useState<'idle' | 'success' | 'error'>('idle')
+    const [saveError, setSaveError] = useState<string | null>(null)
+    const [copiedWorkspaceId, setCopiedWorkspaceId] = useState(false)
+
+    useEffect(() => {
+        let cancelled = false
+        apiClient
+            .getProfile()
+            .then((data) => {
+                if (cancelled) return
+                setProfile(data)
+                setForm(formFrom(data))
+            })
+            .catch((error: unknown) => {
+                if (!cancelled) setLoadError(readableError(error))
+            })
+        return () => {
+            cancelled = true
+        }
+    }, [])
+
+    const flash = useCallback((status: 'success' | 'error', message: string | null = null) => {
+        setSaveStatus(status)
+        setSaveError(message)
+        setTimeout(() => {
+            setSaveStatus('idle')
+            setSaveError(null)
+        }, STATUS_RESET_MS)
+    }, [])
+
+    const handleSave = async () => {
+        if (!profile) return
+        const updates = changedFields(profile, form)
+        if (Object.keys(updates).length === 0) {
+            flash('success')
+            return
+        }
+        setIsSaving(true)
+        try {
+            const saved = await apiClient.updateProfile(updates)
+            setProfile(saved)
+            setForm(formFrom(saved))
+            flash('success')
+        } catch (error: unknown) {
+            flash('error', readableError(error))
+        } finally {
+            setIsSaving(false)
+        }
+    }
+
+    const handleCopyWorkspaceId = async () => {
+        if (!workspaceId) return
+        try {
+            await navigator.clipboard.writeText(workspaceId)
+            setCopiedWorkspaceId(true)
+            setTimeout(() => setCopiedWorkspaceId(false), COPY_RESET_MS)
+        } catch {
+            setCopiedWorkspaceId(false)
+        }
+    }
+
+    if (loadError) {
+        return (
+            <div className="min-h-screen flex items-center justify-center">
+                <p className="text-destructive">Could not load your profile: {loadError}</p>
+            </div>
+        )
+    }
+
+    if (!profile) {
+        return (
+            <div className="min-h-screen flex items-center justify-center">
+                <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-primary" />
+            </div>
+        )
+    }
+
+    const dirty = Object.keys(changedFields(profile, form)).length > 0
+    const displayName = form.name.trim() || profile.email || 'Operator'
+
+    return (
+        <div className="min-h-screen py-8 px-4">
+            <div className="max-w-4xl mx-auto">
+                <div className="mb-8">
+                    <PageHeader
+                        title="Profile"
+                        titleAccent="Settings"
+                        eyebrow="Local edition · operator"
+                        lede="Who Auto is talking to on this instance. There is no login locally — this is a profile, not an account."
+                        actions={
+                            <Button
+                                variant="ghost"
+                                size="sm"
+                                onClick={() => router.back()}
+                                className="text-muted-foreground hover:text-foreground hover:bg-secondary"
+                            >
+                                <ArrowLeft className="w-4 h-4 mr-1" />
+                                Back
+                            </Button>
+                        }
+                    />
+                </div>
+
+                {saveStatus !== 'idle' && (
+                    <div
+                        role="status"
+                        className={`mb-6 p-4 rounded-lg border flex items-center space-x-3 ${saveStatus === 'success'
+                            ? 'bg-success/10 border-success/30 text-success'
+                            : 'bg-destructive/10 border-destructive/30 text-destructive'
+                            }`}
+                    >
+                        {saveStatus === 'success' ? <CheckCircle className="w-5 h-5" /> : <AlertCircle className="w-5 h-5" />}
+                        <span>{saveStatus === 'success' ? 'Profile updated.' : saveError || 'Failed to update profile.'}</span>
+                    </div>
+                )}
+
+                <form
+                    className="glass-card rounded-2xl border border-border p-8 mb-6"
+                    onSubmit={(event) => {
+                        event.preventDefault()
+                        void handleSave()
+                    }}
+                >
+                    <div className="flex items-center space-x-6 mb-8 pb-8 border-b border-border">
+                        {form.avatar_url ? (
+                            <img
+                                src={form.avatar_url}
+                                alt={displayName}
+                                className="w-24 h-24 rounded-full border-4 border-primary/30 object-cover"
+                            />
+                        ) : (
+                            <div
+                                aria-label="Avatar initials"
+                                className="w-24 h-24 rounded-full bg-primary flex items-center justify-center text-2xl font-semibold text-primary-foreground"
+                            >
+                                {initialsFor(form.name, profile.email)}
+                            </div>
+                        )}
+                        <div>
+                            <h2 className="text-2xl font-bold text-foreground mb-1">{displayName}</h2>
+                            <p className="text-muted-foreground">{profile.email}</p>
+                        </div>
+                    </div>
+
+                    <div className="space-y-6">
+                        <div>
+                            <h3 className="text-lg font-semibold text-foreground mb-4 flex items-center">
+                                <User className="w-5 h-5 mr-2 text-primary" />
+                                Personal Information
+                            </h3>
+                            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                <div className="md:col-span-2">
+                                    <label htmlFor="profile-name" className="block text-sm font-medium text-foreground mb-2">
+                                        Display name
+                                    </label>
+                                    <input
+                                        id="profile-name"
+                                        type="text"
+                                        value={form.name}
+                                        maxLength={255}
+                                        onChange={(event) => setForm({ ...form, name: event.target.value })}
+                                        className={INPUT_CLASS}
+                                        placeholder="The name Auto greets you by"
+                                    />
+                                    <p className="mt-2 text-xs text-muted-foreground">
+                                        Auto greets you by this name. Leave it blank and Auto stays generic.
+                                    </p>
+                                </div>
+                                <div>
+                                    <label htmlFor="profile-username" className="block text-sm font-medium text-foreground mb-2">
+                                        Username
+                                    </label>
+                                    <input
+                                        id="profile-username"
+                                        type="text"
+                                        value={form.username}
+                                        maxLength={255}
+                                        onChange={(event) => setForm({ ...form, username: event.target.value })}
+                                        className={INPUT_CLASS}
+                                        placeholder="letters, digits, . _ -"
+                                    />
+                                </div>
+                                <div>
+                                    <label htmlFor="profile-avatar" className="block text-sm font-medium text-foreground mb-2">
+                                        Avatar URL
+                                    </label>
+                                    <input
+                                        id="profile-avatar"
+                                        type="url"
+                                        value={form.avatar_url}
+                                        maxLength={500}
+                                        onChange={(event) => setForm({ ...form, avatar_url: event.target.value })}
+                                        className={INPUT_CLASS}
+                                        placeholder="https://…"
+                                    />
+                                </div>
+                            </div>
+                        </div>
+
+                        <div className="pt-6 border-t border-border">
+                            <h3 className="text-lg font-semibold text-foreground mb-4 flex items-center">
+                                <Mail className="w-5 h-5 mr-2 text-primary" />
+                                Email
+                            </h3>
+                            <label htmlFor="profile-email" className="block text-sm font-medium text-foreground mb-2">
+                                Email
+                            </label>
+                            <input
+                                id="profile-email"
+                                type="email"
+                                value={profile.email ?? ''}
+                                readOnly
+                                aria-readonly="true"
+                                className={READONLY_CLASS}
+                            />
+                            <p className="mt-2 text-xs text-muted-foreground">{profile.email_note}</p>
+                        </div>
+
+                        <div className="flex justify-end">
+                            <Button
+                                type="submit"
+                                disabled={isSaving || !dirty}
+                                className="bg-primary hover:bg-primary/90 text-primary-foreground disabled:opacity-50"
+                            >
+                                {isSaving ? <Loader2 className="w-4 h-4 mr-2 animate-spin" /> : <Save className="w-4 h-4 mr-2" />}
+                                {isSaving ? 'Saving…' : 'Save'}
+                            </Button>
+                        </div>
+                    </div>
+                </form>
+
+                <div className="glass-card rounded-2xl border border-border p-8">
+                    <h3 className="text-lg font-semibold text-foreground mb-4 flex items-center">
+                        <Briefcase className="w-5 h-5 mr-2 text-primary" />
+                        Workspace
+                    </h3>
+                    <label className="block text-sm font-medium text-foreground mb-2">Workspace ID</label>
+                    <div className="flex items-center space-x-2">
+                        <div className="flex-1 px-4 py-2 bg-secondary/30 border border-border rounded-lg">
+                            {workspaceLoading ? (
+                                <span className="text-muted-foreground font-mono text-sm">Loading…</span>
+                            ) : workspaceId ? (
+                                <span className="text-foreground font-mono text-sm break-all">{workspaceId}</span>
+                            ) : (
+                                <span className="text-muted-foreground font-mono text-sm">No workspace</span>
+                            )}
+                        </div>
+                        <Button
+                            type="button"
+                            variant="outline"
+                            size="sm"
+                            onClick={handleCopyWorkspaceId}
+                            disabled={!workspaceId}
+                            className="border-border text-foreground hover:bg-secondary hover:text-foreground disabled:opacity-50"
+                        >
+                            {copiedWorkspaceId ? (
+                                <>
+                                    <Check className="w-4 h-4 mr-2 text-success" />
+                                    Copied
+                                </>
+                            ) : (
+                                <>
+                                    <Copy className="w-4 h-4 mr-2" />
+                                    Copy
+                                </>
+                            )}
+                        </Button>
+                    </div>
+                    <p className="mt-2 text-xs text-muted-foreground">
+                        Include this ID when reporting an issue — it identifies this instance&apos;s workspace in logs.
+                    </p>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/frontend/app/settings/profile/page.tsx
+++ b/frontend/app/settings/profile/page.tsx
@@ -7,9 +7,26 @@ import { User, Mail, Shield, Trash2, Upload, Save, X, CheckCircle, AlertCircle, 
 import { Button } from '@/components/ui/button'
 import { useWorkspace } from '@/hooks/use-workspace'
 import { PageHeader } from '@/components/shared'
+import { isLocal } from '@/lib/auth-edition'
+import { LocalProfileForm } from './local-profile-form'
 
 /**
- * Custom Profile Page
+ * Profile page — one route, two editions (PRD-233 S6).
+ *
+ *   local → the operator's profile row (name / username / avatar; email is the
+ *           lookup key and read-only) via GET/PUT /api/profile. No Clerk, no
+ *           account: a profile, not an identity system.
+ *   saas  → the Clerk-managed profile below, untouched.
+ *
+ * `isLocal` is a build-time constant, so each build renders exactly one branch
+ * and the hooks inside it run unconditionally — the rules of hooks hold.
+ */
+export default function ProfilePage() {
+    return isLocal ? <LocalProfileForm /> : <ClerkProfilePage />
+}
+
+/**
+ * Custom Profile Page (saas — Clerk-managed identity)
  * 
  * Fully custom profile management page with:
  * - Personal information editing
@@ -18,8 +35,7 @@ import { PageHeader } from '@/components/shared'
  * - Security settings
  * - Proper contrast and styling
  */
-
-export default function ProfilePage() {
+function ClerkProfilePage() {
     const router = useRouter()
     const { user, isLoaded } = useUser()
     const [isEditing, setIsEditing] = useState(false)

--- a/frontend/app/sso-callback/page.tsx
+++ b/frontend/app/sso-callback/page.tsx
@@ -1,8 +1,14 @@
 'use client'
 
 import { AuthenticateWithRedirectCallback } from '@clerk/nextjs'
+import { redirect } from 'next/navigation'
+import { isRouteAvailableInEdition } from '@/lib/auth-edition'
 
 export default function SSOCallbackPage() {
+  // PRD-233 S7: Clerk's SSO return leg — no login in the local edition; send home.
+  if (!isRouteAvailableInEdition('/sso-callback')) {
+    redirect('/')
+  }
   return (
     <AuthenticateWithRedirectCallback
       afterSignInUrl="/"

--- a/frontend/app/team/page.tsx
+++ b/frontend/app/team/page.tsx
@@ -2,6 +2,8 @@
 
 import { MainLayout } from '@/components/layout/main-layout'
 import { TeamManagement } from '@/components/team/team-management'
+import { SaasOnlyNotice } from '@/components/local/saas-only-notice'
+import { isRouteAvailableInEdition } from '@/lib/auth-edition'
 import { usePageAPI } from '@/hooks/use-page-api'
 
 export default function TeamPage() {
@@ -10,7 +12,8 @@ export default function TeamPage() {
 
     return (
         <MainLayout>
-            <TeamManagement />
+            {/* PRD-233 S7: Team is a hosted-edition surface — local renders the notice. */}
+            {isRouteAvailableInEdition('/team') ? <TeamManagement /> : <SaasOnlyNotice surface="Team" />}
         </MainLayout>
     )
 }

--- a/frontend/components/auth/__tests__/user-profile-button.test.tsx
+++ b/frontend/components/auth/__tests__/user-profile-button.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * PRD-233 S6 — the profile slot per edition.
+ *
+ * local → the operator's initials (or avatar) + name from GET /api/profile,
+ *         linking to /settings/profile; no Clerk component is rendered.
+ * saas  → Clerk's UserButton exactly as before; the profile API is never called.
+ */
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+const { getProfileMock, clerkUseUserMock } = vi.hoisted(() => ({
+  getProfileMock: vi.fn(),
+  clerkUseUserMock: vi.fn(),
+}))
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...rest }: any) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}))
+
+vi.mock('@/lib/api-client', () => ({
+  apiClient: { getProfile: getProfileMock },
+}))
+
+vi.mock('@clerk/nextjs', () => ({
+  useUser: clerkUseUserMock,
+  useAuth: vi.fn(),
+  useSession: vi.fn(),
+  useOrganization: vi.fn(),
+  useClerk: vi.fn(),
+  UserButton: () => <div data-testid="clerk-user-button" />,
+}))
+
+async function loadButton(edition: 'local' | 'saas') {
+  vi.doMock('@/lib/auth-edition', () => ({
+    authEdition: edition,
+    isLocal: edition === 'local',
+    isSaaS: edition === 'saas',
+  }))
+  return import('../user-profile-button')
+}
+
+beforeEach(() => {
+  getProfileMock.mockReset()
+  clerkUseUserMock.mockReset()
+})
+
+afterEach(() => {
+  vi.doUnmock('@/lib/auth-edition')
+  vi.resetModules()
+})
+
+describe('initialsFor', () => {
+  it('derives initials from the name, then the email, then a placeholder', async () => {
+    const { initialsFor } = await loadButton('local')
+    expect(initialsFor('Ada Lovelace', null)).toBe('AL')
+    expect(initialsFor('Ada Byron Lovelace', null)).toBe('AL')
+    expect(initialsFor('ada', null)).toBe('AD')
+    expect(initialsFor('  ', 'operator@example.test')).toBe('O')
+    expect(initialsFor(null, null)).toBe('?')
+  })
+})
+
+describe('UserProfileButton (PRD-233 S6)', () => {
+  it('local: shows the operator initials + name and links to /settings/profile', async () => {
+    getProfileMock.mockResolvedValue({
+      edition: 'local',
+      editable: true,
+      id: 1,
+      email: 'local@automatos.local',
+      name: 'Local Operator',
+      username: 'local',
+      avatar_url: null,
+      system_role: 'super_admin',
+      email_note: '',
+    })
+    const { UserProfileButton } = await loadButton('local')
+    render(<UserProfileButton />)
+
+    const link = await screen.findByRole('link', { name: /your profile/i })
+    expect(link).toHaveAttribute('href', '/settings/profile')
+    expect(await screen.findByText('Local Operator')).toBeInTheDocument()
+    expect(link).toHaveTextContent('LO')
+    expect(screen.queryByTestId('clerk-user-button')).not.toBeInTheDocument()
+    expect(clerkUseUserMock).not.toHaveBeenCalled()
+  })
+
+  it('local: still links to the profile when the API fails (no name yet)', async () => {
+    getProfileMock.mockRejectedValue(new Error('offline'))
+    const { UserProfileButton } = await loadButton('local')
+    render(<UserProfileButton />)
+
+    const link = await screen.findByRole('link', { name: /your profile/i })
+    expect(link).toHaveAttribute('href', '/settings/profile')
+    expect(link).toHaveTextContent('Operator')
+  })
+
+  it('saas: renders the Clerk UserButton and never calls the profile API', async () => {
+    clerkUseUserMock.mockReturnValue({ isSignedIn: true, isLoaded: true, user: {} })
+    const { UserProfileButton } = await loadButton('saas')
+    render(<UserProfileButton />)
+
+    expect(screen.getByTestId('clerk-user-button')).toBeInTheDocument()
+    expect(getProfileMock).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/components/auth/user-profile-button.tsx
+++ b/frontend/components/auth/user-profile-button.tsx
@@ -1,17 +1,79 @@
 'use client'
 
 import Link from 'next/link'
+import { useEffect, useState } from 'react'
 import { UserButton } from '@clerk/nextjs'
 import { useUser } from '@/lib/auth-hooks'
 import { isSaaS } from '@/lib/auth-edition'
-import { Settings } from 'lucide-react'
+import { apiClient, type ProfileResponse } from '@/lib/api-client'
 
 /**
  * PRD-37: User Profile Button Component
  * 
  * Shows sign in button when logged out, user menu when logged in.
  * Drop-in component for navigation bars.
+ *
+ * PRD-233 S6: in the local edition there is no Clerk and no account — the slot
+ * shows the operator (avatar or initials + name from GET /api/profile) and
+ * links to /settings/profile, where the name Auto greets them by is set.
  */
+
+/** "Ada Lovelace" → "AL"; one word → its first two letters; else the email's first letter. */
+export function initialsFor(name: string | null | undefined, email: string | null | undefined): string {
+    const parts = (name ?? '').trim().split(/\s+/).filter(Boolean)
+    if (parts.length >= 2) return `${parts[0][0]}${parts[parts.length - 1][0]}`.toUpperCase()
+    if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase()
+    const fromEmail = (email ?? '').trim().charAt(0)
+    return fromEmail ? fromEmail.toUpperCase() : '?'
+}
+
+const LOCAL_OPERATOR_FALLBACK_LABEL = 'Operator'
+
+function LocalOperatorButton() {
+    const [profile, setProfile] = useState<ProfileResponse | null>(null)
+
+    useEffect(() => {
+        let cancelled = false
+        apiClient
+            .getProfile()
+            .then((data) => {
+                if (!cancelled) setProfile(data)
+            })
+            .catch(() => {
+                // The link still works without a name; the page itself reports errors.
+            })
+        return () => {
+            cancelled = true
+        }
+    }, [])
+
+    const label = profile?.name?.trim() || profile?.email || LOCAL_OPERATOR_FALLBACK_LABEL
+
+    return (
+        <Link
+            href="/settings/profile"
+            aria-label="Your profile"
+            title={label}
+            className="flex items-center gap-2 rounded-full pr-2 hover:bg-secondary transition-colors"
+        >
+            {profile?.avatar_url ? (
+                <img
+                    src={profile.avatar_url}
+                    alt={label}
+                    className="w-9 h-9 rounded-full border border-primary/30 object-cover"
+                />
+            ) : (
+                <span
+                    aria-hidden="true"
+                    className="flex items-center justify-center w-9 h-9 rounded-full bg-primary text-primary-foreground text-xs font-semibold"
+                >
+                    {initialsFor(profile?.name, profile?.email)}
+                </span>
+            )}
+            <span className="hidden sm:inline text-sm font-medium text-foreground max-w-[10rem] truncate">{label}</span>
+        </Link>
+    )
+}
 
 interface UserProfileButtonProps {
     afterSignInUrl?: string
@@ -24,18 +86,10 @@ export function UserProfileButton({
 }: UserProfileButtonProps) {
     const { isSignedIn, isLoaded } = useUser()
 
-    // Local edition: no Clerk, no account — the profile slot links to settings.
+    // Local edition: no Clerk, no account — the slot is the operator's profile.
     // (UserButton is a Clerk COMPONENT and would throw without ClerkProvider.)
     if (!isSaaS) {
-        return (
-            <Link
-                href="/settings"
-                aria-label="Settings"
-                className="flex items-center justify-center w-9 h-9 rounded-full bg-muted hover:bg-secondary transition-colors"
-            >
-                <Settings className="w-4 h-4 text-muted-foreground" />
-            </Link>
-        )
+        return <LocalOperatorButton />
     }
 
     if (!isLoaded) {

--- a/frontend/components/layout/__tests__/header-edition.test.tsx
+++ b/frontend/components/layout/__tests__/header-edition.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * PRD-233 S7 — the header's account slot is a SaaS surface.
+ *
+ * ProfileMenu's signed-out branch is a "Sign In" button (router.push('/sign-in'))
+ * and its signed-in branch is Clerk's account menu (Profile / Logout). The local
+ * edition has no accounts: the LOCAL_USER seam (lib/auth-hooks) carries a null
+ * user, so ProfileMenu rendered a sign-in affordance on every local page. Both
+ * headers (classic + studio) now mount ProfileMenu only in `saas`; the rest of the
+ * utilities cluster (help, theme, notifications) is edition-neutral and stays.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+
+// Dynamic imports transform the whole rail (framer-motion, lucide) on first use;
+// under CI/parallel load that can exceed vitest's 5s default and a timed-out
+// render would leak DOM into the next case. Generous budget + explicit cleanup.
+vi.setConfig({ testTimeout: 30_000 })
+
+vi.mock('@/components/auth/profile-menu', () => ({
+  ProfileMenu: () => <div data-testid="profile-menu">Sign In</div>,
+}))
+vi.mock('@/components/auth/user-profile-button', () => ({
+  UserProfileButton: () => <button data-testid="user-profile-button">operator</button>,
+}))
+vi.mock('@/components/notifications/notification-bell', () => ({
+  NotificationBell: () => <div data-testid="notification-bell" />,
+}))
+vi.mock('@/components/ui/theme-toggle', () => ({
+  ThemeToggle: () => <div data-testid="theme-toggle" />,
+}))
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllEnvs()
+  vi.resetModules()
+})
+
+async function load(edition: 'local' | 'saas') {
+  vi.stubEnv('NEXT_PUBLIC_AUTH_EDITION', edition)
+  const [{ Header }, { StudioHeader }] = await Promise.all([
+    import('../header'),
+    import('../studio-header'),
+  ])
+  return { Header, StudioHeader }
+}
+
+describe('Header (classic) — account slot per edition', () => {
+  it('local: no ProfileMenu (no sign-in affordance); help, theme, notifications remain', async () => {
+    const { Header } = await load('local')
+    render(<Header onMenuClick={() => {}} />)
+
+    expect(screen.queryByTestId('profile-menu')).toBeNull()
+    expect(screen.queryByText('Sign In')).toBeNull()
+    expect(screen.getByTestId('theme-toggle')).toBeInTheDocument()
+    expect(screen.getByTestId('notification-bell')).toBeInTheDocument()
+    expect(screen.getByLabelText('Help & documentation')).toBeInTheDocument()
+  })
+
+  it('saas: ProfileMenu mounts exactly as today', async () => {
+    const { Header } = await load('saas')
+    render(<Header onMenuClick={() => {}} />)
+
+    expect(screen.getByTestId('profile-menu')).toBeInTheDocument()
+    expect(screen.getByTestId('theme-toggle')).toBeInTheDocument()
+    expect(screen.getByTestId('notification-bell')).toBeInTheDocument()
+  })
+})
+
+describe('StudioHeader — account slot per edition', () => {
+  it('local: no ProfileMenu; the utilities cluster remains', async () => {
+    const { StudioHeader } = await load('local')
+    render(<StudioHeader />)
+
+    expect(screen.queryByTestId('profile-menu')).toBeNull()
+    expect(screen.getByTestId('theme-toggle')).toBeInTheDocument()
+    expect(screen.getByTestId('notification-bell')).toBeInTheDocument()
+    expect(screen.getByLabelText('Open search (⌘K)')).toBeInTheDocument()
+  })
+
+  it('saas: ProfileMenu mounts exactly as today', async () => {
+    const { StudioHeader } = await load('saas')
+    render(<StudioHeader />)
+    expect(screen.getByTestId('profile-menu')).toBeInTheDocument()
+  })
+})

--- a/frontend/components/layout/__tests__/mobile-sidebar-edition.test.tsx
+++ b/frontend/components/layout/__tests__/mobile-sidebar-edition.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * PRD-233 S7 — edition-aware navigation (MobileSidebar mirror).
+ *
+ * Same contract as the desktop rail: `local` drops the SaaS-only entries by the
+ * explicit list (Team) and neutralises the plan-tier exposure (Analytics stays);
+ * `saas` renders exactly as today.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+
+// Dynamic imports transform the whole rail (framer-motion, lucide) on first use;
+// under CI/parallel load that can exceed vitest's 5s default and a timed-out
+// render would leak DOM into the next case. Generous budget + explicit cleanup.
+vi.setConfig({ testTimeout: 30_000 })
+
+vi.mock('next/navigation', () => ({ usePathname: () => '/chat' }))
+vi.mock('@/hooks/use-system-config-api', () => ({
+  useSystemIcons: () => ({ data: {} }),
+}))
+
+const roleRef = vi.hoisted(() => ({ current: { systemRole: 'super_admin', isAdmin: true } }))
+vi.mock('@/contexts/role-context', () => ({
+  useSystemRole: () => roleRef.current,
+}))
+
+const workspaceRef = vi.hoisted(() => ({ current: null as any }))
+vi.mock('@/components/workspace-provider', () => ({
+  useWorkspace: () => ({ workspace: workspaceRef.current }),
+}))
+
+const LOCAL_BASIC_EXPOSURE = { plan: 'basic', families: {}, marketplace_depth: 1, nav: { analytics: false, team: false } }
+const BUSINESS_EXPOSURE = { plan: 'business', families: {}, marketplace_depth: 3, nav: { analytics: true, team: true } }
+
+// Today's mobile rail, in order (the saas invariant).
+const SAAS_RAIL = [
+  '/chat', '/assignments', '/deliverables', '/command-center',
+  '/agents', '/tools', '/marketplace', '/documents',
+  '/team', '/analytics',
+]
+
+async function renderMobile(edition: 'local' | 'saas') {
+  vi.stubEnv('NEXT_PUBLIC_AUTH_EDITION', edition)
+  const { MobileSidebar } = await import('../mobile-sidebar')
+  return render(<MobileSidebar onNavigate={() => {}} />)
+}
+
+function railHrefs(container: HTMLElement): string[] {
+  return Array.from(container.querySelectorAll('nav a')).map((a) => a.getAttribute('href') ?? '')
+}
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllEnvs()
+  vi.resetModules()
+  workspaceRef.current = null
+  roleRef.current = { systemRole: 'super_admin', isAdmin: true }
+})
+
+describe('MobileSidebar — local edition (PRD-233 S7)', () => {
+  it('hides Team, keeps Analytics under the basic-tier exposure of the plan-less local workspace', async () => {
+    workspaceRef.current = { exposure: LOCAL_BASIC_EXPOSURE }
+    const { container } = await renderMobile('local')
+
+    expect(container.querySelector('a[href="/team"]')).toBeNull()
+    expect(screen.queryByText('Team')).toBeNull()
+    expect(container.querySelector('a[href="/analytics"]')).not.toBeNull()
+    expect(screen.getByText('Analytics')).toBeInTheDocument()
+    expect(screen.getByText('Knowledge')).toBeInTheDocument()
+    expect(screen.getByText('Marketplace')).toBeInTheDocument()
+    expect(railHrefs(container)).toEqual(SAAS_RAIL.filter((h) => h !== '/team'))
+  })
+
+  it('keeps Settings (the operator is admin locally)', async () => {
+    const { container } = await renderMobile('local')
+    expect(container.querySelector('a[href="/settings"]')).not.toBeNull()
+  })
+})
+
+describe('MobileSidebar — saas edition renders exactly as today', () => {
+  it('business: full rail in today\'s order', async () => {
+    workspaceRef.current = { exposure: BUSINESS_EXPOSURE }
+    const { container } = await renderMobile('saas')
+    expect(railHrefs(container)).toEqual(SAAS_RAIL)
+  })
+
+  it('basic: US-024 still hides Team + Analytics', async () => {
+    workspaceRef.current = { exposure: LOCAL_BASIC_EXPOSURE }
+    const { container } = await renderMobile('saas')
+    expect(railHrefs(container)).toEqual(SAAS_RAIL.filter((h) => h !== '/team' && h !== '/analytics'))
+  })
+})

--- a/frontend/components/layout/__tests__/sidebar-edition.test.tsx
+++ b/frontend/components/layout/__tests__/sidebar-edition.test.tsx
@@ -1,0 +1,146 @@
+/**
+ * PRD-233 S7 — edition-aware navigation (desktop Sidebar).
+ *
+ * `local`: the SaaS-only surfaces (Team Management, Workspace Admin) are absent
+ * from the rail by the explicit SAAS_ONLY_ROUTES list — NOT by role: the local
+ * operator is deliberately super_admin, so the role gate alone would show
+ * Workspace Admin. Plan-tier exposure is neutralised locally: the backend derives
+ * the `basic` profile from the plan-less local workspace (nav.analytics=false),
+ * which must not hide Analytics on the operator's own instance.
+ *
+ * `saas`: the rail is exactly today's — role gate + US-024 exposure gating.
+ *
+ * The real seam is exercised: the edition env is stubbed and the module graph is
+ * reset per test (the seam reads NEXT_PUBLIC_AUTH_EDITION once at import).
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+
+// Dynamic imports transform the whole rail (framer-motion, lucide) on first use;
+// under CI/parallel load that can exceed vitest's 5s default and a timed-out
+// render would leak DOM into the next case. Generous budget + explicit cleanup.
+vi.setConfig({ testTimeout: 30_000 })
+
+vi.mock('next/navigation', () => ({ usePathname: () => '/chat' }))
+vi.mock('@/hooks/use-system-config-api', () => ({
+  useSystemIcons: () => ({ data: {} }),
+}))
+
+// The local operator is super_admin (role-context.tsx) ⇒ isAdmin is TRUE locally.
+const roleRef = vi.hoisted(() => ({ current: { systemRole: 'super_admin', isAdmin: true } }))
+vi.mock('@/contexts/role-context', () => ({
+  useSystemRole: () => roleRef.current,
+}))
+
+const workspaceRef = vi.hoisted(() => ({ current: null as any }))
+vi.mock('@/components/workspace-provider', () => ({
+  useWorkspace: () => ({ workspace: workspaceRef.current }),
+}))
+
+// The exact exposure GET /api/workspaces/current returns for the plan-less local
+// workspace (exposure_for_plan(None or "basic")) — the trap S7 must not fall into.
+const LOCAL_BASIC_EXPOSURE = {
+  plan: 'basic',
+  families: { codegraph: false, nl2sql: false, team: false, voice: false },
+  marketplace_depth: 1,
+  nav: { analytics: false, team: false },
+}
+const BUSINESS_EXPOSURE = {
+  plan: 'business',
+  families: { codegraph: true, nl2sql: true, team: true, voice: true },
+  marketplace_depth: 3,
+  nav: { analytics: true, team: true },
+}
+
+// Today's desktop rail, in order (the saas invariant).
+const SAAS_RAIL = [
+  '/chat', '/command-center', '/assignments', '/deliverables',
+  '/agents', '/tools', '/documents', '/marketplace',
+  '/team', '/analytics', '/admin/workspaces',
+]
+
+async function renderSidebar(edition: 'local' | 'saas') {
+  vi.stubEnv('NEXT_PUBLIC_AUTH_EDITION', edition)
+  const { Sidebar } = await import('../sidebar')
+  return render(<Sidebar collapsed={false} onToggle={() => {}} />)
+}
+
+function railHrefs(container: HTMLElement): string[] {
+  return Array.from(container.querySelectorAll('nav a')).map((a) => a.getAttribute('href') ?? '')
+}
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllEnvs()
+  vi.resetModules()
+  workspaceRef.current = null
+  roleRef.current = { systemRole: 'super_admin', isAdmin: true }
+})
+
+describe('Sidebar — local edition (PRD-233 S7)', () => {
+  it('hides Team Management + Workspace Admin even though the operator is super_admin', async () => {
+    workspaceRef.current = { exposure: BUSINESS_EXPOSURE }
+    const { container } = await renderSidebar('local')
+
+    expect(screen.queryByText('Team Management')).toBeNull()
+    expect(screen.queryByText('Workspace Admin')).toBeNull()
+    expect(container.querySelector('a[href="/team"]')).toBeNull()
+    expect(container.querySelector('a[href="/admin/workspaces"]')).toBeNull()
+  })
+
+  it('keeps Analytics despite the basic-tier exposure the plan-less local workspace gets', async () => {
+    workspaceRef.current = { exposure: LOCAL_BASIC_EXPOSURE }
+    const { container } = await renderSidebar('local')
+
+    expect(screen.getByText('Analytics')).toBeInTheDocument()
+    expect(container.querySelector('a[href="/analytics"]')).not.toBeNull()
+    expect(screen.getByText('Knowledge Base')).toBeInTheDocument()
+    expect(screen.getByText('Marketplace')).toBeInTheDocument()
+    expect(screen.getByText('Chat')).toBeInTheDocument()
+    expect(screen.queryByText('Team Management')).toBeNull()
+    expect(screen.queryByText('Workspace Admin')).toBeNull()
+  })
+
+  it('renders today\'s rail minus exactly the SaaS-only entries, in order (workspace still loading)', async () => {
+    workspaceRef.current = null
+    const { container } = await renderSidebar('local')
+
+    expect(railHrefs(container)).toEqual(SAAS_RAIL.filter((h) => h !== '/team' && h !== '/admin/workspaces'))
+  })
+
+  it('still offers Settings in the footer', async () => {
+    const { container } = await renderSidebar('local')
+    expect(container.querySelector('a[href="/settings"]')).not.toBeNull()
+  })
+})
+
+describe('Sidebar — saas edition renders exactly as today', () => {
+  it('admin on business: full rail in today\'s order', async () => {
+    workspaceRef.current = { exposure: BUSINESS_EXPOSURE }
+    const { container } = await renderSidebar('saas')
+
+    expect(railHrefs(container)).toEqual(SAAS_RAIL)
+    expect(screen.getByText('Team Management')).toBeInTheDocument()
+    expect(screen.getByText('Workspace Admin')).toBeInTheDocument()
+    expect(screen.getByText('Analytics')).toBeInTheDocument()
+  })
+
+  it('non-admin on basic: US-024 exposure still hides Analytics + Team, role gate hides Workspace Admin', async () => {
+    roleRef.current = { systemRole: 'user', isAdmin: false }
+    workspaceRef.current = { exposure: LOCAL_BASIC_EXPOSURE }
+    const { container } = await renderSidebar('saas')
+
+    expect(screen.queryByText('Analytics')).toBeNull()
+    expect(screen.queryByText('Team Management')).toBeNull()
+    expect(screen.queryByText('Workspace Admin')).toBeNull()
+    expect(railHrefs(container)).toEqual(SAAS_RAIL.filter((h) => !['/team', '/analytics', '/admin/workspaces'].includes(h)))
+  })
+
+  it('unknown exposure fails open (loading / solo) — unchanged', async () => {
+    workspaceRef.current = null
+    await renderSidebar('saas')
+
+    expect(screen.getByText('Analytics')).toBeInTheDocument()
+    expect(screen.getByText('Team Management')).toBeInTheDocument()
+  })
+})

--- a/frontend/components/layout/__tests__/studio-sidebar-edition.test.tsx
+++ b/frontend/components/layout/__tests__/studio-sidebar-edition.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * PRD-233 S7 — edition-aware navigation (Studio rail, the studio-menu consumer).
+ *
+ * `local`: Team Management + Workspace Admin are absent by the explicit list;
+ * Analytics survives the basic-tier exposure of the plan-less local workspace.
+ * `saas`: the 11-item rail + footer render exactly as today.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+
+// Dynamic imports transform the whole rail (framer-motion, lucide) on first use;
+// under CI/parallel load that can exceed vitest's 5s default and a timed-out
+// render would leak DOM into the next case. Generous budget + explicit cleanup.
+vi.setConfig({ testTimeout: 30_000 })
+
+vi.mock('next/navigation', () => ({ usePathname: () => '/chat' }))
+
+const workspaceRef = vi.hoisted(() => ({ current: null as any }))
+vi.mock('@/components/workspace-provider', () => ({
+  useWorkspaceOptional: () => ({ workspace: workspaceRef.current }),
+}))
+
+const LOCAL_BASIC_EXPOSURE = { plan: 'basic', families: {}, marketplace_depth: 1, nav: { analytics: false, team: false } }
+const BUSINESS_EXPOSURE = { plan: 'business', families: {}, marketplace_depth: 3, nav: { analytics: true, team: true } }
+
+const SAAS_RAIL = [
+  '/chat', '/command-center', '/assignments', '/deliverables',
+  '/agents', '/tools', '/documents', '/marketplace',
+  '/team', '/analytics', '/admin/workspaces',
+]
+
+async function renderStudio(edition: 'local' | 'saas') {
+  vi.stubEnv('NEXT_PUBLIC_AUTH_EDITION', edition)
+  const { StudioSidebar } = await import('../studio-sidebar')
+  return render(<StudioSidebar />)
+}
+
+function railHrefs(container: HTMLElement): string[] {
+  return Array.from(container.querySelectorAll('nav a')).map((a) => a.getAttribute('href') ?? '')
+}
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllEnvs()
+  vi.resetModules()
+  workspaceRef.current = null
+})
+
+describe('StudioSidebar — local edition (PRD-233 S7)', () => {
+  it('drops Team Management + Workspace Admin, keeps Analytics under the basic-tier exposure', async () => {
+    workspaceRef.current = { exposure: LOCAL_BASIC_EXPOSURE }
+    const { container } = await renderStudio('local')
+
+    expect(screen.queryByText('Team Management')).toBeNull()
+    expect(screen.queryByText('Workspace Admin')).toBeNull()
+    expect(screen.getByText('Analytics')).toBeInTheDocument()
+    expect(screen.getByText('Knowledge Base')).toBeInTheDocument()
+    expect(screen.getByText('Marketplace')).toBeInTheDocument()
+    expect(railHrefs(container)).toEqual(SAAS_RAIL.filter((h) => h !== '/team' && h !== '/admin/workspaces'))
+  })
+
+  it('keeps the footer (Docs + Settings)', async () => {
+    const { container } = await renderStudio('local')
+    expect(container.querySelector('a[href="/settings"]')).not.toBeNull()
+    expect(container.querySelector('a[href="https://docs.automatos.app"]')).not.toBeNull()
+  })
+})
+
+describe('StudioSidebar — saas edition renders exactly as today', () => {
+  it('business: full rail in today\'s order', async () => {
+    workspaceRef.current = { exposure: BUSINESS_EXPOSURE }
+    const { container } = await renderStudio('saas')
+    expect(railHrefs(container)).toEqual(SAAS_RAIL)
+    expect(screen.getByText('Workspace Admin')).toBeInTheDocument()
+  })
+
+  it('basic: US-024 still hides Team + Analytics (Workspace Admin is not exposure-gated on this rail)', async () => {
+    workspaceRef.current = { exposure: LOCAL_BASIC_EXPOSURE }
+    const { container } = await renderStudio('saas')
+    expect(railHrefs(container)).toEqual(SAAS_RAIL.filter((h) => h !== '/team' && h !== '/analytics'))
+  })
+
+  it('no provider (studio shell in isolation) fails open — unchanged', async () => {
+    workspaceRef.current = null
+    const { container } = await renderStudio('saas')
+    expect(railHrefs(container)).toEqual(SAAS_RAIL)
+  })
+})

--- a/frontend/components/layout/header.tsx
+++ b/frontend/components/layout/header.tsx
@@ -4,7 +4,9 @@ import { Menu, BookOpen, ExternalLink, Code2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { ThemeToggle } from '@/components/ui/theme-toggle'
 import { ProfileMenu } from '@/components/auth/profile-menu'
+import { UserProfileButton } from '@/components/auth/user-profile-button'
 import { NotificationBell } from '@/components/notifications/notification-bell'
+import { isSaaS } from '@/lib/auth-edition'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -92,8 +94,10 @@ export function Header({ onMenuClick }: HeaderProps) {
           {/* Notifications */}
           <NotificationBell />
 
-          {/* User Menu */}
-          <ProfileMenu />
+          {/* User Menu — hosted edition only (PRD-233 S7). ProfileMenu is the
+              account menu, and signed-out it is a sign-in affordance; the local
+              edition has no accounts. Settings stays reachable from the rail. */}
+          {isSaaS ? <ProfileMenu /> : <UserProfileButton />}
         </div>
       </div>
     </header>

--- a/frontend/components/layout/mobile-sidebar.tsx
+++ b/frontend/components/layout/mobile-sidebar.tsx
@@ -25,6 +25,7 @@ import { useSystemIcons } from '@/hooks/use-system-config-api'
 import { useSystemRole } from '@/contexts/role-context'
 import { useWorkspace } from '@/components/workspace-provider'
 import { isNavItemVisible } from '@/lib/nav-exposure'
+import { filterNavForEdition, navExposureForEdition } from '@/lib/auth-edition'
 
 interface MobileSidebarProps {
   onNavigate: () => void
@@ -120,14 +121,17 @@ export function MobileSidebar({ onNavigate }: MobileSidebarProps) {
   const { isAdmin } = useSystemRole()
   const { data: iconMappings = {} } = useSystemIcons()
   const { workspace } = useWorkspace()
+  const navExposure = navExposureForEdition(workspace?.exposure)
 
-  // System-role gate (admin) + plan-tier exposure gate (US-024). A gated
-  // surface is hidden from the rail but its route still resolves (D5).
-  const filteredNavItems = navigationItems.filter(item => {
+  // PRD-233 S7: SaaS-only surfaces are absent in local by the seam's explicit
+  // list (not by role). Then the system-role gate (admin) + plan-tier exposure
+  // gate (US-024). A gated surface is hidden from the rail but its route still
+  // resolves (D5). Exposure is unknown in local, so it fails open there.
+  const filteredNavItems = filterNavForEdition(navigationItems).filter(item => {
     if ((item as any).requiredRole) {
       return (item as any).requiredRole === 'admin' && isAdmin
     }
-    return isNavItemVisible((item as any).requiredExposure, workspace?.exposure)
+    return isNavItemVisible((item as any).requiredExposure, navExposure)
   })
 
   return (

--- a/frontend/components/layout/sidebar.tsx
+++ b/frontend/components/layout/sidebar.tsx
@@ -28,6 +28,7 @@ import { useSystemIcons } from '@/hooks/use-system-config-api'
 import { useSystemRole } from '@/contexts/role-context'
 import { useWorkspace } from '@/components/workspace-provider'
 import { isNavItemVisible } from '@/lib/nav-exposure'
+import { filterNavForEdition, navExposureForEdition } from '@/lib/auth-edition'
 
 interface SidebarProps {
   collapsed: boolean
@@ -134,15 +135,18 @@ export function Sidebar({ collapsed, onToggle }: SidebarProps) {
   const { systemRole, isAdmin } = useSystemRole()
   const { data: iconMappings = {} } = useSystemIcons()
   const { workspace } = useWorkspace()
+  const navExposure = navExposureForEdition(workspace?.exposure)
 
-  // Filter nav items by system role (admin gate) AND plan-tier exposure
-  // (US-024): a tier-gated surface is absent from the rail but its route still
-  // resolves (D5 — hidden ≠ deleted). Exposure fails open while unknown.
-  const filteredNavItems = navigationItems.filter(item => {
+  // PRD-233 S7: SaaS-only surfaces are absent in the local edition by the seam's
+  // explicit list (not by role — the local operator is super_admin). Then filter
+  // by system role (admin gate) AND plan-tier exposure (US-024): a tier-gated
+  // surface is absent from the rail but its route still resolves (D5 — hidden ≠
+  // deleted). Exposure fails open while unknown — and is unknown in local.
+  const filteredNavItems = filterNavForEdition(navigationItems).filter(item => {
     if (item.requiredRole) {
       return item.requiredRole === 'admin' && isAdmin
     }
-    return isNavItemVisible((item as { requiredExposure?: string }).requiredExposure, workspace?.exposure)
+    return isNavItemVisible((item as { requiredExposure?: string }).requiredExposure, navExposure)
   })
 
   return (

--- a/frontend/components/layout/studio-header.tsx
+++ b/frontend/components/layout/studio-header.tsx
@@ -5,6 +5,8 @@ import { Search, BookOpen, HelpCircle, ExternalLink, Code2 } from 'lucide-react'
 import { ThemeToggle } from '@/components/ui/theme-toggle';
 import { NotificationBell } from '@/components/notifications/notification-bell';
 import { ProfileMenu } from '@/components/auth/profile-menu';
+import { UserProfileButton } from '@/components/auth/user-profile-button';
+import { isSaaS } from '@/lib/auth-edition';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -99,8 +101,9 @@ export function StudioHeader() {
         {/* Theme toggle */}
         <ThemeToggle />
 
-        {/* Profile menu */}
-        <ProfileMenu />
+        {/* Profile menu — hosted edition only (PRD-233 S7): signed-out it is a
+            sign-in affordance, and the local edition has no accounts. */}
+        {isSaaS ? <ProfileMenu /> : <UserProfileButton />}
       </div>
     </header>
   );

--- a/frontend/components/layout/studio-sidebar.tsx
+++ b/frontend/components/layout/studio-sidebar.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/lib/studio-menu';
 import { useWorkspaceOptional } from '@/components/workspace-provider';
 import { isNavItemVisible } from '@/lib/nav-exposure';
+import { filterNavForEdition, navExposureForEdition } from '@/lib/auth-edition';
 
 /**
  * StudioSidebar — SIDE-B (labelled rail, 232px) per CD's shell delivery.
@@ -52,7 +53,12 @@ export function StudioSidebar({
   const mark = workspaceMark ?? workspaceName.slice(0, 1).toUpperCase();
   // US-024: plan-tier exposure gating for the studio rail (hidden ≠ deleted).
   // Optional context — the studio shell can render in isolation (fails open).
-  const exposure = useWorkspaceOptional()?.workspace?.exposure;
+  // In local there is no plan: the seam reports exposure as unknown (fail-open).
+  const exposure = navExposureForEdition(useWorkspaceOptional()?.workspace?.exposure);
+  // PRD-233 S7: SaaS-only entries (Team, Workspace Admin) are absent in local —
+  // the seam's explicit list, applied once per menu; not the operator's role.
+  const primaryMenu = filterNavForEdition(STUDIO_MENU_PRIMARY);
+  const footerMenu = filterNavForEdition(STUDIO_MENU_FOOTER);
 
   return (
     <aside
@@ -105,7 +111,7 @@ export function StudioSidebar({
           <div key={group}>
             {!collapsed && <div className="sh-group">{group}</div>}
             {collapsed && <div className="sh-group-rule" aria-hidden />}
-            {STUDIO_MENU_PRIMARY.filter((m) => m.group === group && isNavItemVisible(m.requiredExposure, exposure)).map((m) => {
+            {primaryMenu.filter((m) => m.group === group && isNavItemVisible(m.requiredExposure, exposure)).map((m) => {
               const Icon = m.icon;
               const isActive = activeId === m.id;
               const alert = alerts[m.id];
@@ -135,7 +141,7 @@ export function StudioSidebar({
 
       {/* Footer — Docs external + Settings */}
       <div className="sh-footer">
-        {STUDIO_MENU_FOOTER.map((m) => {
+        {footerMenu.map((m) => {
           const Icon = m.icon;
           const isActive = activeId === m.id;
           if (m.external) {

--- a/frontend/components/local/__tests__/first-run-nudge.test.tsx
+++ b/frontend/components/local/__tests__/first-run-nudge.test.tsx
@@ -1,0 +1,155 @@
+/**
+ * PRD-233 S3 — the local-edition first-run nudge.
+ *
+ * Pure/mocked: apiClient, the edition flag and next/link are stubbed; the
+ * real react-query runs under a test QueryClient. Contract under test:
+ *   empty keys (BYOK + platform)  ⇒ shown, linking to Settings
+ *   any key                        ⇒ hidden
+ *   dismissed (localStorage)       ⇒ hidden, and nothing is fetched
+ *   click dismiss                  ⇒ hidden + remembered
+ *   saas                           ⇒ hidden, nothing fetched
+ *   request failure                ⇒ hidden (never nag on a guess)
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import React from 'react'
+
+const { getMock, edition } = vi.hoisted(() => ({
+  getMock: vi.fn(),
+  edition: { isLocal: true },
+}))
+
+vi.mock('@/lib/api-client', () => ({
+  apiClient: { get: (path: string) => getMock(path) },
+}))
+vi.mock('@/lib/auth-edition', () => ({
+  get isLocal() {
+    return edition.isLocal
+  },
+  get isSaaS() {
+    return !edition.isLocal
+  },
+}))
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...rest }: Record<string, unknown>) => (
+    <a href={href as string} {...(rest as Record<string, string>)}>
+      {children as React.ReactNode}
+    </a>
+  ),
+}))
+
+import {
+  FirstRunNudge,
+  FIRST_RUN_NUDGE_STORAGE_KEY,
+  FIRST_RUN_NUDGE_SETTINGS_HREF,
+  hasAnyLlmKey,
+} from '../first-run-nudge'
+
+const NO_PLATFORM_KEYS = { platform_keys: { openai: { configured: false }, anthropic: { configured: false } } }
+const A_PLATFORM_KEY = { platform_keys: { openai: { configured: false }, openrouter: { configured: true } } }
+const A_BYOK_KEY = [{ id: 1, provider: 'openrouter', is_active: true }]
+
+function respond(keys: unknown, platform: unknown) {
+  getMock.mockImplementation((path: string) => {
+    if (path === '/api/keys') return Promise.resolve(keys)
+    if (path === '/api/keys/platform-status') return Promise.resolve(platform)
+    return Promise.reject(new Error(`unexpected path ${path}`))
+  })
+}
+
+function renderNudge() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={client}>
+      <FirstRunNudge />
+    </QueryClientProvider>,
+  )
+}
+
+async function settled() {
+  await waitFor(() => expect(getMock).toHaveBeenCalledTimes(2))
+  // let the resolved queries render
+  await waitFor(() => expect(getMock).toHaveBeenCalledWith('/api/keys/platform-status'))
+}
+
+describe('FirstRunNudge (PRD-233 S3)', () => {
+  beforeEach(() => {
+    getMock.mockReset()
+    edition.isLocal = true
+    localStorage.clear()
+  })
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('shows when the local workspace has no LLM key at all, linking to Settings', async () => {
+    respond([], NO_PLATFORM_KEYS)
+    renderNudge()
+
+    const nudge = await screen.findByTestId('first-run-nudge')
+    expect(nudge).toHaveTextContent('Add an LLM key to bring Auto to life')
+    expect(screen.getByTestId('first-run-nudge-link')).toHaveAttribute('href', FIRST_RUN_NUDGE_SETTINGS_HREF)
+    expect(getMock).toHaveBeenCalledWith('/api/keys')
+    expect(getMock).toHaveBeenCalledWith('/api/keys/platform-status')
+  })
+
+  it('stays hidden when a BYOK key exists', async () => {
+    respond(A_BYOK_KEY, NO_PLATFORM_KEYS)
+    renderNudge()
+    await settled()
+    await waitFor(() => expect(screen.queryByTestId('first-run-nudge')).toBeNull())
+  })
+
+  it('stays hidden when a platform-level key is configured', async () => {
+    respond([], A_PLATFORM_KEY)
+    renderNudge()
+    await settled()
+    await waitFor(() => expect(screen.queryByTestId('first-run-nudge')).toBeNull())
+  })
+
+  it('stays hidden and fetches nothing once dismissed in localStorage', async () => {
+    localStorage.setItem(FIRST_RUN_NUDGE_STORAGE_KEY, '1')
+    respond([], NO_PLATFORM_KEYS)
+    renderNudge()
+    // give any (wrong) fetch a tick to fire
+    await new Promise((r) => setTimeout(r, 20))
+    expect(screen.queryByTestId('first-run-nudge')).toBeNull()
+    expect(getMock).not.toHaveBeenCalled()
+  })
+
+  it('dismiss hides the banner and remembers it', async () => {
+    respond([], NO_PLATFORM_KEYS)
+    renderNudge()
+    await screen.findByTestId('first-run-nudge')
+
+    fireEvent.click(screen.getByTestId('first-run-nudge-dismiss'))
+
+    expect(screen.queryByTestId('first-run-nudge')).toBeNull()
+    expect(localStorage.getItem(FIRST_RUN_NUDGE_STORAGE_KEY)).toBe('1')
+  })
+
+  it('never renders or fetches in saas', async () => {
+    edition.isLocal = false
+    respond([], NO_PLATFORM_KEYS)
+    renderNudge()
+    await new Promise((r) => setTimeout(r, 20))
+    expect(screen.queryByTestId('first-run-nudge')).toBeNull()
+    expect(getMock).not.toHaveBeenCalled()
+  })
+
+  it('stays hidden when the key lookup fails (no nagging on a guess)', async () => {
+    getMock.mockImplementation(() => Promise.reject(new Error('backend down')))
+    renderNudge()
+    await waitFor(() => expect(getMock).toHaveBeenCalled())
+    await new Promise((r) => setTimeout(r, 20))
+    expect(screen.queryByTestId('first-run-nudge')).toBeNull()
+  })
+
+  it('hasAnyLlmKey reads BYOK rows or a configured platform provider', () => {
+    expect(hasAnyLlmKey(undefined, undefined)).toBe(false)
+    expect(hasAnyLlmKey([], NO_PLATFORM_KEYS)).toBe(false)
+    expect(hasAnyLlmKey(A_BYOK_KEY, NO_PLATFORM_KEYS)).toBe(true)
+    expect(hasAnyLlmKey([], A_PLATFORM_KEY)).toBe(true)
+  })
+})

--- a/frontend/components/local/__tests__/saas-only-notice.test.tsx
+++ b/frontend/components/local/__tests__/saas-only-notice.test.tsx
@@ -1,0 +1,25 @@
+/**
+ * PRD-233 S7 — the shared notice a SaaS-only route renders in the local edition.
+ */
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { SaasOnlyNotice, SAAS_ONLY_NOTICE_COPY } from '../saas-only-notice'
+
+describe('SaasOnlyNotice', () => {
+  it('names the surface and carries the owner\'s copy verbatim', () => {
+    render(<SaasOnlyNotice surface="Team" />)
+
+    expect(screen.getByTestId('saas-only-notice')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Team' })).toBeInTheDocument()
+    expect(SAAS_ONLY_NOTICE_COPY).toBe(
+      'This area is part of the hosted edition; the local edition has no accounts, teams or plans.',
+    )
+    expect(screen.getByText(SAAS_ONLY_NOTICE_COPY)).toBeInTheDocument()
+  })
+
+  it('offers a way back into the product (chat)', () => {
+    render(<SaasOnlyNotice surface="Workspace Admin" />)
+    const back = screen.getByRole('link', { name: /back to chat/i })
+    expect(back).toHaveAttribute('href', '/chat')
+  })
+})

--- a/frontend/components/local/first-run-nudge.tsx
+++ b/frontend/components/local/first-run-nudge.tsx
@@ -1,0 +1,131 @@
+'use client'
+
+/**
+ * PRD-233 S3 — local-edition first-run nudge.
+ *
+ * The local edition boots with a seeded workspace (starter roster, demo
+ * Playbook, welcome Deliverable) but no language model: nothing answers until
+ * the operator stores an LLM key. This banner says so on the landing surface
+ * (chat), and only when the key lists are POSITIVELY empty — an unknown state
+ * (request failed, still loading) renders nothing rather than nagging on a
+ * guess. Dismissal is remembered per browser in localStorage (try/catch —
+ * storage may be unavailable).
+ *
+ * Reads the two queries Settings → API Keys already runs, under the SAME query
+ * keys, so saving a key there hides the nudge without a reload. No new
+ * api-client methods. SaaS: never renders, never fetches.
+ */
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { useQuery } from '@tanstack/react-query'
+import { KeyRound, X } from 'lucide-react'
+import { apiClient } from '@/lib/api-client'
+import { isLocal } from '@/lib/auth-edition'
+
+export const FIRST_RUN_NUDGE_STORAGE_KEY = 'automatos:local-first-run-nudge:dismissed'
+export const FIRST_RUN_NUDGE_SETTINGS_HREF = '/settings'
+export const FIRST_RUN_NUDGE_MESSAGE = 'Add an LLM key to bring Auto to life'
+export const FIRST_RUN_NUDGE_LINK_LABEL = 'Settings → API Keys'
+
+interface ApiKeyOut {
+  id: number
+  provider: string
+  is_active: boolean
+}
+
+interface PlatformKeyStatus {
+  platform_keys: Record<string, { configured: boolean } | undefined>
+}
+
+function readDismissed(): boolean {
+  try {
+    return window.localStorage.getItem(FIRST_RUN_NUDGE_STORAGE_KEY) === '1'
+  } catch {
+    return false
+  }
+}
+
+function persistDismissed(): void {
+  try {
+    window.localStorage.setItem(FIRST_RUN_NUDGE_STORAGE_KEY, '1')
+  } catch {
+    // Storage unavailable (private mode, blocked) — the dismissal lasts this render only.
+  }
+}
+
+/** True when the workspace has any usable LLM key: a BYOK row or a platform-level key. */
+export function hasAnyLlmKey(
+  keys: ApiKeyOut[] | undefined,
+  platform: PlatformKeyStatus | undefined,
+): boolean {
+  const byok = (keys ?? []).length > 0
+  const platformConfigured = Object.values(platform?.platform_keys ?? {}).some(
+    (entry) => entry?.configured === true,
+  )
+  return byok || platformConfigured
+}
+
+export function FirstRunNudge() {
+  // Start hidden and read storage after mount, so hydration never flashes a
+  // banner the operator already dismissed.
+  const [dismissed, setDismissed] = useState(true)
+  useEffect(() => {
+    setDismissed(readDismissed())
+  }, [])
+
+  const armed = isLocal && !dismissed
+
+  const keys = useQuery<ApiKeyOut[]>({
+    queryKey: ['api-keys'],
+    queryFn: () => apiClient.get<ApiKeyOut[]>('/api/keys'),
+    enabled: armed,
+  })
+  const platform = useQuery<PlatformKeyStatus>({
+    queryKey: ['platform-key-status'],
+    queryFn: () => apiClient.get<PlatformKeyStatus>('/api/keys/platform-status'),
+    enabled: armed,
+  })
+
+  if (!armed || !keys.isSuccess || !platform.isSuccess) return null
+  if (hasAnyLlmKey(keys.data, platform.data)) return null
+
+  const dismiss = () => {
+    persistDismissed()
+    setDismissed(true)
+  }
+
+  return (
+    // Zero-height anchor: overlays the top of whichever chat layout hosts it
+    // (classic `relative` container or the studio flex column) without
+    // taking space from the Chat. Inline flex/height beat the studio's
+    // `.sh-chat-main > * { flex: 1 }` rule.
+    <div className="relative z-30" style={{ flex: '0 0 auto', height: 0 }}>
+      <div
+        role="status"
+        aria-live="polite"
+        data-testid="first-run-nudge"
+        className="absolute left-1/2 top-3 flex max-w-[calc(100vw-2rem)] -translate-x-1/2 items-center gap-3 whitespace-nowrap rounded-full border border-border bg-background/95 px-4 py-2 text-sm shadow-lg backdrop-blur"
+      >
+        <KeyRound className="h-4 w-4 shrink-0 text-warning" aria-hidden="true" />
+        <span>{FIRST_RUN_NUDGE_MESSAGE}</span>
+        <Link
+          href={FIRST_RUN_NUDGE_SETTINGS_HREF}
+          data-testid="first-run-nudge-link"
+          className="font-medium underline underline-offset-4 hover:text-foreground"
+        >
+          {FIRST_RUN_NUDGE_LINK_LABEL}
+        </Link>
+        <button
+          type="button"
+          aria-label="Dismiss"
+          data-testid="first-run-nudge-dismiss"
+          onClick={dismiss}
+          className="rounded-full p-1 text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <X className="h-4 w-4" aria-hidden="true" />
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/components/local/saas-only-notice.tsx
+++ b/frontend/components/local/saas-only-notice.tsx
@@ -1,0 +1,37 @@
+import Link from 'next/link'
+import { ArrowLeft, Cloud } from 'lucide-react'
+import { Card, CardContent } from '@/components/ui/card'
+
+/**
+ * PRD-233 S7 — what a SaaS-only route renders in the local edition.
+ *
+ * Route pages under `SAAS_ONLY_ROUTES` (lib/auth-edition) keep their hosted UI
+ * byte-for-byte in `saas` and render this instead in `local`: the route still
+ * resolves (a deep link or a stale bookmark lands somewhere honest), it just
+ * does not pretend the surface exists. The copy is the owner's.
+ */
+export const SAAS_ONLY_NOTICE_COPY =
+  'This area is part of the hosted edition; the local edition has no accounts, teams or plans.'
+
+export function SaasOnlyNotice({ surface }: { surface: string }) {
+  return (
+    <div data-testid="saas-only-notice" className="flex items-center justify-center px-4 py-16">
+      <Card className="w-full max-w-md">
+        <CardContent className="space-y-4 p-8 text-center">
+          <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-muted">
+            <Cloud className="h-6 w-6 text-muted-foreground" aria-hidden="true" />
+          </div>
+          <h1 className="text-xl font-semibold text-foreground">{surface}</h1>
+          <p className="text-sm text-muted-foreground">{SAAS_ONLY_NOTICE_COPY}</p>
+          <Link
+            href="/chat"
+            className="inline-flex items-center gap-2 text-sm font-medium text-primary hover:underline"
+          >
+            <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+            Back to chat
+          </Link>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/frontend/components/onboarding/power-up-card.tsx
+++ b/frontend/components/onboarding/power-up-card.tsx
@@ -15,6 +15,7 @@ import {
 import { Button } from '@/components/ui/button'
 import { apiClient } from '@/lib/api-client'
 import { useWorkspace } from '@/components/workspace-provider'
+import { isSaaS } from '@/lib/auth-edition'
 
 /**
  * PRD-222 US-013 (W1·S3) — the power-up card.
@@ -57,6 +58,8 @@ export function PowerUpCard({ embedded = false }: { embedded?: boolean }) {
 
   // In chat the card only appears at the powerup stage; the exhausted banner
   // (US-014) renders it embedded regardless of stage.
+  // PRD-233 S7: the power-up / plan pitch is a hosted-edition surface.
+  if (!isSaaS) return null
   if (!embedded && workspace?.onboarding?.stage !== 'powerup') return null
   if (dismissed) return null
 

--- a/frontend/components/onboarding/trial-balance-pill.tsx
+++ b/frontend/components/onboarding/trial-balance-pill.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useWorkspace } from '@/components/workspace-provider'
+import { isSaaS } from '@/lib/auth-edition'
 
 /**
  * PRD-222 US-014 (W1·S9) — the trial balance pill.
@@ -18,6 +19,10 @@ import { useWorkspace } from '@/components/workspace-provider'
 export function TrialBalancePill({ className = '' }: { className?: string }) {
   const { workspace } = useWorkspace()
   const trial = workspace?.onboarding?.trial ?? null
+
+  // PRD-233 S7: plan/trial copy is a hosted-edition surface — never in local,
+  // whatever a future local seed puts in onboarding.trial.
+  if (!isSaaS) return null
 
   // No pill for a converted (paid) workspace or one that never got a trial.
   if (!trial || trial.state === 'converted') return null

--- a/frontend/components/settings/SettingsPanel.tsx
+++ b/frontend/components/settings/SettingsPanel.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import { useState } from 'react'
-import { Settings, Key, Webhook, KeyRound, Radio, Brain, Puzzle, Bell } from 'lucide-react'
+import Link from 'next/link'
+import { Settings, Key, Webhook, KeyRound, Radio, Brain, Puzzle, Bell, UserCircle, ArrowRight } from 'lucide-react'
 import { CredentialsTab } from './CredentialsTab'
 import SystemSettingsTab from './SystemSettingsTab'
 import SystemLLMSettingsTab from './SystemLLMSettingsTab'
@@ -12,13 +13,32 @@ import { ApiKeyManager } from './ApiKeyManager'
 import { WidgetSdkTab } from './WidgetSdkTab'
 import { NotificationsSettingsTab } from './NotificationsSettingsTab'
 import { useSystemRole } from '@/contexts/role-context'
+import { isLocal } from '@/lib/auth-edition'
 import { PageHeader, FilterTabs, TabsContent } from '@/components/shared'
+
+/**
+ * PRD-233 S6/S7 — the settings tabs that exist in the local edition. Profile is
+ * local-only here (saas profiles live under Clerk's own surface); Webhooks,
+ * Channels and Widget SDK are hosted-edition surfaces — inbound webhooks and
+ * channel callbacks need a public URL, the widget embed needs the hosted
+ * loader — so they are hidden by this explicit list, never by role (the local
+ * operator is super_admin by design).
+ */
+export const LOCAL_EDITION_SETTINGS_TABS: ReadonlySet<string> = new Set([
+  'profile',
+  'system-settings',
+  'orchestrator',
+  'api-keys',
+  'credentials',
+  'notifications',
+])
 
 export function SettingsPanel() {
   const { isAdmin } = useSystemRole()
   const [activeTab, setActiveTab] = useState(isAdmin ? 'system-settings' : 'orchestrator')
 
-  const tabs = [
+  const allTabs = [
+    ...(isLocal ? [{ value: 'profile', label: 'Profile', icon: UserCircle }] : []),
     ...(isAdmin ? [{ value: 'system-settings', label: 'System Settings', icon: Settings }] : []),
     { value: 'orchestrator', label: 'Orchestrator', icon: Brain },
     { value: 'webhooks', label: 'Webhooks', icon: Webhook },
@@ -28,6 +48,7 @@ export function SettingsPanel() {
     { value: 'notifications', label: 'Notifications', icon: Bell },
     { value: 'widget-sdk', label: 'Widget SDK', icon: Puzzle },
   ]
+  const tabs = isLocal ? allTabs.filter((tab) => LOCAL_EDITION_SETTINGS_TABS.has(tab.value)) : allTabs
 
   return (
     <div className="space-y-6">
@@ -45,6 +66,29 @@ export function SettingsPanel() {
         value={activeTab}
         onValueChange={setActiveTab}
       >
+        {/* PRD-233 S6: local edition — the operator's profile lives at /settings/profile */}
+        {isLocal && (
+          <TabsContent value="profile">
+            <Link
+              href="/settings/profile"
+              className="glass-card flex items-center justify-between rounded-2xl border border-border p-6 transition-colors hover:bg-secondary/40"
+            >
+              <div className="flex items-center gap-4">
+                <div className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/15">
+                  <UserCircle className="h-6 w-6 text-primary" />
+                </div>
+                <div>
+                  <p className="text-base font-semibold text-foreground">Your profile</p>
+                  <p className="text-sm text-muted-foreground">
+                    Name, username and avatar for this instance&apos;s operator. Auto greets you by the name you set here.
+                  </p>
+                </div>
+              </div>
+              <ArrowRight className="h-5 w-5 text-muted-foreground" />
+            </Link>
+          </TabsContent>
+        )}
+
         {/* System Settings Tab — Admin only */}
         {isAdmin && (
           <TabsContent value="system-settings">

--- a/frontend/components/settings/__tests__/settings-panel-edition.test.tsx
+++ b/frontend/components/settings/__tests__/settings-panel-edition.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * PRD-233 S6/S7 — the Settings tabs per edition.
+ *
+ * local → only what exists locally: Profile (S6), System Settings, Orchestrator,
+ *         API Keys, Credentials, Notifications. Webhooks / Channels / Widget SDK
+ *         (hosted-edition surfaces) are hidden by the explicit allowlist, not by
+ *         role — the local operator is super_admin.
+ * saas  → the eight tabs exactly as before; no Profile tab (Clerk owns it).
+ *
+ * Tab bodies are stubbed — this is about WHICH tabs exist, not their content.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+vi.mock('next/link', () => ({
+  default: ({ href, children }: any) => <a href={href}>{children}</a>,
+}))
+
+vi.mock('@/contexts/role-context', () => ({
+  useSystemRole: () => ({ isAdmin: true, systemRole: 'super_admin', isLoading: false }),
+}))
+
+vi.mock('@/components/shared', () => ({
+  PageHeader: () => null,
+  FilterTabs: ({ tabs, children }: any) => (
+    <div>
+      <nav aria-label="settings tabs">
+        {tabs.map((tab: any) => (
+          <button key={tab.value} type="button">
+            {tab.label}
+          </button>
+        ))}
+      </nav>
+      {children}
+    </div>
+  ),
+  TabsContent: ({ children }: any) => <section>{children}</section>,
+}))
+
+vi.mock('../CredentialsTab', () => ({ CredentialsTab: () => null }))
+vi.mock('../SystemSettingsTab', () => ({ default: () => null }))
+vi.mock('../SystemLLMSettingsTab', () => ({ default: () => null }))
+vi.mock('../WebhooksSettingsTab', () => ({ default: () => null }))
+vi.mock('../ApiKeysSettingsTab', () => ({ ApiKeysSettingsTab: () => null }))
+vi.mock('../ChannelsSettingsTab', () => ({ ChannelsSettingsTab: () => null }))
+vi.mock('../ApiKeyManager', () => ({ ApiKeyManager: () => null }))
+vi.mock('../WidgetSdkTab', () => ({ WidgetSdkTab: () => null }))
+vi.mock('../NotificationsSettingsTab', () => ({ NotificationsSettingsTab: () => null }))
+
+async function loadPanel(edition: 'local' | 'saas') {
+  vi.doMock('@/lib/auth-edition', () => ({
+    authEdition: edition,
+    isLocal: edition === 'local',
+    isSaaS: edition === 'saas',
+  }))
+  const mod = await import('../SettingsPanel')
+  return mod
+}
+
+function tabLabels(): string[] {
+  return screen.getAllByRole('button').map((button) => button.textContent ?? '')
+}
+
+afterEach(() => {
+  vi.doUnmock('@/lib/auth-edition')
+  vi.resetModules()
+})
+
+describe('SettingsPanel edition gating (PRD-233 S6/S7)', () => {
+  it('local: shows Profile + the tabs that exist locally, hides hosted-only surfaces', async () => {
+    const { SettingsPanel, LOCAL_EDITION_SETTINGS_TABS } = await loadPanel('local')
+    render(<SettingsPanel />)
+
+    expect(tabLabels()).toEqual([
+      'Profile',
+      'System Settings',
+      'Orchestrator',
+      'API Keys',
+      'Credentials',
+      'Notifications',
+    ])
+    expect(screen.getByRole('link', { name: /your profile/i })).toHaveAttribute('href', '/settings/profile')
+    for (const hidden of ['webhooks', 'channels', 'widget-sdk']) {
+      expect(LOCAL_EDITION_SETTINGS_TABS.has(hidden)).toBe(false)
+    }
+  })
+
+  it('saas: the eight tabs render exactly as before and there is no Profile tab', async () => {
+    const { SettingsPanel } = await loadPanel('saas')
+    render(<SettingsPanel />)
+
+    expect(tabLabels()).toEqual([
+      'System Settings',
+      'Orchestrator',
+      'Webhooks',
+      'API Keys',
+      'Credentials',
+      'Channels',
+      'Notifications',
+      'Widget SDK',
+    ])
+    expect(screen.queryByRole('link', { name: /your profile/i })).not.toBeInTheDocument()
+  })
+})

--- a/frontend/components/tools/__tests__/integrations-disabled-card.test.tsx
+++ b/frontend/components/tools/__tests__/integrations-disabled-card.test.tsx
@@ -1,0 +1,83 @@
+// PRD-233 S2 — the Tools page must not show an empty grid as if nothing
+// exists: without a Composio key it says integrations are disabled, why, and
+// how to fix it. Pure component test — no hooks, no network.
+
+import { describe, it, expect, afterEach } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import React from 'react'
+
+import {
+  IntegrationsDisabledCard,
+  INTEGRATIONS_DISABLED_NO_KEY_TITLE,
+  INTEGRATIONS_DISABLED_TITLE,
+  CATALOGUE_SYNCING_TITLE,
+  CATALOGUE_SYNC_FAILED_TITLE,
+} from '../integrations-disabled-card'
+import type { IntegrationsStatus } from '@/hooks/use-tools-api'
+
+afterEach(() => cleanup())
+
+const noKey: IntegrationsStatus = {
+  available: false,
+  reason: 'COMPOSIO_API_KEY is not configured',
+  key_configured: false,
+  apps_cached: 0,
+  last_sync: null,
+  sync_status: null,
+}
+
+const keyed = { available: true, reason: null, key_configured: true }
+
+describe('PRD-233 S2 — IntegrationsDisabledCard', () => {
+  it('renders the honest disabled state with the fix and the reason when there is no key', () => {
+    render(<IntegrationsDisabledCard status={noKey} />)
+    const card = screen.getByTestId('integrations-disabled')
+    expect(card).toHaveAttribute('role', 'alert')
+    expect(screen.getByText(INTEGRATIONS_DISABLED_NO_KEY_TITLE)).toBeInTheDocument()
+    const text = card.textContent || ''
+    expect(text).toContain(
+      'Add COMPOSIO_API_KEY to .env, then docker compose up -d backend; the catalogue syncs automatically on boot.',
+    )
+    expect(text).toContain('Reason: COMPOSIO_API_KEY is not configured')
+    expect(text).toContain('Native platform tools keep working')
+  })
+
+  it('names the generic title (and the reason) when a key is set but the SDK is missing', () => {
+    render(
+      <IntegrationsDisabledCard
+        status={{ ...noKey, key_configured: true, reason: 'Composio SDK is not installed (composio-core package missing)' }}
+      />,
+    )
+    expect(screen.getByText(INTEGRATIONS_DISABLED_TITLE)).toBeInTheDocument()
+    expect(screen.queryByText(INTEGRATIONS_DISABLED_NO_KEY_TITLE)).not.toBeInTheDocument()
+    expect(screen.getByTestId('integrations-disabled').textContent).toContain('composio-core package missing')
+  })
+
+  it('renders nothing when integrations are available', () => {
+    const { container } = render(
+      <IntegrationsDisabledCard
+        status={{ ...keyed, apps_cached: 880, last_sync: '2026-08-29T00:00:00Z', sync_status: 'completed' }}
+      />,
+    )
+    expect(container).toBeEmptyDOMElement()
+    expect(screen.queryByTestId('integrations-disabled')).not.toBeInTheDocument()
+  })
+
+  it('renders nothing while the status is still loading', () => {
+    const { container } = render(<IntegrationsDisabledCard status={undefined} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('says the catalogue is syncing on a keyed boot with an empty cache', () => {
+    render(<IntegrationsDisabledCard status={{ ...keyed, apps_cached: 0, last_sync: null, sync_status: 'running' }} />)
+    expect(screen.getByTestId('integrations-syncing')).toBeInTheDocument()
+    expect(screen.getByText(CATALOGUE_SYNCING_TITLE)).toBeInTheDocument()
+    expect(screen.queryByTestId('integrations-disabled')).not.toBeInTheDocument()
+  })
+
+  it('says the last sync failed instead of pretending to sync forever', () => {
+    render(<IntegrationsDisabledCard status={{ ...keyed, apps_cached: 0, last_sync: null, sync_status: 'failed' }} />)
+    expect(screen.getByTestId('integrations-sync-failed')).toBeInTheDocument()
+    expect(screen.getByText(CATALOGUE_SYNC_FAILED_TITLE)).toBeInTheDocument()
+  })
+})

--- a/frontend/components/tools/integrations-disabled-card.tsx
+++ b/frontend/components/tools/integrations-disabled-card.tsx
@@ -1,0 +1,76 @@
+/**
+ * PRD-233 S2 — the honest integration states for the Tools page.
+ *
+ * Without a Composio key the backend offers NO Composio tools to agents and
+ * the marketplace grid is empty. Rendering an empty grid would be a lie about
+ * what the platform can do; this card says why and how to fix it. Native
+ * platform tools are unaffected, so the rest of the page still renders.
+ *
+ * A keyed boot with an EMPTY catalogue is the other empty-grid case: the
+ * backend syncs the catalogue itself on that boot, so the card says
+ * "syncing" (or "last sync failed") instead of nothing.
+ */
+'use client'
+
+import React from 'react'
+import { PlugZap, RefreshCw } from 'lucide-react'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import type { IntegrationsStatus } from '@/hooks/use-tools-api'
+
+export const INTEGRATIONS_DISABLED_NO_KEY_TITLE =
+  'Integrations are disabled — no Composio API key is configured.'
+export const INTEGRATIONS_DISABLED_TITLE = 'Integrations are disabled.'
+export const CATALOGUE_SYNCING_TITLE = 'Integration catalogue is syncing.'
+export const CATALOGUE_SYNC_FAILED_TITLE = 'Integration catalogue sync failed.'
+
+interface IntegrationsDisabledCardProps {
+  /** `undefined` while loading — nothing renders until the state is known. */
+  status: IntegrationsStatus | undefined
+}
+
+export function IntegrationsDisabledCard({ status }: IntegrationsDisabledCardProps) {
+  if (!status) return null
+
+  if (!status.available) {
+    const title = status.key_configured ? INTEGRATIONS_DISABLED_TITLE : INTEGRATIONS_DISABLED_NO_KEY_TITLE
+    return (
+      <Alert data-testid="integrations-disabled" className="border-[hsl(var(--warning))]/40">
+        <PlugZap className="h-4 w-4" />
+        <AlertTitle>{title}</AlertTitle>
+        <AlertDescription className="space-y-1">
+          <p>
+            Add <code>COMPOSIO_API_KEY</code> to <code>.env</code>, then{' '}
+            <code>docker compose up -d backend</code>; the catalogue syncs automatically on boot.
+          </p>
+          {status.reason ? <p className="text-muted-foreground">Reason: {status.reason}</p> : null}
+          <p className="text-muted-foreground">
+            Native platform tools keep working; only third-party app integrations are off.
+          </p>
+        </AlertDescription>
+      </Alert>
+    )
+  }
+
+  if (status.apps_cached > 0) return null
+
+  const failed = status.sync_status === 'failed'
+  return (
+    <Alert data-testid={failed ? 'integrations-sync-failed' : 'integrations-syncing'}>
+      <RefreshCw className="h-4 w-4" />
+      <AlertTitle>{failed ? CATALOGUE_SYNC_FAILED_TITLE : CATALOGUE_SYNCING_TITLE}</AlertTitle>
+      <AlertDescription>
+        {failed ? (
+          <p>
+            The last catalogue sync did not complete — check that <code>COMPOSIO_API_KEY</code> is valid
+            (backend logs carry the error), then run Sync or restart the backend.
+          </p>
+        ) : (
+          <p>
+            A Composio key is configured and the catalogue is being fetched in the background (first
+            keyed boot). Refresh this page in a minute.
+          </p>
+        )}
+      </AlertDescription>
+    </Alert>
+  )
+}

--- a/frontend/components/tools/tools-dashboard.tsx
+++ b/frontend/components/tools/tools-dashboard.tsx
@@ -56,7 +56,8 @@ import { ToolConfigModal } from './tool-config-modal'
 import { ToolDetailsModal } from './tool-details-modal'
 // import { AgentToolAssignment } from './agent-tool-assignment'
 import { EnhancedPagination } from '@/components/ui/pagination'
-import { useTools, useToolsStats, useToolCategories } from '@/hooks/use-tools-api'
+import { useTools, useToolsStats, useToolCategories, useIntegrationsStatus } from '@/hooks/use-tools-api'
+import { IntegrationsDisabledCard } from './integrations-disabled-card' // PRD-233 S2: honest no-key state
 import { ToolLogo } from '@/components/ui/tool-logo'
 import { ComposioAppsSection } from './composio-apps-section' // PRD-36: Composio Integration
 import { ToolActionsModal } from './tool-actions-modal'
@@ -169,6 +170,7 @@ export function ToolsDashboard() {
   })
   const { data: statsData, error: statsError } = useToolsStats()
   const { data: categoriesData, error: categoriesError } = useToolCategories()
+  const { data: integrationsStatus } = useIntegrationsStatus()
   const disconnectAppMutation = useDisconnectApp()
   const queryClient = useQueryClient()
   const syncCacheMutation = useMutation({
@@ -618,6 +620,9 @@ export function ToolsDashboard() {
         }
       />
       </div>
+
+      {/* PRD-233 S2: no Composio key ⇒ say so instead of an empty grid */}
+      <IntegrationsDisabledCard status={integrationsStatus} />
 
       {/* Statistics Cards */}
       <StatsBar

--- a/frontend/hooks/use-tools-api.ts
+++ b/frontend/hooks/use-tools-api.ts
@@ -81,3 +81,23 @@ export function useSyncToolsCache() {
   })
 }
 
+export type IntegrationsStatus = Awaited<ReturnType<typeof apiClient.getIntegrationsStatus>>
+
+/**
+ * PRD-233 S2 — can Composio integrations run on this server? Drives the
+ * "integrations disabled" card on the Tools page; `available` is the same
+ * predicate the backend tool router uses, so the UI never claims more than
+ * the agents can actually reach.
+ */
+export function useIntegrationsStatus() {
+  const { isLoaded, isSignedIn } = useAuth()
+  return useQuery({
+    queryKey: ['tools', 'integrations-status'],
+    queryFn: () => apiClient.getIntegrationsStatus(),
+    staleTime: 5 * 60 * 1000, // 5 minutes — flips only on a backend restart
+    enabled: isLoaded && isSignedIn,
+    retry: (failureCount, error) => shouldRetry(error) && failureCount < 1,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+  })
+}

--- a/frontend/lib/__tests__/auth-edition-routes.test.ts
+++ b/frontend/lib/__tests__/auth-edition-routes.test.ts
@@ -1,0 +1,139 @@
+/**
+ * PRD-233 S7 — the edition seam's route allowlist.
+ *
+ * SaaS-only surfaces are hidden in `local` by ONE explicit list of route
+ * prefixes (`SAAS_ONLY_ROUTES`), never by role: the local operator is
+ * deliberately super_admin. In `saas` every helper is the identity so the
+ * running product renders exactly as before.
+ *
+ * The seam reads NEXT_PUBLIC_AUTH_EDITION once at import, so each case stubs the
+ * env and re-imports the module (same pattern as the PRD-175 seam test).
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  vi.resetModules()
+})
+
+async function seam(edition: 'local' | 'saas') {
+  vi.stubEnv('NEXT_PUBLIC_AUTH_EDITION', edition)
+  return import('@/lib/auth-edition')
+}
+
+// The owner's list (decisions recorded 2026-08-29): Workspace Admin, Team,
+// invitations, sign-in/up (+ the Clerk-bound sign-in sub-flows), the hosted
+// hub's plugin-moderation queue and the Clerk-only dev reset page.
+const EXPECTED_LIST = [
+  '/admin/workspaces',
+  '/team',
+  '/accept-invitation',
+  '/sign-in',
+  '/sign-up',
+  '/reset-password',
+  '/sso-callback',
+  '/admin/plugins',
+  '/dev/reset-onboarding',
+]
+
+describe('SAAS_ONLY_ROUTES — the explicit allowlist', () => {
+  it('names exactly the hosted-edition surfaces, as path prefixes', async () => {
+    const { SAAS_ONLY_ROUTES } = await seam('local')
+    expect([...SAAS_ONLY_ROUTES]).toEqual(EXPECTED_LIST)
+    for (const prefix of SAAS_ONLY_ROUTES) {
+      expect(prefix.startsWith('/')).toBe(true)
+      expect(prefix.endsWith('/')).toBe(false)
+    }
+  })
+
+  it('is the same list in saas (the list is data; the edition decides whether it applies)', async () => {
+    const { SAAS_ONLY_ROUTES } = await seam('saas')
+    expect([...SAAS_ONLY_ROUTES]).toEqual(EXPECTED_LIST)
+  })
+})
+
+describe('isRouteAvailableInEdition', () => {
+  it('saas: every route is available, listed or not', async () => {
+    const { isRouteAvailableInEdition } = await seam('saas')
+    for (const href of [...EXPECTED_LIST, '/team/members', '/chat', '/analytics', '/settings']) {
+      expect(isRouteAvailableInEdition(href)).toBe(true)
+    }
+  })
+
+  it('local: a listed prefix is unavailable — exact, nested, with query or hash', async () => {
+    const { isRouteAvailableInEdition } = await seam('local')
+    expect(isRouteAvailableInEdition('/team')).toBe(false)
+    expect(isRouteAvailableInEdition('/team/invitations')).toBe(false)
+    expect(isRouteAvailableInEdition('/admin/workspaces')).toBe(false)
+    expect(isRouteAvailableInEdition('/admin/workspaces?page=2')).toBe(false)
+    expect(isRouteAvailableInEdition('/accept-invitation?token=abc')).toBe(false)
+    expect(isRouteAvailableInEdition('/sign-in#top')).toBe(false)
+    expect(isRouteAvailableInEdition('/sign-up/verify-email')).toBe(false)
+    expect(isRouteAvailableInEdition('/reset-password')).toBe(false)
+    expect(isRouteAvailableInEdition('/sso-callback')).toBe(false)
+  })
+
+  it('local: everything else stays available — including near-misses of a listed prefix', async () => {
+    const { isRouteAvailableInEdition } = await seam('local')
+    for (const href of ['/', '/chat', '/analytics', '/documents', '/marketplace', '/settings', '/settings/profile']) {
+      expect(isRouteAvailableInEdition(href)).toBe(true)
+    }
+    // Prefix matching is on a segment boundary: '/team' must not swallow '/teams'.
+    expect(isRouteAvailableInEdition('/teams')).toBe(true)
+    // Only Workspace Admin is listed under /admin — the plugin console is not.
+    expect(isRouteAvailableInEdition('/admin/settings')).toBe(true)
+    // External links are never on the list.
+    expect(isRouteAvailableInEdition('https://docs.automatos.app')).toBe(true)
+  })
+})
+
+describe('filterNavForEdition', () => {
+  const items = [
+    { id: 'chat', href: '/chat' },
+    { id: 'team', href: '/team' },
+    { id: 'analytics', href: '/analytics' },
+    { id: 'admin', href: '/admin/workspaces' },
+    { id: 'docs', href: 'https://docs.automatos.app' },
+  ]
+
+  it('saas: returns the same items in the same order', async () => {
+    const { filterNavForEdition } = await seam('saas')
+    expect(filterNavForEdition(items)).toEqual(items)
+  })
+
+  it('local: drops exactly the listed hrefs, keeps order, does not mutate the input', async () => {
+    const { filterNavForEdition } = await seam('local')
+    const before = [...items]
+    const result = filterNavForEdition(items)
+    expect(result.map((i) => i.id)).toEqual(['chat', 'analytics', 'docs'])
+    expect(items).toEqual(before)
+    expect(result).not.toBe(items)
+  })
+
+  it('preserves the item type (extra fields survive the filter)', async () => {
+    const { filterNavForEdition } = await seam('local')
+    const typed = [{ href: '/chat', label: 'Chat', requiredExposure: 'analytics' as const }]
+    const [first] = filterNavForEdition(typed)
+    expect(first.label).toBe('Chat')
+    expect(first.requiredExposure).toBe('analytics')
+  })
+})
+
+describe('navExposureForEdition — plan-tier exposure as nav gating must honour it', () => {
+  // What GET /api/workspaces/current returns for the plan-less local workspace
+  // today: exposure_for_plan(plan or "basic") ⇒ the basic tier's nav profile.
+  const localBasic = { plan: 'basic', nav: { analytics: false, team: false } }
+
+  it('saas: passes the exposure through untouched (null and undefined included)', async () => {
+    const { navExposureForEdition } = await seam('saas')
+    expect(navExposureForEdition(localBasic)).toBe(localBasic)
+    expect(navExposureForEdition(null)).toBeNull()
+    expect(navExposureForEdition(undefined)).toBeUndefined()
+  })
+
+  it('local: there is no plan — exposure is unknown, so nav-exposure fails open', async () => {
+    const { navExposureForEdition } = await seam('local')
+    expect(navExposureForEdition(localBasic)).toBeUndefined()
+    expect(navExposureForEdition(null)).toBeUndefined()
+  })
+})

--- a/frontend/lib/api-client.ts
+++ b/frontend/lib/api-client.ts
@@ -359,6 +359,27 @@ export interface WatchDetailResponse {
   recent_events: WatchEventRow[]
 }
 
+// ===== PRD-233 S6 Local profile: who Auto is talking to =====
+export interface ProfileResponse {
+  edition: 'local' | 'saas'
+  // true only in the local edition — saas profiles are managed by Clerk
+  editable: boolean
+  id: number | null
+  email: string | null
+  name: string | null
+  username: string | null
+  avatar_url: string | null
+  system_role: string
+  // Why email is read-only (the operator lookup key / the identity provider)
+  email_note: string
+}
+
+export interface ProfileUpdateRequest {
+  name?: string
+  username?: string
+  avatar_url?: string
+}
+
 class ApiClient {
   private baseUrl: string
   private defaultHeaders: Record<string, string>
@@ -562,6 +583,18 @@ class ApiClient {
 
   async getApiHealth() {
     return this.request('/api/health/endpoints')
+  }
+
+  // ===== PRD-233 S6 Local profile (GET both editions, PUT local only) =====
+  async getProfile(): Promise<ProfileResponse> {
+    return this.request<ProfileResponse>('/api/profile')
+  }
+
+  async updateProfile(data: ProfileUpdateRequest): Promise<ProfileResponse> {
+    return this.request<ProfileResponse>('/api/profile', {
+      method: 'PUT',
+      body: JSON.stringify(data),
+    })
   }
 
   async getSystemConfig() {
@@ -1744,6 +1777,19 @@ class ApiClient {
 
   async syncToolsCache(syncType: 'full' | 'incremental' = 'full') {
     return this.request(`/api/tools/sync?sync_type=${syncType}`, { method: 'POST' })
+  }
+
+  async getIntegrationsStatus() {
+    // PRD-233 S2: honest integrations state — the same predicate the tool
+    // router uses to decide whether Composio tools are offered at all.
+    return this.request<{
+      available: boolean
+      reason: string | null
+      key_configured: boolean
+      apps_cached: number
+      last_sync: string | null
+      sync_status: 'running' | 'completed' | 'failed' | string | null
+    }>('/api/tools/integrations/status')
   }
 
   async syncOpenRouterCache() {

--- a/frontend/lib/auth-edition.ts
+++ b/frontend/lib/auth-edition.ts
@@ -14,6 +14,12 @@
  * An unknown value falls back to `saas` so a typo never silently un-guards the
  * app. Nothing else in the frontend should read `process.env.NEXT_PUBLIC_AUTH_EDITION`
  * directly — import `isSaaS` / `isLocal` / `authEdition` from here.
+ *
+ * PRD-233 S7 — this file is also the ONLY place that says which surfaces exist
+ * in the hosted edition but not locally (`SAAS_ONLY_ROUTES` below). Nav sources
+ * and route pages consult that list through `isRouteAvailableInEdition` /
+ * `filterNavForEdition`; in `saas` every helper is the identity, so the running
+ * product renders exactly as before.
  */
 export type AuthEdition = 'local' | 'saas'
 
@@ -25,3 +31,79 @@ function resolveEdition(): AuthEdition {
 export const authEdition: AuthEdition = resolveEdition()
 export const isSaaS: boolean = authEdition === 'saas'
 export const isLocal: boolean = authEdition === 'local'
+
+/**
+ * PRD-233 S7 — the hosted-edition surfaces, as route prefixes (owner decision
+ * recorded 2026-08-29). The local edition has no accounts, teams or plans:
+ *
+ *   /admin/workspaces   Workspace Admin — cross-tenant platform administration
+ *   /team               Team — members, roles, invitations
+ *   /accept-invitation  invitation acceptance (Clerk-bound)
+ *   /sign-in, /sign-up, /reset-password, /sso-callback
+ *                       identity flows (Clerk-bound; sign-in/up already send
+ *                       visitors home in local — PRD-175)
+ *
+ * Why a list and not the role: the local operator is deliberately `super_admin`
+ * (role-context.tsx; hybrid.py's anonymous lane), so a role gate would either
+ * show every hosted-only surface on the operator's machine or demote the
+ * operator. Hiding is by this list ONLY — nothing else decides. Plan/trial
+ * pills are not routes: they read the trial ledger, which a local workspace
+ * never has.
+ *
+ * Matching is on a path-segment boundary (`/team` covers `/team/x`, never
+ * `/teams`); query and hash are ignored.
+ */
+export const SAAS_ONLY_ROUTES: readonly string[] = [
+  '/admin/workspaces',
+  '/team',
+  '/accept-invitation',
+  '/sign-in',
+  '/sign-up',
+  '/reset-password',
+  '/sso-callback',
+  '/admin/plugins',
+  '/dev/reset-onboarding',
+]
+
+function routePath(href: string): string {
+  const cut = href.search(/[?#]/)
+  return cut === -1 ? href : href.slice(0, cut)
+}
+
+function isUnderPrefix(path: string, prefix: string): boolean {
+  return path === prefix || path.startsWith(`${prefix}/`)
+}
+
+/**
+ * Does `href` exist in this edition? Always true in `saas`; false in `local`
+ * for anything under SAAS_ONLY_ROUTES.
+ */
+export function isRouteAvailableInEdition(href: string): boolean {
+  if (isSaaS) return true
+  const path = routePath(href)
+  return !SAAS_ONLY_ROUTES.some((prefix) => isUnderPrefix(path, prefix))
+}
+
+/**
+ * The nav items of this edition — a new array holding only the entries whose
+ * `href` exists here, in the given order. Identity in `saas`.
+ */
+export function filterNavForEdition<T extends { href: string }>(items: readonly T[]): T[] {
+  return items.filter((item) => isRouteAvailableInEdition(item.href))
+}
+
+/**
+ * The plan-tier exposure (PRD-222 US-024) as nav gating must honour it here.
+ *
+ *   saas  → the workspace's exposure, untouched.
+ *   local → undefined. There is no plan locally: the entrypoint seeds the local
+ *           workspace with `plan = NULL`, and `GET /api/workspaces/current`
+ *           derives the `basic` profile from the missing plan
+ *           (`exposure_for_plan(plan or "basic")` → nav.analytics = false),
+ *           which would hide Analytics on the operator's own instance.
+ *           nav-exposure fails open on an unknown exposure, so the only thing
+ *           hidden locally is SAAS_ONLY_ROUTES.
+ */
+export function navExposureForEdition<T>(exposure: T | null | undefined): T | null | undefined {
+  return isSaaS ? exposure : undefined
+}

--- a/orchestrator/Dockerfile
+++ b/orchestrator/Dockerfile
@@ -90,7 +90,11 @@ ENTRYPOINT ["docker-entrypoint.sh"]
 # multiple unmerged heads; ``head`` (singular) errors out. If any
 # migration fails the container fails to boot — loud is better than
 # silent UndefinedColumn errors at request time.
-CMD sh -c "alembic upgrade heads && uvicorn main:app --host 0.0.0.0 --port 8000 --reload"
+# --timeout-graceful-shutdown (dev stage only; prod runs --workers below): a
+# --reload first waits for open HTTP connections to close and the browser's SSE
+# streams (notifications, board events) never do, so every code edit wedged the
+# server in "Waiting for connections to close" until a restart (PRD-233 finding).
+CMD sh -c "alembic upgrade heads && uvicorn main:app --host 0.0.0.0 --port 8000 --reload --timeout-graceful-shutdown 5"
 
 # =============================================================================
 # Production Stage - Optimized & Minimal

--- a/orchestrator/README.md
+++ b/orchestrator/README.md
@@ -1,422 +1,136 @@
-# 🚀 Automatos AI - The Future of Multi-Agent Orchestration
+# Automatos AI — orchestrator (backend)
 
-> **"What if your AI agents could truly collaborate, learn, and evolve - just like a team of expert developers?"**
+The FastAPI service behind the platform: the REST/SSE API, the agent runtime,
+Playbook and Mission execution, RAG, memory, the tool router and the seeds. One
+codebase serves both editions — the local edition (`AUTH_EDITION=local`, the
+compose stack) and the hosted edition (`saas`) — behind one runtime flag; see
+[docs/getting-started/self-hosting.md](../docs/getting-started/self-hosting.md),
+section 13.
 
-![Automatos AI Dashboard](../docs/assets/images/main_dashboard.png)
-
----
-
-## 💡 The Problem We're Solving
-
-**Every developer has been here:**
-- You want AI to help build complex systems, but single-agent LLMs hit walls
-- Tools like LangChain give you chains, but not true **collaboration**
-- You need agents that can reason together, disagree, and reach consensus
-- Existing frameworks feel like "glue code" - you're still doing the hard work
-
-**We asked ourselves:** *What if AI agents could work like a senior engineering team?*
-
-**The answer:** **Automatos AI** 🤖
-
----
-
-## ✨ What Makes Automatos Different?
-
-### 🧠 **True Multi-Agent Intelligence**
-Not just agents calling each other - **actual collaborative reasoning** with consensus mechanisms, conflict resolution, and emergent behaviors.
-
-```python
-# Other frameworks
-for agent in agents:
-    result = agent.run(task)  # Sequential, isolated
-
-# Automatos
-result = await multi_agent.collaborative_reasoning(
-    task=complex_problem,
-    agents=[strategy, security, execution],
-    consensus_threshold=0.8
-)
-# Agents debate, vote, reach consensus - like a real team
-```
-
-![Workflow Execution](../docs/assets/images/workflow_execution.png)
-
-### 🛠️ **Tool Registry Architecture**
-**One registry. Infinite tools. Zero duplication.**
-
-```python
-# Register once, use everywhere
-@tool_registry.register(category=ToolCategory.RESEARCH)
-def web_search(query: str) -> dict:
-    return search_results
-
-# Any agent, any workflow, any API endpoint can use it
-executor.execute_tool("web_search", {"query": "AI news"})
-```
-
-### 🌊 **Real-Time Analytics & Streaming**
-Server-Sent Events (SSE) + AI SDK format = **simpler, faster, better**.
-
-```javascript
-// Watch your workflow execute in real-time
-const stream = new EventSource('/api/workflows/executions/123/stream');
-stream.onmessage = (event) => {
-  // Live updates: stage progress, logs, results
-  console.log(JSON.parse(event.data));
-};
-```
-
-![Analytics Dashboard](../docs/assets/images/analytics_dashboard.png)
-
-### 📊 **CodeGraph Intelligence**
-Your codebase becomes **searchable, semantic knowledge**.
-
-```python
-# Not just grep - semantic code understanding
-results = await codegraph.search_semantic(
-    query="authentication middleware",
-    language="python"
-)
-# Returns: actual auth code, call graphs, usage examples
-```
-
-![CodeGraph Interface](../docs/assets/images/chat_interface.png)
-
----
-
-## 🎯 Real-World Use Cases
-
-### 1️⃣ **Autonomous Software Teams**
-Deploy a team of agents that:
-- **Plan** architecture (Strategy Agent)
-- **Write** code (Developer Agent)
-- **Review** security (Security Agent)
-- **Test** and deploy (QA Agent)
-
-### 2️⃣ **Intelligent Document Processing**
-Not just RAG - **multi-modal knowledge extraction**:
-- PDF → Structured data
-- Code → Searchable symbols
-- Images → Contextual understanding
-- All connected in a knowledge graph
-
-### 3️⃣ **Learning Systems**
-Agents that **actually get better** over time:
-- Track what works, what fails
-- Optimize context assembly
-- Adaptive tool selection
-- Performance self-improvement
-
----
-
-## 🏗️ Architecture That Makes Sense
-
-We built Automatos with **clarity and modularity** as core principles:
+## Layout
 
 ```
 orchestrator/
-├── api/        👉 Your REST/SSE gateway (52 endpoints)
-├── core/       👉 The foundation (DB, LLM, Redis, Utils)
-├── modules/    👉 Where the magic happens (12 domains)
-└── consumers/  👉 Background workers (streaming, processing)
+├── main.py              FastAPI app; boot stages (core → trust gate → extensions);
+│                        /health, /health/ready, /health/bootstrap
+├── config.py            the ONLY module that reads the environment — every dial, every default
+├── api/                 routers, one file per surface (the committed route manifest is
+│                        checked against the frontend's calls by the route-contract CI lane)
+├── core/                database + models; auth (core/auth/hybrid.py — the edition-aware
+│                        request context); credentials; the Composio client and its boot
+│                        bootstrap; the S3 client factory (core/storage/s3.py); seeds
+│                        (core/seeds/) and the seed loader (core/database/load_seed_data.py)
+├── modules/             domain modules — agents, tools (router + action registry), rag,
+│                        memory, context, documents, …
+├── consumers/           the streaming chat service and background consumers
+├── services/            cross-cutting services
+├── channels/ integrations/ jobs/ contracts/ evals/
+├── alembic/             migrations (alembic.ini); exactly one head is a CI gate
+├── scripts/             init_fresh_db.py (fresh-database schema), init_test_db.py
+│                        (CI schema + seed), seed_*.py
+└── tests/               the pytest suite (pytest.ini also collects modules/**/tests
+                         and integrations/**/tests)
 ```
 
-### The Layers Explained
+## Development setup — the compose stack is the dev environment
 
-**🔵 API Layer** - Clean, documented REST endpoints
-- Every feature is exposed via FastAPI
-- OpenAPI/Swagger auto-generated
-- SSE streaming for real-time updates
-
-**🟢 Core Layer** - Solid infrastructure
-- Database ORM (SQLAlchemy)
-- Multi-provider LLM support
-- Redis pub/sub for real-time
-- Shared utilities
-
-**🟡 Modules Layer** - Domain-driven design
-- Each module is **self-contained**
-- Clear responsibilities
-- Easy to extend
-- Examples: `agents/`, `tools/`, `rag/`, `memory/`, `codegraph/`
-
-**🔴 Consumers Layer** - Background processing
-- Async document processing
-- Workflow execution
-- Streaming chat service
-
----
-
-## 🚀 Get Started in 5 Minutes
+There is no bare-metal setup to maintain. From the repository root:
 
 ```bash
-# 1. Clone and start
-git clone https://github.com/AutomatosAI/automatos-ai
-cd automatos-ai
-docker-compose up
-
-# 2. Open the UI
-open http://localhost:3000
-
-# 3. Create your first agent
-curl -X POST http://localhost:8000/api/agents \
-  -H "Content-Type: application/json" \
-  -d '{
-    "name": "My First Agent",
-    "agent_type": "custom",
-    "provider": "openai",
-    "model": "gpt-4"
-  }'
-
-# 4. Watch it work! 🎉
+cp .env.example .env     # POSTGRES_PASSWORD, REDIS_PASSWORD, API_KEY (+ one LLM key)
+docker compose up
 ```
 
-**That's it.** You're running a multi-agent AI orchestration platform.
+- The `backend` service builds this directory with the `development` target,
+  bind-mounts it at `/app` and runs `uvicorn main:app --reload`, so edits are
+  live. Dependency or Dockerfile changes need
+  `docker compose up -d --build backend`.
+- Configuration is layered: `envs/api.defaults` (committed local topology,
+  `AUTH_EDITION=local`), `envs/api.local` (gitignored overrides for any
+  `config.py` dial) and the compose `environment:` block (secrets substituted
+  from `.env`). `.env` reaches the container only through compose
+  substitution.
+- Logs: `docker compose logs -f backend`. API reference:
+  http://localhost:8000/docs.
+- Everything the backend needs — Postgres with pgvector, Redis, MinIO, the
+  workspace-worker — is in the same compose file.
 
----
+## Database lifecycle — what the entrypoint does
 
-## 🎨 Why Developers Love Building With Automatos
+`docker-entrypoint.sh` (repository root, mounted into the container) is the
+single owner of the schema lifecycle:
 
-### 1. **Modular by Design**
-Want to add a new tool? Drop it in `modules/tools/`.  
-Need a new workflow type? Extend `modules/orchestrator/`.  
-Everything has a place.
+1. **Empty database** (no `alembic_version`): `python -m scripts.init_fresh_db`
+   builds the full schema — `Base.metadata.create_all` plus the raw-DDL
+   extras, then a statement-tolerant replay of the migration forest — and
+   stamps Alembic at heads. It refuses a non-empty database that has no
+   `alembic_version`. No SQL snapshot is committed; the generator is the
+   fresh path.
+2. **Every boot**: `alembic upgrade heads`, fail-closed — a failing migration
+   stops the container.
+3. `python -m core.database.load_seed_data` — idempotent seeds (credential
+   types, models, skills, personas, plugin categories, the marketplace
+   catalogue; in the local edition also the first-run content: Auto, the
+   Researcher/Writer/Analyst roster, the *Two-minute brief* Playbook and a
+   welcome Deliverable).
+4. In the local edition, the local workspace (`DEFAULT_WORKSPACE_ID`) and the
+   operator user are ensured, fail-closed.
 
-### 2. **Type-Safe & Modern**
-- Python 3.11+ with type hints
-- Pydantic for validation
-- SQLAlchemy 2.0 ORM
-- FastAPI async/await
+Adding a migration: a revision under `alembic/versions/`, keeping **one head**
+(the `alembic-from-zero` CI job asserts it and re-runs the fresh-clone path).
+The `schema-drift` job (`scripts/ci/schema_drift_check.py`, repository root)
+goes red when a migration `ALTER`s a table that no writer — migration, model
+or raw-DDL extra — `CREATE`s.
 
-### 3. **Observable**
-- Real-time SSE streams
-- Structured logging
-- Built-in analytics
-- Health checks everywhere
+## Tests — CI is the gate
 
-### 4. **Extensible**
-- Plugin-based tools
-- MCP protocol support
-- Custom modules
-- Override anything
+The `test` workflow (`.github/workflows/test.yml`) runs on every push and pull
+request:
 
----
+| Job | What it runs |
+|---|---|
+| `orchestrator-tests` (required) | `python scripts/init_test_db.py` against an ephemeral Postgres, then `pytest tests` in the local edition (`AUTH_EDITION=local`, `DEFAULT_WORKSPACE_ID` set) with a coverage ratchet (`scripts/check_coverage_baseline.py`). |
+| `orchestrator-module-tests` | The `modules/**/tests` and `integrations/**/tests` trees (some need live services). |
+| `alembic-from-zero` | Exactly one Alembic head; `init_fresh_db` then `upgrade heads` from an empty database. |
+| `schema-drift` | The four-writer drift check. |
+| eval lanes | NL2SQL, retrieval-recall, memory-recall and graph-uplift harness self-tests (informational). |
 
-## 🌟 Innovation Highlights
+Alongside it: `smoke-fresh-clone` (a real `docker compose up` from an empty
+checkout must reach a green `/health` and `/health/ready`), `import-linter`
+(module-boundary contracts in `orchestrator/.importlinter`), `dco`,
+`gitleaks`, `CodeQL`, `malware-scan` and `check-shopify-isolation`.
 
-### **Field Theory for Context**
-We don't just "stuff context" - we use **mathematical field theory**:
-
-```
-C = A(c₁, c₂, c₃, c₄, c₅, c₆)
-```
-
-Where:
-- `c₁` = Semantic relevance (vector similarity)
-- `c₂` = Temporal relevance (recency)
-- `c₃` = Structural importance (graph centrality)
-- `c₄` = Causal relationships
-- `c₅` = Contextual coherence
-- `c₆` = User preferences
-
-**Result:** Agents get the RIGHT context, not just ANY context.
-
-### **Collaborative Reasoning**
-Agents can:
-- **Propose** solutions
-- **Debate** approaches
-- **Vote** on decisions
-- **Reach consensus** (with configurable thresholds)
-- **Learn** from outcomes
-
-### **Tool Registry Pattern**
-**DRY taken seriously:**
-- Define tool once
-- Use in any agent
-- Available to all workflows
-- Automatic documentation
-- Centralized maintenance
-
----
-
-## 🤝 How to Contribute
-
-### We Need YOU! 🙌
-
-Whether you're an AI researcher, backend engineer, frontend wizard, or documentation guru - **there's a place for you**.
-
-### 🎯 Quick Contribution Pathways
-
-#### **1. Build New Tools** (Easiest Entry Point!)
-```python
-# modules/tools/implementations/your_tool.py
-from modules.tools import tool_registry, ToolCategory
-
-@tool_registry.register(
-    category=ToolCategory.PRODUCTIVITY,
-    name="notion_sync",
-    description="Sync data with Notion"
-)
-async def notion_sync(page_id: str, content: dict) -> dict:
-    # Your implementation
-    return {"status": "synced"}
-```
-
-**Impact:** Every agent, workflow, and user can now use Notion! 🚀
-
-#### **2. Enhance Modules**
-Pick a module that interests you:
-- `modules/agents/` - Improve agent coordination
-- `modules/rag/` - Better document processing
-- `modules/memory/` - Smarter memory systems
-- `modules/codegraph/` - More language support
-- `modules/learning/` - Enhanced learning algorithms
-
-#### **3. Add LLM Providers**
-```python
-# core/llm/providers/your_provider.py
-class CustomLLMProvider(BaseLLMProvider):
-    async def generate_completion(self, ...):
-        # Support for new LLM!
-```
-
-#### **4. Frontend Features**
-- React/TypeScript components
-- Real-time visualizations
-- New UI workflows
-- Dashboard improvements
-
-#### **5. Documentation & Examples**
-- Write tutorials
-- Create example workflows
-- Improve guides
-- Record demos
-
-### 📋 Current Focus Areas
-
-| Area | Difficulty | Impact | Status |
-|------|-----------|--------|--------|
-| Tool Ecosystem | 🟢 Easy | 🔥 High | **Accepting PRs** |
-| Multi-modal RAG | 🟡 Medium | 🔥 High | **In Progress** |
-| Agent Templates | 🟢 Easy | ⭐ Medium | **Help Wanted** |
-| Performance Optimization | 🔴 Hard | ⭐ Medium | **Research Phase** |
-| Mobile UI | 🟡 Medium | ⭐ Medium | **Planned** |
-
----
-
-## 🗺️ The Vision
-
-### **Where We Are** (v2.0)
-✅ Multi-agent orchestration  
-✅ Tool registry system  
-✅ RAG & semantic search  
-✅ CodeGraph intelligence  
-✅ SSE streaming  
-✅ MCP protocol support  
-
-### **Where We're Going** (2025)
-
-**Q1 2025: Agent Marketplace**
-- Pre-built specialist agents
-- Community-contributed tools
-- One-click agent deployment
-
-**Q2 2025: Autonomous Teams**
-- Agents that hire other agents
-- Budget management
-- Goal decomposition
-- Self-organizing workflows
-
-**Q3 2025: Learning at Scale**
-- Cross-organization learning
-- Federated agent knowledge
-- Performance benchmarking
-- Best practice sharing
-
-**Q4 2025: The Agent OS**
-- Automatos as the operating system for AI agents
-- Plugin ecosystem
-- Agent-to-agent protocols
-- Distributed agent networks
-
----
-
-## 💬 Join the Community
-
-### **Discord** 💜
-Real-time chat, help, and collaboration
-[discord.gg/automatos](https://discord.gg/automatos)
-
-### **GitHub Discussions** 💭
-Feature requests, roadmap discussions
-[github.com/AutomatosAI/automatos-ai/discussions](https://github.com/AutomatosAI/automatos-ai/discussions)
-
-### **Twitter/X** 🐦
-Updates, demos, and AI insights
-[@AutomatosAI](https://twitter.com/AutomatosAI)
-
-### **Weekly Office Hours** 📅
-Every Friday, 2pm PST - Come chat with the core team!
-
----
-
-## 📚 Deep Dives
-
-Want to understand a specific part of the system? Check out our module guides:
-
-- **[Agents Module](modules/agents/README.md)** - How agents think and collaborate
-- **[Tools Module](modules/tools/README.md)** - The tool registry architecture
-- **[RAG Module](modules/rag/README.md)** - Document processing pipeline
-- **[Memory Module](modules/memory/README.md)** - Hierarchical memory systems
-- **[CodeGraph Module](modules/codegraph/README.md)** - Code intelligence engine
-- **[Orchestrator Module](modules/orchestrator/README.md)** - Workflow execution
-- **[Consumers](consumers/README.md)** - Background processing
-
----
-
-## ⚡ Quick Facts
-
-- **Language:** Python 3.11+ (Backend), TypeScript (Frontend)
-- **Database:** PostgreSQL 15+ with pgvector
-- **Real-time:** Redis + SSE (not WebSocket!)
-- **AI Providers:** OpenAI, Anthropic, + custom
-- **License:** MIT (truly open source)
-- **Status:** Production-ready, actively developed
-
----
-
-## 🎖️ Recognition
-
-- **Featured** on Hacker News (Top 10)
-- **1000+ Stars** on GitHub
-- **50+ Contributors** worldwide
-- **Research-backed** (IBM Zurich, Princeton, Indiana University)
-
----
-
-## 🚀 Ready to Build the Future?
+Pure tests (no database) can be run inside the compose image:
 
 ```bash
-# Let's go!
-git clone https://github.com/AutomatosAI/automatos-ai
-cd automatos-ai
-docker-compose up
-
-# You're now running the future of AI orchestration 🎉
+docker compose run --rm --no-deps -v "$PWD:/repo" -w /repo/orchestrator backend \
+  python -m pytest tests/test_prd209_quickstart_honest.py -q -p no:cacheprovider
 ```
 
-**Questions?** Open an issue or join our Discord!  
-**Ideas?** We love PRs and discussions!  
-**Just curious?** Star the repo and follow our journey!
+Tests that need Postgres need the schema `init_test_db.py` builds; CI is the
+reference run for those.
 
----
+## Conventions enforced here
 
-<div align="center">
+- `config.py` is the only environment reader (`os.getenv` nowhere else).
+- Every S3 client comes from `core/storage/s3.py` (a source guard fails on a
+  stray `boto3.client(`); locally that is MinIO, in the hosted edition AWS S3.
+- Composio is consulted through one availability predicate
+  (`core/composio/client.py: composio_available()`); without a key the router
+  excludes Composio tools instead of failing open — see
+  [modules/tools/README.md](modules/tools/README.md).
+- Anything hosted-only is gated by `config.AUTH_EDITION`, never by role; the
+  local operator is `super_admin` by design.
+- Canonical terms: Playbook, Mission, Task, Deliverable, Knowledge Graph,
+  Command Center, Auto.
 
-### Built with ❤️ by developers, for developers
+## Module guides
 
-**[🌟 Star on GitHub](https://github.com/AutomatosAI/automatos-ai)** • **[📖 Read the Docs](https://docs.automatos.ai)** • **[💬 Join Discord](https://discord.gg/automatos)**
+- [modules/agents/README.md](modules/agents/README.md)
+- [modules/tools/README.md](modules/tools/README.md)
+- [modules/codegraph/README.md](modules/codegraph/README.md)
+- [modules/nl2sql/README.md](modules/nl2sql/README.md)
+- [consumers/README.md](consumers/README.md)
 
-*Making AI agents work together shouldn't be rocket science. So we made it beautiful instead.* ✨
-
-</div>
+Contributing: [CONTRIBUTING.md](../CONTRIBUTING.md) — DCO sign-off on every
+commit; capability first, core second. Licence: Apache-2.0.

--- a/orchestrator/api/documents.py
+++ b/orchestrator/api/documents.py
@@ -255,6 +255,7 @@ async def handle_request(
             }.get(file_type, DocumentType.TEXT)
             
             # Process document directly
+            processing_error = None
             document.status = "processing"
             db.commit()
 
@@ -270,13 +271,20 @@ async def handle_request(
         except Exception as e:
             logger.error(f"Error processing document {document.id}: {e}")
             document.status = "failed"
+            processing_error = str(e)[:200]
             db.commit()
         
         return DocumentUploadResponse(
             document_id=document.id,
             filename=document.filename,
             status=document.status,
-            message="Document uploaded successfully"
+            # PRD-233: never say "successfully" over a failed pipeline — every local
+            # upload had ended status=failed (no embedding provider) behind this text.
+            message=(
+                "Document uploaded successfully"
+                if document.status != "failed"
+                else f"Uploaded, but processing failed: {processing_error or 'see backend logs'}"
+            ),
         )
         
     except HTTPException:

--- a/orchestrator/api/profile.py
+++ b/orchestrator/api/profile.py
@@ -1,0 +1,176 @@
+"""PRD-233 S6 — the profile behind the session: who Auto is talking to.
+
+GET /api/profile (both editions)
+    Identity from the request context plus the resolved ``users`` row when one
+    exists. Resolution order is the tree's own (api/chat.py ``get_user_id``):
+    ``users.clerk_user_id == ctx.user.id`` then ``users.email == ctx.user.email``
+    — NEVER ``ctx.user.id`` as ``users.id`` (it is a Clerk string in saas and
+    the operator's email in local).
+
+PUT /api/profile (LOCAL edition only)
+    Edits the operator's row — ``name`` / ``username`` / ``avatar_url``. Email is
+    READ-ONLY: it is the lookup key the anonymous lane resolves the row by
+    (``LOCAL_OPERATOR_EMAIL`` in ``.env``), so changing it here would orphan
+    the session from its own row. In saas the profile is managed by the
+    identity provider (Clerk) → 403. Every write invalidates hybrid.py's
+    operator-row cache so the next request already carries the new name.
+"""
+from __future__ import annotations
+
+import logging
+import re
+from typing import Optional
+from urllib.parse import urlparse
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from config import config
+from core.auth.dependencies import RequestContext
+from core.auth.hybrid import get_request_context_hybrid, invalidate_local_operator_cache
+from core.auth.workspace_permission import require_workspace_permission
+from core.database.database import get_db
+from core.models.core import User
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/profile", tags=["profile"])
+
+# Editing the operator's identity is a workspace-owner act in the single-operator
+# edition (the anonymous local session IS the owner — PRD-175 lane contract).
+# Module constant so tests override the exact dependency object.
+_PROFILE_WRITE_GATE = require_workspace_permission("workspace:manage")
+
+LOCAL_EDITION = "local"
+EMAIL_NOTE_LOCAL = (
+    "Email is the operator lookup key — it is set by LOCAL_OPERATOR_EMAIL in .env "
+    "and cannot be changed here."
+)
+EMAIL_NOTE_SAAS = "Managed by your identity provider."
+MANAGED_BY_IDENTITY_PROVIDER = "Profile is managed by your identity provider"
+OPERATOR_ROW_MISSING = "Local operator row not found — the entrypoint seed did not run"
+USERNAME_TAKEN = "username is already taken"
+
+_HTML_MARKERS = re.compile(r"[<>]")
+_ALLOWED_AVATAR_SCHEMES = ("http", "https")
+_USERNAME_PATTERN = r"^[A-Za-z0-9][A-Za-z0-9._-]*$"
+# Columns a blank value clears (NULL); username is NOT NULL + unique and may not be blanked.
+_CLEARABLE_FIELDS = frozenset({"name", "avatar_url"})
+
+
+class ProfileOut(BaseModel):
+    edition: str
+    editable: bool
+    id: Optional[int] = None
+    email: Optional[str] = None
+    name: Optional[str] = None
+    username: Optional[str] = None
+    avatar_url: Optional[str] = None
+    system_role: str
+    email_note: str
+
+
+class ProfileUpdate(BaseModel):
+    """Omitted fields are unchanged; ``name`` / ``avatar_url`` accept "" to clear."""
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    name: Optional[str] = Field(default=None, max_length=255)
+    username: Optional[str] = Field(
+        default=None, min_length=1, max_length=255, pattern=_USERNAME_PATTERN
+    )
+    avatar_url: Optional[str] = Field(default=None, max_length=500)
+
+    @field_validator("name")
+    @classmethod
+    def _name_has_no_markup(cls, value: Optional[str]) -> Optional[str]:
+        if value is not None and _HTML_MARKERS.search(value):
+            raise ValueError("name must not contain HTML")
+        return value
+
+    @field_validator("avatar_url")
+    @classmethod
+    def _avatar_is_http_url_or_blank(cls, value: Optional[str]) -> Optional[str]:
+        if not value:
+            return value
+        parsed = urlparse(value)
+        if parsed.scheme not in _ALLOWED_AVATAR_SCHEMES or not parsed.netloc:
+            raise ValueError("avatar_url must be an http(s) URL")
+        return value
+
+
+def _resolve_user_row(db: Session, ctx: RequestContext) -> Optional[User]:
+    """The caller's ``users`` row, or None — same order as api/chat.py get_user_id."""
+    user = ctx.user
+    if user is None:
+        return None
+    clerk_uid = user.clerk_user_id or (user.id if isinstance(user.id, str) else None)
+    row = None
+    if clerk_uid:
+        row = db.query(User).filter(User.clerk_user_id == clerk_uid).first()
+    if row is None and user.email:
+        row = db.query(User).filter(User.email == user.email).first()
+    return row
+
+
+def _to_out(ctx: RequestContext, row: Optional[User]) -> ProfileOut:
+    is_local = config.AUTH_EDITION == LOCAL_EDITION
+    return ProfileOut(
+        edition=config.AUTH_EDITION,
+        editable=is_local,
+        id=row.id if row is not None else None,
+        email=row.email if row is not None else ctx.user.email,
+        name=row.name if row is not None else None,
+        username=row.username if row is not None else None,
+        avatar_url=row.avatar_url if row is not None else None,
+        system_role=ctx.user.system_role,
+        email_note=EMAIL_NOTE_LOCAL if is_local else EMAIL_NOTE_SAAS,
+    )
+
+
+def _update_values(body: ProfileUpdate) -> dict:
+    """Column values for the fields the client actually sent (blank clears)."""
+    changes = body.model_dump(exclude_unset=True)
+    return {
+        field: (value or None) if field in _CLEARABLE_FIELDS else value
+        for field, value in changes.items()
+    }
+
+
+@router.get("", response_model=ProfileOut)
+async def get_profile(
+    ctx: RequestContext = Depends(get_request_context_hybrid),
+    db: Session = Depends(get_db),
+) -> ProfileOut:
+    """Who the platform thinks is talking (both editions)."""
+    return _to_out(ctx, _resolve_user_row(db, ctx))
+
+
+@router.put("", response_model=ProfileOut, dependencies=[Depends(_PROFILE_WRITE_GATE)])
+async def update_profile(
+    body: ProfileUpdate,
+    ctx: RequestContext = Depends(get_request_context_hybrid),
+    db: Session = Depends(get_db),
+) -> ProfileOut:
+    """Edit the local operator's profile row (local edition only)."""
+    if config.AUTH_EDITION != LOCAL_EDITION:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=MANAGED_BY_IDENTITY_PROVIDER)
+
+    operator = User.email == config.LOCAL_OPERATOR_EMAIL
+    if db.query(User.id).filter(operator).first() is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=OPERATOR_ROW_MISSING)
+
+    values = _update_values(body)
+    if values:
+        try:
+            db.query(User).filter(operator).update(values, synchronize_session=False)
+            db.commit()
+        except IntegrityError:
+            db.rollback()
+            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=USERNAME_TAKEN)
+        invalidate_local_operator_cache()
+        logger.info("Local operator profile updated: %s", sorted(values))
+
+    return _to_out(ctx, db.query(User).filter(operator).first())

--- a/orchestrator/api/tools.py
+++ b/orchestrator/api/tools.py
@@ -15,16 +15,16 @@ from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel, Field
-from sqlalchemy import text
+from sqlalchemy import func, text
 from sqlalchemy.orm import Session
 
 from core.auth.dependencies import RequestContext
 from core.auth.hybrid import get_request_context_hybrid
 from core.auth.workspace_permission import require_workspace_permission
-from core.composio.client import get_composio_client
+from core.composio.client import composio_available, composio_unavailable_reason, get_composio_client
 from core.composio.entity_manager import EntityManager
 from core.database.database import get_db
-from core.models.composio_cache import ComposioActionCache, ComposioAppCache, ComposioStatsCache
+from core.models.composio_cache import ComposioActionCache, ComposioAppCache, ComposioStatsCache, ComposioSyncJob
 from services.metadata_sync_service import MetadataSyncService
 from config import config
 
@@ -131,6 +131,17 @@ class StatsOut(BaseModel):
     connected_apps: int
     categories: Dict[str, Any]
     last_synced: Optional[str] = None
+
+
+class IntegrationsStatusOut(BaseModel):
+    """PRD-233 S2 — honest integration state for the Tools page."""
+    available: bool
+    reason: Optional[str] = None
+    key_configured: bool
+    apps_cached: int
+    last_sync: Optional[str] = None
+    # Latest composio_sync_jobs row: running | completed | failed | None (never synced).
+    sync_status: Optional[str] = None
 
 
 class ConnectIn(BaseModel):
@@ -264,6 +275,41 @@ async def stats(
         connected_apps=connected,
         categories=stats.get("categories") or {},
         last_synced=(stats.get("last_full_sync") or {}).get("timestamp"),
+    )
+
+
+@router.get("/integrations/status", response_model=IntegrationsStatusOut)
+async def integrations_status(
+    ctx: RequestContext = Depends(get_request_context_hybrid),
+    db: Session = Depends(get_db),
+):
+    """Whether Composio integrations can run here — and why not when they can't.
+
+    ``available`` is the SAME predicate the tool router uses to decide whether
+    Composio tools are offered at all (PRD-233 S2), so the Tools page and the
+    model always agree. ``apps_cached`` / ``last_sync`` describe the local
+    catalogue (``composio_apps_cache``), which syncs itself on the first keyed
+    boot.
+    """
+    apps_cached = db.query(func.count(ComposioAppCache.id)).scalar() or 0
+    last_sync_row = (
+        db.query(ComposioStatsCache)
+        .filter(ComposioStatsCache.stat_key == "last_full_sync")
+        .first()
+    )
+    last_sync = (last_sync_row.stat_value or {}).get("timestamp") if last_sync_row else None
+    latest_job = (
+        db.query(ComposioSyncJob)
+        .order_by(ComposioSyncJob.started_at.desc())
+        .first()
+    )
+    return IntegrationsStatusOut(
+        available=composio_available(),
+        reason=composio_unavailable_reason(),
+        key_configured=bool(config.COMPOSIO_API_KEY),
+        apps_cached=int(apps_cached),
+        last_sync=last_sync,
+        sync_status=latest_job.status if latest_job else None,
     )
 
 

--- a/orchestrator/api/workspaces.py
+++ b/orchestrator/api/workspaces.py
@@ -107,7 +107,7 @@ async def get_current_workspace(
 
         member_role = resolve_workspace_role(db, ctx) or "viewer"
 
-    from services.plan_tiers import exposure_for_plan
+    from services.plan_tiers import exposure_for_local_edition, exposure_for_plan
 
     return {
         "id": str(workspace.id),
@@ -121,7 +121,12 @@ async def get_current_workspace(
         # marketplace depth + tier display info. Field addition only, same route
         # (route-manifest unchanged). Hidden ≠ deleted (D5): the client trims
         # nav/marketplace labels; no route or data is removed.
-        "exposure": exposure_for_plan(workspace.plan or "basic"),
+        "exposure": (
+            # PRD-233 S7: the local edition is never plan-gated (see plan_tiers).
+            exposure_for_local_edition()
+            if config.AUTH_EDITION == "local"
+            else exposure_for_plan(workspace.plan or "basic")
+        ),
         # PRD-222 W1S2: server-side onboarding stage + trial snapshot ({stage,
         # trial}). Field addition only — no new route (route-manifest unchanged).
         # PRD-222 W2·S6 (US-022) retired the legacy new-workspace boolean — its

--- a/orchestrator/consumers/chatbot/service.py
+++ b/orchestrator/consumers/chatbot/service.py
@@ -158,6 +158,40 @@ def build_tool_caller_context(
     return ctx or None
 
 
+def resolve_known_user_name(db, user_id: Optional[int]) -> Optional[str]:
+    """PRD-233 S6: the driving human's display name from their ``users`` row.
+
+    ``user_id`` is the INTERNAL integer ``users.id`` (the value
+    ``api/chat.py::get_user_id`` resolves — never ``ctx.user.id``, which is a
+    Clerk string in saas and the operator's email in local). Blank/whitespace
+    names and missing rows resolve to None so the greeting path keeps its
+    "ready to help" fallback. Best effort: a DB error never fails a turn.
+    """
+    if not user_id:
+        return None
+    try:
+        from core.models import User
+
+        row = db.query(User.name).filter(User.id == user_id).first()
+    except Exception:  # noqa: BLE001 — identity is a nicety, never a failed turn
+        logger.debug("[PRD-233] users.name lookup skipped for user %s", user_id, exc_info=True)
+        return None
+    name = (row[0] or "").strip() if row else ""
+    return name or None
+
+
+def atom_identity_clause(user_name: Optional[str]) -> str:
+    """The ATOM prompt's "who am I talking to" clause (PRD-233 S6).
+
+    Mirrors the full path's personality wording ("You're talking to <name>",
+    consumers/chatbot/personality.py) so both lanes greet from ONE source —
+    ``ConversationState.user_name``. Empty (prompt byte-identical) when the
+    name is unknown.
+    """
+    name = user_name.strip() if isinstance(user_name, str) else ""
+    return f" You're talking to {name}." if name else ""
+
+
 class ToolExecutionTracker:
     """
     Tracks tool executions within a conversation turn to prevent looping.
@@ -869,6 +903,18 @@ class StreamingChatService:
             widget_mode=self.widget_mode,
             db_session=self.db,
         )
+        # PRD-233 S6: seed the greeting with the driving human's name from their
+        # users row. IdentitySection already renders the ``user_name`` kwarg the
+        # orchestrator forwards from this state ("You're talking to <name>");
+        # memory-derived names still win there (``_user_name`` is read first).
+        # The ATOM prompt below reads the same state — one source, both lanes.
+        # Local edition only (owner rule for this wave: the SaaS prompt stays
+        # byte-identical). Flipping the seed on for saas is this one condition.
+        if config.AUTH_EDITION == "local":
+            smart_chat.orchestrator.state.user_name = (
+                smart_chat.orchestrator.state.user_name
+                or resolve_known_user_name(self.db, getattr(self, "_driving_user_id", None))
+            )
 
         _complexity = (
             complexity_assessment.complexity
@@ -1027,7 +1073,8 @@ class StreamingChatService:
 
         _atom_prompt = (
             f"You are {agent_runtime.metadata.name}, an AI assistant on the Automatos platform.\n\n"
-            f"{_time_ctx}. Read the conversation and match the user's energy. "
+            f"{_time_ctx}.{atom_identity_clause(smart_chat.get_user_name())} "
+            "Read the conversation and match the user's energy. "
             "If they're frustrated, be direct — skip the niceties and lead with the answer. "
             "If they're curious, explain the why. If they're casual, be casual back. "
             "If they're formal, match it. Never be artificially cheerful when someone is having a bad time. "
@@ -2127,6 +2174,9 @@ class StreamingChatService:
         # recall guard (user_id here is the INTERNAL integer id — the same
         # value the PRD-196 subject tag carries at store time).
         self._viewer_subject_id = f"user:{user_id}" if user_id else None
+        # PRD-233 S6: the same integer id seeds the greeting (see
+        # _prepare_llm_messages → resolve_known_user_name).
+        self._driving_user_id = user_id
 
         try:
             # Ensure workspace_id is available

--- a/orchestrator/core/auth/hybrid.py
+++ b/orchestrator/core/auth/hybrid.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hmac as _hmac
 import logging
 import secrets
+import time
 from typing import Callable, Optional
 from urllib.parse import urlparse
 from uuid import UUID, uuid4
@@ -494,6 +495,93 @@ def _resolve_workspace_for_clerk_user(
     return None
 
 
+# ---------------------------------------------------------------------------
+# PRD-233 S6 — the local operator's identity: ONE users row, resolved by email
+# ---------------------------------------------------------------------------
+
+# Backstop only: PUT /api/profile invalidates explicitly after every write; the
+# TTL bounds staleness for writers that bypass the API (psql, a re-seed).
+_LOCAL_OPERATOR_CACHE_TTL_SECONDS = 60.0
+_LOCAL_OPERATOR_COLUMNS = ("id", "email", "name", "username", "avatar_url")
+_local_operator_cache: dict = {}
+
+
+def invalidate_local_operator_cache() -> None:
+    """Drop the cached operator row so the next request re-reads ``users``."""
+    _local_operator_cache.clear()
+
+
+def _load_local_operator_row(db, email: str) -> Optional[dict]:
+    """The operator's ``users`` row by email (the seed's lookup key) or None."""
+    row = db.execute(
+        text(
+            "SELECT id, email, name, username, avatar_url FROM users "
+            "WHERE email = :email LIMIT 1"
+        ),
+        {"email": email},
+    ).fetchone()
+    if not row:
+        return None
+    values = tuple(row[index] for index in range(len(_LOCAL_OPERATOR_COLUMNS)))
+    # A real row carries an integer PK and the email it was looked up by;
+    # anything else (a stubbed session in tests, a malformed row) is "no row".
+    if not isinstance(values[0], int) or values[1] != email:
+        return None
+    return dict(zip(_LOCAL_OPERATOR_COLUMNS, values))
+
+
+def _resolve_local_operator(db, email: str) -> Optional[dict]:
+    """Cached read of the operator row; a miss is never cached (a seed that
+    lands later must be picked up immediately) and a DB error never 500s the
+    request — the caller falls back to PRD-209's email-only lane."""
+    now = time.monotonic()
+    cached = _local_operator_cache.get(email)
+    if cached and (now - cached["fetched_at"]) < _LOCAL_OPERATOR_CACHE_TTL_SECONDS:
+        return cached["row"]
+    try:
+        row = _load_local_operator_row(db, email)
+    except Exception as exc:  # noqa: BLE001 — identity enrichment must never break auth
+        logger.warning("Local operator row lookup failed (%s); using email-only lane", exc)
+        try:
+            db.rollback()
+        except Exception:  # noqa: BLE001
+            pass
+        return None
+    if row is None:
+        logger.warning("Local operator row missing for %s — entrypoint seed did not run?", email)
+        return None
+    _local_operator_cache[email] = {"row": row, "fetched_at": now}
+    return row
+
+
+def _local_operator_user_context(db) -> Optional[UserContext]:
+    """Bind the anonymous local session to the operator's ``users`` row.
+
+    ``id`` carries the EMAIL, not the integer PK: every resolver in the tree
+    maps ``ctx.user.id`` → ``users`` via ``clerk_user_id == ctx.user.id`` and
+    then ``email == ctx.user.email`` (api/chat.py get_user_id, marketplace,
+    notifications, workflow_recipes, harness, team), and the Clerk lane itself
+    binds ``id = clerk_user_id or email``. An integer here would 500 the
+    ``clerk_user_id == ctx.user.id`` sites (varchar = integer). The integer PK
+    rides ``raw_claims["user_id"]`` for callers that want it without a query.
+    """
+    row = _resolve_local_operator(db, config.LOCAL_OPERATOR_EMAIL)
+    if row is None:
+        return None
+    return UserContext(
+        id=row["email"],
+        email=row["email"],
+        system_role="super_admin",
+        raw_claims={
+            "source": "local_operator",
+            "user_id": row["id"],
+            "name": row["name"],
+            "username": row["username"],
+            "avatar_url": row["avatar_url"],
+        },
+    )
+
+
 def _get_api_key(request: Request) -> Optional[str]:
     # Common patterns
     api_key = request.headers.get("x-api-key") or request.headers.get("X-Api-Key")
@@ -854,10 +942,11 @@ async def get_request_context_hybrid(request: Request) -> RequestContext:
         # system settings, credentials, admin analytics all belong to them).
         # In saas, the anonymous dev-fallback remains a plain user.
         if config.AUTH_EDITION == "local":
-            # The operator's seeded users row is resolved by email (api/chat.py,
-            # widgets/chat.py); `id` stays unset on purpose — ctx.user.id is a
-            # Clerk-string elsewhere and must never be read as users.id.
-            anon_user = UserContext(email=config.LOCAL_OPERATOR_EMAIL, system_role="super_admin")
+            # PRD-233 S6: bind the operator's seeded users row (email-keyed; see
+            # _local_operator_user_context for why `id` is the email, never the
+            # PK). A missing row keeps PRD-209's email-only lane — never a 500.
+            anon_user = _local_operator_user_context(db) or \
+                UserContext(email=config.LOCAL_OPERATOR_EMAIL, system_role="super_admin")
         else:
             anon_user = UserContext()
         result = RequestContext(workspace_id=resolved, user=anon_user, auth_type="anonymous")

--- a/orchestrator/core/composio/bootstrap.py
+++ b/orchestrator/core/composio/bootstrap.py
@@ -1,0 +1,265 @@
+"""PRD-233 S2 — Composio catalogue bootstrap + seeded-agent rebind.
+
+Nothing used to sync the Composio catalogue on boot: the only triggers were
+``POST /api/tools/sync`` (Tools page **Sync**) and two manual scripts. On a
+keyless first boot the two marketplace seeders (``scripts/seed_starter_agents.py``,
+``scripts/seed_marketplace_agents_v2.py``) look each agent's apps up in
+``composio_apps_cache``, find nothing ("Tool 'SLACK' not found"), and write
+``metadata.tools = []`` / ``metadata.tool_icons = []`` — keeping only the
+intended names in ``metadata.tool_names``. Their by-name idempotency never
+re-binds later, so adding a key afterwards left every seeded agent unbound.
+
+This module closes both gaps from ONE startup stage (``main.py`` →
+``BootstrapStage.TOOL_SYNC``):
+
+* key + SDK, **empty** catalogue     → full sync in a background thread, then rebind
+* key + SDK, **populated** catalogue → rebind only (a no-op once every seed is bound)
+* no key / no SDK                    → log the reason, touch nothing
+
+Never blocks or fails boot: the sync runs off the event loop, and every
+failure is logged + recorded via ``record_error(subsystem="startup")`` like the
+other boot seeds (``core/boot/startup_tasks.py``).
+"""
+from __future__ import annotations
+
+import json
+import logging
+import threading
+from datetime import datetime, timedelta
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
+
+from sqlalchemy import func, text
+
+from core.composio.client import composio_available, composio_unavailable_reason
+from core.database.database import SessionLocal
+from core.models.composio_cache import ComposioAppCache, ComposioSyncJob
+from core.utils.exception_telemetry import record_error
+
+logger = logging.getLogger(__name__)
+
+# Both seeders stamp their marketplace rows with this creator; user-published
+# items carry the publisher's name, so this is the seeded-set discriminator.
+SEEDED_CREATOR_NAME = "Automatos Team"
+SEEDED_ITEM_TYPE = "agent"
+# A 'running' composio_sync_jobs row younger than this means a sync is already
+# in flight (another worker, or the Tools page) — don't start a second one.
+# Kept short on purpose: a full sync takes a few minutes, and a dev hot-reload
+# that kills the background thread leaves its job row 'running' forever, so a
+# long window would silently postpone the next boot's sync.
+RUNNING_SYNC_FRESH_MINUTES = 10
+BACKGROUND_THREAD_NAME = "composio-catalog-bootstrap"
+
+# {APP_NAME: (cache_id, logo_url)} — the seeder lookup, materialised once.
+Catalog = Dict[str, Tuple[int, Optional[str]]]
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers (unit-tested without a DB)
+# ---------------------------------------------------------------------------
+
+
+def resolve_seeded_bindings(tool_names: Sequence[Any], catalog: Catalog) -> Tuple[List[int], List[str]]:
+    """Re-run the seeders' per-name lookup against ``catalog``.
+
+    Mirrors ``scripts/seed_starter_agents.py`` exactly: an app that is not in
+    the cache is skipped (no id, no icon); a hit contributes its id and its
+    logo URL (``""`` when the cache has none).
+    """
+    ids: List[int] = []
+    icons: List[str] = []
+    for name in tool_names:
+        hit = catalog.get(str(name).upper())
+        if hit is None:
+            continue
+        ids.append(hit[0])
+        icons.append(hit[1] or "")
+    return ids, icons
+
+
+def rebound_metadata(metadata: Dict[str, Any], catalog: Catalog) -> Optional[Dict[str, Any]]:
+    """New metadata dict with re-resolved bindings, or ``None`` when unchanged.
+
+    Never mutates ``metadata``; the caller writes only when a dict comes back,
+    which is what makes the rebind idempotent.
+    """
+    names = metadata.get("tool_names") or []
+    ids, icons = resolve_seeded_bindings(names, catalog)
+    if ids == (metadata.get("tools") or []) and icons == (metadata.get("tool_icons") or []):
+        return None
+    return {**metadata, "tools": ids, "tool_icons": icons}
+
+
+# ---------------------------------------------------------------------------
+# DB helpers
+# ---------------------------------------------------------------------------
+
+
+def catalog_app_count(db) -> int:
+    """Number of apps in ``composio_apps_cache`` (0 ⇒ never synced)."""
+    return int(db.query(func.count(ComposioAppCache.id)).scalar() or 0)
+
+
+def _sync_in_flight(db) -> bool:
+    cutoff = datetime.utcnow() - timedelta(minutes=RUNNING_SYNC_FRESH_MINUTES)
+    row = (
+        db.query(ComposioSyncJob.id)
+        .filter(ComposioSyncJob.status == "running", ComposioSyncJob.started_at >= cutoff)
+        .first()
+    )
+    return row is not None
+
+
+def _load_catalog(db, names: Sequence[str]) -> Catalog:
+    if not names:
+        return {}
+    rows = (
+        db.query(ComposioAppCache.id, ComposioAppCache.app_name, ComposioAppCache.logo_url)
+        .filter(func.upper(ComposioAppCache.app_name).in_(list(names)))
+        .all()
+    )
+    return {str(app_name).upper(): (int(app_id), logo_url) for app_id, app_name, logo_url in rows}
+
+
+def _seeded_rows_needing_bindings(db):
+    """Seeded rows whose bound ids lag their intended names.
+
+    On SaaS (every seed bound at seed time) this returns nothing, so the boot
+    rebind is a single indexed-free SELECT and no write.
+    """
+    return db.execute(
+        text(
+            """
+            SELECT id, metadata FROM marketplace_items
+            WHERE type = :item_type AND creator_name = :creator
+              AND jsonb_array_length(COALESCE(metadata->'tools', CAST('[]' AS jsonb)))
+                  < jsonb_array_length(COALESCE(metadata->'tool_names', CAST('[]' AS jsonb)))
+            ORDER BY id
+            """
+        ),
+        {"item_type": SEEDED_ITEM_TYPE, "creator": SEEDED_CREATOR_NAME},
+    ).fetchall()
+
+
+def rebind_seeded_agents(db) -> int:
+    """Re-resolve the seeded marketplace agents' app bindings from the cache.
+
+    Touches ONLY ``marketplace_items`` rows of type ``agent`` created by the
+    seeders (``creator_name = 'Automatos Team'``) — never the ``agents`` table,
+    never user-published items. Idempotent: a row is written only when its
+    recomputed bindings differ. Returns the number of rows updated.
+    """
+    rows = _seeded_rows_needing_bindings(db)
+    if not rows:
+        return 0
+    wanted = sorted(
+        {
+            str(name).upper()
+            for _item_id, metadata in rows
+            for name in ((metadata or {}).get("tool_names") or [])
+        }
+    )
+    catalog = _load_catalog(db, wanted)
+    updated = 0
+    for item_id, metadata in rows:
+        new_metadata = rebound_metadata(metadata or {}, catalog)
+        if new_metadata is None:
+            continue
+        db.execute(
+            text(
+                "UPDATE marketplace_items SET metadata = CAST(:metadata AS jsonb), updated_at = NOW() "
+                "WHERE id = :item_id"
+            ),
+            {"metadata": json.dumps(new_metadata), "item_id": item_id},
+        )
+        updated += 1
+    if updated:
+        db.commit()
+    return updated
+
+
+# ---------------------------------------------------------------------------
+# Background sync + the boot entry point
+# ---------------------------------------------------------------------------
+
+
+def run_catalog_sync_and_rebind() -> Dict[str, Any]:
+    """Blocking full catalogue sync, then the seeded-agent rebind.
+
+    Runs on the background thread with its OWN session — the boot session is
+    long gone by the time the SDK paging finishes. Self-guarding: never raises.
+    """
+    from services.metadata_sync_service import MetadataSyncService
+
+    logger.info("[PRD-233 S2] Composio catalogue sync starting (composio_apps_cache was empty)")
+    db = SessionLocal()
+    try:
+        result = MetadataSyncService(db).run_full_sync()
+        rebound = rebind_seeded_agents(db)
+        logger.info(
+            "[PRD-233 S2] Composio catalogue sync finished: apps=%s actions=%s errors=%s; "
+            "seeded agents re-bound=%d",
+            result.get("apps_synced"),
+            result.get("actions_synced"),
+            result.get("errors_count", result.get("errors")),
+            rebound,
+        )
+        return {"status": "completed", "sync": result, "rebound": rebound}
+    except Exception as exc:  # noqa: BLE001 — background task must not raise
+        db.rollback()
+        logger.warning("[PRD-233 S2] Composio catalogue sync failed: %s", exc, exc_info=True)
+        record_error(subsystem="startup", operation="composio_catalog_sync", error=exc)
+        return {"status": "failed", "error": str(exc)}
+    finally:
+        db.close()
+
+
+def _start_daemon_thread(target: Callable[[], Any]) -> None:
+    threading.Thread(target=target, name=BACKGROUND_THREAD_NAME, daemon=True).start()
+
+
+def ensure_catalog_on_boot(
+    *, start_background: Callable[[Callable[[], Any]], None] = _start_daemon_thread
+) -> Dict[str, Any]:
+    """The boot stage body. Cheap, self-guarding, never blocks boot.
+
+    ``start_background`` is injectable so tests can capture the scheduled
+    callable instead of spawning a thread.
+    """
+    if not composio_available():
+        reason = composio_unavailable_reason()
+        logger.info(
+            "[PRD-233 S2] Composio integrations disabled — %s. Composio tools are not "
+            "offered to agents; the Tools page shows why.",
+            reason,
+        )
+        return {"status": "unavailable", "reason": reason}
+
+    try:
+        db = SessionLocal()
+        try:
+            apps_cached = catalog_app_count(db)
+            if apps_cached > 0:
+                rebound = rebind_seeded_agents(db)
+                if rebound:
+                    logger.info(
+                        "[PRD-233 S2] Re-bound %d seeded marketplace agent(s) to the Composio catalogue",
+                        rebound,
+                    )
+                return {"status": "ready", "apps_cached": apps_cached, "rebound": rebound}
+            if _sync_in_flight(db):
+                logger.info("[PRD-233 S2] Composio catalogue sync already in flight — not starting another")
+                return {"status": "in_flight", "apps_cached": 0}
+        finally:
+            db.close()
+    except Exception as exc:  # noqa: BLE001 — a boot probe must never abort boot
+        logger.warning("[PRD-233 S2] Composio catalogue probe failed (non-fatal): %s", exc, exc_info=True)
+        record_error(subsystem="startup", operation="composio_catalog_probe", error=exc)
+        return {"status": "error", "error": str(exc)}
+
+    start_background(run_catalog_sync_and_rebind)
+    logger.info(
+        "[PRD-233 S2] composio_apps_cache is empty and a Composio key is configured — "
+        "full catalogue sync scheduled in the background (thread %s)",
+        BACKGROUND_THREAD_NAME,
+    )
+    return {"status": "scheduled", "apps_cached": 0}

--- a/orchestrator/core/composio/client.py
+++ b/orchestrator/core/composio/client.py
@@ -13,7 +13,7 @@ Features:
 
 import logging
 from datetime import datetime
-from typing import List, Optional, Dict, Any
+from typing import List, Optional, Dict, Any, Tuple
 from uuid import UUID
 
 from config import config
@@ -1423,3 +1423,56 @@ def get_composio_client() -> ComposioClient:
     if _client_instance is None:
         _client_instance = ComposioClient()
     return _client_instance
+
+
+# =============================================================================
+# PRD-233 S2 — availability predicate (the ONE degrade seam)
+# =============================================================================
+#
+# "Available" means the platform can actually reach Composio: a key is
+# configured (config only — never os.getenv here) AND the SDK imports. Every
+# consumer that decides whether to OFFER or RUN a Composio tool asks this one
+# predicate; nothing else probes the key. Evaluated once per process (the key
+# is env-only and the SDK install is static) — ``reset_composio_availability``
+# exists for tests that flip the config.
+
+COMPOSIO_UNAVAILABLE_NO_KEY = "COMPOSIO_API_KEY is not configured"
+# NOTE: keep "composio-openai" out of this string — tool_router's
+# _is_fatal_dependency_error() keys on it and would replace the honest
+# message with a generic "restart the backend" line.
+COMPOSIO_UNAVAILABLE_NO_SDK = "Composio SDK is not installed (composio-core package missing)"
+
+_availability: Optional[Tuple[bool, Optional[str]]] = None
+
+
+def _probe_composio_availability() -> Tuple[bool, Optional[str]]:
+    if not config.COMPOSIO_API_KEY:
+        return False, COMPOSIO_UNAVAILABLE_NO_KEY
+    try:
+        _get_composio()
+    except ImportError:
+        return False, COMPOSIO_UNAVAILABLE_NO_SDK
+    return True, None
+
+
+def _composio_availability() -> Tuple[bool, Optional[str]]:
+    global _availability
+    if _availability is None:
+        _availability = _probe_composio_availability()
+    return _availability
+
+
+def composio_available() -> bool:
+    """True when a Composio key is configured AND the SDK is importable."""
+    return _composio_availability()[0]
+
+
+def composio_unavailable_reason() -> Optional[str]:
+    """Human-readable reason Composio is unavailable; ``None`` when available."""
+    return _composio_availability()[1]
+
+
+def reset_composio_availability() -> None:
+    """Forget the cached probe (tests flip config / SDK presence)."""
+    global _availability
+    _availability = None

--- a/orchestrator/core/database/load_seed_data.py
+++ b/orchestrator/core/database/load_seed_data.py
@@ -122,9 +122,8 @@ def load_seed_data(load_credentials: bool = True, load_platform_defaults: bool =
             # Load System Settings (PRD-25)
             print("\n📂 Loading system settings...")
             try:
-                sys.path.insert(0, str(Path(__file__).parent.parent))
-                from seeds.seed_system_settings import seed_system_settings
-                from database.database import get_db_session
+                from core.seeds.seed_system_settings import seed_system_settings
+                from core.database.database import get_db_session
                 
                 with get_db_session() as db:
                     created, updated = seed_system_settings(db)
@@ -136,7 +135,7 @@ def load_seed_data(load_credentials: bool = True, load_platform_defaults: bool =
             # Load LLM Models
             print("\n📂 Loading LLM models...")
             try:
-                from seeds.seed_models import seed_models
+                from core.seeds.seed_models import seed_models
                 seed_models()
                 print("  ✅ LLM models seeded")
             except Exception as e:
@@ -145,7 +144,7 @@ def load_seed_data(load_credentials: bool = True, load_platform_defaults: bool =
             # Load Skills and Patterns
             print("\n📂 Loading skills and patterns...")
             try:
-                from seeds.seed_skills import seed_skills, seed_patterns
+                from core.seeds.seed_skills import seed_skills, seed_patterns
                 seed_skills()
                 seed_patterns()
                 print("  ✅ Skills and patterns seeded")
@@ -155,8 +154,8 @@ def load_seed_data(load_credentials: bool = True, load_platform_defaults: bool =
             # Load Personas
             print("\n📂 Loading personas...")
             try:
-                from seeds.seed_personas import seed_personas
-                from database.database import get_db_session as _get_db_session
+                from core.seeds.seed_personas import seed_personas
+                from core.database.database import get_db_session as _get_db_session
 
                 with _get_db_session() as db:
                     created, updated = seed_personas(db)
@@ -171,7 +170,7 @@ def load_seed_data(load_credentials: bool = True, load_platform_defaults: bool =
             # reference) — so they run only into an EMPTY catalog.
             print("\n📂 Loading marketplace catalog...")
             try:
-                from database.database import get_db_session as _mk_session
+                from core.database.database import get_db_session as _mk_session
                 from sqlalchemy import text as _sql
                 with _mk_session() as db:
                     catalog_rows = db.execute(_sql("SELECT count(*) FROM marketplace_items")).scalar() or 0
@@ -185,13 +184,13 @@ def load_seed_data(load_credentials: bool = True, load_platform_defaults: bool =
             except Exception as e:
                 print(f"  ⚠️  Error loading marketplace agents: {e}")
             try:
-                from seeds.seed_shopify_agents import seed_shopify_agents
+                from core.seeds.seed_shopify_agents import seed_shopify_agents
                 seed_shopify_agents()
                 print("  ✅ Shopify agents seeded")
             except Exception as e:
                 print(f"  ⚠️  Error loading Shopify agents: {e}")
             try:
-                from seeds.seed_packages import seed_packages
+                from core.seeds.seed_packages import seed_packages
                 created, updated = seed_packages()
                 print(f"  ✅ Packages: {created} created, {updated} updated")
             except Exception as e:
@@ -200,8 +199,8 @@ def load_seed_data(load_credentials: bool = True, load_platform_defaults: bool =
             # Load Plugin Categories
             print("\n📂 Loading plugin categories...")
             try:
-                from seeds.seed_plugin_categories import seed_plugin_categories
-                from database.database import get_db_session as __get_db_session
+                from core.seeds.seed_plugin_categories import seed_plugin_categories
+                from core.database.database import get_db_session as __get_db_session
 
                 with __get_db_session() as db:
                     created, updated = seed_plugin_categories(db)

--- a/orchestrator/core/database/load_seed_data.py
+++ b/orchestrator/core/database/load_seed_data.py
@@ -209,6 +209,23 @@ def load_seed_data(load_credentials: bool = True, load_platform_defaults: bool =
             except Exception as e:
                 print(f"  ⚠️  Error loading plugin categories: {e}")
 
+            # PRD-233 S3: local-edition first-run content — the workspace +
+            # operator rows, Auto, a starter roster, one demo Playbook and a
+            # welcome Deliverable. Gated INSIDE the seed on AUTH_EDITION=local
+            # + DEFAULT_WORKSPACE_ID (saas ⇒ no-op); idempotent-refresh, never
+            # overwrites edits. Package-qualified imports so the seed shares the
+            # app's ORM session/model objects (module mode: python -m ...).
+            print("\n📂 Loading local-edition first-run content...")
+            try:
+                from core.seeds.seed_local_first_run import seed_local_first_run
+                from core.database.database import get_db_session as _local_session
+
+                with _local_session() as db:
+                    outcome = seed_local_first_run(db)
+                    print(f"  ✅ Local first-run: {outcome}")
+            except Exception as e:
+                print(f"  ⚠️  Error loading local-edition first-run content: {e}")
+
         print("\n" + "=" * 60)
         print("✅ SEED DATA LOADED SUCCESSFULLY!")
         print(f"   {cred_count} credential types + system settings + models + skills")

--- a/orchestrator/core/seeds/seed_local_first_run.py
+++ b/orchestrator/core/seeds/seed_local_first_run.py
@@ -1,0 +1,718 @@
+"""
+Local-edition first-run seed — the two-minute demo (PRD-233 S3)
+================================================================
+
+Runs inside the existing entrypoint seed step (``core.database.load_seed_data``)
+and only in the local edition: ``config.AUTH_EDITION == "local"`` with a
+``config.DEFAULT_WORKSPACE_ID``. SaaS never enters this module's write path.
+
+What it seeds, all scoped to the DEFAULT_WORKSPACE_ID workspace:
+
+* the workspace row itself and the single operator ``users`` row — the same
+  idempotent shape as ``docker-entrypoint.sh`` / ``scripts/init_test_db.py`` —
+  so the content below is attributable on the very first boot regardless of
+  which lifecycle step runs first;
+* Auto, through the existing per-workspace seeder (``seed_auto_agent`` —
+  reused, never duplicated);
+* a three-agent starter roster (Researcher / Writer / Analyst) that uses the
+  platform's native tools only — no Composio app assignments;
+* one demo Playbook (``workflow_recipes``) the roster can run with nothing
+  but an LLM key: no integrations, no worker;
+* a welcome Deliverable — a ``blog_posts`` row, the one member of the
+  ``v_workspace_outputs`` union whose content lives in the database, so the
+  Deliverables tab opens it with no worker / object-storage round-trip.
+
+Idempotent-REFRESH — the ``seed_auto_agent`` persona-hash pattern, generalised:
+
+* identity per row is stable: agent ``slug`` / Playbook ``template_id`` /
+  post ``slug``, each within the workspace;
+* a row whose content fingerprint equals the CURRENT seed is left alone;
+* a row whose fingerprint matches a PRIOR shipped version
+  (``PRIOR_SEED_FINGERPRINTS``) is refreshed to the current content;
+* any other fingerprint is a user edit — never overwritten (``customized``);
+* a seeded row the user deleted is not resurrected: the workspace's
+  ``settings["local_first_run"]`` ledger records what was seeded once.
+
+Running the seed twice yields identical state — nothing is assigned unless it
+differs, so no UPDATE is emitted. Seed content lives here; the database is the
+runtime source (CLAUDE.md §4 — no file hacks).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import math
+from collections import Counter
+from copy import deepcopy
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from functools import partial
+from types import SimpleNamespace
+from typing import Any, Callable, Optional
+from uuid import UUID
+
+from sqlalchemy import inspect as sa_inspect, text
+from sqlalchemy.orm import Session
+from sqlalchemy.orm.attributes import flag_modified
+
+from config import config
+from core.models.core import Agent, BlogPost, User, WorkflowTemplate
+from core.models.workspaces import Workspace
+from core.seeds.seed_auto_agent import seed_auto_agent
+
+# NOTE: nothing from core.services is imported here on purpose. The seed
+# loader (core/database/load_seed_data.py) puts /app/core at sys.path[0], so
+# under it `core/services/__init__` → analytics_engine → core.redis resolves
+# `import redis` to the app's own core/redis package and dies with
+# "No module named 'redis.asyncio'". Keep this module's import chain to
+# models + the Auto seeder.
+
+logger = logging.getLogger(__name__)
+
+# Same estimate BlogService uses (200 wpm, minimum 1) — kept local, see above.
+_READING_WORDS_PER_MINUTE = 200
+
+LEDGER_KEY = "local_first_run"  # workspaces.settings[LEDGER_KEY]
+LEDGER_VERSION = 1
+
+# Same shape as docker-entrypoint.sh ensure_local_workspace() and
+# scripts/init_test_db.py: one workspace, one operator; users.id 1 is
+# api/chat.py's own fallback (SELECT id FROM users WHERE id = 1).
+LOCAL_WORKSPACE_NAME = "Local Workspace"
+LOCAL_WORKSPACE_SLUG = "local"
+LOCAL_OPERATOR_USER_ID = 1
+LOCAL_OPERATOR_USERNAME = "local"
+LOCAL_OPERATOR_PLACEHOLDER_NAME = "Local Operator"  # PRD-233 S6 makes it editable
+
+# Fingerprints of PRIOR shipped versions of the content below. When you change
+# any seed text, add the fingerprint the OLD content produced (capture it with
+# ``current_fingerprints()`` before editing) so untouched rows keep refreshing.
+# Rows hashing to none of current ∪ prior are user edits and are never touched.
+PRIOR_SEED_FINGERPRINTS: frozenset[str] = frozenset()
+
+# ── Roster ───────────────────────────────────────────────────────────────────
+
+ROSTER_TEAM = "Starter team"
+ROSTER_AGENT_TYPE = "specialized"
+
+ROSTER: tuple[dict[str, Any], ...] = (
+    {
+        "slug": "local-researcher",
+        "name": "Researcher",
+        "job_title": "Research Analyst",
+        "marketplace_category": "Research",
+        "description": (
+            "Gathers the facts on a topic — from the workspace's documents and "
+            "knowledge and from what the model already knows — and hands back "
+            "research notes that say plainly what is known and what is assumed."
+        ),
+        "persona": (
+            "You are the Researcher on a small starter team.\n"
+            "- Collect the facts that matter for the topic you are given; use the "
+            "workspace's own documents and knowledge first when they exist.\n"
+            "- Label every point as established, likely, or unverified — never "
+            "present a guess as a fact.\n"
+            "- Hand over compact research notes (bullets, with sources where you "
+            "have them) that a writer can build on without re-reading everything."
+        ),
+        "responsibilities": [
+            "Collect and organise the facts on a topic",
+            "Separate what is known from what is assumed",
+            "Hand over research notes the Writer can build on",
+        ],
+        "tags": ["research", "starter", "local-edition"],
+    },
+    {
+        "slug": "local-writer",
+        "name": "Writer",
+        "job_title": "Content Writer",
+        "marketplace_category": "Marketing",
+        "description": (
+            "Turns research notes into finished prose — briefs, summaries, "
+            "posts, emails — in the length and tone asked for, without adding "
+            "claims the notes do not support."
+        ),
+        "persona": (
+            "You are the Writer on a small starter team.\n"
+            "- Write from the material you are given; do not invent facts to "
+            "fill gaps — flag them instead.\n"
+            "- Plain language, short paragraphs, a clear structure, no hype.\n"
+            "- Deliver the requested format (Markdown by default) and nothing "
+            "else; the reader should be able to use it as-is."
+        ),
+        "responsibilities": [
+            "Turn research notes into finished, structured prose",
+            "Keep to the requested length, tone and format",
+            "Flag gaps rather than filling them with guesses",
+        ],
+        "tags": ["writing", "starter", "local-edition"],
+    },
+    {
+        "slug": "local-analyst",
+        "name": "Analyst",
+        "job_title": "Business Analyst",
+        "marketplace_category": "Operations",
+        "description": (
+            "Reviews drafts, data and plans: finds the gaps, risks and "
+            "unsupported claims, then returns a corrected version with a short "
+            "list of what changed and what to do next."
+        ),
+        "persona": (
+            "You are the Analyst on a small starter team.\n"
+            "- Review what you are given critically: gaps, risks, unsupported "
+            "claims, missing next steps.\n"
+            "- Be specific and brief — one line per finding, most important first.\n"
+            "- Always return the corrected work in full so it can be used "
+            "immediately, and say when nothing needed changing."
+        ),
+        "responsibilities": [
+            "Review drafts and plans for gaps, risks and unsupported claims",
+            "Return corrected work ready to use",
+            "Recommend concrete next steps",
+        ],
+        "tags": ["analysis", "review", "starter", "local-edition"],
+    },
+)
+
+# ── Demo Playbook ────────────────────────────────────────────────────────────
+
+PLAYBOOK_TEMPLATE_ID = "local-two-minute-brief"
+PLAYBOOK_TOPIC_DEFAULT = "How a small team can put AI agents to work"
+
+# Steps carry the roster slug; the stored rows carry the resolved ``agent_id``
+# (what the executor and the create route's agent check read). ``agent`` is
+# NOT a step key — GET /{id} reserves it for enrichment.
+PLAYBOOK: dict[str, Any] = {
+    "template_id": PLAYBOOK_TEMPLATE_ID,
+    "name": "Two-minute brief",
+    "description": (
+        "Research, write and review a one-page brief on any topic. Three steps, "
+        "three agents, nothing required beyond your LLM key — run it to see the "
+        "starter roster work together, then change the topic or the prompts."
+    ),
+    "inputs": {
+        "topic": {
+            "type": "string",
+            "required": True,
+            "description": "What the brief should cover",
+            "default": PLAYBOOK_TOPIC_DEFAULT,
+        },
+    },
+    "outputs": {
+        "final_brief": {
+            "type": "string",
+            "description": "The reviewed one-page brief (the Analyst's output)",
+        },
+    },
+    "steps": (
+        {
+            "step_id": "research",
+            "order": 1,
+            "agent_slug": "local-researcher",
+            "error_handling": "stop",
+            "output_key": "research_notes",
+            "prompt_template": (
+                "Research this topic: {input.topic}\n\n"
+                "Produce research notes for a one-page brief: 6-10 bullet points "
+                "covering what it is, why it matters, the main options or "
+                "approaches, and the pitfalls. Mark each point as established, "
+                "likely, or unverified. Use the workspace's knowledge tools first "
+                "if any are available; otherwise draw on what you know and say "
+                "so. Finish with the three questions a decision-maker would "
+                "still ask."
+            ),
+        },
+        {
+            "step_id": "write",
+            "order": 2,
+            "agent_slug": "local-writer",
+            "error_handling": "stop",
+            "output_key": "draft_brief",
+            "prompt_template": (
+                "Write a one-page brief on: {input.topic}\n\n"
+                "Use the Researcher's notes from the previous step as your "
+                "source material — do not add claims they do not support. "
+                "Structure: a title, a two-sentence summary, three short "
+                "sections with headings, and a closing 'Next steps' list of "
+                "three actions. Plain language, no hype, under 450 words. "
+                "Output the brief in Markdown."
+            ),
+        },
+        {
+            "step_id": "review",
+            "order": 3,
+            "agent_slug": "local-analyst",
+            "error_handling": "stop",
+            "output_key": "final_brief",
+            "prompt_template": (
+                "Review the brief from the previous step on: {input.topic}\n\n"
+                "First list up to three gaps, risks or unsupported claims (one "
+                "line each). Then output the corrected brief in full under the "
+                "heading 'Final brief', with your fixes applied and nothing else "
+                "changed. If nothing needs fixing, say so and repeat the brief "
+                "unchanged."
+            ),
+        },
+    ),
+    # Timeouts in seconds (the executor normalises); same defaults the create
+    # route applies when a caller omits execution_config.
+    "execution_config": {
+        "mode": "sequential",
+        "max_retries": 1,
+        "timeout_per_step": 300,
+        "total_timeout": 900,
+        "auto_learning": True,
+    },
+    "schedule_config": {"type": "manual"},
+    "template_definition": {"steps": [], "agents": [], "config": {}, "variables": []},
+    "tags": ["demo", "starter", "local-edition", "brief"],
+    "version": "1.0",
+}
+
+# ── Welcome Deliverable ──────────────────────────────────────────────────────
+
+WELCOME_SLUG = "welcome-to-automatos-local-edition"
+WELCOME_TITLE = "Welcome to Automatos (local edition)"
+WELCOME_AUTHOR = "Auto"
+WELCOME_CATEGORY = "guide"
+WELCOME_TAGS = ["welcome", "local-edition", "getting-started"]
+WELCOME_EXCERPT = (
+    "What is already in this workspace, the one thing to do first, and how to "
+    "run the demo Playbook."
+)
+WELCOME_CONTENT = """# Welcome to Automatos (local edition)
+
+This workspace runs entirely on your machine — the API, Postgres, Redis and object storage in Docker. There is no account and no login: the session you are using is the workspace operator.
+
+## What is already here
+
+- **Auto** — the workspace orchestrator. Chat with Auto to create agents, run Playbooks and manage the workspace.
+- **A starter roster** — Researcher, Writer and Analyst, on the Agents page. They use the platform's native tools only.
+- **A demo Playbook** — *Two-minute brief*, on the Playbooks page. Researcher → Writer → Analyst produce a reviewed one-page brief on a topic you choose.
+- **This Deliverable** — the first entry in your Deliverables tab. Everything your agents produce lands there.
+
+## The one thing to do first
+
+Agents need a language model. Add an API key under **Settings → API Keys** (OpenRouter, OpenAI, Anthropic, Google and others are supported). Nothing answers until a key is present; everything listed above works with only that key.
+
+## Try it
+
+1. Open **Playbooks** and run *Two-minute brief* with a topic of your own.
+2. Follow the execution log step by step; the final brief is the Analyst's output.
+3. Ask Auto in chat: "What can I do here?"
+
+## What is not here yet
+
+- Third-party integrations (Slack, GitHub, Google Workspace and the rest) run through Composio. Without a `COMPOSIO_API_KEY` in your `.env` they are not offered.
+- Agents acting on files on your own machine use the workspace worker service — the self-hosting guide covers how to enable it.
+
+Everything seeded here is yours to edit or delete. Seeded items are refreshed by platform updates only while they are untouched; once you change one, it stays as you left it.
+"""
+
+# ── Fingerprints ─────────────────────────────────────────────────────────────
+
+_AGENT_CONTENT_FIELDS: tuple[str, ...] = (
+    "name", "description", "job_title", "team", "agent_type",
+    "marketplace_category", "status", "use_custom_persona",
+    "custom_persona_prompt", "tags", "responsibilities", "configuration",
+    "model_config",
+)
+_PLAYBOOK_CONTENT_FIELDS: tuple[str, ...] = (
+    "name", "description", "template_definition", "inputs", "outputs",
+    "execution_config", "schedule_config", "tags", "recommended_agents",
+    "required_tools", "is_public", "is_featured", "version",
+)
+_PLAYBOOK_REFRESH_FIELDS: tuple[str, ...] = _PLAYBOOK_CONTENT_FIELDS + ("steps",)
+_POST_CONTENT_FIELDS: tuple[str, ...] = (
+    "title", "excerpt", "content", "tags", "category", "status", "author_name",
+)
+_POST_REFRESH_FIELDS: tuple[str, ...] = _POST_CONTENT_FIELDS + ("reading_time_minutes",)
+
+
+def _fingerprint(payload: dict[str, Any]) -> str:
+    return hashlib.sha256(
+        json.dumps(payload, sort_keys=True, default=str).encode("utf-8")
+    ).hexdigest()
+
+
+def agent_fingerprint(row: Any) -> str:
+    """Content fingerprint of a roster row (ORM row or column namespace)."""
+    return _fingerprint({f: getattr(row, f, None) for f in _AGENT_CONTENT_FIELDS})
+
+
+def _normalized_steps(steps: list[dict[str, Any]], id_to_slug: dict[int, str]) -> list[dict[str, Any]]:
+    """Steps with ``agent_id`` replaced by the roster slug — the stable identity —
+    so a re-created roster agent (new id) still hashes as seed content."""
+    normalized = []
+    for step in steps:
+        agent_id = step.get("agent_id")
+        rest = {k: v for k, v in step.items() if k != "agent_id"}
+        normalized.append({**rest, "agent_slug": id_to_slug.get(agent_id, agent_id)})
+    return normalized
+
+
+def playbook_fingerprint(row: Any, id_to_slug: dict[int, str]) -> str:
+    """Content fingerprint of a Playbook row, agent ids normalised to slugs."""
+    payload = {f: getattr(row, f, None) for f in _PLAYBOOK_CONTENT_FIELDS}
+    payload["steps"] = _normalized_steps(list(getattr(row, "steps", None) or []), id_to_slug)
+    return _fingerprint(payload)
+
+
+def post_fingerprint(row: Any) -> str:
+    """Content fingerprint of the welcome post."""
+    return _fingerprint({f: getattr(row, f, None) for f in _POST_CONTENT_FIELDS})
+
+
+# ── Column builders (the ONE definition of what a seeded row holds) ──────────
+
+def _agent_columns(spec: dict[str, Any], workspace_id: UUID, operator: Optional[User]) -> dict[str, Any]:
+    return {
+        "name": spec["name"],
+        "slug": spec["slug"],
+        "description": spec["description"],
+        "job_title": spec["job_title"],
+        "team": ROSTER_TEAM,
+        "agent_type": ROSTER_AGENT_TYPE,
+        "marketplace_category": spec["marketplace_category"],
+        "status": "active",
+        "use_custom_persona": True,
+        "custom_persona_prompt": spec["persona"],
+        "tags": list(spec["tags"]),
+        "responsibilities": list(spec["responsibilities"]),
+        "configuration": {},
+        # No model_config: like wizard-created agents, the roster resolves its
+        # LLM at runtime from the workspace's configured provider/key.
+        "model_config": None,
+        "workspace_id": workspace_id,
+        "owner_type": "workspace",
+        "owner_id": str(workspace_id),
+        "is_system_agent": False,
+        "is_shared": True,
+        "created_by": config.LOCAL_OPERATOR_EMAIL,
+        "created_by_user_id": operator.id if operator else None,
+    }
+
+
+def _stored_steps(steps: tuple[dict[str, Any], ...], slug_to_id: dict[str, int]) -> list[dict[str, Any]]:
+    stored = []
+    for step in steps:
+        rest = {k: deepcopy(v) for k, v in step.items() if k != "agent_slug"}
+        stored.append({**rest, "agent_id": slug_to_id[step["agent_slug"]]})
+    return stored
+
+
+def _playbook_columns(
+    spec: dict[str, Any], workspace_id: UUID, operator: Optional[User], slug_to_id: dict[str, int]
+) -> dict[str, Any]:
+    return {
+        "template_id": spec["template_id"],
+        "name": spec["name"],
+        "description": spec["description"],
+        "workspace_id": workspace_id,
+        "owner_type": "workspace",
+        "owner_id": str(workspace_id),
+        "template_definition": deepcopy(spec["template_definition"]),
+        "steps": _stored_steps(spec["steps"], slug_to_id),
+        "inputs": deepcopy(spec["inputs"]),
+        "outputs": deepcopy(spec["outputs"]),
+        "execution_config": deepcopy(spec["execution_config"]),
+        "schedule_config": deepcopy(spec["schedule_config"]),
+        "tags": list(spec["tags"]),
+        "recommended_agents": [],
+        "required_tools": [],  # native tools only — nothing to install
+        "is_public": True,
+        "is_featured": True,
+        "is_system": False,  # the operator may delete it; the ledger keeps it deleted
+        "is_approved": False,
+        "version": spec["version"],
+        "created_by": config.LOCAL_OPERATOR_EMAIL,
+        "created_by_user_id": operator.id if operator else None,
+    }
+
+
+def _reading_time_minutes(content: str) -> int:
+    return max(1, math.ceil(len(content.split()) / _READING_WORDS_PER_MINUTE))
+
+
+def _post_columns(workspace_id: UUID, auto_agent_id: Optional[int]) -> dict[str, Any]:
+    return {
+        "workspace_id": workspace_id,
+        "author_agent_id": auto_agent_id,
+        "author_name": WELCOME_AUTHOR,
+        "title": WELCOME_TITLE,
+        "slug": WELCOME_SLUG,
+        "excerpt": WELCOME_EXCERPT,
+        "content": WELCOME_CONTENT,
+        "file_path": None,  # content stays in the DB — no workspace file to fetch
+        "tags": list(WELCOME_TAGS),
+        "category": WELCOME_CATEGORY,
+        "status": "published",
+        "reading_time_minutes": _reading_time_minutes(WELCOME_CONTENT),
+    }
+
+
+def validate_playbook(recipe: WorkflowTemplate) -> None:
+    """The create route's validation path (api/workflow_recipes.create), raised
+    instead of HTTP-mapped. Seed time and tests share it."""
+    for check in (recipe.validate_steps, recipe.validate_execution_config, recipe.validate_schedule_config):
+        ok, error = check()
+        if not ok:
+            raise ValueError(f"demo Playbook is invalid: {error}")
+
+
+def current_fingerprints() -> dict[str, str]:
+    """{identity: fingerprint} of the content as currently shipped. Capture
+    BEFORE editing seed text and add the old values to PRIOR_SEED_FINGERPRINTS."""
+    ws = UUID(int=0)
+    slug_to_id = {spec["slug"]: index + 1 for index, spec in enumerate(ROSTER)}
+    id_to_slug = {v: k for k, v in slug_to_id.items()}
+    out = {
+        spec["slug"]: agent_fingerprint(SimpleNamespace(**_agent_columns(spec, ws, None)))
+        for spec in ROSTER
+    }
+    out[PLAYBOOK_TEMPLATE_ID] = playbook_fingerprint(
+        SimpleNamespace(**_playbook_columns(PLAYBOOK, ws, None, slug_to_id)), id_to_slug
+    )
+    out[WELCOME_SLUG] = post_fingerprint(SimpleNamespace(**_post_columns(ws, None)))
+    return out
+
+
+# ── Refresh mechanics ────────────────────────────────────────────────────────
+
+def _assign(row: Any, field: str, value: Any) -> bool:
+    """Assign only when different (no UPDATE for identical content). New
+    objects for JSON values; flagged so a reassigned JSON(B) column persists."""
+    if getattr(row, field, None) == value:
+        return False
+    setattr(row, field, deepcopy(value))
+    if isinstance(value, (dict, list)) and sa_inspect(row, raiseerr=False) is not None:
+        flag_modified(row, field)
+    return True
+
+
+def _backfill_attribution(row: Any, columns: dict[str, Any]) -> None:
+    """A seed-owned row created before the operator existed gets its
+    created_by_user_id once the user row is there (never on customized rows)."""
+    if not hasattr(row, "created_by_user_id") or columns.get("created_by_user_id") is None:
+        return
+    if getattr(row, "created_by_user_id", None) is None:
+        row.created_by_user_id = columns["created_by_user_id"]
+
+
+def _refresh(
+    row: Any,
+    columns: dict[str, Any],
+    fields: tuple[str, ...],
+    fingerprint: Callable[[Any], str],
+    current: str,
+) -> str:
+    """current ⇒ untouched; a PRIOR shipped version ⇒ refreshed to the current
+    content; anything else is the user's edit ⇒ customized, never overwritten."""
+    found = fingerprint(row)
+    if found == current:
+        _backfill_attribution(row, columns)
+        return "current"
+    if found not in PRIOR_SEED_FINGERPRINTS:
+        return "customized"
+    for field in fields:
+        _assign(row, field, columns[field])
+    _backfill_attribution(row, columns)
+    return "refreshed"
+
+
+# ── Workspace, operator, ledger ──────────────────────────────────────────────
+
+def _ensure_workspace(db: Session, workspace_id: UUID) -> str:
+    result = db.execute(
+        text(
+            "INSERT INTO workspaces (id, name, slug, is_personal, is_active) "
+            "VALUES (CAST(:id AS uuid), :name, :slug, TRUE, TRUE) "
+            "ON CONFLICT (id) DO NOTHING"
+        ),
+        {"id": str(workspace_id), "name": LOCAL_WORKSPACE_NAME, "slug": LOCAL_WORKSPACE_SLUG},
+    )
+    return "created" if result.rowcount == 1 else "present"
+
+
+def _ensure_operator_user(db: Session) -> tuple[Optional[User], str]:
+    """The single operator, resolved by config.LOCAL_OPERATOR_EMAIL (how
+    api/chat.py and hybrid.py find it). Inserted only when missing — a name the
+    operator typed later (S6) is never touched."""
+    email = config.LOCAL_OPERATOR_EMAIL
+    user = db.query(User).filter(User.email == email).first()
+    if user is not None:
+        return user, "present"
+    db.execute(
+        text(
+            "INSERT INTO users (id, username, email, name, is_active) "
+            "VALUES (:id, :username, :email, :name, TRUE) ON CONFLICT DO NOTHING"
+        ),
+        {
+            "id": LOCAL_OPERATOR_USER_ID,
+            "username": LOCAL_OPERATOR_USERNAME,
+            "email": email,
+            "name": LOCAL_OPERATOR_PLACEHOLDER_NAME,
+        },
+    )
+    db.execute(text(
+        "SELECT setval(pg_get_serial_sequence('users','id'), GREATEST((SELECT max(id) FROM users), 1))"
+    ))
+    user = db.query(User).filter(User.email == email).first()
+    if user is not None:
+        return user, "created"
+    logger.warning(
+        "PRD-233 S3: could not seed the local operator (%s) — users.id %s or username %r "
+        "is already taken by another row; seeded content will carry no user attribution",
+        email, LOCAL_OPERATOR_USER_ID, LOCAL_OPERATOR_USERNAME,
+    )
+    return None, "unresolved"
+
+
+@dataclass
+class _SeedContext:
+    db: Session
+    workspace_id: UUID
+    operator: Optional[User]
+    ledger: dict[str, set[str]]
+
+
+def _read_ledger(workspace: Workspace) -> dict[str, set[str]]:
+    seeded = ((workspace.settings or {}).get(LEDGER_KEY) or {}).get("seeded") or {}
+    return {kind: set(seeded.get(kind) or []) for kind in ("agents", "playbooks", "deliverables")}
+
+
+def _present_identities(ctx: _SeedContext) -> dict[str, set[str]]:
+    db, ws = ctx.db, ctx.workspace_id
+    roster_slugs = [spec["slug"] for spec in ROSTER]
+    agents = {
+        slug for (slug,) in db.query(Agent.slug)
+        .filter(Agent.workspace_id == ws, Agent.slug.in_(roster_slugs)).all()
+    }
+    playbooks = {
+        tid for (tid,) in db.query(WorkflowTemplate.template_id)
+        .filter(WorkflowTemplate.workspace_id == ws, WorkflowTemplate.template_id == PLAYBOOK_TEMPLATE_ID).all()
+    }
+    posts = {
+        slug for (slug,) in db.query(BlogPost.slug)
+        .filter(BlogPost.workspace_id == ws, BlogPost.slug == WELCOME_SLUG).all()
+    }
+    return {"agents": agents, "playbooks": playbooks, "deliverables": posts}
+
+
+def _record_ledger(workspace: Workspace, ctx: _SeedContext) -> bool:
+    """Remember every identity seeded at least once (rebuild, never mutate the
+    stored dict). Returns True when the workspace row changed."""
+    present = _present_identities(ctx)
+    entry = {
+        "version": LEDGER_VERSION,
+        "seeded": {kind: sorted(ctx.ledger[kind] | present[kind]) for kind in ctx.ledger},
+    }
+    settings = dict(workspace.settings or {})
+    if settings.get(LEDGER_KEY) == entry:
+        return False
+    workspace.settings = {**settings, LEDGER_KEY: entry}
+    if sa_inspect(workspace, raiseerr=False) is not None:
+        flag_modified(workspace, "settings")
+    return True
+
+
+# ── Upserts ──────────────────────────────────────────────────────────────────
+
+def _upsert_agent(ctx: _SeedContext, spec: dict[str, Any]) -> str:
+    row = (
+        ctx.db.query(Agent)
+        .filter(Agent.workspace_id == ctx.workspace_id, Agent.slug == spec["slug"])
+        .first()
+    )
+    columns = _agent_columns(spec, ctx.workspace_id, ctx.operator)
+    if row is None:
+        if spec["slug"] in ctx.ledger["agents"]:
+            return "deleted_by_user"
+        ctx.db.add(Agent(**columns))
+        ctx.db.flush()
+        return "created"
+    current = agent_fingerprint(SimpleNamespace(**columns))
+    return _refresh(row, columns, _AGENT_CONTENT_FIELDS, agent_fingerprint, current)
+
+
+def _roster_ids(ctx: _SeedContext) -> dict[str, int]:
+    rows = (
+        ctx.db.query(Agent.slug, Agent.id)
+        .filter(Agent.workspace_id == ctx.workspace_id, Agent.slug.in_([s["slug"] for s in ROSTER]))
+        .all()
+    )
+    return {slug: agent_id for slug, agent_id in rows}
+
+
+def _upsert_playbook(ctx: _SeedContext, spec: dict[str, Any], slug_to_id: dict[str, int]) -> str:
+    needed = {step["agent_slug"] for step in spec["steps"]}
+    if not needed <= set(slug_to_id):
+        return "missing_agent"  # a roster agent it needs is gone — leave it alone
+    # template_id is globally unique (ix_workflow_recipes_template_id), so the
+    # lookup is by template_id; a row owned by another workspace is a conflict.
+    row = ctx.db.query(WorkflowTemplate).filter(WorkflowTemplate.template_id == spec["template_id"]).first()
+    if row is not None and str(row.workspace_id) != str(ctx.workspace_id):
+        logger.warning("PRD-233 S3: template_id %r belongs to workspace %s — not seeding", spec["template_id"], row.workspace_id)
+        return "template_id_taken"
+    columns = _playbook_columns(spec, ctx.workspace_id, ctx.operator, slug_to_id)
+    fingerprint = partial(playbook_fingerprint, id_to_slug={v: k for k, v in slug_to_id.items()})
+    if row is None:
+        if spec["template_id"] in ctx.ledger["playbooks"]:
+            return "deleted_by_user"
+        recipe = WorkflowTemplate(**columns)
+        validate_playbook(recipe)
+        ctx.db.add(recipe)
+        ctx.db.flush()
+        return "created"
+    return _refresh(row, columns, _PLAYBOOK_REFRESH_FIELDS, fingerprint, fingerprint(SimpleNamespace(**columns)))
+
+
+def _upsert_welcome_post(ctx: _SeedContext, auto_agent_id: Optional[int]) -> str:
+    row = (
+        ctx.db.query(BlogPost)
+        .filter(BlogPost.workspace_id == ctx.workspace_id, BlogPost.slug == WELCOME_SLUG)
+        .first()
+    )
+    columns = _post_columns(ctx.workspace_id, auto_agent_id)
+    if row is None:
+        if WELCOME_SLUG in ctx.ledger["deliverables"]:
+            return "deleted_by_user"
+        ctx.db.add(BlogPost(**columns, published_at=datetime.now(timezone.utc)))
+        ctx.db.flush()
+        return "created"
+    current = post_fingerprint(SimpleNamespace(**columns))
+    return _refresh(row, columns, _POST_REFRESH_FIELDS, post_fingerprint, current)
+
+
+# ── Entry point ──────────────────────────────────────────────────────────────
+
+def seed_local_first_run(db: Session) -> dict[str, Any]:
+    """Seed (or refresh) the local edition's first-run content. The caller owns
+    the commit. Returns per-kind outcome counts; ``{"skipped": ...}`` outside
+    the local edition — SaaS is never written to."""
+    if config.AUTH_EDITION != "local":
+        return {"skipped": "not-local"}
+    raw_workspace_id = (config.DEFAULT_WORKSPACE_ID or "").strip()
+    if not raw_workspace_id:
+        return {"skipped": "no-default-workspace"}
+    workspace_id = UUID(raw_workspace_id)
+
+    result: dict[str, Any] = {"workspace_id": str(workspace_id)}
+    result["workspace"] = _ensure_workspace(db, workspace_id)
+    operator, result["operator_user"] = _ensure_operator_user(db)
+    auto = seed_auto_agent(db, workspace_id)  # existing per-workspace seeder, idempotent
+    result["auto_agent_id"] = auto.id
+
+    workspace = db.query(Workspace).filter(Workspace.id == workspace_id).one()
+    ctx = _SeedContext(db=db, workspace_id=workspace_id, operator=operator, ledger=_read_ledger(workspace))
+
+    result["agents"] = dict(Counter(_upsert_agent(ctx, spec) for spec in ROSTER))
+    result["playbooks"] = dict(Counter([_upsert_playbook(ctx, PLAYBOOK, _roster_ids(ctx))]))
+    result["deliverables"] = dict(Counter([_upsert_welcome_post(ctx, auto.id)]))
+    result["ledger_updated"] = _record_ledger(workspace, ctx)
+    db.flush()
+
+    logger.info("PRD-233 S3 local first-run seed: %s", result)
+    return result

--- a/orchestrator/core/seeds/seed_local_first_run.py
+++ b/orchestrator/core/seeds/seed_local_first_run.py
@@ -585,14 +585,14 @@ def _read_ledger(workspace: Workspace) -> dict[str, set[str]]:
 
 def _present_identities(ctx: _SeedContext) -> dict[str, set[str]]:
     db, ws = ctx.db, ctx.workspace_id
-    roster_slugs = [spec["slug"] for spec in ROSTER]
+    roster_slugs = [c for spec in ROSTER for c in _slug_candidates(spec["slug"], ws)]
     agents = {
-        slug for (slug,) in db.query(Agent.slug)
+        _base_slug(slug, ws) for (slug,) in db.query(Agent.slug)
         .filter(Agent.workspace_id == ws, Agent.slug.in_(roster_slugs)).all()
     }
     playbooks = {
-        tid for (tid,) in db.query(WorkflowTemplate.template_id)
-        .filter(WorkflowTemplate.workspace_id == ws, WorkflowTemplate.template_id == PLAYBOOK_TEMPLATE_ID).all()
+        _base_slug(tid, ws) for (tid,) in db.query(WorkflowTemplate.template_id)
+        .filter(WorkflowTemplate.workspace_id == ws, WorkflowTemplate.template_id.in_(_slug_candidates(PLAYBOOK_TEMPLATE_ID, ws))).all()
     }
     posts = {
         slug for (slug,) in db.query(BlogPost.slug)
@@ -620,52 +620,99 @@ def _record_ledger(workspace: Workspace, ctx: _SeedContext) -> bool:
 
 # ── Upserts ──────────────────────────────────────────────────────────────────
 
+# agents.slug is GLOBALLY unique (idx_agents_slug_unique), while the roster's
+# identity is per workspace. One local install has one workspace, so the plain
+# slug is the norm; when another workspace already owns it (the CI seed tests'
+# throwaway workspaces, a second local workspace), THIS workspace stores a
+# suffixed slug. Every lookup and fingerprint maps back to the base slug, so the
+# seed's refresh contract is identical in both cases.
+def _ws_suffix(workspace_id: UUID) -> str:
+    return str(workspace_id).replace("-", "")[:8]
+
+
+def _slug_candidates(base: str, workspace_id: UUID) -> tuple[str, str]:
+    return (base, f"{base}-{_ws_suffix(workspace_id)}")
+
+
+def _base_slug(stored: str, workspace_id: UUID) -> str:
+    suffix = f"-{_ws_suffix(workspace_id)}"
+    return stored[: -len(suffix)] if stored.endswith(suffix) else stored
+
+
+def _free_slug(db, base: str, workspace_id: UUID) -> str:
+    taken_elsewhere = (
+        db.query(Agent.id).filter(Agent.slug == base, Agent.workspace_id != workspace_id).first() is not None
+    )
+    return _slug_candidates(base, workspace_id)[1] if taken_elsewhere else base
+
+
 def _upsert_agent(ctx: _SeedContext, spec: dict[str, Any]) -> str:
     row = (
         ctx.db.query(Agent)
-        .filter(Agent.workspace_id == ctx.workspace_id, Agent.slug == spec["slug"])
+        .filter(
+            Agent.workspace_id == ctx.workspace_id,
+            Agent.slug.in_(_slug_candidates(spec["slug"], ctx.workspace_id)),
+        )
         .first()
     )
     columns = _agent_columns(spec, ctx.workspace_id, ctx.operator)
     if row is None:
         if spec["slug"] in ctx.ledger["agents"]:
             return "deleted_by_user"
+        columns["slug"] = _free_slug(ctx.db, spec["slug"], ctx.workspace_id)
         ctx.db.add(Agent(**columns))
         ctx.db.flush()
         return "created"
+    columns["slug"] = row.slug  # identity is the base slug; the stored one stays
     current = agent_fingerprint(SimpleNamespace(**columns))
     return _refresh(row, columns, _AGENT_CONTENT_FIELDS, agent_fingerprint, current)
 
 
 def _roster_ids(ctx: _SeedContext) -> dict[str, int]:
+    candidates = [c for spec in ROSTER for c in _slug_candidates(spec["slug"], ctx.workspace_id)]
     rows = (
         ctx.db.query(Agent.slug, Agent.id)
-        .filter(Agent.workspace_id == ctx.workspace_id, Agent.slug.in_([s["slug"] for s in ROSTER]))
+        .filter(Agent.workspace_id == ctx.workspace_id, Agent.slug.in_(candidates))
         .all()
     )
-    return {slug: agent_id for slug, agent_id in rows}
+    return {_base_slug(slug, ctx.workspace_id): agent_id for slug, agent_id in rows}
 
 
 def _upsert_playbook(ctx: _SeedContext, spec: dict[str, Any], slug_to_id: dict[str, int]) -> str:
     needed = {step["agent_slug"] for step in spec["steps"]}
     if not needed <= set(slug_to_id):
         return "missing_agent"  # a roster agent it needs is gone — leave it alone
-    # template_id is globally unique (ix_workflow_recipes_template_id), so the
-    # lookup is by template_id; a row owned by another workspace is a conflict.
-    row = ctx.db.query(WorkflowTemplate).filter(WorkflowTemplate.template_id == spec["template_id"]).first()
-    if row is not None and str(row.workspace_id) != str(ctx.workspace_id):
-        logger.warning("PRD-233 S3: template_id %r belongs to workspace %s — not seeding", spec["template_id"], row.workspace_id)
-        return "template_id_taken"
+    # template_id is globally unique (ix_workflow_recipes_template_id) while the
+    # Playbook's identity is per workspace — same rule as the roster slugs: the
+    # plain id is the norm, a workspace suffix only when another workspace owns
+    # the plain one. The ledger and the refresh contract key on the base id.
+    row = (
+        ctx.db.query(WorkflowTemplate)
+        .filter(
+            WorkflowTemplate.workspace_id == ctx.workspace_id,
+            WorkflowTemplate.template_id.in_(_slug_candidates(spec["template_id"], ctx.workspace_id)),
+        )
+        .first()
+    )
     columns = _playbook_columns(spec, ctx.workspace_id, ctx.operator, slug_to_id)
     fingerprint = partial(playbook_fingerprint, id_to_slug={v: k for k, v in slug_to_id.items()})
     if row is None:
         if spec["template_id"] in ctx.ledger["playbooks"]:
             return "deleted_by_user"
+        taken_elsewhere = (
+            ctx.db.query(WorkflowTemplate.id)
+            .filter(WorkflowTemplate.template_id == spec["template_id"], WorkflowTemplate.workspace_id != ctx.workspace_id)
+            .first()
+            is not None
+        )
+        if taken_elsewhere:
+            columns["template_id"] = _slug_candidates(spec["template_id"], ctx.workspace_id)[1]
         recipe = WorkflowTemplate(**columns)
         validate_playbook(recipe)
         ctx.db.add(recipe)
         ctx.db.flush()
         return "created"
+    columns["template_id"] = row.template_id  # identity is the base id; the stored one stays
     return _refresh(row, columns, _PLAYBOOK_REFRESH_FIELDS, fingerprint, fingerprint(SimpleNamespace(**columns)))
 
 

--- a/orchestrator/core/seeds/seed_skills.py
+++ b/orchestrator/core/seeds/seed_skills.py
@@ -12,7 +12,7 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy import text
-from core.database import engine
+from core.database.database import engine
 from core.models import Skill, Pattern
 
 # Create session

--- a/orchestrator/main.py
+++ b/orchestrator/main.py
@@ -317,6 +317,19 @@ async def _seed_semantic_embeddings():
     _asyncio.create_task(ensure_field_memory_collection())
 
 
+def _bootstrap_composio_catalog() -> None:
+    """PRD-233 S2: Composio catalogue bootstrap (core/composio/bootstrap.py).
+
+    Key + empty ``composio_apps_cache`` ⇒ full sync on a background thread,
+    then the seeded marketplace agents are re-bound; key + populated cache ⇒
+    one COUNT and a no-op rebind; no key ⇒ logs why integrations are off.
+    Self-guarding — never blocks or fails boot.
+    """
+    from core.composio.bootstrap import ensure_catalog_on_boot
+
+    ensure_catalog_on_boot()
+
+
 class TrustGateError(RuntimeError):
     """Raised when the trust gate check fails — platform runs in degraded mode."""
 
@@ -562,6 +575,8 @@ async def lifespan(app: FastAPI):
         await run_stage(report, BootstrapStage.DATABASE_INIT, _boot_phase_1_core)
         # Seed embeddings (fire-and-forget background task)
         await run_stage(report, BootstrapStage.SEMANTIC_EMBEDDINGS, _seed_semantic_embeddings)
+        # PRD-233 S2: Composio catalogue — sync on the first keyed boot, re-bind seeds.
+        await run_stage(report, BootstrapStage.TOOL_SYNC, _bootstrap_composio_catalog)
 
         logger.info("Phase 1 complete: core ready")
 

--- a/orchestrator/modules/tools/README.md
+++ b/orchestrator/modules/tools/README.md
@@ -1,410 +1,110 @@
-# 🛠️ Tools Module - The Tool Registry Revolution
+# Tools module
 
-> **"One tool, infinite uses. Zero duplication."**
+`orchestrator/modules/tools/` is where an agent's tool surface is assembled and
+executed: which tools an agent is offered, how a call is validated and routed,
+and how results come back. It serves both editions; the only edition-sensitive
+piece is Composio availability (below).
 
----
-
-## 💡 The Problem
-
-**Every AI framework does this:**
-```python
-# In agent file
-def web_search(...): ...
-
-# In workflow file  
-def web_search(...): ...  # Copy-pasted!
-
-# In API file
-def web_search(...): ...  # Again!?
-```
-
-**Result:** 3x the code, 3x the bugs, 3x the maintenance. 😤
-
----
-
-## ✨ The Automatos Solution
-
-### **The Tool Registry Pattern**
-
-**Define once. Use everywhere. Forever.**
-
-```python
-# Define in ONE place
-@tool_registry.register(
-    category=ToolCategory.RESEARCH,
-    name="web_search",
-    description="Search the web for information"
-)
-async def search_web(query: str, max_results: int = 10) -> dict:
-    """Your implementation"""
-    return search_results
-```
-
-**Use ANYWHERE:**
-```python
-# In agents
-agent.use_tool("web_search", {"query": "AI news"})
-
-# In workflows
-workflow.add_step("web_search", {"query": "...", "max_results": 5})
-
-# In API endpoints
-POST /api/tools/execute {"tool": "web_search", "args": {...}}
-
-# In chat
-# LLM automatically has access via function calling!
-```
-
-**ONE source of truth. ZERO duplication.** 🎯
-
----
-
-## 🏗️ Architecture
+## Layout
 
 ```
 modules/tools/
-├── __init__.py              # Tool registry export
-├── registry.py              # ToolRegistry class
-├── executor.py              # UnifiedToolExecutor
-├── base.py                  # BaseTool interface
-├── categories.py            # Tool categories enum
-├── implementations/         # Where tools live
-│   ├── research/            # Web search, knowledge lookup
-│   ├── database/            # SQL query, data analysis
-│   ├── file_ops/            # File read/write, git ops
-│   ├── communication/       # Email, Slack, notifications
-│   └── ai_services/         # LLM calls, embeddings
-└── formatting/              # Result formatters
-    ├── result_formatter.py  # Standardize tool outputs
-    └── ui_formatter.py      # Format for frontend
+├── tool_router.py            ToolRouter — get_tools_for_agent(), execute_tool(), validation,
+│                             the capability filter; the ONE place Composio availability is consulted
+├── composio_tool_router.py   the Composio leg of routing
+├── registry/                 ToolRegistry, ToolSpec, ToolCategory, SecurityLevel — register_tool(ToolSpec)
+├── execution/                UnifiedToolExecutor
+├── discovery/                the platform actions Auto executes: ActionRegistry plus
+│                             actions_<domain>.py / handlers_<domain>.py pairs
+├── builtin/                  built-in tools (scratchpad)
+├── capabilities/ services/ sync/   capability filtering, supporting services, the Composio catalogue sync
+├── formatting/               result_formatter — the standard result shape for LLMs and the UI
+├── widget_callback.py
+└── tests/
 ```
 
----
+## Where an agent's tools come from
 
-## 🎯 Tool Categories
+`get_tools_for_agent(agent_id, workspace_id)` (exported from `modules.tools`)
+is the single source of truth for an agent's tool schemas. Three sources feed
+it:
 
-We organize tools by purpose:
+1. **Platform actions** — `platform_*` operations Auto runs against the
+   platform itself (agents, Playbooks, Deliverables, documents, Missions,
+   analytics, …), defined as `ActionDefinition`s in
+   `discovery/actions_<domain>.py` and executed by
+   `discovery/handlers_<domain>.py`. Each definition carries its OpenAI
+   function schema, a permission level (`read` / `write` / `destructive`),
+   and the confirmation / admin / super-admin flags.
+2. **Registry tools** — `ToolSpec`s registered on the `ToolRegistry`
+   (`registry/`), including the built-ins.
+3. **Composio tools** — third-party app actions from the Composio catalogue
+   (`composio_apps_cache`), bound per agent — when Composio is available.
 
-| Category | Purpose | Examples |
-|----------|---------|----------|
-| **RESEARCH** | Find information | `web_search`, `wikipedia`, `arxiv` |
-| **DATABASE_TOOLS** | Data operations | `query_database`, `run_sql`, `data_analysis` |
-| **FILE_OPERATIONS** | File management | `read_file`, `write_file`, `git_commit` |
-| **COMMUNICATION** | Send messages | `send_email`, `slack_message`, `notify` |
-| **AI_SERVICES** | AI capabilities | `generate_image`, `transcribe_audio` |
-| **CODE_OPS** | Code manipulation | `format_code`, `run_tests`, `lint_check` |
-| **PRODUCTIVITY** | Workflow tools | `create_task`, `set_reminder`, `calendar` |
+## Composio availability — the degrade seam (PRD-233 S2)
 
----
+Composio is a hosted service that needs a key. The platform key is a
+hosted-edition concern; the local edition is bring-your-own
+(`COMPOSIO_API_KEY` in `.env`, env-only). The module handles absence
+explicitly instead of failing open:
 
-## 🚀 Creating Your First Tool
+- **One predicate.** `core/composio/client.py: composio_available()` is true
+  when `config.COMPOSIO_API_KEY` is set *and* the SDK imports;
+  `composio_unavailable_reason()` says which is missing. Evaluated once per
+  process.
+- **One exclusion point.** `tool_router.py` consults the predicate at a single
+  seam: unavailable ⇒ Composio tools are excluded from discovery and schemas,
+  so the model is never offered a tool that cannot run. Platform actions and
+  registry tools route as before.
+- **One refusal shape.** A direct call to a Composio tool while unavailable
+  returns `{"success": false, "error_code": "integrations_unavailable", …}`
+  with the reason and the fix — never a silent success or a pass-through.
+- **The UI agrees.** `GET /api/tools/integrations/status` (`api/tools.py`)
+  returns the same predicate plus `key_configured`, `apps_cached`,
+  `last_sync` and `sync_status`; the Tools page renders *"Integrations are
+  disabled — no Composio API key is configured."* from it.
+- **Boot.** `core/composio/bootstrap.py` runs as a boot stage: key + empty
+  catalogue ⇒ a full catalogue sync on a background thread, then the seeded
+  marketplace agents are re-bound to their apps; key + populated catalogue ⇒
+  rebind only; no key ⇒ a log line saying why integrations are off. It never
+  blocks or fails the boot.
 
-### **Step 1: Create the Tool File**
+Regression rule: the router's access gate stays fail-closed. Do not add a
+second place that decides whether Composio is on.
+
+## Adding a platform action
+
+Two files in `discovery/`, one for the definition and one for the handler —
+follow an existing pair such as `actions_blog.py` / `handlers_blog.py`:
+
+1. In `actions_<domain>.py`, a `register_<domain>_actions(registry)` function
+   that calls `registry.register(ActionDefinition(name="platform_…",
+   description=…, category=…, parameters={…OpenAI JSON schema…},
+   permission_level=…, requires_confirmation=…))`. The description is
+   embedded for semantic selection, so write it for the model.
+2. In `handlers_<domain>.py`, the handler that performs the operation and
+   returns the standard result shape.
+3. A test under `modules/tools/tests/`.
+
+Prefer extending an existing action over adding a near-duplicate, and a
+platform action over a new Composio dependency for anything the platform can
+do itself.
+
+## Result shape
+
+Handlers and tools return a dict the formatter
+(`formatting/result_formatter.py`) can standardise:
 
 ```python
-# modules/tools/implementations/productivity/notion_sync.py
-
-from typing import Dict, Any
-from modules.tools import tool_registry, ToolCategory
-
-@tool_registry.register(
-    category=ToolCategory.PRODUCTIVITY,
-    name="notion_sync",
-    description="Sync content to a Notion page",
-    parameters={
-        "page_id": {
-            "type": "string",
-            "description": "Notion page ID",
-            "required": True
-        },
-        "content": {
-            "type": "object",
-            "description": "Content to sync",
-            "required": True
-        },
-        "merge_mode": {
-            "type": "string",
-            "description": "How to merge: 'replace' or 'append'",
-            "default": "replace"
-        }
-    }
-)
-async def notion_sync(
-    page_id: str,
-    content: Dict[str, Any],
-    merge_mode: str = "replace"
-) -> Dict[str, Any]:
-    """Sync content to Notion"""
-    
-    # Your implementation
-    notion_client = get_notion_client()
-    
-    if merge_mode == "replace":
-        result = notion_client.pages.update(page_id, content)
-    else:
-        result = notion_client.blocks.append(page_id, content)
-    
-    return {
-        "success": True,
-        "page_id": page_id,
-        "url": f"https://notion.so/{page_id}",
-        "synced_at": datetime.now().isoformat()
-    }
+{"success": True, "data": ..., "metadata": {...}}                       # ok
+{"success": False, "error": "what went wrong", "error_code": "..."}    # expected failure
 ```
 
-### **Step 2: That's It!**
+## Conventions
 
-Your tool is now available:
-- ✅ In all agents
-- ✅ In all workflows  
-- ✅ In the API (`/api/tools`)
-- ✅ In LLM function calling
-- ✅ In the UI tool picker
-
-**No registration code. No config files. Just works.**
-
----
-
-## 🎨 Advanced Features
-
-### **1. Tool Dependencies**
-
-Tools can use other tools:
-
-```python
-@tool_registry.register(cat category=ToolCategory.RESEARCH)
-async def research_and_summarize(topic: str) -> dict:
-    # Use existing tools
-    search_results = await executor.execute_tool(
-        "web_search", 
-        {"query": topic}
-    )
-    
-    summary = await executor.execute_tool(
-        "llm_summarize",
-        {"text": search_results["content"]}
-    )
-    
-    return {"topic": topic, "summary": summary}
-```
-
-### **2. Credential Integration**
-
-Tools automatically get credentials:
-
-```python
-@tool_registry.register(
-    category=ToolCategory.COMMUNICATION,
-    required_credentials=["slack_token"]  # Auto-injected!
-)
-async def slack_message(channel: str, message: str) -> dict:
-    # Credentials resolved automatically
-    slack_token = get_credential("slack_token")
-    # Send message...
-```
-
-### **3. Result Formatting**
-
-Standardized output for LLMs and UIs:
-
-```python
-return {
-    "success": True,
-    "results": [...],      # Main data
-    "metadata": {...},     # Context about execution
-    "ui_display": {...}    # How to show in frontend
-}
-```
-
----
-
-## 🔥 Why This Is Revolutionary
-
-### **Before Tool Registry**
-
-❌ Tools scattered across files  
-❌ Duplicate implementations  
-❌ Inconsistent interfaces  
-❌ Hard to discover  
-❌ Manual registration  
-❌ No validation  
-
-### **With Tool Registry**
-
-✅ **Single source of truth**  
-✅ **Zero duplication**  
-✅ **Automatic registration**  
-✅ **Type-safe parameters**  
-✅ **Built-in validation**  
-✅ **Self-documenting**  
-✅ **Instant availability**  
-
----
-
-## 🤝 Contributing Tools
-
-### **High-Impact Tools We Need**
-
-| Tool | Category | Difficulty | Impact |
-|------|----------|-----------|---------|
-| `jira_integration` | PRODUCTIVITY | 🟢 Easy | 🔥 High |
-| `figma_export` | DESIGN | 🟡 Medium | ⭐ Medium |
-| `stripe_payments` | FINANCE | 🟡 Medium | 🔥 High |
-| `aws_deploy` | DEPLOYMENT | 🔴 Hard | 🔥 High |
-| `linear_tasks` | PRODUCTIVITY | 🟢 Easy | ⭐ Medium |
-| `github_actions` | CI/CD | 🟡 Medium | 🔥 High |
-
-### **Tool Contribution Checklist**
-
-- [ ] Implements `BaseTool` or uses `@tool_registry.register`
-- [ ] Clear parameter descriptions
-- [ ] Type hints everywhere
-- [ ] Async implementation (if I/O)
-- [ ] Error handling with helpful messages
-- [ ] Return standardized result format
-- [ ] Add example in docstring
-- [ ] Test file in `tests/tools/`
-
----
-
-## 📚 Examples
-
-### **Simple Tool**
-```python
-@tool_registry.register(category=ToolCategory.RESEARCH)
-async def coin_flip() -> dict:
-    """Flip a coin"""
-    return {
-        "success": True,
-        "result": random.choice(["heads", "tails"])
-    }
-```
-
-### **Complex Tool**
-```python
-@tool_registry.register(
-    category=ToolCategory.DATABASE_TOOLS,
-    required_credentials=["db_connection"]
-)
-async def complex_query(
-    query: str,
-    params: dict,
-    timeout: int = 30
-) -> dict:
-    """Execute complex database query with retries"""
-    
-    conn = get_db_connection()
-    
-    try:
-        async with timeout_context(timeout):
-            result = await conn.execute(query, params)
-            
-        return {
-            "success": True,
-            "rows": result.fetchall(),
-            "row_count": len(result),
-            "execution_time": result.execution_time
-        }
-    except TimeoutError:
-        return {"success": False, "error": "Query timeout"}
-    except Exception as e:
-        logger.error(f"Query failed: {e}")
-        return {"success": False, "error": str(e)}
-```
-
----
-
-## 🎯 Tool Execution Flow
-
-```
-1. Tool Request
-   ↓
-2. Registry Lookup (by name)
-   ↓
-3. Parameter Validation (Pydantic)
-   ↓
-4. Credential Resolution (if needed)
-   ↓
-5. Tool Execution (async)
-   ↓
-6. Result Formatting
-   ↓
-7. Return Standardized Output
-```
-
----
-
-## 🔍 Discovering Tools
-
-### **Programmatically**
-```python
-from modules.tools import ToolRegistry
-
-registry = ToolRegistry()
-
-# Get all tools
-all_tools = registry.get_all_tools()
-
-# Get by category
-research_tools = registry.get_tools_by_category(ToolCategory.RESEARCH)
-
-# Search by name
-search_tool = registry.get_tool("web_search")
-```
-
-### **Via API**
-```bash
-# List all tools
-GET /api/tools
-
-# Get tool details
-GET /api/tools/{tool_id}
-
-# Execute tool
-POST /api/tools/execute
-{
-  "tool": "web_search",
-  "args": {"query": "AI news"}
-}
-```
-
----
-
-## ⚡ Performance
-
-- **Lazy loading:** Tools loaded on first use
-- **Caching:** Registry cached after initialization
-- **Async:** All tools support async execution
-- **Parallel:** Execute multiple tools concurrently
-
----
-
-## 🌟 Pro Tips
-
-1. **Make tools composable** - Small, focused tools > monolithic ones
-2. **Return rich metadata** - Help LLMs understand results
-3. **Handle errors gracefully** - Return `success: false` with helpful messages
-4. **Use type hints** - Enables automatic validation
-5. **Add examples** - In docstrings, help users understand usage
-
----
-
-## 🚀 Get Started
-
-```python
-# 1. Import the registry
-from modules.tools import tool_registry, ToolCategory
-
-# 2. Register your tool
-@tool_registry.register(category=ToolCategory.YOUR_CATEGORY)
-async def your_amazing_tool(param: str) -> dict:
-    return {"success": True, "result": "🎉"}
-
-# 3. That's it! Tool is now available everywhere!
-```
-
----
-
-**Ready to build the tool that changes everything?** 🛠️
-
-Start in `modules/tools/implementations/` and make your mark!
+- No `os.getenv` here — read `config`.
+- Errors are explicit: a tool that cannot run says so in the result; the
+  router never turns "unavailable" into "allowed".
+- `super_admin_only` definitions are excluded from every listing and
+  selection path unless explicitly included (fail-closed); keep destructive
+  actions behind `requires_confirmation=True`.

--- a/orchestrator/modules/tools/execution/unified_executor.py
+++ b/orchestrator/modules/tools/execution/unified_executor.py
@@ -649,6 +649,22 @@ class UnifiedToolExecutor:
             if _policy_block is not None:
                 return _policy_block
 
+            # PRD-233 S2: ONE Composio availability seam for EVERY caller. The
+            # router refuses routed calls; agent_factory and approval-grant
+            # replays call this executor directly and used to fall through to
+            # the executor's misleading composio_not_connected error. Without
+            # a key ⇒ explicit integrations_unavailable, never a fall-through;
+            # with a key ⇒ one cached boolean check.
+            from core.composio.client import composio_available
+            from modules.tools.tool_router import (
+                _integrations_unavailable_result,
+                _is_composio_tool_name,
+            )
+            if (
+                _is_composio_tool_name(tool_name) or tool_name in self.composio_actions
+            ) and not composio_available():
+                return _integrations_unavailable_result(tool_name, trace)
+
             # PRD-64: Single dispatcher for platform actions
             if tool_name == "platform_execute":
                 action_name = (parameters.get("action") or "").strip()

--- a/orchestrator/modules/tools/tool_router.py
+++ b/orchestrator/modules/tools/tool_router.py
@@ -31,6 +31,7 @@ from modules.tools.execution import UnifiedToolExecutor
 from modules.tools.formatting.result_formatter import ToolResultFormatter
 from modules.tools.discovery.signal_recorder import ToolSignal, get_tool_signal_recorder
 from core.database.database import SessionLocal
+from core.composio.client import composio_available, composio_unavailable_reason
 
 # Capability-based filtering imports (PRD-37)
 try:
@@ -113,6 +114,73 @@ def _is_fatal_dependency_error(error: Optional[str]) -> bool:
         return False
     lowered = error.lower()
     return "composio openai sdk not available" in lowered or "composio-openai" in lowered
+
+
+# =============================================================================
+# PRD-233 S2: Composio degrade seam — honest without a key
+# =============================================================================
+#
+# One predicate (core.composio.client.composio_available), one discovery
+# exclusion point (_offerable_candidates, called from _get_tools_for_agent_core
+# before any access check) and one refusal shape (_integrations_unavailable_result,
+# returned by the execution entries below before any session/executor work).
+# With a key configured every helper here is a pass-through — SaaS unchanged.
+# This is deliberately NOT fail-open: an unavailable integration is refused
+# with an explicit error, never re-routed to another tool.
+
+INTEGRATIONS_UNAVAILABLE = "integrations_unavailable"
+_composio_exclusion_logged = False
+
+
+def _is_composio_tool_name(tool_name: Optional[str]) -> bool:
+    name = tool_name or ""
+    return name == "composio_execute" or name.startswith("composio_")
+
+
+def _is_composio_tool(tool: Any) -> bool:
+    if _is_composio_tool_name(getattr(tool, "name", None)):
+        return True
+    meta = getattr(tool, "metadata", None)
+    return isinstance(meta, dict) and meta.get("integration_type") == "composio"
+
+
+def _offerable_candidates(candidates: List[Any], trace_id: str) -> List[Any]:
+    """Drop every Composio tool from the offered candidates when Composio is
+    unavailable. Returns the SAME list object when it is available."""
+    global _composio_exclusion_logged
+    if composio_available():
+        return candidates
+    kept = [t for t in candidates if not _is_composio_tool(t)]
+    dropped = len(candidates) - len(kept)
+    if dropped:
+        message = (
+            f"[tool-trace {trace_id}] {dropped} Composio tool(s) not offered — "
+            f"integrations unavailable: {composio_unavailable_reason()}"
+        )
+        if _composio_exclusion_logged:
+            logger.debug(message)
+        else:
+            logger.info(message)
+            _composio_exclusion_logged = True
+    return kept
+
+
+def _integrations_unavailable_result(tool_name: str, trace: str) -> Dict[str, Any]:
+    """The explicit refusal for a direct Composio call without Composio."""
+    reason = composio_unavailable_reason()
+    logger.warning(f"[tool-trace {trace}] {tool_name} refused — integrations unavailable: {reason}")
+    return {
+        "success": False,
+        "error": (
+            f"Integrations are disabled on this server ({reason}). "
+            "Configure COMPOSIO_API_KEY and restart the backend — the catalogue "
+            "syncs automatically on boot."
+        ),
+        "error_type": INTEGRATIONS_UNAVAILABLE,
+        "error_code": INTEGRATIONS_UNAVAILABLE,
+        "tool": tool_name,
+        "data": None,
+    }
 
 
 # =============================================================================
@@ -623,6 +691,9 @@ def _get_tools_for_agent_core(
     try:
         registry = registry_get_tool_registry(db_session=session_used)
         all_candidates = registry.get_all_tools(active_only=True)
+        # PRD-233 S2: without Composio its tools are not offered at all —
+        # excluded here, ahead of access checks — never offered-then-erroring.
+        all_candidates = _offerable_candidates(all_candidates, trace_id)
         filtered_tools = all_candidates
         denied: List[Dict[str, Any]] = []
 
@@ -1068,6 +1139,10 @@ async def execute_tool(
     from core.database.database import SessionLocal
 
     trace = trace_id or _new_trace_id()
+    # PRD-233 S2: a direct Composio call without Composio is refused here —
+    # explicit error, no session, no executor, no re-route to another tool.
+    if _is_composio_tool_name(tool_name) and not composio_available():
+        return _integrations_unavailable_result(tool_name, trace)
     db_session = SessionLocal()
     try:
         if workspace_id is None and agent_id:
@@ -1467,6 +1542,18 @@ async def get_filtered_composio_actions(
     Returns:
         Dict with filtered actions and metadata
     """
+    # PRD-233 S2: without Composio there is nothing to filter — say why.
+    if not composio_available():
+        reason = composio_unavailable_reason()
+        logger.info(f"Capability filter skipped — integrations unavailable: {reason}")
+        return {
+            "success": False,
+            "error": reason,
+            "error_code": INTEGRATIONS_UNAVAILABLE,
+            "actions": [],
+            "capabilities": [],
+        }
+
     if not CAPABILITY_FILTER_AVAILABLE:
         logger.warning("Capability filter not available, returning empty result")
         return {
@@ -1666,6 +1753,12 @@ async def execute_tool_with_validation(
 
     # Only validate Composio actions
     is_composio = tool_name.startswith("composio_") or tool_name == "composio_execute"
+
+    # PRD-233 S2: nothing to validate when the integration cannot run at all —
+    # refused ahead of the F018 gate (strictly more closed; the gate itself is
+    # untouched and still fails closed for destructive intent when Composio is up).
+    if is_composio and not composio_available():
+        return _integrations_unavailable_result(tool_name, trace_id)
 
     if is_composio and original_intent:
         # Extract action ID from tool name or args

--- a/orchestrator/reports/route-manifest.json
+++ b/orchestrator/reports/route-manifest.json
@@ -1,5 +1,5 @@
 {
-  "route_count": 773,
+  "route_count": 776,
   "routes": [
     {
       "method": "GET",
@@ -1838,6 +1838,14 @@
       "path": "/api/policy/{policy_id}/assemble"
     },
     {
+      "method": "GET",
+      "path": "/api/profile"
+    },
+    {
+      "method": "PUT",
+      "path": "/api/profile"
+    },
+    {
       "method": "POST",
       "path": "/api/query/platform-help"
     },
@@ -2160,6 +2168,10 @@
     {
       "method": "GET",
       "path": "/api/tools/debug/connections"
+    },
+    {
+      "method": "GET",
+      "path": "/api/tools/integrations/status"
     },
     {
       "method": "GET",

--- a/orchestrator/router_manifest.py
+++ b/orchestrator/router_manifest.py
@@ -83,6 +83,8 @@ MANIFEST_ROUTERS: tuple[RouterSpec, ...] = (
     RouterSpec("api.watches"),
     # PRD-228 -- the one new fleet-state route (GET /api/v1/fleet).
     RouterSpec("api.fleet"),
+    # PRD-233 S6 -- the operator's profile (GET both editions, PUT local only).
+    RouterSpec("api.profile"),
 )
 
 

--- a/orchestrator/scripts/generate_schema_baseline.py
+++ b/orchestrator/scripts/generate_schema_baseline.py
@@ -22,6 +22,7 @@ there is no snapshot artifact that can rot. First boot pays ~2-3 minutes once.
 
 Run against an EMPTY database (DATABASE_URL). Prints the skipped-revision log.
 """
+import pathlib
 import sys
 from alembic import command
 from alembic.config import Config as AlembicConfig
@@ -150,6 +151,123 @@ def _drop_relics(engine, script: ScriptDirectory) -> list[str]:
     return dropped
 
 
+# --------------------------------------------------------------------------- #
+# PRD-233 live-test finding: orphan-root ORDERING loses columns and views.
+# prd82a (a root) adds agent_reports.orchestration_task_id before the revision
+# that creates agent_reports has run; the tolerant replay skips the ALTER and
+# nothing re-tries it, so prd133b's v_workspace_outputs (another root) fails on
+# the missing column and the Deliverables feed 500s on every fresh database.
+# Two idempotent passes close the class: (1) add every model column the DB
+# lacks (create_all never ALTERs); (2) re-run the forest's idempotent raw SQL
+# (IF NOT EXISTS indexes / column adds, DO-block column adds, OR REPLACE views)
+# at the end, views last, until a round adds nothing.
+# --------------------------------------------------------------------------- #
+_IDEMPOTENT_MARKERS = ("create or replace view", "create index if not exists",
+                       "create unique index if not exists", "add column if not exists", "do $$")
+_FORBIDDEN_MARKERS = ("drop table", "drop column", "truncate", "drop view", "drop index")
+
+
+def _model_metadata():
+    try:
+        from core.database.database import Base  # type: ignore
+        return Base.metadata
+    except Exception:  # noqa: BLE001
+        from core.models import Base  # type: ignore
+        return Base.metadata
+
+
+def _reconcile_model_columns(engine) -> list[str]:
+    """ALTER TABLE ... ADD COLUMN for every model column missing from the DB."""
+    from sqlalchemy import inspect as sa_inspect
+    added: list[str] = []
+    meta = _model_metadata()
+    insp = sa_inspect(engine)
+    existing_tables = set(insp.get_table_names())
+    for table in meta.sorted_tables:
+        if table.name not in existing_tables:
+            continue
+        have = {c["name"] for c in insp.get_columns(table.name)}
+        for col in table.columns:
+            if col.name in have:
+                continue
+            try:
+                ctype = col.type.compile(dialect=engine.dialect)
+            except Exception:  # noqa: BLE001
+                continue
+            ddl = f'ALTER TABLE "{table.name}" ADD COLUMN IF NOT EXISTS "{col.name}" {ctype}'
+            if col.server_default is not None and getattr(col.server_default, "arg", None) is not None:
+                arg = col.server_default.arg
+                ddl += f" DEFAULT {getattr(arg, 'text', arg)}"
+            for fk in col.foreign_keys:
+                target = fk.column.table.name
+                if target in existing_tables:
+                    ddl += f' REFERENCES "{target}"("{fk.column.name}")'
+                    if fk.ondelete:
+                        ddl += f" ON DELETE {fk.ondelete}"
+            with engine.begin() as conn:
+                try:
+                    conn.execute(text(ddl))
+                    added.append(f"{table.name}.{col.name}")
+                except Exception as exc:  # noqa: BLE001
+                    print(f"   column {table.name}.{col.name}: {str(exc).strip().splitlines()[0][:120]}")
+    return added
+
+
+def _upgrade_raw_sql(script: ScriptDirectory) -> list[tuple[str, str]]:
+    """(revision, sql) for every op.execute string literal inside upgrade()."""
+    import re
+    out: list[tuple[str, str]] = []
+    for rev in script.walk_revisions():
+        try:
+            src = pathlib.Path(rev.path).read_text()
+        except Exception:  # noqa: BLE001
+            continue
+        up = src.split("def downgrade", 1)[0]
+        for m in re.finditer(r'op\.execute\(\s*(?:"""|\'\'\')(.*?)(?:"""|\'\'\')\s*\)', up, re.S):
+            out.append((rev.revision, m.group(1)))
+        for m in re.finditer(r'op\.execute\(\s*"((?:[^"\\]|\\.)*)"\s*\)', up):
+            out.append((rev.revision, m.group(1)))
+    return out
+
+
+def _replay_idempotent_raw_sql(engine, script: ScriptDirectory) -> int:
+    """Re-run the forest's idempotent raw SQL until a round adds nothing; views last."""
+    bodies = []
+    for rev, sql in _upgrade_raw_sql(script):
+        low = sql.lower()
+        if any(f in low for f in _FORBIDDEN_MARKERS):
+            continue
+        if not any(mk in low for mk in _IDEMPOTENT_MARKERS):
+            continue
+        if "do $$" in low and "add column" not in low:
+            continue
+        bodies.append((rev, sql, "create or replace view" in low))
+    applied_total = 0
+    for is_view_pass in (False, True):
+        pending = [(r, q) for r, q, v in bodies if v == is_view_pass]
+        for _round in range(4):
+            progressed = 0
+            still = []
+            for rev, sql in pending:
+                with engine.connect() as conn:
+                    tx = conn.begin()
+                    try:
+                        conn.execute(text(sql))
+                        tx.commit()
+                        progressed += 1
+                    except Exception:  # noqa: BLE001
+                        tx.rollback()
+                        still.append((rev, sql))
+            applied_total += progressed
+            pending = still
+            if not still or progressed == 0:
+                break
+        for rev, sql in pending:
+            head = " ".join(sql.split())[:90]
+            print(f"   raw-sql still failing ({rev}): {head}")
+    return applied_total
+
+
 def build_schema(engine) -> int:
     """Build the complete fresh schema on an EMPTY database and leave alembic at
     heads. Returns the table count. Used by scripts/init_fresh_db.py (the boot
@@ -204,10 +322,14 @@ def build_schema(engine) -> int:
     # Re-assert the model layer + raw-DDL extras: a migration's raw
     # `conn.execute(text("DROP ..."))` bypasses alembic ops and can remove an extra;
     # create_all is checkfirst and the extras are IF NOT EXISTS, so this is idempotent.
-    print("== 3/4 re-asserting the model layer + raw-DDL extras")
+    print("== 3/6 re-asserting the model layer + raw-DDL extras")
     init_db()
+    added = _reconcile_model_columns(engine)
+    print(f"== 4/6 model-column reconciliation: added {len(added)} column(s) create_all could not: {added}")
+    raw = _replay_idempotent_raw_sql(engine, script)
+    print(f"== 5/6 idempotent raw-SQL re-run (indexes, column adds, views last): {raw} statement(s) applied")
     relics = _drop_relics(engine, script)
-    print(f"== 4/4 relic parity pass: dropped {len(relics)} table(s) whose final forest state is DROP: {relics}")
+    print(f"== 6/6 relic parity pass: dropped {len(relics)} table(s) whose final forest state is DROP: {relics}")
     with engine.begin() as conn:
         total = conn.execute(text("SELECT count(*) FROM information_schema.tables WHERE table_schema='public'")).scalar()
     print(f"== done: {applied} revisions applied, {skipped} stamped past; {total} tables")

--- a/orchestrator/scripts/seed_marketplace_agents_v2.py
+++ b/orchestrator/scripts/seed_marketplace_agents_v2.py
@@ -277,6 +277,20 @@ def seed_marketplace_agents_v2():
         trans = db.begin()
 
         try:
+            # PRD-233: stable ids across boots. The local edition runs this seeder on
+            # EVERY boot (SaaS never did — its entrypoint is a stub); clear+recreate
+            # churned every marketplace_items id each time. Skip when the full v2
+            # set is already present; the clear+create below then only runs on a
+            # fresh or partial catalogue.
+            existing = {row[0] for row in db.execute(text(
+                "SELECT name FROM marketplace_items WHERE type = 'agent' AND creator_name = 'Automatos Team'"
+            )).fetchall()}
+            wanted = {agent_config["name"] for agent_config in MARKETPLACE_AGENTS_V2}
+            if wanted <= existing:
+                print(f"✓ v2 marketplace agents already present ({len(wanted)}) — ids left stable\n")
+                trans.rollback()
+                return
+
             # Clear only v2 agents (identified by creator_name), per-name deletes
             for agent_config in MARKETPLACE_AGENTS_V2:
                 db.execute(text(

--- a/orchestrator/services/plan_tiers.py
+++ b/orchestrator/services/plan_tiers.py
@@ -199,6 +199,34 @@ def exposure_for_plan(plan: str, tiers: Optional[dict] = None) -> dict:
     }
 
 
+LOCAL_EDITION_PLAN = "local"
+
+
+def exposure_for_local_edition(tiers: Optional[dict] = None) -> dict:
+    """PRD-233 S7 — the local edition's exposure profile: UNRESTRICTED.
+
+    Owner rule for Basic: paid tiers gate organisational features and hosting,
+    never product capability. The single local workspace has no plan (the
+    entrypoint seeds ``plan = NULL``), and falling back to the entry tier hid
+    Analytics and put plan chips on marketplace items. So: every nav item,
+    no family restrictions, the deepest marketplace tier. SaaS-only surfaces
+    are hidden by the frontend's explicit route allowlist (lib/auth-edition.ts),
+    never by a plan. Never called in saas (api/workspaces.py branches on
+    ``config.AUTH_EDITION``).
+    """
+    resolved = _tiers(tiers)
+    depths = [int(t.get("marketplace_depth", 1) or 1) for t in resolved.values() if isinstance(t, dict)]
+    return {
+        "plan": LOCAL_EDITION_PLAN,
+        "display_name": "Local edition",
+        "display_price_usd": None,
+        "price_label": None,
+        "families": {},
+        "marketplace_depth": max(depths) if depths else 1,
+        "nav": _nav_exposure({}, declares_families=False),
+    }
+
+
 # --------------------------------------------------------------------------- #
 # US-024 — Auto's per-turn tool surface, trimmed to the tier's families
 # --------------------------------------------------------------------------- #

--- a/orchestrator/tests/test_prd209_quickstart_honest.py
+++ b/orchestrator/tests/test_prd209_quickstart_honest.py
@@ -1,15 +1,19 @@
-"""PRD-209 S8 — QUICKSTART tells the truth (against the merged reality).
+"""PRD-209 S8 + PRD-233 S5 — the install docs tell the truth (against the merged reality).
 
 The old QUICKSTART claimed "That's it! No `.env` file needed" while compose hard-fails
 on three ``${VAR:?}``-required secrets, and it invented default passwords compose no
-longer sets. These guards are pure (read the two docs + the compose file, no services)
+longer sets. These guards are pure (read the docs + the compose file, no services)
 and lock the docs to the compose reality US-001..008 made true:
 
 * every ``${VAR:?}``-required variable in docker-compose.yml is named in QUICKSTART.md
-  (a reader can't miss a secret compose will refuse to start without);
+  AND in the self-hosting guide (a reader can't miss a secret compose will refuse to
+  start without) — the same checker, shared, as PRD-233 S5 asks;
 * the dishonest "no .env needed" claim is gone from both QUICKSTART.md and README.md;
-* the honest Composio limitation line is present (the 1,000+ integrations need a key —
-  PRD-233 owns first-class local setup).
+* the honest Composio limitation line is present (the integrations need a key —
+  PRD-233 owns first-class local setup);
+* the self-hosting guide names the local edition's dials: the worker host-access
+  directory, the bring-your-own Composio key, the object store's credential name
+  and the edition flag.
 """
 from __future__ import annotations
 
@@ -20,13 +24,30 @@ _REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
 _COMPOSE = _REPO_ROOT / "docker-compose.yml"
 _QUICKSTART = _REPO_ROOT / "QUICKSTART.md"
 _README = _REPO_ROOT / "README.md"
+_SELF_HOSTING = _REPO_ROOT / "docs" / "getting-started" / "self-hosting.md"
 
 # ${VAR:?message} — a variable compose treats as REQUIRED (errors if unset/empty).
 _REQUIRED_VAR = re.compile(r"\$\{([A-Z_][A-Z0-9_]*):\?")
 
+# PRD-233 S5: the local-edition dials the guide must document by name.
+_SELF_HOSTING_REQUIRED_MENTIONS = (
+    "AUTOMATOS_WORKSPACE_DIR",  # S1 — the worker's host-access directory
+    "COMPOSIO_API_KEY",  # S2 — bring-your-own Composio key (env-only)
+    "S3_ACCESS_KEY_ID",  # S4 — the local object store's credential name (not AWS_*)
+    "AUTH_EDITION",  # PRD-175 — the one edition flag
+)
+
 
 def _required_secrets() -> set[str]:
     return set(_REQUIRED_VAR.findall(_COMPOSE.read_text(encoding="utf-8")))
+
+
+def _missing_required_secrets(doc: pathlib.Path) -> list[str]:
+    """The ``${VAR:?}`` secrets ``doc`` does not name — the shared checker."""
+    text = doc.read_text(encoding="utf-8")
+    required = _required_secrets()
+    assert required, "no ${VAR:?} required secrets parsed from docker-compose.yml — parser drift"
+    return sorted(v for v in required if v not in text)
 
 
 def test_compose_has_exactly_the_three_required_secrets():
@@ -36,14 +57,44 @@ def test_compose_has_exactly_the_three_required_secrets():
 
 
 def test_quickstart_documents_every_required_secret():
-    quickstart = _QUICKSTART.read_text(encoding="utf-8")
-    required = _required_secrets()
-    assert required, "no ${VAR:?} required secrets parsed from docker-compose.yml — parser drift"
-    missing = sorted(v for v in required if v not in quickstart)
+    missing = _missing_required_secrets(_QUICKSTART)
     assert not missing, (
         f"QUICKSTART.md does not name required compose secret(s) {missing}; compose refuses "
         "to start without them, so the quickstart must tell the reader to set them."
     )
+
+
+def test_self_hosting_guide_exists():
+    # PRD-233 S5: the real guide supersedes the scattered compose pages, which point at it.
+    assert _SELF_HOSTING.is_file(), f"{_SELF_HOSTING} is missing — PRD-233 S5's guide"
+
+
+def test_self_hosting_guide_documents_every_required_secret():
+    missing = _missing_required_secrets(_SELF_HOSTING)
+    assert not missing, (
+        f"docs/getting-started/self-hosting.md does not name required compose secret(s) "
+        f"{missing}; compose refuses to start without them, so the guide must tell the "
+        "reader to set them."
+    )
+
+
+def test_self_hosting_guide_names_the_local_edition_dials():
+    text = _SELF_HOSTING.read_text(encoding="utf-8")
+    missing = [name for name in _SELF_HOSTING_REQUIRED_MENTIONS if name not in text]
+    assert not missing, (
+        f"docs/getting-started/self-hosting.md does not mention {missing} — the worker "
+        "host-access dial, the BYO Composio key, the object store's S3_* credential name "
+        "and the edition flag are the local edition's dials and must be documented."
+    )
+
+
+def test_self_hosting_guide_is_linked_from_quickstart_and_readme():
+    # The short path and the README both hand the reader on to the full guide.
+    for path in (_QUICKSTART, _README):
+        text = path.read_text(encoding="utf-8")
+        assert "docs/getting-started/self-hosting.md" in text, (
+            f"{path.name} must link docs/getting-started/self-hosting.md (the full guide)"
+        )
 
 
 def test_no_no_env_needed_claim_in_quickstart_or_readme():

--- a/orchestrator/tests/test_prd233_s1_worker_local_profile.py
+++ b/orchestrator/tests/test_prd233_s1_worker_local_profile.py
@@ -1,0 +1,291 @@
+"""PRD-233 S1 — workspace-worker joins the local profile (container-free).
+
+The Code Canvas runtime (``services/workspace-worker``) ships to the laptop:
+compose runs it by default against a designated HOST directory
+(``${AUTOMATOS_WORKSPACE_DIR:-./workspaces}`` bind-mounted at ``/workspaces``),
+and the worker resolves its confinement root through ONE seam,
+``worker_config.workspace_root()`` — env reads live only in ``worker_config``
+(the worker's mirror of the orchestrator's ``config.py`` discipline).
+
+Proven here:
+  * root resolution: default when unset (Railway parity: ``/workspaces``),
+    override honoured, blank == unset (never a cwd-relative root), read at
+    CALL time rather than import time;
+  * the per-workspace root ``<root>/<workspace_id>`` (``WorkspaceManager.root``)
+    derives from that seam, and ``evaluate_tool_confinement`` bound to it
+    denies escapes from the resolved host directory (outside the dial, ``..``
+    traversal, a sibling workspace inside the same host dir, bash references)
+    while re-binding in-root relative paths. The dial moves WHERE the root is,
+    never what a session may reach. ``test_prd170_canvas_session_manager``
+    covers the confinement primitives against a literal root; this file
+    covers the root-from-config seam that feeds them;
+  * compose source guard: worker in the default profile (no ``profiles``),
+    the host bind mount on the worker (rw) and the backend (ro) with the same
+    source, no named ``workspace_data`` volume left behind, mount target ==
+    the worker's ``WORKSPACE_VOLUME_PATH`` == the config default, credential
+    passthrough + resource limits kept, and the backend's ``WORKER_INTERNAL_URL``
+    (``envs/api.defaults``) pointing at the compose service on the worker's
+    health port;
+  * the default host directory is gitignored (public repo, user deliverables).
+
+Pure stdlib + yaml + pytest: no DB, no docker, no SDK.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_WORKER_DIR = _REPO_ROOT / "services" / "workspace-worker"
+_COMPOSE = _REPO_ROOT / "docker-compose.yml"
+_API_DEFAULTS = _REPO_ROOT / "envs" / "api.defaults"
+_GITIGNORE = _REPO_ROOT / ".gitignore"
+
+# The worker is a flat-module service (hyphenated dir, not a package) — put
+# its directory on sys.path just long enough to import the modules under
+# test, then remove the entry so nothing else resolves against it.
+sys.path.insert(0, str(_WORKER_DIR))
+try:
+    import worker_config as wc
+    from canvas_confinement import evaluate_tool_confinement
+    from workspace_manager import WorkspaceManager
+finally:
+    sys.path.remove(str(_WORKER_DIR))
+
+WORKER_SERVICE = "workspace-worker"
+BACKEND_SERVICE = "backend"
+MOUNT_TARGET = "/workspaces"
+# The designated host directory — Q1 owner decision: one dial, safe default.
+HOST_DIR_SOURCE = "${AUTOMATOS_WORKSPACE_DIR:-./workspaces}"
+RETIRED_VOLUME = "workspace_data"
+CREDENTIAL_PASSTHROUGH = ("ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN")
+
+
+# ---------------------------------------------------------------------------
+# worker_config.workspace_root — the ONE env seam for the mount root
+# ---------------------------------------------------------------------------
+
+
+def test_workspace_root_defaults_to_railway_parity_value(monkeypatch):
+    monkeypatch.delenv(wc.WORKSPACE_ROOT_ENV, raising=False)
+    assert wc.workspace_root() == Path(wc.DEFAULT_WORKSPACE_ROOT) == Path("/workspaces")
+
+
+def test_workspace_root_honours_override(monkeypatch, tmp_path):
+    monkeypatch.setenv(wc.WORKSPACE_ROOT_ENV, str(tmp_path / "host-dir"))
+    assert wc.workspace_root() == tmp_path / "host-dir"
+
+
+@pytest.mark.parametrize("blank", ["", "   ", "\t"])
+def test_workspace_root_blank_counts_as_unset(monkeypatch, blank):
+    monkeypatch.setenv(wc.WORKSPACE_ROOT_ENV, blank)
+    root = wc.workspace_root()
+    assert root == Path(wc.DEFAULT_WORKSPACE_ROOT)
+    assert root.is_absolute(), "a cwd-relative root must never be returned"
+
+
+def test_workspace_root_is_read_at_call_time(monkeypatch, tmp_path):
+    monkeypatch.setenv(wc.WORKSPACE_ROOT_ENV, str(tmp_path / "a"))
+    first = wc.workspace_root()
+    monkeypatch.setenv(wc.WORKSPACE_ROOT_ENV, str(tmp_path / "b"))
+    assert first == tmp_path / "a"
+    assert wc.workspace_root() == tmp_path / "b"
+
+
+def test_workspace_manager_root_derives_from_worker_config(monkeypatch, tmp_path):
+    monkeypatch.setenv(wc.WORKSPACE_ROOT_ENV, str(tmp_path / "host-dir"))
+    assert WorkspaceManager("ws-a").root == tmp_path / "host-dir" / "ws-a"
+    # An explicit root still wins (the health server + canvas manager pass one).
+    explicit = WorkspaceManager("ws-a", str(tmp_path / "other"))
+    assert explicit.root == tmp_path / "other" / "ws-a"
+
+
+# ---------------------------------------------------------------------------
+# Confinement against the RESOLVED host root (extends test_prd170 coverage)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def host_dir(monkeypatch, tmp_path) -> Path:
+    """A designated host directory holding two workspaces, wired as the root."""
+    host = tmp_path / "host-dir"
+    for workspace_id in ("ws-a", "ws-b"):
+        (host / workspace_id / "reports").mkdir(parents=True)
+    (tmp_path / "outside.txt").write_text("host file outside the dial\n")
+    monkeypatch.setenv(wc.WORKSPACE_ROOT_ENV, str(host))
+    return host
+
+
+def _root(workspace_id: str) -> Path:
+    """Same derivation the canvas manager uses: ``WorkspaceManager(...).root.resolve()``."""
+    return WorkspaceManager(workspace_id).root.resolve()
+
+
+@pytest.mark.parametrize(
+    "tool_name, tool_input",
+    [
+        ("Read", {"file_path": "{tmp}/outside.txt"}),  # host path outside the dial
+        ("Read", {"file_path": "../ws-b/reports/x.md"}),  # traversal into a sibling
+        ("Write", {"file_path": "{host}/ws-b/reports/x.md"}),  # absolute sibling, same host dir
+        ("Read", {"file_path": "../../outside.txt"}),  # traversal out of the host dir
+        ("Bash", {"command": "cat {host}/ws-b/reports/x.md"}),  # bash reference to a sibling
+        ("Bash", {"command": "ls ../"}),  # bash parent-directory component
+    ],
+)
+def test_confinement_denies_escapes_from_resolved_host_root(
+    host_dir, tmp_path, tool_name, tool_input
+):
+    filled = {k: v.format(tmp=tmp_path, host=host_dir) for k, v in tool_input.items()}
+    verdict = evaluate_tool_confinement(tool_name, filled, _root("ws-a"))
+    assert not verdict.allowed, f"{tool_name} {filled} must be denied"
+    assert verdict.reason
+
+
+def test_confinement_rebinds_in_root_relative_paths(host_dir):
+    root = _root("ws-a")
+    verdict = evaluate_tool_confinement(
+        "Write", {"file_path": "reports/out.md", "content": "x"}, root
+    )
+    assert verdict.allowed
+    assert verdict.updated_input["file_path"] == str(root / "reports" / "out.md")
+    assert verdict.updated_input["content"] == "x"
+
+
+def test_confinement_follows_the_dial_not_a_baked_in_path(monkeypatch, tmp_path):
+    """Move the dial: the same absolute path flips from denied to allowed."""
+    first, second = tmp_path / "first", tmp_path / "second"
+    for host in (first, second):
+        (host / "ws-a").mkdir(parents=True)
+    target = {"file_path": str(second / "ws-a" / "notes.md")}
+
+    monkeypatch.setenv(wc.WORKSPACE_ROOT_ENV, str(first))
+    assert not evaluate_tool_confinement("Read", target, _root("ws-a")).allowed
+
+    monkeypatch.setenv(wc.WORKSPACE_ROOT_ENV, str(second))
+    assert evaluate_tool_confinement("Read", target, _root("ws-a")).allowed
+
+
+# ---------------------------------------------------------------------------
+# Compose source guard — the local profile carries the worker
+# ---------------------------------------------------------------------------
+
+# Short-syntax volume entry: SOURCE:TARGET[:MODE]. The source may itself hold
+# ':' (``${VAR:-default}``), so the target is anchored on the first ':/'.
+_SHORT_VOLUME_RE = re.compile(r"^(?P<source>.+?):(?P<target>/[^:]*)(?::(?P<mode>[a-zA-Z,]+))?$")
+
+
+def _compose() -> dict:
+    return yaml.safe_load(_COMPOSE.read_text(encoding="utf-8"))
+
+
+def _mounts(service: dict) -> list[dict]:
+    """Normalise short- and long-syntax volume entries to source/target/read_only."""
+    out: list[dict] = []
+    for entry in service.get("volumes", []) or []:
+        if isinstance(entry, dict):
+            out.append({
+                "source": entry.get("source"),
+                "target": entry.get("target"),
+                "read_only": bool(entry.get("read_only")),
+            })
+            continue
+        match = _SHORT_VOLUME_RE.match(entry)
+        if not match:  # anonymous volume, e.g. "/app/node_modules"
+            out.append({"source": None, "target": entry, "read_only": False})
+            continue
+        mode = (match.group("mode") or "").split(",")
+        out.append({
+            "source": match.group("source"),
+            "target": match.group("target"),
+            "read_only": "ro" in mode,
+        })
+    return out
+
+
+def _mount(service: dict, target: str) -> dict:
+    hits = [m for m in _mounts(service) if m["target"] == target]
+    assert len(hits) == 1, f"expected exactly one mount at {target}, got {hits}"
+    return hits[0]
+
+
+def _env(service: dict) -> dict[str, str]:
+    env = service.get("environment", {}) or {}
+    if isinstance(env, list):
+        env = dict(item.split("=", 1) for item in env)
+    return {k: "" if v is None else str(v) for k, v in env.items()}
+
+
+def _api_defaults() -> dict[str, str]:
+    out: dict[str, str] = {}
+    for line in _API_DEFAULTS.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        out[key.strip()] = value.strip()
+    return out
+
+
+def test_worker_runs_in_the_default_profile():
+    svc = _compose()["services"][WORKER_SERVICE]
+    assert "profiles" not in svc, (
+        "workspace-worker must not sit behind a compose profile — it is the local edition's runtime"
+    )
+
+
+def test_worker_mounts_the_designated_host_directory_read_write():
+    mount = _mount(_compose()["services"][WORKER_SERVICE], MOUNT_TARGET)
+    assert mount["source"] == HOST_DIR_SOURCE
+    assert mount["read_only"] is False
+
+
+def test_backend_mounts_the_same_host_directory_read_only():
+    mount = _mount(_compose()["services"][BACKEND_SERVICE], MOUNT_TARGET)
+    assert mount["source"] == HOST_DIR_SOURCE
+    assert mount["read_only"] is True
+
+
+def test_named_workspace_volume_is_gone():
+    compose = _compose()
+    assert RETIRED_VOLUME not in (compose.get("volumes") or {}), (
+        f"top-level volume {RETIRED_VOLUME} must be deleted with its last reference"
+    )
+    for name, svc in compose["services"].items():
+        for mount in _mounts(svc):
+            assert mount["source"] != RETIRED_VOLUME, f"{name} still mounts {RETIRED_VOLUME}"
+
+
+def test_mount_target_matches_worker_config_default():
+    compose = _compose()
+    worker_env = _env(compose["services"][WORKER_SERVICE])
+    assert worker_env[wc.WORKSPACE_ROOT_ENV] == MOUNT_TARGET == wc.DEFAULT_WORKSPACE_ROOT
+    # The backend's view of the same directory (config.WORKSPACE_VOLUME_PATH).
+    assert _api_defaults()[wc.WORKSPACE_ROOT_ENV] == MOUNT_TARGET
+
+
+def test_worker_keeps_credential_passthrough_and_limits():
+    svc = _compose()["services"][WORKER_SERVICE]
+    env = _env(svc)
+    for key in CREDENTIAL_PASSTHROUGH:
+        assert env.get(key) == f"${{{key}:-}}", f"{key} must pass through from .env without blocking boot"
+    limits = svc.get("deploy", {}).get("resources", {}).get("limits", {})
+    assert limits.get("cpus") and limits.get("memory"), "worker resource limits must stay"
+
+
+def test_backend_reaches_worker_at_compose_service_url():
+    worker_env = _env(_compose()["services"][WORKER_SERVICE])
+    expected = f"http://{WORKER_SERVICE}:{worker_env['WORKER_HEALTH_PORT']}"
+    assert _api_defaults().get("WORKER_INTERNAL_URL") == expected, (
+        "envs/api.defaults must point WORKER_INTERNAL_URL at the compose service "
+        "(config.py's localhost default reaches nothing inside the backend container)"
+    )
+
+
+def test_default_host_directory_is_gitignored():
+    default_dir = re.fullmatch(r"\$\{AUTOMATOS_WORKSPACE_DIR:-\./([^}]+)\}", HOST_DIR_SOURCE).group(1)
+    lines = [line.strip() for line in _GITIGNORE.read_text(encoding="utf-8").splitlines()]
+    assert f"/{default_dir}/" in lines, f"/{default_dir}/ must be gitignored (user deliverables, public repo)"

--- a/orchestrator/tests/test_prd233_s2_composio_degrade.py
+++ b/orchestrator/tests/test_prd233_s2_composio_degrade.py
@@ -1,0 +1,654 @@
+"""PRD-233 S2 — tool-routing degrade seam: honest without Composio.
+
+One predicate (``core.composio.client.composio_available``: key configured via
+config AND SDK importable), ONE discovery exclusion point
+(``tool_router._offerable_candidates``), one explicit refusal shape
+(``error_code == "integrations_unavailable"``) at the execution entries, and a
+boot bootstrap that syncs the catalogue on the first keyed boot and re-binds
+the seeded marketplace agents.
+
+Locked here:
+* key configured ⇒ Composio tools offered + executed exactly as today;
+* key absent ⇒ (a) excluded from discovery, (b) native tools still route,
+  (c) a direct Composio call returns ``integrations_unavailable`` — never a
+  silent success, never a fail-open re-route, (d) the F018 destructive gate is
+  untouched;
+* bootstrap: empty cache + key ⇒ sync scheduled; populated ⇒ no sync; no key
+  ⇒ nothing; the rebind is idempotent and never touches user-created items.
+
+Everything but the last class is pure (no DB, no network). The real-DB rebind
+test follows the test.yml Postgres pattern and skips when none is reachable.
+"""
+from __future__ import annotations
+
+# CI collection-order guard (see PR #434).
+import sys as _sys_guard  # noqa: E402
+for _name in [n for n, m in list(_sys_guard.modules.items())
+              if (n == "modules" or n.startswith("modules.")
+                  or n == "consumers" or n.startswith("consumers.")
+                  or n == "services" or n.startswith("services."))
+              and getattr(m, "__spec__", None) is None]:
+    _sys_guard.modules.pop(_name, None)
+
+import json  # noqa: E402
+import logging  # noqa: E402
+import uuid  # noqa: E402
+from typing import Any, Dict, List  # noqa: E402
+from unittest.mock import MagicMock, patch  # noqa: E402
+
+import pytest  # noqa: E402
+
+import core.composio.bootstrap as bs  # noqa: E402
+import core.composio.client as cc  # noqa: E402
+import modules.tools.tool_router as tr  # noqa: E402
+from config import config  # noqa: E402
+from modules.tools.registry.tool_registry import ToolCategory, ToolSpec  # noqa: E402
+
+DESTRUCTIVE_INTENT = "delete every message in #general"
+BENIGN_INTENT = "send hello to #general"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: flip the ONE predicate
+# ---------------------------------------------------------------------------
+
+
+class _FakeSDK:
+    """Stands in for ``composio.Composio`` — the import succeeded."""
+
+
+@pytest.fixture
+def composio_on(monkeypatch):
+    monkeypatch.setattr(config, "COMPOSIO_API_KEY", "test-key-not-a-secret")
+    monkeypatch.setattr(cc, "_get_composio", lambda: _FakeSDK)
+    cc.reset_composio_availability()
+    yield
+    cc.reset_composio_availability()
+
+
+@pytest.fixture
+def composio_off(monkeypatch):
+    monkeypatch.setattr(config, "COMPOSIO_API_KEY", None)
+    cc.reset_composio_availability()
+    yield
+    cc.reset_composio_availability()
+
+
+# ---------------------------------------------------------------------------
+# 1. The predicate
+# ---------------------------------------------------------------------------
+
+
+def test_available_with_key_and_sdk(composio_on):
+    assert cc.composio_available() is True
+    assert cc.composio_unavailable_reason() is None
+
+
+def test_unavailable_without_key(composio_off):
+    assert cc.composio_available() is False
+    assert cc.composio_unavailable_reason() == cc.COMPOSIO_UNAVAILABLE_NO_KEY
+    assert "COMPOSIO_API_KEY" in cc.composio_unavailable_reason()
+
+
+def test_unavailable_when_sdk_missing(monkeypatch):
+    monkeypatch.setattr(config, "COMPOSIO_API_KEY", "test-key-not-a-secret")
+
+    def _no_sdk():
+        raise ImportError("composio not installed")
+
+    monkeypatch.setattr(cc, "_get_composio", _no_sdk)
+    cc.reset_composio_availability()
+    try:
+        assert cc.composio_available() is False
+        assert cc.composio_unavailable_reason() == cc.COMPOSIO_UNAVAILABLE_NO_SDK
+        # The honest reason must survive tool_router's fatal-dependency
+        # classifier (it keys on "composio-openai").
+        assert tr._is_fatal_dependency_error(cc.COMPOSIO_UNAVAILABLE_NO_SDK) is False
+    finally:
+        cc.reset_composio_availability()
+
+
+def test_probe_is_cached_per_process_and_resettable(monkeypatch):
+    monkeypatch.setattr(config, "COMPOSIO_API_KEY", None)
+    cc.reset_composio_availability()
+    try:
+        assert cc.composio_available() is False
+        # Flipping config WITHOUT a reset keeps the cached verdict.
+        monkeypatch.setattr(config, "COMPOSIO_API_KEY", "now-set")
+        monkeypatch.setattr(cc, "_get_composio", lambda: _FakeSDK)
+        assert cc.composio_available() is False
+        cc.reset_composio_availability()
+        assert cc.composio_available() is True
+    finally:
+        cc.reset_composio_availability()
+
+
+# ---------------------------------------------------------------------------
+# 2. Discovery — the ONE exclusion point
+# ---------------------------------------------------------------------------
+
+
+def _spec(name: str, integration: str | None = None) -> ToolSpec:
+    return ToolSpec(
+        name=name,
+        category=ToolCategory.API_TOOLS,
+        description=f"{name} description",
+        executor_class="Fake",
+        executor_method="run",
+        metadata={"integration_type": integration} if integration else {},
+    )
+
+
+NATIVE = "search_knowledge"
+COMPOSIO_TOOLS = ("composio_execute", "composio_SLACK_SEND_MESSAGE", "sdk_named_composio_tool")
+_CANDIDATES = [
+    _spec(NATIVE),
+    _spec("composio_execute", "composio"),
+    _spec("composio_SLACK_SEND_MESSAGE", "composio"),
+    # metadata-only marker (no composio_ prefix) — the seam must catch it too
+    _spec("sdk_named_composio_tool", "composio"),
+]
+
+
+def _dispatcher_schema() -> Dict[str, Any]:
+    return {
+        "type": "function",
+        "function": {
+            "name": "platform_execute",
+            "description": "dispatcher",
+            "parameters": {"type": "object", "properties": {"action": {"enum": ["platform_list_agents"]}}},
+        },
+    }
+
+
+def _discover() -> List[str]:
+    fake_tool_registry = MagicMock()
+    fake_tool_registry.get_all_tools.return_value = list(_CANDIDATES)
+    action_registry = MagicMock()
+    action_registry.to_dispatcher_schema.return_value = _dispatcher_schema()
+    action_registry.get_all.return_value = []
+    action_registry.to_first_class_schemas.return_value = []
+    with patch.object(tr, "registry_get_tool_registry", return_value=fake_tool_registry), \
+            patch.object(tr, "SessionLocal", return_value=MagicMock()), \
+            patch("modules.tools.discovery.get_action_registry", return_value=action_registry):
+        tools = tr.get_tools_for_agent(agent_id=None, workspace_id=None)
+    return [t["function"]["name"] for t in tools]
+
+
+def test_key_configured_offers_composio_tools_as_today(composio_on):
+    names = _discover()
+    for name in COMPOSIO_TOOLS:
+        assert name in names, f"{name} must be offered when a key is configured"
+    assert NATIVE in names
+    assert "platform_execute" in names
+
+
+def test_key_absent_excludes_every_composio_tool_from_discovery(composio_off):
+    names = _discover()
+    for name in COMPOSIO_TOOLS:
+        assert name not in names, f"{name} must NOT be offered without a key"
+    # (b) native platform tools + the dispatcher are untouched
+    assert NATIVE in names
+    assert "platform_execute" in names
+
+
+def test_exclusion_is_a_passthrough_when_available(composio_on):
+    candidates = list(_CANDIDATES)
+    assert tr._offerable_candidates(candidates, "trace") is candidates
+
+
+def test_exclusion_logs_once_at_info_with_the_reason(composio_off, monkeypatch, caplog):
+    monkeypatch.setattr(tr, "_composio_exclusion_logged", False)
+    with caplog.at_level(logging.DEBUG, logger=tr.logger.name):
+        tr._offerable_candidates(list(_CANDIDATES), "t1")
+        tr._offerable_candidates(list(_CANDIDATES), "t2")
+    info = [r for r in caplog.records if r.levelno == logging.INFO and "not offered" in r.getMessage()]
+    assert len(info) == 1
+    assert cc.COMPOSIO_UNAVAILABLE_NO_KEY in info[0].getMessage()
+    assert "3 Composio tool(s)" in info[0].getMessage()
+
+
+@pytest.mark.asyncio
+async def test_filtered_composio_actions_empty_with_reason(composio_off):
+    result = await tr.get_filtered_composio_actions("send a message", ["SLACK"], db_session=MagicMock())
+    assert result["success"] is False
+    assert result["actions"] == []
+    assert result["error_code"] == tr.INTEGRATIONS_UNAVAILABLE
+    assert result["error"] == cc.COMPOSIO_UNAVAILABLE_NO_KEY
+
+
+@pytest.mark.asyncio
+async def test_filtered_composio_actions_unchanged_when_available(composio_on, monkeypatch):
+    # Today's first branch (filter module absent) — byte-for-byte the old shape.
+    monkeypatch.setattr(tr, "CAPABILITY_FILTER_AVAILABLE", False)
+    result = await tr.get_filtered_composio_actions("send a message", ["SLACK"], db_session=MagicMock())
+    assert result == {
+        "success": False,
+        "error": "Capability filter not available",
+        "actions": [],
+        "capabilities": [],
+    }
+
+
+# ---------------------------------------------------------------------------
+# 3. Execution seam
+# ---------------------------------------------------------------------------
+
+
+class _FakeExecutor:
+    def __init__(self) -> None:
+        self.calls: List[str] = []
+
+    async def execute_tool(self, tool_name, tool_args, agent_id, **kwargs):
+        self.calls.append(tool_name)
+        return {"success": True, "data": {"ok": True}, "tool": tool_name}
+
+
+def _executor_patches(executor: _FakeExecutor):
+    session = MagicMock()
+    return (
+        patch.object(tr, "_get_executor_for_request", return_value=executor),
+        # execute_tool imports SessionLocal locally from the database module.
+        patch("core.database.database.SessionLocal", return_value=session),
+    )
+
+
+@pytest.mark.asyncio
+async def test_native_tools_still_route_without_composio(composio_off):
+    executor = _FakeExecutor()
+    p1, p2 = _executor_patches(executor)
+    with p1, p2:
+        result = await tr.execute_tool(NATIVE, {"query": "x"}, agent_id=1, workspace_id=uuid.uuid4())
+    assert result["success"] is True
+    assert executor.calls == [NATIVE]
+
+
+@pytest.mark.asyncio
+async def test_direct_composio_call_refused_explicitly_without_composio(composio_off):
+    executor = _FakeExecutor()
+    p1, p2 = _executor_patches(executor)
+    with p1, p2:
+        result = await tr.execute_tool(
+            "composio_execute",
+            {"action": "SLACK_SEND_MESSAGE", "params": {"channel": "#general", "text": "hi"}},
+            agent_id=1,
+            workspace_id=uuid.uuid4(),
+        )
+    assert result["success"] is False
+    assert result["error_code"] == tr.INTEGRATIONS_UNAVAILABLE
+    assert result["error_type"] == tr.INTEGRATIONS_UNAVAILABLE
+    assert cc.COMPOSIO_UNAVAILABLE_NO_KEY in result["error"]
+    assert "COMPOSIO_API_KEY" in result["error"]
+    # never a fail-open pass-through: nothing reached the executor
+    assert executor.calls == []
+
+
+@pytest.mark.asyncio
+async def test_per_action_composio_tool_refused_too(composio_off):
+    executor = _FakeExecutor()
+    p1, p2 = _executor_patches(executor)
+    with p1, p2:
+        result = await tr.execute_tool("composio_SLACK_SEND_MESSAGE", {"channel": "#g"}, agent_id=1)
+    assert result["error_code"] == tr.INTEGRATIONS_UNAVAILABLE
+    assert executor.calls == []
+
+
+@pytest.mark.asyncio
+async def test_composio_call_passes_through_when_available(composio_on):
+    executor = _FakeExecutor()
+    p1, p2 = _executor_patches(executor)
+    with p1, p2:
+        result = await tr.execute_tool("composio_execute", {"action": "SLACK_SEND_MESSAGE"}, agent_id=1)
+    assert result["success"] is True
+    assert executor.calls == ["composio_execute"]
+    assert "error_code" not in result
+
+
+@pytest.mark.asyncio
+async def test_router_envelope_carries_integrations_unavailable(composio_off):
+    executor = _FakeExecutor()
+    p1, p2 = _executor_patches(executor)
+    with p1, p2:
+        envelope = await tr.ToolRouter().execute_and_format(
+            "composio_execute",
+            {"action": "SLACK_DELETE_MESSAGE", "params": {"ts": "1"}},
+            agent_id=1,
+            workspace_id=uuid.uuid4(),
+            original_intent=DESTRUCTIVE_INTENT,  # would hit F018 if it ever got that far
+        )
+    assert envelope["success"] is False
+    assert envelope["error_type"] == tr.INTEGRATIONS_UNAVAILABLE
+    assert envelope["raw_result"]["error_code"] == tr.INTEGRATIONS_UNAVAILABLE
+    assert envelope["fatal_error"] is False  # honest message, not the generic "restart"
+    assert "Integrations are disabled" in envelope["llm_context"]
+    assert executor.calls == []
+
+
+# ---------------------------------------------------------------------------
+# 4. F018 fail-closed gate — unchanged in BOTH availability states
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("state", ["composio_on", "composio_off"])
+def test_f018_gate_unchanged(state, request, monkeypatch):
+    request.getfixturevalue(state)
+    monkeypatch.setattr(tr, "CAPABILITY_FILTER_AVAILABLE", False)
+    monkeypatch.setattr(config, "COMPOSIO_DESTRUCTIVE_FAIL_CLOSED", True)
+
+    eligible, reason = tr.validate_action_for_intent("SLACK_DELETE_MESSAGE", DESTRUCTIVE_INTENT)
+    assert eligible is False
+    assert "confirmation required" in reason
+
+    eligible, reason = tr.validate_action_for_intent("SLACK_SEND_MESSAGE", BENIGN_INTENT)
+    assert eligible is True
+
+    # explicit authorisation still opens the gate, exactly as before
+    eligible, _ = tr.validate_action_for_intent("SLACK_DELETE_MESSAGE", DESTRUCTIVE_INTENT, allow_destructive=True)
+    assert eligible is True
+
+
+@pytest.mark.asyncio
+async def test_validated_execution_blocked_by_f018_when_available(composio_on, monkeypatch):
+    monkeypatch.setattr(tr, "CAPABILITY_FILTER_AVAILABLE", False)
+    monkeypatch.setattr(config, "COMPOSIO_DESTRUCTIVE_FAIL_CLOSED", True)
+    executor = _FakeExecutor()
+    p1, p2 = _executor_patches(executor)
+    with p1, p2:
+        result = await tr.execute_tool_with_validation(
+            "composio_execute", {"action": "SLACK_DELETE_MESSAGE"}, DESTRUCTIVE_INTENT, agent_id=1
+        )
+    assert result["error_type"] == "validation_blocked"
+    assert result["blocked_by"] == "capability_validation"
+    assert executor.calls == []
+
+
+@pytest.mark.asyncio
+async def test_validated_execution_refused_before_f018_when_unavailable(composio_off, monkeypatch):
+    monkeypatch.setattr(tr, "CAPABILITY_FILTER_AVAILABLE", False)
+    executor = _FakeExecutor()
+    p1, p2 = _executor_patches(executor)
+    with p1, p2:
+        result = await tr.execute_tool_with_validation(
+            "composio_execute", {"action": "SLACK_DELETE_MESSAGE"}, DESTRUCTIVE_INTENT, agent_id=1
+        )
+    # honest: "no integrations" — not "confirm this destructive action"
+    assert result["error_code"] == tr.INTEGRATIONS_UNAVAILABLE
+    assert executor.calls == []
+
+
+# ---------------------------------------------------------------------------
+# 4b. GET /api/tools/integrations/status — the UI reads the SAME predicate
+# ---------------------------------------------------------------------------
+
+
+def _status_session(apps_cached: int, last_sync: str | None, job_status: str | None) -> MagicMock:
+    session = MagicMock()
+    session.query.return_value.scalar.return_value = apps_cached
+    stats_row = MagicMock(stat_value={"timestamp": last_sync}) if last_sync else None
+    session.query.return_value.filter.return_value.first.return_value = stats_row
+    job = MagicMock(status=job_status) if job_status else None
+    session.query.return_value.order_by.return_value.first.return_value = job
+    return session
+
+
+@pytest.mark.asyncio
+async def test_status_endpoint_reports_disabled_state(composio_off):
+    from api.tools import integrations_status
+
+    out = await integrations_status(ctx=MagicMock(), db=_status_session(0, None, None))
+    assert out.available is False
+    assert out.reason == cc.COMPOSIO_UNAVAILABLE_NO_KEY
+    assert out.key_configured is False
+    assert out.apps_cached == 0
+    assert out.last_sync is None
+    assert out.sync_status is None
+
+
+@pytest.mark.asyncio
+async def test_status_endpoint_reports_available_state(composio_on):
+    from api.tools import integrations_status
+
+    out = await integrations_status(
+        ctx=MagicMock(), db=_status_session(880, "2026-08-29T00:00:00Z", "completed")
+    )
+    assert out.available is True and out.reason is None
+    assert out.key_configured is True
+    assert out.apps_cached == 880
+    assert out.last_sync == "2026-08-29T00:00:00Z"
+    assert out.sync_status == "completed"
+
+
+# ---------------------------------------------------------------------------
+# 5. Boot bootstrap (pure — session + service mocked)
+# ---------------------------------------------------------------------------
+
+
+def _boot_session(apps_cached: int) -> MagicMock:
+    session = MagicMock()
+    session.query.return_value.scalar.return_value = apps_cached  # catalog_app_count
+    session.query.return_value.filter.return_value.first.return_value = None  # no sync in flight
+    return session
+
+
+class _Runner:
+    def __init__(self) -> None:
+        self.scheduled: List[Any] = []
+
+    def __call__(self, target) -> None:
+        self.scheduled.append(target)
+
+
+def test_bootstrap_schedules_sync_when_key_and_empty_cache(composio_on, monkeypatch):
+    session = _boot_session(0)
+    runner = _Runner()
+    rebind = MagicMock(return_value=0)
+    monkeypatch.setattr(bs, "SessionLocal", lambda: session)
+    monkeypatch.setattr(bs, "rebind_seeded_agents", rebind)
+    result = bs.ensure_catalog_on_boot(start_background=runner)
+    assert result["status"] == "scheduled"
+    assert runner.scheduled == [bs.run_catalog_sync_and_rebind]
+    rebind.assert_not_called()  # the rebind runs AFTER the sync, on the thread
+    session.close.assert_called_once()
+
+
+def test_bootstrap_no_sync_when_cache_populated(composio_on, monkeypatch):
+    session = _boot_session(880)
+    runner = _Runner()
+    rebind = MagicMock(return_value=0)
+    monkeypatch.setattr(bs, "SessionLocal", lambda: session)
+    monkeypatch.setattr(bs, "rebind_seeded_agents", rebind)
+    result = bs.ensure_catalog_on_boot(start_background=runner)
+    assert result == {"status": "ready", "apps_cached": 880, "rebound": 0}
+    assert runner.scheduled == []
+    rebind.assert_called_once_with(session)
+
+
+def test_bootstrap_touches_nothing_without_key(composio_off, monkeypatch):
+    factory = MagicMock()
+    runner = _Runner()
+    monkeypatch.setattr(bs, "SessionLocal", factory)
+    result = bs.ensure_catalog_on_boot(start_background=runner)
+    assert result == {"status": "unavailable", "reason": cc.COMPOSIO_UNAVAILABLE_NO_KEY}
+    factory.assert_not_called()
+    assert runner.scheduled == []
+
+
+def test_bootstrap_probe_failure_never_raises(composio_on, monkeypatch):
+    session = MagicMock()
+    session.query.side_effect = RuntimeError("relation does not exist")
+    recorded = MagicMock()
+    monkeypatch.setattr(bs, "SessionLocal", lambda: session)
+    monkeypatch.setattr(bs, "record_error", recorded)
+    result = bs.ensure_catalog_on_boot(start_background=_Runner())
+    assert result["status"] == "error"
+    recorded.assert_called_once()
+    session.close.assert_called_once()
+
+
+def test_background_sync_runs_service_then_rebind(monkeypatch):
+    session = MagicMock()
+    service = MagicMock()
+    service.run_full_sync.return_value = {"apps_synced": 5, "actions_synced": 50, "errors_count": 0}
+    service_cls = MagicMock(return_value=service)
+    rebind = MagicMock(return_value=31)
+    monkeypatch.setattr(bs, "SessionLocal", lambda: session)
+    monkeypatch.setattr(bs, "rebind_seeded_agents", rebind)
+    monkeypatch.setattr("services.metadata_sync_service.MetadataSyncService", service_cls)
+    result = bs.run_catalog_sync_and_rebind()
+    service_cls.assert_called_once_with(session)
+    service.run_full_sync.assert_called_once_with()
+    rebind.assert_called_once_with(session)
+    assert result["status"] == "completed" and result["rebound"] == 31
+    session.close.assert_called_once()
+
+
+def test_background_sync_failure_is_recorded_not_raised(monkeypatch):
+    session = MagicMock()
+    service = MagicMock()
+    service.run_full_sync.side_effect = RuntimeError("composio 401")
+    recorded = MagicMock()
+    monkeypatch.setattr(bs, "SessionLocal", lambda: session)
+    monkeypatch.setattr("services.metadata_sync_service.MetadataSyncService", MagicMock(return_value=service))
+    monkeypatch.setattr(bs, "record_error", recorded)
+    result = bs.run_catalog_sync_and_rebind()
+    assert result["status"] == "failed" and "composio 401" in result["error"]
+    recorded.assert_called_once()
+    session.rollback.assert_called_once()
+    session.close.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# 6. Rebind — pure resolution
+# ---------------------------------------------------------------------------
+
+
+_CATALOG = {"SLACK": (11, "https://logo/slack.png"), "GMAIL": (12, None)}
+
+
+def test_rebound_metadata_resolves_intended_names():
+    before = {"tools": [], "tool_names": ["SLACK", "GMAIL", "NOTINCACHE"], "tool_icons": [], "skills": ["x"]}
+    after = bs.rebound_metadata(before, _CATALOG)
+    assert after == {"tools": [11, 12], "tool_names": ["SLACK", "GMAIL", "NOTINCACHE"],
+                     "tool_icons": ["https://logo/slack.png", ""], "skills": ["x"]}
+    # input never mutated
+    assert before["tools"] == [] and before["tool_icons"] == []
+
+
+def test_rebound_metadata_is_none_when_already_bound():
+    bound = {"tools": [11, 12], "tool_names": ["slack", "gmail"], "tool_icons": ["https://logo/slack.png", ""]}
+    assert bs.rebound_metadata(bound, _CATALOG) is None
+
+
+def test_rebound_metadata_is_none_when_nothing_resolvable():
+    unresolved = {"tools": [], "tool_names": ["NOTINCACHE"], "tool_icons": []}
+    assert bs.rebound_metadata(unresolved, _CATALOG) is None
+
+
+# ---------------------------------------------------------------------------
+# 7. Rebind — real DB, idempotent, seeded rows only
+# ---------------------------------------------------------------------------
+
+PROBE_APP = "PRD233TESTAPP"
+PROBE_LOGO = "https://logo/prd233.png"
+PROBE_NAMES = [PROBE_APP, "PRD233MISSING"]
+
+
+@pytest.fixture(scope="module")
+def engine():
+    """Real Postgres engine; skip the whole class cleanly when none is up."""
+    from sqlalchemy import create_engine, text
+    from core.database.database import get_database_url
+
+    try:
+        eng = create_engine(get_database_url(), pool_pre_ping=True)
+        with eng.connect() as c:
+            c.execute(text("SELECT 1"))
+            # marketplace_items has no ORM model (alembic-only), so a create_all
+            # test DB may lack it — skip honestly rather than error at INSERT.
+            present = c.execute(
+                text("SELECT to_regclass('marketplace_items') IS NOT NULL "
+                     "AND to_regclass('composio_apps_cache') IS NOT NULL")
+            ).scalar()
+    except Exception as exc:  # noqa: BLE001
+        pytest.skip(f"rebind suite needs a reachable Postgres: {exc}")
+    if not present:
+        pytest.skip("rebind suite needs marketplace_items + composio_apps_cache (alembic schema)")
+    yield eng
+    eng.dispose()
+
+
+def _insert_item(session, creator: str, name: str) -> int:
+    from sqlalchemy import text
+
+    metadata = {"tools": [], "tool_names": PROBE_NAMES, "tool_icons": [], "agent_type": "custom"}
+    return session.execute(
+        text(
+            "INSERT INTO marketplace_items (type, name, description, creator_name, category, tags, "
+            "install_count, is_featured, is_approved, version, metadata, created_at, updated_at) "
+            "VALUES ('agent', :name, 'prd233 probe', :creator, 'Test', CAST('[]' AS jsonb), "
+            "0, false, false, '1.0.0', CAST(:metadata AS jsonb), NOW(), NOW()) RETURNING id"
+        ),
+        {"name": name, "creator": creator, "metadata": json.dumps(metadata)},
+    ).scalar()
+
+
+@pytest.fixture
+def probe_rows(engine, new_session):
+    """One throwaway cache app + one seeded item + one user item; all deleted on teardown."""
+    from sqlalchemy import text
+
+    s = new_session()
+    s.execute(text("DELETE FROM composio_apps_cache WHERE app_name = :n"), {"n": PROBE_APP})
+    s.execute(
+        text(
+            "INSERT INTO composio_apps_cache (app_name, app_slug, display_name, logo_url, categories, auth_schemes, "
+            "action_count, trigger_count, status) VALUES (:n, :slug, :d, :logo, CAST('[]' AS jsonb), "
+            "CAST('[]' AS jsonb), 0, 0, 'ACTIVE') RETURNING id"
+        ),
+        {"n": PROBE_APP, "slug": PROBE_APP.lower(), "d": "PRD233 Probe App", "logo": PROBE_LOGO},
+    )
+    seeded_id = _insert_item(s, bs.SEEDED_CREATOR_NAME, "PRD233 Rebind Probe (seeded)")
+    user_id = _insert_item(s, "Some User", "PRD233 Rebind Probe (user)")
+    s.commit()
+    yield seeded_id, user_id
+    t = new_session.sweep()
+    t.execute(text("DELETE FROM marketplace_items WHERE id IN (:a, :b)"), {"a": seeded_id, "b": user_id})
+    t.execute(text("DELETE FROM composio_apps_cache WHERE app_name = :n"), {"n": PROBE_APP})
+    t.commit()
+    t.close()
+
+
+def _metadata(session, item_id: int) -> Dict[str, Any]:
+    from sqlalchemy import text
+
+    return session.execute(text("SELECT metadata FROM marketplace_items WHERE id = :id"), {"id": item_id}).scalar()
+
+
+@pytest.mark.integration
+def test_rebind_is_idempotent_and_touches_only_seeded_rows(probe_rows, new_session):
+    from sqlalchemy import text
+
+    seeded_id, user_id = probe_rows
+    cache_id = None
+    s = new_session()
+    cache_id = s.execute(
+        text("SELECT id FROM composio_apps_cache WHERE app_name = :n"), {"n": PROBE_APP}
+    ).scalar()
+
+    # first pass binds the seeded row (only the app that exists in the cache)
+    assert bs.rebind_seeded_agents(s) == 1
+    seeded = _metadata(s, seeded_id)
+    assert seeded["tools"] == [cache_id]
+    assert seeded["tool_icons"] == [PROBE_LOGO]
+    assert seeded["tool_names"] == PROBE_NAMES  # intended names preserved
+    assert seeded["agent_type"] == "custom"       # unrelated metadata untouched
+
+    # the user-published item with the same shape is never touched
+    user = _metadata(s, user_id)
+    assert user["tools"] == [] and user["tool_icons"] == []
+
+    # second pass: same rows, zero writes
+    assert bs.rebind_seeded_agents(s) == 0
+    assert _metadata(s, seeded_id) == seeded
+    assert _metadata(s, user_id) == user
+    s.close()

--- a/orchestrator/tests/test_prd233_s2_executor_chokepoint.py
+++ b/orchestrator/tests/test_prd233_s2_executor_chokepoint.py
@@ -1,0 +1,55 @@
+"""PRD-233 S2 — ONE Composio availability seam for every caller.
+
+The router refuses routed calls (test_prd233_s2_composio_degrade); this covers
+the executor chokepoint that catches the two production callers which bypass
+the router (agent_factory direct execution, approval-grant replays).
+"""
+from __future__ import annotations
+
+import pytest
+
+from modules.tools.execution.unified_executor import UnifiedToolExecutor
+
+
+def _bare_executor() -> UnifiedToolExecutor:
+    # No constructor: the seam sits before every sub-executor is touched.
+    ex = UnifiedToolExecutor.__new__(UnifiedToolExecutor)
+    ex.composio_actions = {"SLACK_SEND_MESSAGE": {"app": "slack"}}
+    ex.db = None
+    return ex
+
+
+@pytest.fixture
+def no_policy_gate(monkeypatch):
+    monkeypatch.setattr(UnifiedToolExecutor, "_policy_gate_check", lambda self, *a, **k: None)
+
+
+@pytest.mark.asyncio
+async def test_direct_composio_call_is_refused_when_unavailable(monkeypatch, no_policy_gate):
+    monkeypatch.setattr("core.composio.client.composio_available", lambda: False)
+    ex = _bare_executor()
+    for name, params in (("composio_execute", {"action": "SLACK_SEND_MESSAGE"}), ("composio_slack_send", {}), ("SLACK_SEND_MESSAGE", {})):
+        res = await ex.execute_tool(name, params, agent_id=1, trace_id="t-chokepoint")
+        assert res["success"] is False, name
+        assert res.get("error_code") == "integrations_unavailable", (name, res)
+
+
+@pytest.mark.asyncio
+async def test_native_tools_pass_the_seam(monkeypatch, no_policy_gate):
+    monkeypatch.setattr("core.composio.client.composio_available", lambda: False)
+    ex = _bare_executor()
+    # platform_execute without an action reaches the dispatcher's own validation —
+    # proof the seam let a native tool through.
+    res = await ex.execute_tool("platform_execute", {}, agent_id=1, trace_id="t-native")
+    assert res.get("error_code") != "integrations_unavailable"
+    assert "action" in (res.get("error") or "")
+
+
+@pytest.mark.asyncio
+async def test_with_a_key_the_seam_is_a_no_op(monkeypatch, no_policy_gate):
+    monkeypatch.setattr("core.composio.client.composio_available", lambda: True)
+    ex = _bare_executor()
+    res = await ex.execute_tool("composio_execute", {"action": "SLACK_SEND_MESSAGE"}, agent_id=1, trace_id="t-key")
+    # Past the seam the bare executor has no sub-executors — whatever it returns,
+    # it is NOT the unavailable refusal.
+    assert res.get("error_code") != "integrations_unavailable"

--- a/orchestrator/tests/test_prd233_s3_first_run_seed.py
+++ b/orchestrator/tests/test_prd233_s3_first_run_seed.py
@@ -34,6 +34,8 @@ from core.seeds.seed_local_first_run import (
     ROSTER,
     WELCOME_CONTENT,
     WELCOME_SLUG,
+    _base_slug,
+    _slug_candidates,
     WELCOME_TITLE,
     agent_fingerprint,
     current_fingerprints,
@@ -352,8 +354,8 @@ def test_rows_are_workspace_scoped_attributed_and_listable_like_the_api(local_ed
     ).scalar()
     assert operator_id is not None
 
-    roster = s.query(Agent).filter(Agent.workspace_id == ws, Agent.slug.in_(ROSTER_SLUGS)).all()
-    assert sorted(a.slug for a in roster) == sorted(ROSTER_SLUGS)
+    roster = s.query(Agent).filter(Agent.workspace_id == ws, Agent.slug.in_([c for b in ROSTER_SLUGS for c in _slug_candidates(b, ws)])).all()
+    assert sorted(_base_slug(a.slug, ws) for a in roster) == sorted(ROSTER_SLUGS)
     for agent in roster:
         assert agent.is_system_agent is False and agent.owner_type == "workspace"
         assert agent.created_by_user_id == operator_id
@@ -379,7 +381,7 @@ def test_rows_are_workspace_scoped_attributed_and_listable_like_the_api(local_ed
         )
         .all()
     )
-    assert [p.template_id for p in listed] == [PLAYBOOK_TEMPLATE_ID]
+    assert [p.template_id.startswith(PLAYBOOK_TEMPLATE_ID) for p in listed] == [True]
     playbook = listed[0]
     validate_playbook(playbook)
     assert {step["agent_id"] for step in playbook.steps} <= roster_ids
@@ -410,9 +412,9 @@ def test_user_edits_are_never_overwritten(local_edition, new_session):
     _run(s)
     ws = local_edition
 
-    writer = s.query(Agent).filter(Agent.workspace_id == ws, Agent.slug == "local-writer").one()
+    writer = s.query(Agent).filter(Agent.workspace_id == ws, Agent.slug.in_(_slug_candidates("local-writer", ws))).one()
     writer.description = "Writes only haiku now."
-    playbook = s.query(WorkflowTemplate).filter(WorkflowTemplate.template_id == PLAYBOOK_TEMPLATE_ID).one()
+    playbook = s.query(WorkflowTemplate).filter(WorkflowTemplate.workspace_id == ws).one()
     edited_steps = [dict(step) for step in playbook.steps]
     edited_steps[0] = {**edited_steps[0], "prompt_template": "Research {input.topic} my way."}
     playbook.steps = edited_steps
@@ -439,7 +441,7 @@ def test_rows_still_on_a_prior_seed_version_are_refreshed(local_edition, new_ses
     _run(s)
     ws = local_edition
 
-    researcher = s.query(Agent).filter(Agent.workspace_id == ws, Agent.slug == "local-researcher").one()
+    researcher = s.query(Agent).filter(Agent.workspace_id == ws, Agent.slug.in_(_slug_candidates("local-researcher", ws))).one()
     researcher.description = "An older shipped description."
     s.commit()
     older_fingerprint = agent_fingerprint(researcher)
@@ -458,13 +460,15 @@ def test_deleted_seed_rows_are_not_resurrected(local_edition, new_session):
 
     s = new_session()
     _run(s)
-    s.execute(text("DELETE FROM workflow_recipes WHERE template_id = :t"), {"t": PLAYBOOK_TEMPLATE_ID})
+    # Scoped to THIS workspace: template_id is globally unique and another
+    # workspace (the live default one) may own the plain id.
+    s.execute(text("DELETE FROM workflow_recipes WHERE workspace_id = CAST(:w AS uuid)"), {"w": str(local_edition)})
     s.commit()
 
     second = _run(s)
     assert second["playbooks"] == {"deleted_by_user": 1}
     assert s.execute(
-        text("SELECT count(*) FROM workflow_recipes WHERE template_id = :t"), {"t": PLAYBOOK_TEMPLATE_ID}
+        text("SELECT count(*) FROM workflow_recipes WHERE workspace_id = CAST(:w AS uuid)"), {"w": str(local_edition)}
     ).scalar() == 0
 
 

--- a/orchestrator/tests/test_prd233_s3_first_run_seed.py
+++ b/orchestrator/tests/test_prd233_s3_first_run_seed.py
@@ -1,0 +1,480 @@
+"""PRD-233 S3 — the local-edition first-run seed (the two-minute demo).
+
+Pure tests (no DB) pin the gate (saas ⇒ the session is never touched), the
+fingerprint mechanics (current ⇒ untouched / prior ⇒ refreshed / anything else
+⇒ never overwritten), the demo Playbook's validity through the SAME validators
+the create route runs, the native-tools-only invariant, content hygiene (no
+personal data), and the load_seed_data wiring.
+
+@integration tests run the real seed against the database with a THROWAWAY
+workspace id monkeypatched into config — never the live default workspace —
+and sweep every row they made: twice ⇒ identical state, rows workspace-scoped
+and listable exactly as the API lists them, user edits preserved, prior-version
+rows refreshed, deleted rows not resurrected. Skip without Postgres; CI runs them.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import re
+import uuid
+from functools import partial
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from config import config
+import core.seeds.seed_local_first_run as seed_mod
+from core.models.core import WorkflowTemplate
+from core.seeds.seed_local_first_run import (
+    LEDGER_KEY,
+    PLAYBOOK,
+    PLAYBOOK_TEMPLATE_ID,
+    ROSTER,
+    WELCOME_CONTENT,
+    WELCOME_SLUG,
+    WELCOME_TITLE,
+    agent_fingerprint,
+    current_fingerprints,
+    playbook_fingerprint,
+    post_fingerprint,
+    seed_local_first_run,
+    validate_playbook,
+)
+
+_ORCH = pathlib.Path(__file__).resolve().parents[1]
+_SEED_SRC = pathlib.Path(seed_mod.__file__).read_text(encoding="utf-8")
+ROSTER_SLUGS = [spec["slug"] for spec in ROSTER]
+
+
+def _fake_ids() -> dict[str, int]:
+    return {slug: 100 + index for index, slug in enumerate(ROSTER_SLUGS)}
+
+
+# --------------------------------------------------------------------------- #
+# Gate — SaaS invariant: the seed never runs outside the local edition
+# --------------------------------------------------------------------------- #
+
+
+def test_saas_is_a_no_op_that_never_touches_the_session(monkeypatch):
+    monkeypatch.setattr(config, "AUTH_EDITION", "saas")
+    monkeypatch.setattr(config, "DEFAULT_WORKSPACE_ID", str(uuid.uuid4()))
+    db = MagicMock()
+    assert seed_local_first_run(db) == {"skipped": "not-local"}
+    db.execute.assert_not_called()
+    db.query.assert_not_called()
+    db.add.assert_not_called()
+
+
+def test_local_without_a_default_workspace_is_a_no_op(monkeypatch):
+    monkeypatch.setattr(config, "AUTH_EDITION", "local")
+    monkeypatch.setattr(config, "DEFAULT_WORKSPACE_ID", "  ")
+    db = MagicMock()
+    assert seed_local_first_run(db) == {"skipped": "no-default-workspace"}
+    db.execute.assert_not_called()
+    db.add.assert_not_called()
+
+
+# --------------------------------------------------------------------------- #
+# Refresh mechanics — the hash pattern (current / prior / customized)
+# --------------------------------------------------------------------------- #
+
+
+def test_agent_row_current_prior_and_customized_outcomes(monkeypatch):
+    spec = ROSTER[0]
+    columns = seed_mod._agent_columns(spec, uuid.uuid4(), None)
+    current = agent_fingerprint(SimpleNamespace(**columns))
+    row = SimpleNamespace(**columns)
+
+    assert seed_mod._refresh(row, columns, seed_mod._AGENT_CONTENT_FIELDS, agent_fingerprint, current) == "current"
+
+    row.description = "my own words about this agent"
+    assert seed_mod._refresh(row, columns, seed_mod._AGENT_CONTENT_FIELDS, agent_fingerprint, current) == "customized"
+    assert row.description == "my own words about this agent"  # never overwritten
+
+    monkeypatch.setattr(seed_mod, "PRIOR_SEED_FINGERPRINTS", frozenset({agent_fingerprint(row)}))
+    assert seed_mod._refresh(row, columns, seed_mod._AGENT_CONTENT_FIELDS, agent_fingerprint, current) == "refreshed"
+    assert row.description == spec["description"]
+    # a second pass over the refreshed row is a no-op
+    assert seed_mod._refresh(row, columns, seed_mod._AGENT_CONTENT_FIELDS, agent_fingerprint, current) == "current"
+
+
+def test_playbook_fingerprint_is_stable_across_re_created_agent_ids():
+    """Agent ids are normalised to roster slugs, so a roster agent re-created
+    with a new id still hashes as seed content (and can be re-pointed)."""
+    ws = uuid.uuid4()
+    ids_a = _fake_ids()
+    ids_b = {slug: agent_id + 1000 for slug, agent_id in ids_a.items()}
+    row_a = SimpleNamespace(**seed_mod._playbook_columns(PLAYBOOK, ws, None, ids_a))
+    row_b = SimpleNamespace(**seed_mod._playbook_columns(PLAYBOOK, ws, None, ids_b))
+    fp_a = playbook_fingerprint(row_a, {v: k for k, v in ids_a.items()})
+    fp_b = playbook_fingerprint(row_b, {v: k for k, v in ids_b.items()})
+    assert fp_a == fp_b
+    # an edited prompt is a different fingerprint
+    row_a.steps[0]["prompt_template"] = "do something else"
+    assert playbook_fingerprint(row_a, {v: k for k, v in ids_a.items()}) != fp_b
+
+
+def test_assign_only_writes_when_different_and_rebuilds_json_values():
+    row = SimpleNamespace(tags=["a"], description="x")
+    assert seed_mod._assign(row, "description", "x") is False
+    original = ["a"]
+    assert seed_mod._assign(row, "tags", original) is False  # equal ⇒ untouched
+    assert seed_mod._assign(row, "tags", ["a", "b"]) is True
+    assert row.tags == ["a", "b"] and row.tags is not original
+
+
+def test_ledger_is_rebuilt_never_mutated():
+    ws = SimpleNamespace(settings={"other": 1})
+    before = ws.settings
+    ctx = SimpleNamespace(ledger={"agents": {"local-writer"}, "playbooks": set(), "deliverables": set()})
+    monkeypatch_present = {"agents": {"local-researcher"}, "playbooks": {PLAYBOOK_TEMPLATE_ID}, "deliverables": set()}
+    original = seed_mod._present_identities
+    seed_mod._present_identities = lambda _ctx: monkeypatch_present
+    try:
+        assert seed_mod._record_ledger(ws, ctx) is True
+    finally:
+        seed_mod._present_identities = original
+    assert ws.settings is not before and before == {"other": 1}
+    assert ws.settings["other"] == 1
+    assert ws.settings[LEDGER_KEY]["seeded"] == {
+        "agents": ["local-researcher", "local-writer"],
+        "playbooks": [PLAYBOOK_TEMPLATE_ID],
+        "deliverables": [],
+    }
+    assert seed_mod._read_ledger(ws) == {
+        "agents": {"local-researcher", "local-writer"},
+        "playbooks": {PLAYBOOK_TEMPLATE_ID},
+        "deliverables": set(),
+    }
+
+
+def test_current_fingerprints_cover_every_seeded_identity():
+    fps = current_fingerprints()
+    assert set(fps) == set(ROSTER_SLUGS) | {PLAYBOOK_TEMPLATE_ID, WELCOME_SLUG}
+    assert all(re.fullmatch(r"[0-9a-f]{64}", fp) for fp in fps.values())
+    assert len(set(fps.values())) == len(fps)
+
+
+# --------------------------------------------------------------------------- #
+# The demo Playbook — valid through the create route's own validators,
+# runnable with only an LLM key
+# --------------------------------------------------------------------------- #
+
+
+def test_demo_playbook_passes_the_create_routes_validators():
+    ids = _fake_ids()
+    columns = seed_mod._playbook_columns(PLAYBOOK, uuid.uuid4(), None, ids)
+    recipe = WorkflowTemplate(**columns)  # ORM object, no session needed
+    validate_playbook(recipe)  # raises on any validator failure
+    for field in ("template_id", "name", "description", "template_definition", "steps"):
+        assert columns[field], f"create route requires {field}"
+    assert columns["schedule_config"] == {"type": "manual"}
+    assert columns["execution_config"]["mode"] == "sequential"
+
+
+def test_demo_playbook_steps_bind_only_roster_agents_and_the_declared_input():
+    ids = _fake_ids()
+    columns = seed_mod._playbook_columns(PLAYBOOK, uuid.uuid4(), None, ids)
+    assert [s["order"] for s in columns["steps"]] == [1, 2, 3]
+    for step in columns["steps"]:
+        assert step["agent_id"] in ids.values()
+        assert "agent" not in step and "agent_slug" not in step  # GET /{id} enrichment key stays free
+        assert "{input.topic}" in step["prompt_template"]
+        assert step["error_handling"] == "stop"
+    assert set(PLAYBOOK["inputs"]) == {"topic"}
+    assert PLAYBOOK["inputs"]["topic"]["default"]
+    # LLM-only: nothing to install, no integration named as a requirement
+    assert columns["required_tools"] == []
+    assert columns["recommended_agents"] == []
+    assert columns["is_public"] is True  # the list route defaults to is_public=True
+
+
+def test_roster_is_native_tools_only_and_runtime_llm_resolution():
+    for spec in ROSTER:
+        columns = seed_mod._agent_columns(spec, uuid.uuid4(), None)
+        assert columns["is_system_agent"] is False  # visible on the Agents page
+        assert columns["model_config"] is None  # resolves the workspace's key at runtime
+        assert columns["configuration"] == {}  # no Composio app ids / tool bindings
+        assert columns["use_custom_persona"] is True and columns["custom_persona_prompt"]
+        assert spec["slug"].startswith("local-")
+
+
+# --------------------------------------------------------------------------- #
+# Source guards — hygiene, config discipline, wiring
+# --------------------------------------------------------------------------- #
+
+
+def test_seed_module_reads_config_only_and_carries_no_personal_data():
+    assert "os.getenv" not in _SEED_SRC
+    content = json.dumps([ROSTER, PLAYBOOK, WELCOME_CONTENT, WELCOME_TITLE])
+    assert "@" not in content, "seed content must not carry email addresses"
+    assert "gerard" not in _SEED_SRC.lower()
+    assert "clerk" not in content.lower()
+
+
+def test_welcome_post_is_the_db_resident_outputs_member():
+    columns = seed_mod._post_columns(uuid.uuid4(), None)
+    assert columns["file_path"] is None  # content served from blog_posts.content — no worker fetch
+    assert columns["status"] == "published"
+    assert columns["content"] == WELCOME_CONTENT
+    assert len(columns["excerpt"]) <= 500
+    assert "Settings" in WELCOME_CONTENT and "Two-minute brief" in WELCOME_CONTENT
+
+
+def test_load_seed_data_calls_the_seed_gated_inside_its_own_try_except():
+    src = (_ORCH / "core" / "database" / "load_seed_data.py").read_text(encoding="utf-8")
+    at = src.index("seed_local_first_run(db)")
+    before = src[max(0, at - 500):at]
+    after = src[at:at + 400]
+    assert "from core.seeds.seed_local_first_run import seed_local_first_run" in before
+    assert "try:" in before
+    assert "except Exception" in after, "a seed failure must not abort the other seeders"
+    # the gate lives in the seed itself (config.AUTH_EDITION), not in the loader
+    assert 'config.AUTH_EDITION != "local"' in _SEED_SRC
+
+
+# --------------------------------------------------------------------------- #
+# @integration — the real seed against the database, throwaway workspace only
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture(scope="module")
+def engine():
+    from sqlalchemy import create_engine, text
+
+    from core.database.database import get_database_url
+
+    try:
+        eng = create_engine(get_database_url(), pool_pre_ping=True)
+        with eng.connect() as c:
+            c.execute(text("SELECT 1"))
+    except Exception as exc:  # noqa: BLE001
+        pytest.skip(f"PRD-233 S3 seed integration test needs a reachable Postgres: {exc}")
+    yield eng
+    eng.dispose()
+
+
+@pytest.fixture
+def local_edition(monkeypatch, engine, new_session):
+    """One throwaway local workspace per test: config patched to local + a
+    fresh DEFAULT_WORKSPACE_ID (NEVER the live default workspace). Teardown
+    sweeps every row the seed made for that workspace, and the operator user
+    only if this test created it."""
+    from sqlalchemy import text
+
+    ws_id = uuid.uuid4()
+    monkeypatch.setattr(config, "AUTH_EDITION", "local")
+    monkeypatch.setattr(config, "DEFAULT_WORKSPACE_ID", str(ws_id))
+    probe = new_session()
+    operator_existed = probe.execute(
+        text("SELECT 1 FROM users WHERE email = :e"), {"e": config.LOCAL_OPERATOR_EMAIL}
+    ).fetchone() is not None
+    probe.close()
+
+    yield ws_id
+
+    sweep = new_session.sweep()
+    try:
+        params = {"w": str(ws_id)}
+        sweep.execute(text(
+            "DELETE FROM agent_skills WHERE agent_id IN "
+            "(SELECT id FROM agents WHERE workspace_id = CAST(:w AS uuid))"
+        ), params)
+        sweep.execute(text("DELETE FROM agents WHERE workspace_id = CAST(:w AS uuid)"), params)
+        # blog_posts + workflow_recipes cascade from the workspace
+        sweep.execute(text("DELETE FROM workspaces WHERE id = CAST(:w AS uuid)"), params)
+        if not operator_existed:
+            sweep.execute(text("DELETE FROM users WHERE email = :e"), {"e": config.LOCAL_OPERATOR_EMAIL})
+        sweep.commit()
+    finally:
+        sweep.close()
+
+
+def _snapshot(session, ws_id: uuid.UUID) -> dict:
+    """Every column of every seeded row (updated_at included) — the identical-
+    state oracle for the run-twice test."""
+    from sqlalchemy import text
+
+    params = {"w": str(ws_id)}
+
+    def rows(sql: str):
+        return [tuple(r) for r in session.execute(text(sql), params).fetchall()]
+
+    return {
+        "agents": rows("SELECT * FROM agents WHERE workspace_id = CAST(:w AS uuid) ORDER BY slug"),
+        "playbooks": rows("SELECT * FROM workflow_recipes WHERE workspace_id = CAST(:w AS uuid) ORDER BY template_id"),
+        "posts": rows("SELECT * FROM blog_posts WHERE workspace_id = CAST(:w AS uuid) ORDER BY slug"),
+        "workspace": rows("SELECT name, slug, settings, is_active, updated_at FROM workspaces WHERE id = CAST(:w AS uuid)"),
+    }
+
+
+def _run(session) -> dict:
+    out = seed_local_first_run(session)
+    session.commit()
+    return out
+
+
+@pytest.mark.integration
+def test_seed_twice_yields_identical_state(local_edition, new_session):
+    s = new_session()
+    first = _run(s)
+    assert first["workspace_id"] == config.DEFAULT_WORKSPACE_ID == str(local_edition)
+    assert first["workspace"] == "created"
+    assert first["operator_user"] in ("created", "present")
+    assert first["agents"] == {"created": len(ROSTER)}
+    assert first["playbooks"] == {"created": 1}
+    assert first["deliverables"] == {"created": 1}
+    assert first["ledger_updated"] is True
+
+    before = _snapshot(s, local_edition)
+    second = _run(s)
+    assert second["agents"] == {"current": len(ROSTER)}
+    assert second["playbooks"] == {"current": 1}
+    assert second["deliverables"] == {"current": 1}
+    assert second["ledger_updated"] is False
+    assert _snapshot(s, local_edition) == before
+
+
+@pytest.mark.integration
+def test_rows_are_workspace_scoped_attributed_and_listable_like_the_api(local_edition, new_session):
+    from sqlalchemy import text
+
+    from core.models.core import Agent, BlogPost
+
+    s = new_session()
+    outcome = _run(s)
+    ws = local_edition
+
+    operator_id = s.execute(
+        text("SELECT id FROM users WHERE email = :e"), {"e": config.LOCAL_OPERATOR_EMAIL}
+    ).scalar()
+    assert operator_id is not None
+
+    roster = s.query(Agent).filter(Agent.workspace_id == ws, Agent.slug.in_(ROSTER_SLUGS)).all()
+    assert sorted(a.slug for a in roster) == sorted(ROSTER_SLUGS)
+    for agent in roster:
+        assert agent.is_system_agent is False and agent.owner_type == "workspace"
+        assert agent.created_by_user_id == operator_id
+        assert agent.model_config is None
+    roster_ids = {a.id for a in roster}
+    assert s.execute(
+        text("SELECT count(*) FROM agent_app_assignments WHERE agent_id = ANY(:ids)"),
+        {"ids": list(roster_ids)},
+    ).scalar() == 0  # native tools only — no Composio bindings
+
+    # Auto: the existing per-workspace seeder ran (reused, not duplicated)
+    auto = s.query(Agent).filter(Agent.workspace_id == ws, Agent.slug == f"auto-{ws}").all()
+    assert len(auto) == 1 and auto[0].id == outcome["auto_agent_id"]
+
+    # The list route's exact filter finds the Playbook; its steps pass the
+    # create route's agent check and validators.
+    listed = (
+        s.query(WorkflowTemplate)
+        .filter(
+            WorkflowTemplate.owner_type == "workspace",
+            WorkflowTemplate.workspace_id == ws,
+            WorkflowTemplate.is_public.is_(True),
+        )
+        .all()
+    )
+    assert [p.template_id for p in listed] == [PLAYBOOK_TEMPLATE_ID]
+    playbook = listed[0]
+    validate_playbook(playbook)
+    assert {step["agent_id"] for step in playbook.steps} <= roster_ids
+    assert playbook.created_by_user_id == operator_id
+    assert playbook.created_by == config.LOCAL_OPERATOR_EMAIL
+
+    post = s.query(BlogPost).filter(BlogPost.workspace_id == ws, BlogPost.slug == WELCOME_SLUG).one()
+    assert post.title == WELCOME_TITLE and post.status == "published"
+    assert post.content == WELCOME_CONTENT and post.file_path is None
+    assert post.author_agent_id == outcome["auto_agent_id"]
+
+    # Surfaces in the Deliverables tab (v_workspace_outputs) when the view exists
+    if s.execute(text("SELECT to_regclass('v_workspace_outputs')")).scalar():
+        rows = s.execute(
+            text("SELECT title, artifact_type, status FROM v_workspace_outputs WHERE workspace_id = CAST(:w AS uuid)"),
+            {"w": str(ws)},
+        ).fetchall()
+        assert (WELCOME_TITLE, "blog_post", "published") in [tuple(r) for r in rows]
+
+
+@pytest.mark.integration
+def test_user_edits_are_never_overwritten(local_edition, new_session):
+    from sqlalchemy import text
+
+    from core.models.core import Agent, BlogPost
+
+    s = new_session()
+    _run(s)
+    ws = local_edition
+
+    writer = s.query(Agent).filter(Agent.workspace_id == ws, Agent.slug == "local-writer").one()
+    writer.description = "Writes only haiku now."
+    playbook = s.query(WorkflowTemplate).filter(WorkflowTemplate.template_id == PLAYBOOK_TEMPLATE_ID).one()
+    edited_steps = [dict(step) for step in playbook.steps]
+    edited_steps[0] = {**edited_steps[0], "prompt_template": "Research {input.topic} my way."}
+    playbook.steps = edited_steps
+    post = s.query(BlogPost).filter(BlogPost.workspace_id == ws, BlogPost.slug == WELCOME_SLUG).one()
+    post.status = "draft"
+    s.commit()
+
+    second = _run(s)
+    assert second["agents"] == {"current": len(ROSTER) - 1, "customized": 1}
+    assert second["playbooks"] == {"customized": 1}
+    assert second["deliverables"] == {"customized": 1}
+
+    s.expire_all()
+    assert s.query(Agent).filter(Agent.id == writer.id).one().description == "Writes only haiku now."
+    assert s.query(WorkflowTemplate).filter(WorkflowTemplate.id == playbook.id).one().steps[0]["prompt_template"] == "Research {input.topic} my way."
+    assert s.execute(text("SELECT status FROM blog_posts WHERE id = :id"), {"id": str(post.id)}).scalar() == "draft"
+
+
+@pytest.mark.integration
+def test_rows_still_on_a_prior_seed_version_are_refreshed(local_edition, new_session, monkeypatch):
+    from core.models.core import Agent
+
+    s = new_session()
+    _run(s)
+    ws = local_edition
+
+    researcher = s.query(Agent).filter(Agent.workspace_id == ws, Agent.slug == "local-researcher").one()
+    researcher.description = "An older shipped description."
+    s.commit()
+    older_fingerprint = agent_fingerprint(researcher)
+    monkeypatch.setattr(seed_mod, "PRIOR_SEED_FINGERPRINTS", frozenset({older_fingerprint}))
+
+    second = _run(s)
+    assert second["agents"] == {"current": len(ROSTER) - 1, "refreshed": 1}
+    s.expire_all()
+    assert s.query(Agent).filter(Agent.id == researcher.id).one().description == ROSTER[0]["description"]
+    assert _run(s)["agents"] == {"current": len(ROSTER)}
+
+
+@pytest.mark.integration
+def test_deleted_seed_rows_are_not_resurrected(local_edition, new_session):
+    from sqlalchemy import text
+
+    s = new_session()
+    _run(s)
+    s.execute(text("DELETE FROM workflow_recipes WHERE template_id = :t"), {"t": PLAYBOOK_TEMPLATE_ID})
+    s.commit()
+
+    second = _run(s)
+    assert second["playbooks"] == {"deleted_by_user": 1}
+    assert s.execute(
+        text("SELECT count(*) FROM workflow_recipes WHERE template_id = :t"), {"t": PLAYBOOK_TEMPLATE_ID}
+    ).scalar() == 0
+
+
+@pytest.mark.integration
+def test_saas_gate_writes_nothing_to_the_database(local_edition, new_session, monkeypatch):
+    from sqlalchemy import text
+
+    monkeypatch.setattr(config, "AUTH_EDITION", "saas")
+    s = new_session()
+    assert _run(s) == {"skipped": "not-local"}
+    assert s.execute(
+        text("SELECT count(*) FROM workspaces WHERE id = CAST(:w AS uuid)"), {"w": str(local_edition)}
+    ).scalar() == 0

--- a/orchestrator/tests/test_prd233_s6_local_profile.py
+++ b/orchestrator/tests/test_prd233_s6_local_profile.py
@@ -1,0 +1,507 @@
+"""PRD-233 S6 — local profile: Auto knows who it is talking to.
+
+The local edition has exactly one operator and no login. PRD-209 seeded the
+``users`` row and made the anonymous lane carry its email; this story binds the
+row (id / name / email) into the session, adds the profile API that edits it,
+and threads the name into Auto's greeting through the path the platform already
+had for names. Pins:
+
+* hybrid.py local lane — the anonymous context carries the operator row (email
+  as ``id`` — the tree's own Clerk-less binding — integer PK + name in
+  ``raw_claims``); a missing row or a DB error keeps PRD-209's email-only lane
+  (never a 500); the saas lane is untouched (``UserContext()``).
+* the operator-row cache — one read per TTL; ``invalidate_local_operator_cache``
+  (called by PUT /api/profile) and TTL expiry both force a re-read.
+* GET/PUT /api/profile — local round-trip (PUT name → GET reflects, cache
+  invalidated, next session carries the new name); email is read-only (422);
+  no markup / no non-http avatar / no blank username (422); username clash
+  (409); saas PUT is 403 "managed by your identity provider".
+* greeting — ``resolve_known_user_name`` reads ``users.name`` by the INTEGER id
+  (blank → None); ``atom_identity_clause`` mirrors the personality wording and
+  is empty when unknown; IdentitySection renders "talking to <name>" from the
+  ``user_name`` kwarg it already had, "ready to help" without; source guards
+  pin the seam in consumers/chatbot/service.py.
+
+DB-free: an in-memory SQLite ``users`` table stands in for Postgres. No
+personal data — placeholder names only (public repo).
+"""
+from __future__ import annotations
+
+import importlib
+import os
+import re
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+# Blessed preamble: dummy POSTGRES_* satisfies the config import chain; the
+# closed port refuses instantly and nothing here touches a real database.
+os.environ.setdefault("POSTGRES_USER", "test")
+os.environ.setdefault("POSTGRES_PASSWORD", "test")
+os.environ.setdefault("POSTGRES_HOST", "127.0.0.1")
+os.environ.setdefault("POSTGRES_PORT", "59432")
+os.environ.setdefault("POSTGRES_DB", "test")
+
+_ORCH = Path(__file__).resolve().parents[1]
+if str(_ORCH) not in sys.path:
+    sys.path.insert(0, str(_ORCH))
+
+import api.profile as profile_mod  # noqa: E402
+import core.auth.hybrid as hybrid  # noqa: E402
+from core.auth.dependencies import RequestContext, UserContext  # noqa: E402
+from core.database.database import get_db  # noqa: E402
+from core.models.core import User  # noqa: E402
+from uuid import UUID  # noqa: E402
+
+OPERATOR_EMAIL = "operator@example.test"
+OPERATOR_ID = 1
+SEEDED_NAME = "Local Operator"
+LOCAL_WS = UUID("00000000-0000-0000-0000-0000000000aa")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def users_db():
+    """An in-memory ``users`` table seeded like docker-entrypoint.sh does."""
+    engine = create_engine(
+        "sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool
+    )
+    User.__table__.create(bind=engine)
+    session = sessionmaker(bind=engine)()
+    session.add(
+        User(id=OPERATOR_ID, username="local", email=OPERATOR_EMAIL, name=SEEDED_NAME, is_active=True)
+    )
+    session.commit()
+    try:
+        yield session
+    finally:
+        session.close()
+        engine.dispose()
+
+
+@pytest.fixture
+def local_lane(users_db, monkeypatch):
+    """Drive hybrid.py into the local posture against the SQLite users table."""
+    hybrid.invalidate_local_operator_cache()
+    monkeypatch.setattr(hybrid.config, "AUTH_EDITION", "local")
+    monkeypatch.setattr(hybrid.config, "REQUIRE_AUTH", False)
+    monkeypatch.setattr(hybrid.config, "DEFAULT_WORKSPACE_ID", str(LOCAL_WS))
+    monkeypatch.setattr(hybrid.config, "WORKSPACE_ID", None)
+    monkeypatch.setattr(hybrid.config, "AUTH_DEBUG", False)
+    monkeypatch.setattr(hybrid.config, "LOCAL_OPERATOR_EMAIL", OPERATOR_EMAIL)
+    monkeypatch.setattr(hybrid, "SessionLocal", lambda: users_db)
+    monkeypatch.setattr(hybrid, "_workspace_exists", lambda db, ws: True)
+    monkeypatch.setattr(hybrid, "_assert_workspace_usable", lambda db, ws, *, is_admin: None)
+    monkeypatch.setattr(hybrid, "_enrich_log_context", lambda ctx: None)
+    yield users_db
+    hybrid.invalidate_local_operator_cache()
+
+
+def _anonymous_request():
+    request = MagicMock()
+    request.method = "GET"
+    request.headers = {}
+    request.query_params = {}
+    request.state = MagicMock(spec=[])
+    return request
+
+
+def _local_ctx():
+    return RequestContext(
+        workspace_id=LOCAL_WS,
+        user=UserContext(id=OPERATOR_EMAIL, email=OPERATOR_EMAIL, system_role="super_admin"),
+        auth_type="anonymous",
+    )
+
+
+def _client(db, ctx):
+    app = FastAPI()
+    app.include_router(profile_mod.router)
+    app.dependency_overrides[hybrid.get_request_context_hybrid] = lambda: ctx
+    app.dependency_overrides[get_db] = lambda: db
+    app.dependency_overrides[profile_mod._PROFILE_WRITE_GATE] = lambda: ctx
+    return TestClient(app)
+
+
+def _chat_service_module():
+    """consumers.chatbot.service, re-imported if a sibling left a stub."""
+    mod = sys.modules.get("consumers.chatbot.service")
+    if mod is None or not getattr(mod, "__file__", None):
+        mod = importlib.import_module("consumers.chatbot.service")
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# hybrid.py — the local lane binds the operator row
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_local_anonymous_session_carries_the_operator_row(local_lane):
+    ctx = await hybrid.get_request_context_hybrid(_anonymous_request())
+
+    assert ctx.auth_type == "anonymous"
+    assert ctx.workspace_id == LOCAL_WS
+    assert ctx.user.system_role == "super_admin"
+    assert ctx.user.email == OPERATOR_EMAIL
+    # The Clerk-less binding the tree already uses (clerk lane: id = clerk id
+    # OR email): every resolver falls back to users.email == ctx.user.email.
+    assert ctx.user.id == OPERATOR_EMAIL
+    assert ctx.user.clerk_user_id is None
+    assert ctx.user.raw_claims["source"] == "local_operator"
+    assert ctx.user.raw_claims["user_id"] == OPERATOR_ID
+    assert ctx.user.raw_claims["name"] == SEEDED_NAME
+    assert ctx.user.raw_claims["username"] == "local"
+
+
+@pytest.mark.asyncio
+async def test_ctx_user_id_is_never_the_integer_pk_and_resolves_by_email(local_lane):
+    """The trap: ``ctx.user.id`` is compared against ``users.clerk_user_id``
+    (varchar) across api/*; an integer there is a Postgres type error. The
+    platform's resolution order (clerk id, then email) must land on the row."""
+    ctx = await hybrid.get_request_context_hybrid(_anonymous_request())
+    assert not isinstance(ctx.user.id, int)
+
+    by_clerk = local_lane.query(User).filter(User.clerk_user_id == ctx.user.id).first()
+    by_email = local_lane.query(User).filter(User.email == ctx.user.email).first()
+    assert by_clerk is None
+    assert by_email is not None and by_email.id == OPERATOR_ID
+
+
+@pytest.mark.asyncio
+async def test_missing_operator_row_keeps_prd209_email_only_lane(local_lane):
+    local_lane.query(User).delete()
+    local_lane.commit()
+
+    ctx = await hybrid.get_request_context_hybrid(_anonymous_request())
+
+    assert ctx.user.email == OPERATOR_EMAIL
+    assert ctx.user.system_role == "super_admin"
+    assert ctx.user.id is None
+    assert ctx.user.raw_claims is None
+
+
+@pytest.mark.asyncio
+async def test_operator_lookup_db_error_never_500s(local_lane, monkeypatch):
+    def _boom(db, email):
+        raise RuntimeError("users table unreachable")
+
+    monkeypatch.setattr(hybrid, "_load_local_operator_row", _boom)
+    ctx = await hybrid.get_request_context_hybrid(_anonymous_request())
+    assert ctx.user.email == OPERATOR_EMAIL
+    assert ctx.user.raw_claims is None
+
+
+@pytest.mark.asyncio
+async def test_saas_anonymous_lane_is_byte_identical(local_lane, monkeypatch):
+    monkeypatch.setattr(hybrid.config, "AUTH_EDITION", "saas")
+    loads = []
+    monkeypatch.setattr(hybrid, "_load_local_operator_row", lambda db, email: loads.append(email))
+
+    ctx = await hybrid.get_request_context_hybrid(_anonymous_request())
+
+    assert ctx.user == UserContext()
+    assert loads == [], "saas must never touch the operator-row lookup"
+
+
+# ---------------------------------------------------------------------------
+# The operator-row cache
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_cache_reads_once_until_invalidated_or_expired(local_lane, monkeypatch):
+    real_load = hybrid._load_local_operator_row
+    calls = []
+
+    def _counting(db, email):
+        calls.append(email)
+        return real_load(db, email)
+
+    monkeypatch.setattr(hybrid, "_load_local_operator_row", _counting)
+    clock = {"now": 1000.0}
+    monkeypatch.setattr(hybrid.time, "monotonic", lambda: clock["now"])
+
+    await hybrid.get_request_context_hybrid(_anonymous_request())
+    await hybrid.get_request_context_hybrid(_anonymous_request())
+    assert len(calls) == 1, "second request inside the TTL must hit the cache"
+
+    hybrid.invalidate_local_operator_cache()
+    await hybrid.get_request_context_hybrid(_anonymous_request())
+    assert len(calls) == 2, "explicit invalidation forces a re-read"
+
+    clock["now"] += hybrid._LOCAL_OPERATOR_CACHE_TTL_SECONDS + 1
+    await hybrid.get_request_context_hybrid(_anonymous_request())
+    assert len(calls) == 3, "TTL expiry is the backstop for out-of-band writers"
+
+
+@pytest.mark.asyncio
+async def test_missing_row_is_not_cached(local_lane, monkeypatch):
+    """A seed that lands after the first request must be picked up at once."""
+    local_lane.query(User).delete()
+    local_lane.commit()
+    await hybrid.get_request_context_hybrid(_anonymous_request())
+
+    local_lane.add(User(id=OPERATOR_ID, username="local", email=OPERATOR_EMAIL, name="Late Seed"))
+    local_lane.commit()
+    ctx = await hybrid.get_request_context_hybrid(_anonymous_request())
+    assert ctx.user.raw_claims["name"] == "Late Seed"
+
+
+# ---------------------------------------------------------------------------
+# GET / PUT /api/profile
+# ---------------------------------------------------------------------------
+
+def test_get_profile_local_reflects_the_operator_row(users_db, monkeypatch):
+    monkeypatch.setattr(profile_mod.config, "AUTH_EDITION", "local")
+    monkeypatch.setattr(profile_mod.config, "LOCAL_OPERATOR_EMAIL", OPERATOR_EMAIL)
+    client = _client(users_db, _local_ctx())
+
+    resp = client.get("/api/profile")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["edition"] == "local" and body["editable"] is True
+    assert body["id"] == OPERATOR_ID
+    assert body["email"] == OPERATOR_EMAIL
+    assert body["name"] == SEEDED_NAME
+    assert body["username"] == "local"
+    assert body["system_role"] == "super_admin"
+    assert "LOCAL_OPERATOR_EMAIL" in body["email_note"]
+
+
+def test_put_then_get_round_trip_and_cache_invalidation(users_db, monkeypatch):
+    monkeypatch.setattr(profile_mod.config, "AUTH_EDITION", "local")
+    monkeypatch.setattr(profile_mod.config, "LOCAL_OPERATOR_EMAIL", OPERATOR_EMAIL)
+    invalidations = []
+    monkeypatch.setattr(profile_mod, "invalidate_local_operator_cache", lambda: invalidations.append(1))
+    client = _client(users_db, _local_ctx())
+
+    resp = client.put(
+        "/api/profile",
+        json={"name": "Test Operator", "username": "tester", "avatar_url": "https://example.test/a.png"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["name"] == "Test Operator"
+    assert invalidations == [1]
+
+    got = client.get("/api/profile").json()
+    assert got["name"] == "Test Operator"
+    assert got["username"] == "tester"
+    assert got["avatar_url"] == "https://example.test/a.png"
+    assert got["email"] == OPERATOR_EMAIL, "email is the lookup key — untouched"
+
+
+@pytest.mark.asyncio
+async def test_put_name_reaches_the_next_session(local_lane, monkeypatch):
+    """End to end inside the process: the hybrid lane cached the seeded name;
+    PUT invalidates; the very next anonymous request carries the new name."""
+    monkeypatch.setattr(profile_mod.config, "AUTH_EDITION", "local")
+    monkeypatch.setattr(profile_mod.config, "LOCAL_OPERATOR_EMAIL", OPERATOR_EMAIL)
+    first = await hybrid.get_request_context_hybrid(_anonymous_request())
+    assert first.user.raw_claims["name"] == SEEDED_NAME
+
+    client = _client(local_lane, _local_ctx())
+    assert client.put("/api/profile", json={"name": "Renamed Operator"}).status_code == 200
+
+    second = await hybrid.get_request_context_hybrid(_anonymous_request())
+    assert second.user.raw_claims["name"] == "Renamed Operator"
+
+
+def test_put_partial_update_leaves_other_fields_alone(users_db, monkeypatch):
+    monkeypatch.setattr(profile_mod.config, "AUTH_EDITION", "local")
+    monkeypatch.setattr(profile_mod.config, "LOCAL_OPERATOR_EMAIL", OPERATOR_EMAIL)
+    client = _client(users_db, _local_ctx())
+
+    assert client.put("/api/profile", json={"username": "solo"}).status_code == 200
+    got = client.get("/api/profile").json()
+    assert got["username"] == "solo"
+    assert got["name"] == SEEDED_NAME
+
+
+def test_put_blank_name_clears_it_so_the_greeting_falls_back(users_db, monkeypatch):
+    monkeypatch.setattr(profile_mod.config, "AUTH_EDITION", "local")
+    monkeypatch.setattr(profile_mod.config, "LOCAL_OPERATOR_EMAIL", OPERATOR_EMAIL)
+    client = _client(users_db, _local_ctx())
+
+    resp = client.put("/api/profile", json={"name": "   "})
+    assert resp.status_code == 200
+    assert resp.json()["name"] is None
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"email": "someone@else.test"},              # read-only lookup key
+        {"name": "<script>alert(1)</script>"},        # no HTML
+        {"avatar_url": "javascript:alert(1)"},        # http(s) only
+        {"avatar_url": "not a url"},
+        {"username": ""},                             # NOT NULL + unique column
+        {"username": "bad name!"},
+        {"system_role": "user"},                      # unknown field
+        {"name": "x" * 256},                          # length
+    ],
+)
+def test_put_rejects_invalid_input(users_db, monkeypatch, payload):
+    monkeypatch.setattr(profile_mod.config, "AUTH_EDITION", "local")
+    monkeypatch.setattr(profile_mod.config, "LOCAL_OPERATOR_EMAIL", OPERATOR_EMAIL)
+    client = _client(users_db, _local_ctx())
+
+    assert client.put("/api/profile", json=payload).status_code == 422
+    assert client.get("/api/profile").json()["name"] == SEEDED_NAME
+
+
+def test_put_username_clash_is_409(users_db, monkeypatch):
+    monkeypatch.setattr(profile_mod.config, "AUTH_EDITION", "local")
+    monkeypatch.setattr(profile_mod.config, "LOCAL_OPERATOR_EMAIL", OPERATOR_EMAIL)
+    users_db.add(User(id=2, username="taken", email="second@example.test"))
+    users_db.commit()
+    client = _client(users_db, _local_ctx())
+
+    resp = client.put("/api/profile", json={"username": "taken"})
+    assert resp.status_code == 409
+    assert client.get("/api/profile").json()["username"] == "local"
+
+
+def test_put_without_operator_row_is_404_not_500(users_db, monkeypatch):
+    monkeypatch.setattr(profile_mod.config, "AUTH_EDITION", "local")
+    monkeypatch.setattr(profile_mod.config, "LOCAL_OPERATOR_EMAIL", "nobody@example.test")
+    client = _client(users_db, _local_ctx())
+    assert client.put("/api/profile", json={"name": "x"}).status_code == 404
+
+
+def test_put_in_saas_is_403_managed_by_identity_provider(users_db, monkeypatch):
+    monkeypatch.setattr(profile_mod.config, "AUTH_EDITION", "saas")
+    monkeypatch.setattr(profile_mod.config, "LOCAL_OPERATOR_EMAIL", OPERATOR_EMAIL)
+    client = _client(users_db, _local_ctx())
+
+    resp = client.put("/api/profile", json={"name": "Nope"})
+
+    assert resp.status_code == 403
+    assert resp.json()["detail"] == profile_mod.MANAGED_BY_IDENTITY_PROVIDER
+    assert users_db.query(User).filter(User.email == OPERATOR_EMAIL).one().name == SEEDED_NAME
+
+
+def test_get_profile_saas_resolves_by_clerk_id_and_is_read_only(users_db, monkeypatch):
+    monkeypatch.setattr(profile_mod.config, "AUTH_EDITION", "saas")
+    users_db.add(User(id=7, username="clerk_user", email="member@example.test", clerk_user_id="user_abc", name="Member"))
+    users_db.commit()
+    ctx = RequestContext(
+        workspace_id=LOCAL_WS,
+        user=UserContext(id="user_abc", email="member@example.test", clerk_user_id="user_abc"),
+        auth_type="clerk",
+    )
+    client = _client(users_db, ctx)
+
+    body = client.get("/api/profile").json()
+
+    assert body["edition"] == "saas" and body["editable"] is False
+    assert body["id"] == 7 and body["name"] == "Member"
+    assert body["email_note"] == profile_mod.EMAIL_NOTE_SAAS
+
+
+def test_put_is_gated_by_the_workspace_permission_dependency():
+    put_routes = [r for r in profile_mod.router.routes if "PUT" in getattr(r, "methods", set())]
+    assert len(put_routes) == 1
+    gate_calls = [d.call for d in put_routes[0].dependant.dependencies]
+    assert profile_mod._PROFILE_WRITE_GATE in gate_calls
+
+
+def test_router_is_declared_in_the_mount_manifest():
+    from router_manifest import MANIFEST_ROUTERS
+
+    assert any(spec.module == "api.profile" and not spec.optional for spec in MANIFEST_ROUTERS)
+
+
+# ---------------------------------------------------------------------------
+# Greeting / context — one source for the name, both prompt lanes
+# ---------------------------------------------------------------------------
+
+def test_resolve_known_user_name_reads_users_name_by_integer_id(users_db):
+    svc = _chat_service_module()
+    assert svc.resolve_known_user_name(users_db, OPERATOR_ID) == SEEDED_NAME
+    assert svc.resolve_known_user_name(users_db, 999) is None
+    assert svc.resolve_known_user_name(users_db, None) is None
+
+
+def test_resolve_known_user_name_blank_name_is_none(users_db):
+    svc = _chat_service_module()
+    users_db.query(User).filter(User.id == OPERATOR_ID).update({"name": "   "})
+    users_db.commit()
+    assert svc.resolve_known_user_name(users_db, OPERATOR_ID) is None
+
+
+def test_resolve_known_user_name_db_error_is_none():
+    svc = _chat_service_module()
+    db = MagicMock()
+    db.query.side_effect = RuntimeError("down")
+    assert svc.resolve_known_user_name(db, OPERATOR_ID) is None
+
+
+def test_atom_identity_clause_mirrors_personality_wording():
+    svc = _chat_service_module()
+    assert svc.atom_identity_clause("Test Operator") == " You're talking to Test Operator."
+    assert svc.atom_identity_clause(None) == ""
+    assert svc.atom_identity_clause("   ") == ""
+    assert svc.atom_identity_clause(MagicMock()) == ""
+
+
+@pytest.mark.asyncio
+async def test_identity_section_greets_by_name_from_the_user_name_kwarg(monkeypatch):
+    """The path the platform already had: IdentitySection → personality
+    prompt renders ``user_name``. Present → "talking to <name>"; blank → the
+    "ready to help" fallback. No second greeting path."""
+    import consumers.chatbot.personality as personality
+    from modules.context.sections.base import SectionContext
+    from modules.context.sections.identity import IdentitySection
+
+    monkeypatch.setattr(personality, "load_orchestrator_settings", lambda ws: {})
+    agent = SimpleNamespace(
+        id=1, name="Auto", agent_type="assistant", description=None,
+        use_custom_persona=False, custom_persona_prompt=None, persona=None,
+    )
+
+    def _ctx(**kwargs):
+        return SectionContext(agent=agent, workspace_id="ws_1", workspace_name="WS", kwargs=kwargs)
+
+    named = await IdentitySection().render(_ctx(personality=True, user_name="Test Operator"))
+    assert "talking to Test Operator" in named
+
+    blank = await IdentitySection().render(_ctx(personality=True, user_name=None))
+    assert "ready to help" in blank
+    assert "talking to" not in blank
+
+
+def test_chat_service_seeds_the_greeting_state_from_the_users_row():
+    """Source guard: the seam lives in ONE module — the driving human's integer
+    id is remembered next to the viewer subject, the orchestrator state is
+    seeded from users.name, and the ATOM prompt reads that same state."""
+    src = (_ORCH / "consumers" / "chatbot" / "service.py").read_text(encoding="utf-8")
+
+    assert re.search(
+        r'self\._viewer_subject_id = f"user:\{user_id\}" if user_id else None\s*\n'
+        r"(?:.*\n){0,3}\s*self\._driving_user_id = user_id",
+        src,
+    ), "stream_response_with_agent must remember the driving users.id"
+    assert re.search(
+        r"smart_chat\.orchestrator\.state\.user_name = \(\s*\n\s*smart_chat\.orchestrator\.state\.user_name\s*\n"
+        r"\s*or resolve_known_user_name\(self\.db, getattr\(self, \"_driving_user_id\", None\)\)",
+        src,
+    ), "_prepare_llm_messages must seed ConversationState.user_name from the users row"
+    assert 'atom_identity_clause(smart_chat.get_user_name())' in src, (
+        "the ATOM prompt must read the same ConversationState.user_name"
+    )
+    # The full path forwards the state as the `user_name` kwarg IdentitySection reads.
+    orch = (_ORCH / "consumers" / "chatbot" / "smart_orchestrator.py").read_text(encoding="utf-8")
+    assert "user_name=self.state.user_name," in orch
+    identity = (_ORCH / "modules" / "context" / "sections" / "identity.py").read_text(encoding="utf-8")
+    assert 'ctx.kwargs.get("_user_name") or ctx.kwargs.get("user_name")' in identity

--- a/orchestrator/tests/test_prd233_s7_local_exposure.py
+++ b/orchestrator/tests/test_prd233_s7_local_exposure.py
@@ -1,0 +1,51 @@
+"""PRD-233 S7 (backend half) — the local edition is never plan-gated.
+
+The entrypoint seeds the single local workspace with ``plan = NULL``; falling
+back to the entry tier hid Analytics and put plan chips on marketplace items
+in an edition where nothing is gated (owner rule: paid tiers gate
+organisational features and hosting, never product capability).
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from services.plan_tiers import (
+    LOCAL_EDITION_PLAN,
+    _tiers,
+    exposure_for_local_edition,
+    exposure_for_plan,
+)
+
+_WORKSPACES_SRC = (Path(__file__).resolve().parents[1] / "api" / "workspaces.py").read_text()
+
+
+def test_local_edition_exposure_is_unrestricted():
+    e = exposure_for_local_edition()
+    assert e["plan"] == LOCAL_EDITION_PLAN
+    assert e["families"] == {}
+    assert e["nav"] and all(e["nav"].values()), e["nav"]
+    assert e["display_price_usd"] is None and e["price_label"] is None
+
+
+def test_local_marketplace_depth_is_the_deepest_tier():
+    e = exposure_for_local_edition()
+    deepest = max(int(t.get("marketplace_depth", 1) or 1) for t in _tiers().values() if isinstance(t, dict))
+    assert e["marketplace_depth"] == deepest
+    assert e["marketplace_depth"] >= exposure_for_plan("business")["marketplace_depth"]
+
+
+def test_saas_tiers_unchanged():
+    # The entry tier still restricts (nav.team off) — S7 only adds a profile.
+    basic = exposure_for_plan("basic")
+    assert basic["plan"] == "basic"
+    assert basic["nav"].get("team") is False
+    assert exposure_for_plan("nonsense")["plan"] == "nonsense"  # unknown ⇒ entry-tier profile, label kept
+
+
+def test_current_workspace_branches_on_edition_not_role():
+    # One seam: api/workspaces.py picks the profile by AUTH_EDITION, and the
+    # saas branch is the exact pre-existing call.
+    assert re.search(r'exposure_for_local_edition\(\)\s*\n\s*if config\.AUTH_EDITION == "local"', _WORKSPACES_SRC)
+    assert 'exposure_for_plan(workspace.plan or "basic")' in _WORKSPACES_SRC
+    assert _WORKSPACES_SRC.count("exposure_for_local_edition()") == 1

--- a/services/workspace-worker/main.py
+++ b/services/workspace-worker/main.py
@@ -13,7 +13,8 @@ Startup:
 Configuration (env vars):
     REDIS_URL              - Redis connection string (required)
     DATABASE_URL           - PostgreSQL connection string (required)
-    WORKSPACE_VOLUME_PATH  - Mount path for persistent volume (default: /workspaces)
+    WORKSPACE_VOLUME_PATH  - Workspace mount root (default: /workspaces; read only
+                             via worker_config.workspace_root — PRD-233 S1)
     WORKSPACE_DEFAULT_QUOTA_GB - Default storage per workspace (default: 5)
     WORKER_CONCURRENCY     - Max concurrent tasks (default: 3)
     WORKER_HEALTH_PORT     - Health check HTTP port (default: 8081)
@@ -39,6 +40,8 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "orchestr
 from automatos_logging import setup_logging
 setup_logging(service="workspace-worker")
 logger = logging.getLogger("workspace-worker")
+
+from worker_config import workspace_root
 
 # Redis key patterns (must match queued.py)
 QUEUE_NAMES = [
@@ -85,8 +88,7 @@ class WorkspaceWorker:
         """Start the worker — runs until SIGTERM/SIGINT."""
         logger.info(
             "Workspace Worker starting (id=%s, concurrency=%d, volume=%s)",
-            self._worker_id, self.concurrency,
-            os.environ.get("WORKSPACE_VOLUME_PATH", "/workspaces"),
+            self._worker_id, self.concurrency, workspace_root(),
         )
 
         import redis.asyncio as aioredis
@@ -465,7 +467,7 @@ class WorkspaceWorker:
         from aiohttp import web
         from workspace_manager import WorkspaceManager, SecurityError
 
-        volume_path = os.environ.get("WORKSPACE_VOLUME_PATH", "/workspaces")
+        volume_path = str(workspace_root())
         max_file_size = 2 * 1024 * 1024  # 2 MB
         max_dir_entries = 500
         internal_token = os.environ.get("WORKER_INTERNAL_TOKEN", "")

--- a/services/workspace-worker/worker_config.py
+++ b/services/workspace-worker/worker_config.py
@@ -15,7 +15,16 @@ with the orchestrator's ``config.py`` that ``main.py`` transiently places on
 from __future__ import annotations
 
 import os
+from pathlib import Path
 from typing import Dict
+
+# Workspace mount root inside the worker container (PRD-233 S1). Compose
+# bind-mounts the host directory ``${AUTOMATOS_WORKSPACE_DIR:-./workspaces}``
+# here; Railway mounts its persistent volume here. Per-workspace roots are
+# ``workspace_root() / <workspace_id>`` (``WorkspaceManager.root``) — the
+# boundary every canvas tool call is re-bound against (canvas_confinement).
+WORKSPACE_ROOT_ENV = "WORKSPACE_VOLUME_PATH"
+DEFAULT_WORKSPACE_ROOT = "/workspaces"
 
 
 def model_auth_env() -> Dict[str, str]:
@@ -42,3 +51,14 @@ def model_auth_env() -> Dict[str, str]:
 def has_model_auth() -> bool:
     """True iff a model credential is configured for the SDK subprocess."""
     return bool(model_auth_env())
+
+
+def workspace_root() -> Path:
+    """The workspace mount root (``WORKSPACE_VOLUME_PATH``, default ``/workspaces``).
+
+    Read at call time, not import time, so it always reflects the process
+    environment. Blank/whitespace counts as unset: a relative root silently
+    anchored to the process cwd is the one thing this must never return.
+    """
+    raw = os.environ.get(WORKSPACE_ROOT_ENV, "").strip()
+    return Path(raw or DEFAULT_WORKSPACE_ROOT)

--- a/services/workspace-worker/workspace_manager.py
+++ b/services/workspace-worker/workspace_manager.py
@@ -31,9 +31,10 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
+from worker_config import workspace_root
+
 logger = logging.getLogger(__name__)
 
-VOLUME_PATH = os.environ.get("WORKSPACE_VOLUME_PATH", "/workspaces")
 DEFAULT_QUOTA_GB = int(os.environ.get("WORKSPACE_DEFAULT_QUOTA_GB", "5"))
 
 
@@ -50,7 +51,9 @@ class WorkspaceManager:
 
     def __init__(self, workspace_id: str, volume_path: Optional[str] = None) -> None:
         self.workspace_id = workspace_id
-        self.volume_path = volume_path or VOLUME_PATH
+        # Default root = the mount root from worker_config (WORKSPACE_VOLUME_PATH),
+        # resolved at construction time; callers may pass an explicit root.
+        self.volume_path = volume_path or str(workspace_root())
         self.root = Path(self.volume_path) / workspace_id
         self.quota_bytes = DEFAULT_QUOTA_GB * (1024 ** 3)
         self._current_usage: int = 0


### PR DESCRIPTION
## Summary
Stacked on PR #650 (PRD-209, Phase 0). Merge order: #650 → this → the S4 storage PR.

**PRD-233 stories, all built and proven on a live local stack:**
- **S1** workspace-worker in the default profile against `./workspaces` (`AUTOMATOS_WORKSPACE_DIR`), confinement + approvals on; `WORKER_INTERNAL_URL` fix.
- **S2** Composio availability seam: one predicate, one exclusion point, explicit `integrations_unavailable` (router + executor chokepoint), boot catalogue sync + seeded-agent re-bind on the first keyed boot, `GET /api/tools/integrations/status`, honest Tools card.
- **S3** first-run seed: Auto, a 3-agent roster, the "Two-minute brief" Playbook, a welcome Deliverable — idempotent-refresh, ledger keeps user deletions; identities workspace-aware (`agents.slug` / `template_id` are globally unique).
- **S5** `docs/getting-started/self-hosting.md`, DCO lane (`dco.yml`), CONTRIBUTING (Apache-2.0 §5 deal, capability-first), every README/doc page corrected.
- **S6** local profile (`GET/PUT /api/profile`, Settings → Profile form, operator button) and Auto greets by name (proven: *"I'm talking to you, Test Operator!"*).
- **S7** SaaS-only surfaces hidden by an explicit allowlist (Workspace Admin, Team, invitations, sign-in/up, plugin moderation, dev reset) + an unrestricted local exposure profile (the seeded workspace has `plan = NULL` and was falling back to the entry tier).

**Fixes found by running it:** fresh DBs were missing `v_workspace_outputs` (orphan-root ordering — generator gains model-column + idempotent raw-SQL passes; CI Gate 2 asserts it); every local upload had ended `status: failed` behind "uploaded successfully" (embeddings never saw the operator's key — `PLATFORM_KEY_WORKSPACE_ID` → local workspace; message honest); seed loader `sys.path` trap, dead skills seeder, v2 marketplace id churn; a developer's `AWS_*` hijacking MinIO; uvicorn dev reloads wedging on open SSE streams (`--timeout-graceful-shutdown`, dev stage only).

## SaaS safety
Every change is compose/envs/Dockerfile-dev-stage (never read by Railway), local-edition-only by `AUTH_EDITION` (saas lanes byte-identical, pinned by tests), or additive (new routes/endpoints/stage). Reviewer's list of the only hunks that execute in SaaS: the S2 availability check (one cached boolean with a key present; discovery returns the same list object), the `tool_sync` boot stage (one COUNT + one SELECT), the greeting seed (gated to local), `exposure_for_local_edition` (never called in saas). The storage factory (S4) is deliberately NOT here — see its own PR.

## Test plan
- CI: full suite, schema-drift, alembic-from-zero (Gate 2 now asserts the view/column), smoke-fresh-clone, route-contract (0 new), DCO (all commits signed).
- Local (done): backend subsets 207/207 (repo-root guards mounted), vitest 462/462, headless pass over every local surface with zero console errors, chat/agent/upload/Playbook/profile proofs on the live stack.

## Owner decisions still open
Q1 host-access default (built: designated dir) · Q2 BYO-Composio placement (built: documented, secondary) · Q4 MCP-in-router → PRD-234 · Q5 hub v1 form · `role/title` profile field (no column) · `TASK_RUNNER_BACKEND=queued` locally (clone-a-repo) · uploaded originals live in the container's `/tmp` (pre-existing).