### PR TITLE
hotfix(frontend): Dockerfile edition default is saas — #650 baked the local edition into prod (Clerk outage)

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -57,9 +57,12 @@ FROM base as builder
 # API keys should be handled server-side only (see frontend/app/api/chat/route.ts)
 ARG NEXT_PUBLIC_API_URL
 # PRD-233: NEXT_PUBLIC_* are inlined at BUILD time, so the edition and the
-# API/WS origins must be build args for the standalone image. Defaults are the
-# local edition's (compose passes them); SaaS builds on Railway use Railpack,
-# not this file, and set their own env.
+# API/WS origins must be build args for the standalone image. The DEFAULT is
+# the hosted product (saas) — Railway DOES build this Dockerfile (it prefers a
+# Dockerfile over Railpack when one exists in the service root), and a `local`
+# default here shipped the Clerk-less edition to production on 2026-08-30 (#650
+# → #668). The local edition passes NEXT_PUBLIC_AUTH_EDITION=local explicitly
+# via docker-compose.yml build args.
 ARG NEXT_PUBLIC_AUTH_EDITION=saas
 ARG NEXT_PUBLIC_WS_URL
 ARG NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -60,7 +60,7 @@ ARG NEXT_PUBLIC_API_URL
 # API/WS origins must be build args for the standalone image. Defaults are the
 # local edition's (compose passes them); SaaS builds on Railway use Railpack,
 # not this file, and set their own env.
-ARG NEXT_PUBLIC_AUTH_EDITION=local
+ARG NEXT_PUBLIC_AUTH_EDITION=saas
 ARG NEXT_PUBLIC_WS_URL
 ARG NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
 ARG NEXT_PUBLIC_CLERK_SIGN_IN_URL=/sign-in


### PR DESCRIPTION
**Prod outage 2026-08-30 ~14:14–now: Clerk gone from the SaaS UI, API 401 on every request.**

Root cause: #650 (PRD-209 S7) added `ARG NEXT_PUBLIC_AUTH_EDITION=local` to `frontend/Dockerfile`. Railway's frontend service (`automotas-ai-frontend`) has no such variable — it didn't exist before #650 — so the 13:14Z rebuild baked the **local edition** (`auth-edition.ts`: no login, no Clerk mount) into the production bundle. Every API call went out unauthenticated; the SaaS API correctly 401'd. Constraint A (SaaS byte-identical) held for `config.py` but not for this image.

**Immediate restore (done):** `NEXT_PUBLIC_AUTH_EDITION=saas` set on the Railway frontend service → redeploy picks the build arg.
**This PR (permanent):** Dockerfile default → `saas`. Local edition unaffected: `docker-compose.yml` already passes `NEXT_PUBLIC_AUTH_EDITION: ${NEXT_PUBLIC_AUTH_EDITION:-local}` as a build arg.

One-line diff; no tests affected. **Merge freeze:** Gerard/onboarding pod to click.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated the default authentication edition for container builds to the SaaS edition.
  * Local deployments must now explicitly select the local authentication edition during builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->