### PR TITLE
fix(prod): Dockerfile ARG defaults are production values — closes the #650 outage class

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -541,6 +541,38 @@ jobs:
           echo "v_workspace_outputs answers (rows=${ROWS})"
           echo "Fresh-clone boot path succeeded: complete schema + stamp + no-op upgrade."
 
+  # Prod-image parity (2026-08-30, after #650 shipped the local edition's
+  # Dockerfile defaults to production — Clerk outage, #668). Railway builds the
+  # three Dockerfiles with NO build args (railway.json: DOCKERFILE, target
+  # production), so this lane builds exactly that and checks what got baked:
+  # the frontend's edition literal, the backend's graph extras, the worker's
+  # browser. Non-required like the other lanes; the required flip is the repo
+  # admin's call.
+  prod-image-parity:
+    name: Prod images built with default args carry production behaviour (non-required)
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v4
+      - name: Frontend — edition baked with no args must be saas
+        run: |
+          docker build --target production -t parity-fe frontend/
+          LOCAL=$(docker run --rm parity-fe sh -c 'grep -rlF "\"local\"||\"\"" .next 2>/dev/null | wc -l')
+          SAAS=$(docker run --rm parity-fe sh -c 'grep -rlF "\"saas\"||\"\"" .next 2>/dev/null | wc -l')
+          echo "chunks with local literal: $LOCAL; with saas literal: $SAAS"
+          if [ "$LOCAL" != "0" ] || [ "$SAAS" = "0" ]; then
+            echo "::error::the production frontend image bakes the LOCAL edition — check ARG NEXT_PUBLIC_AUTH_EDITION in frontend/Dockerfile"
+            exit 1
+          fi
+      - name: Backend — graph extras present with no args
+        run: |
+          docker build --target production -t parity-be orchestrator/
+          docker run --rm parity-be python -c "import graspologic, graphify.cluster; print('leiden extras present')"
+      - name: Worker — headless browser present with no args
+        run: |
+          docker build -t parity-wk services/workspace-worker/
+          docker run --rm parity-wk sh -c 'ls /opt/playwright-browsers | grep -q chromium && echo "chromium present"'
+
   # PRD-209 S4 (F051 / deployability J4) — the schema-drift net for the "four
   # writers of schema truth" (init_complete_schema.sql, the Alembic migration
   # forest, create_all-at-boot, and inline ALTERs inside migrations). No lane

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -573,7 +573,9 @@ jobs:
       - name: Worker — headless browser present with no args
         run: |
           docker build -t parity-wk services/workspace-worker/
-          docker run --rm parity-wk sh -c 'ls /opt/playwright-browsers | grep -q chromium && echo "chromium present"'
+          # --entrypoint: the worker image's entrypoint.sh execs the worker itself
+          # (ignoring CMD) and dies on Redis — we only want to look inside the image.
+          docker run --rm --entrypoint sh parity-wk -c 'ls /opt/playwright-browsers | grep -q chromium && echo "chromium present"'
 
   # PRD-209 S4 (F051 / deployability J4) — the schema-drift net for the "four
   # writers of schema truth" (init_complete_schema.sql, the Alembic migration

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -557,8 +557,10 @@ jobs:
       - name: Frontend — edition baked with no args must be saas
         run: |
           docker build --target production -t parity-fe frontend/
-          LOCAL=$(docker run --rm parity-fe sh -c 'grep -rlF "\"local\"||\"\"" .next 2>/dev/null | wc -l')
-          SAAS=$(docker run --rm parity-fe sh -c 'grep -rlF "\"saas\"||\"\"" .next 2>/dev/null | wc -l')
+          # lib/auth-edition.ts compiles to `"local"===<INLINED>.trim().toLowerCase()?"local":"saas"`
+          # (Next folds the `|| ''` away), so the baked edition is the literal on the right.
+          LOCAL=$(docker run --rm parity-fe sh -c 'grep -rlF "\"local\"===\"local\".trim()" .next 2>/dev/null | wc -l')
+          SAAS=$(docker run --rm parity-fe sh -c 'grep -rlF "\"local\"===\"saas\".trim()" .next 2>/dev/null | wc -l')
           echo "chunks with local literal: $LOCAL; with saas literal: $SAAS"
           if [ "$LOCAL" != "0" ] || [ "$SAAS" = "0" ]; then
             echo "::error::the production frontend image bakes the LOCAL edition — check ARG NEXT_PUBLIC_AUTH_EDITION in frontend/Dockerfile"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -114,6 +114,10 @@ services:
     build:
       context: ./orchestrator
       dockerfile: Dockerfile
+      args:
+        # The Dockerfile defaults are PRODUCTION values (Railway builds it). The
+        # local edition opts out of the ~660 MB Leiden clustering stack here.
+        INSTALL_GRAPH_EXTRAS: "false"
       target: development
     container_name: automatos_backend
     restart: unless-stopped
@@ -283,6 +287,10 @@ services:
     build:
       context: ./services/workspace-worker
       dockerfile: Dockerfile
+      args:
+        # Production default is a bundled Chromium (1.18 GB); the local edition
+        # opts out — workspace_html_to_png says so honestly if used.
+        INSTALL_BROWSER: "false"
     container_name: automatos_workspace_worker
     restart: unless-stopped
     depends_on:

--- a/infrastructure/railway-manifest.json
+++ b/infrastructure/railway-manifest.json
@@ -4,483 +4,856 @@
   "_project": "Automatos AI",
   "_environment": "production",
   "_project_id": "e2e8cf82-c1c0-4afb-8b88-1a7c32c41606",
-
   "domains": {
     "api.automatos.app": "automatos-ai-api",
     "ui.automatos.app": "automotas-ai-frontend",
     "automatos.app": "automatos-ai-landing"
   },
-
   "service_groups": {
     "core": {
       "description": "Core platform — API, Frontend, Workers",
       "repo": "AutomatosAI/automatos-ai",
-      "services": ["automatos-ai-api", "automotas-ai-frontend", "agent-workspace-worker", "agent-opt-worker"]
+      "services": [
+        "automatos-ai-api",
+        "automotas-ai-frontend",
+        "agent-workspace-worker",
+        "agent-opt-worker"
+      ]
     },
     "voice": {
       "description": "Voice processing — TTS, STT, pipeline",
       "repo": "AutomatosAI/automatos-voice",
-      "services": ["voice-service", "voice-pipeline"]
+      "services": [
+        "voice-service",
+        "voice-pipeline"
+      ]
     },
     "memory": {
       "description": "Long-term memory — Mem0 OpenMemory server",
       "repo": "AutomatosAI/automatos-mem0",
-      "services": ["automatos-ai-mem0-Server", "automatos-ai-mem0-pgvector"]
+      "services": [
+        "automatos-ai-mem0-Server",
+        "automatos-ai-mem0-pgvector"
+      ]
     },
     "monitoring": {
       "description": "Observability — metrics, logs, alerts, dashboards",
       "repo": "AutomatosAI/automatos-monitoring",
-      "services": ["prometheus", "grafana", "loki", "log-relay", "alertmanager", "postgres-exporter", "redis-exporter"]
+      "services": [
+        "prometheus",
+        "grafana",
+        "loki",
+        "log-relay",
+        "alertmanager",
+        "postgres-exporter",
+        "redis-exporter"
+      ]
     },
     "data": {
       "description": "Data infrastructure — databases, caches, vector stores",
-      "services": ["automatos-ai-pgvector", "Redis", "Qdrant"]
+      "services": [
+        "automatos-ai-pgvector",
+        "Redis",
+        "Qdrant"
+      ]
     },
     "landing": {
       "description": "Marketing landing page",
       "repo": "AutomatosAI/automatos-ai-landing",
-      "services": ["automatos-ai-landing"]
+      "services": [
+        "automatos-ai-landing"
+      ]
     }
   },
-
   "services": {
     "automatos-ai-api": {
       "group": "core",
-      "source": {"repo": "AutomatosAI/automatos-ai", "root_dir": "/orchestrator"},
-      "builder": "RAILPACK",
+      "source": {
+        "repo": "AutomatosAI/automatos-ai",
+        "root_dir": "/orchestrator"
+      },
+      "builder": "DOCKERFILE",
       "dockerfile": null,
       "start_command": null,
       "port": 8000,
       "healthcheck": null,
-      "restart_policy": {"type": "ON_FAILURE", "max_retries": 10},
+      "restart_policy": {
+        "type": "ON_FAILURE",
+        "max_retries": 10
+      },
       "sleep": false,
       "replicas": null,
       "domains": {
-        "railway": ["automatos-ai-production.up.railway.app"],
-        "custom": ["api.automatos.app"]
+        "railway": [
+          "automatos-ai-production.up.railway.app"
+        ],
+        "custom": [
+          "api.automatos.app"
+        ]
       },
       "volumes": [],
       "env_keys": [
-        "ADAPTER_ADMIN_BASE_URL", "ADAPTER_ADMIN_TOKEN", "ADMINER_PORT",
-        "AGENT_OPT_WORKER_URL", "ALERT_INGEST_TOKEN", "ANTHROPIC_API_KEY",
-        "API_KEY", "API_PORT", "AUTOMATOS_DOCUMENTS_DIR",
-        "AWS_ACCESS_KEY_ID", "AWS_REGION", "AWS_SECRET_ACCESS_KEY",
-        "BACKEND_URL", "CLERK_JWKS_URL", "CLERK_SECRET_KEY",
-        "COMPOSIO_KEY", "COMPOSIO_WEBHOOK_SECRET", "CORS_ALLOW_ORIGINS",
-        "CREDENTIAL_ENCRYPTION_KEY", "DATABASE_PUBLIC_URL", "DATABASE_URL",
-        "EMBEDDING_DIMENSION", "EMBEDDING_MODEL", "EMBEDDING_PROVIDER",
-        "ENVIRONMENT", "FRONTEND_PORT", "FRONTEND_URL",
-        "FUTUREAGI_API_KEY", "FUTUREAGI_ENABLED", "FUTUREAGI_SECRET_KEY",
-        "GITHUB", "GITHUB_DEFAULT_BRANCH", "GITHUB_REPO_NAME",
-        "GITHUB_REPO_OWNER", "GITHUB_WEBHOOK_SECRET", "GOOGLE_API_KEY",
-        "GRAFANA_LOKI_DATASOURCE_UID", "GRAFANA_SERVICE_ACCOUNT_TOKEN", "GRAFANA_URL",
-        "HUGGINGFACE_API_KEY", "LLM_MAX_TOKENS", "LLM_MODEL",
-        "LLM_PROVIDER", "LLM_TEMPERATURE", "LOG_LEVEL",
-        "LOG_RELAY_ENABLED", "LOG_RELAY_URL", "MEM0_API_URL",
-        "NEXT_PUBLIC_API_KEY", "NEXT_PUBLIC_API_URL", "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY",
-        "NEXT_PUBLIC_WS_URL", "OPENAI_API_KEY", "OPENROUTER_API_KEY",
-        "POSTGRES_DB", "POSTGRES_PASSWORD", "POSTGRES_PORT", "POSTGRES_USER",
-        "QDRANT_URL", "RAILWAY_API_TOKEN",
-        "REDIS_HOST", "REDIS_PASSWORD", "REDIS_PORT", "REDIS_URL",
-        "S3_VECTORS_BUCKET", "S3_VECTORS_DIMENSION", "S3_VECTORS_ENABLED",
-        "S3_VECTORS_INDEX_NAME", "S3_VECTORS_METRIC",
-        "S3_VECTOR_BUCKET", "S3_VECTOR_INDEX", "S3_VECTOR_REGION",
-        "SERVICE_NAME", "SHARED_CONTEXT_BACKEND",
-        "SLACK_API_KEY", "TASK_RUNNER_BACKEND",
-        "VOICE_ENABLED", "VOICE_SERVICE_URL", "VOICE_STT_MODEL",
-        "VOICE_TTS_DEFAULT_VOICE", "VOICE_TTS_MODEL",
-        "WIDGET_TOKEN_SECRET", "WORKER_INTERNAL_TOKEN", "WORKER_INTERNAL_URL"
+        "ADAPTER_ADMIN_BASE_URL",
+        "ADAPTER_ADMIN_TOKEN",
+        "ADMINER_PORT",
+        "AGENT_OPT_WORKER_URL",
+        "ALERT_INGEST_TOKEN",
+        "ANTHROPIC_API_KEY",
+        "API_KEY",
+        "API_PORT",
+        "AUTOMATOS_DOCUMENTS_DIR",
+        "AWS_ACCESS_KEY_ID",
+        "AWS_REGION",
+        "AWS_SECRET_ACCESS_KEY",
+        "BACKEND_URL",
+        "CLERK_JWKS_URL",
+        "CLERK_SECRET_KEY",
+        "COMPOSIO_KEY",
+        "COMPOSIO_WEBHOOK_SECRET",
+        "CORS_ALLOW_ORIGINS",
+        "CREDENTIAL_ENCRYPTION_KEY",
+        "DATABASE_PUBLIC_URL",
+        "DATABASE_URL",
+        "EMBEDDING_DIMENSION",
+        "EMBEDDING_MODEL",
+        "EMBEDDING_PROVIDER",
+        "ENVIRONMENT",
+        "FRONTEND_PORT",
+        "FRONTEND_URL",
+        "FUTUREAGI_API_KEY",
+        "FUTUREAGI_ENABLED",
+        "FUTUREAGI_SECRET_KEY",
+        "GITHUB",
+        "GITHUB_DEFAULT_BRANCH",
+        "GITHUB_REPO_NAME",
+        "GITHUB_REPO_OWNER",
+        "GITHUB_WEBHOOK_SECRET",
+        "GOOGLE_API_KEY",
+        "GRAFANA_LOKI_DATASOURCE_UID",
+        "GRAFANA_SERVICE_ACCOUNT_TOKEN",
+        "GRAFANA_URL",
+        "HUGGINGFACE_API_KEY",
+        "LLM_MAX_TOKENS",
+        "LLM_MODEL",
+        "LLM_PROVIDER",
+        "LLM_TEMPERATURE",
+        "LOG_LEVEL",
+        "LOG_RELAY_ENABLED",
+        "LOG_RELAY_URL",
+        "MEM0_API_URL",
+        "NEXT_PUBLIC_API_KEY",
+        "NEXT_PUBLIC_API_URL",
+        "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY",
+        "NEXT_PUBLIC_WS_URL",
+        "OPENAI_API_KEY",
+        "OPENROUTER_API_KEY",
+        "POSTGRES_DB",
+        "POSTGRES_PASSWORD",
+        "POSTGRES_PORT",
+        "POSTGRES_USER",
+        "QDRANT_URL",
+        "RAILWAY_API_TOKEN",
+        "REDIS_HOST",
+        "REDIS_PASSWORD",
+        "REDIS_PORT",
+        "REDIS_URL",
+        "S3_VECTORS_BUCKET",
+        "S3_VECTORS_DIMENSION",
+        "S3_VECTORS_ENABLED",
+        "S3_VECTORS_INDEX_NAME",
+        "S3_VECTORS_METRIC",
+        "S3_VECTOR_BUCKET",
+        "S3_VECTOR_INDEX",
+        "S3_VECTOR_REGION",
+        "SERVICE_NAME",
+        "SHARED_CONTEXT_BACKEND",
+        "SLACK_API_KEY",
+        "TASK_RUNNER_BACKEND",
+        "VOICE_ENABLED",
+        "VOICE_SERVICE_URL",
+        "VOICE_STT_MODEL",
+        "VOICE_TTS_DEFAULT_VOICE",
+        "VOICE_TTS_MODEL",
+        "WIDGET_TOKEN_SECRET",
+        "WORKER_INTERNAL_TOKEN",
+        "WORKER_INTERNAL_URL"
       ]
     },
-
     "automotas-ai-frontend": {
       "group": "core",
-      "source": {"repo": "AutomatosAI/automatos-ai", "root_dir": "/frontend"},
-      "builder": "RAILPACK",
+      "source": {
+        "repo": "AutomatosAI/automatos-ai",
+        "root_dir": "/frontend"
+      },
+      "builder": "DOCKERFILE",
       "dockerfile": "/frontend/Dockerfile",
       "start_command": null,
       "port": 3000,
       "healthcheck": null,
-      "restart_policy": {"type": "ON_FAILURE", "max_retries": 10},
+      "restart_policy": {
+        "type": "ON_FAILURE",
+        "max_retries": 10
+      },
       "sleep": true,
       "replicas": null,
       "domains": {
-        "railway": ["automotas-ai-frontend-production.up.railway.app"],
-        "custom": ["ui.automatos.app"]
+        "railway": [
+          "automotas-ai-frontend-production.up.railway.app"
+        ],
+        "custom": [
+          "ui.automatos.app"
+        ]
       },
       "volumes": [],
       "env_keys": [
-        "ADAPTER_ADMIN_BASE_URL", "ADAPTER_ADMIN_TOKEN", "ADMINER_PORT",
-        "API_KEY", "API_PORT", "CLERK_JWKS_URL", "CLERK_SECRET_KEY",
-        "CORS_ALLOW_ORIGINS", "ENVIRONMENT", "LOG_LEVEL",
-        "NEXT_PUBLIC_API_KEY", "NEXT_PUBLIC_API_URL",
-        "NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL", "NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL",
-        "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY", "NEXT_PUBLIC_CLERK_SIGN_IN_URL",
-        "NEXT_PUBLIC_CLERK_SIGN_UP_URL", "NEXT_PUBLIC_VOICE_PIPELINE_URL"
+        "ADAPTER_ADMIN_BASE_URL",
+        "ADAPTER_ADMIN_TOKEN",
+        "ADMINER_PORT",
+        "API_KEY",
+        "API_PORT",
+        "CLERK_JWKS_URL",
+        "CLERK_SECRET_KEY",
+        "CORS_ALLOW_ORIGINS",
+        "ENVIRONMENT",
+        "LOG_LEVEL",
+        "NEXT_PUBLIC_API_KEY",
+        "NEXT_PUBLIC_API_URL",
+        "NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL",
+        "NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL",
+        "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY",
+        "NEXT_PUBLIC_CLERK_SIGN_IN_URL",
+        "NEXT_PUBLIC_CLERK_SIGN_UP_URL",
+        "NEXT_PUBLIC_VOICE_PIPELINE_URL"
       ]
     },
-
     "agent-workspace-worker": {
       "group": "core",
-      "source": {"repo": "AutomatosAI/automatos-ai", "root_dir": "/services/workspace-worker"},
-      "builder": "RAILPACK",
+      "source": {
+        "repo": "AutomatosAI/automatos-ai",
+        "root_dir": "/services/workspace-worker"
+      },
+      "builder": "DOCKERFILE",
       "dockerfile": null,
       "start_command": null,
       "port": 8081,
       "healthcheck": null,
-      "restart_policy": {"type": "ON_FAILURE", "max_retries": 10},
-      "sleep": false,
-      "replicas": null,
-      "domains": {"railway": [], "custom": []},
-      "volumes": [
-        {"name": "agent-workspace-data", "mount": "/workspaces", "size_mb": 50000}
-      ],
-      "env_keys": [
-        "DATABASE_URL", "ENVIRONMENT", "LOG_LEVEL", "LOG_RELAY_ENABLED",
-        "QDRANT_URL", "REDIS_URL", "SERVICE_NAME",
-        "WORKER_CONCURRENCY", "WORKER_HEALTH_PORT", "WORKER_INTERNAL_TOKEN",
-        "WORKSPACE_DEFAULT_QUOTA_GB", "WORKSPACE_VOLUME_PATH"
-      ]
-    },
-
-    "agent-opt-worker": {
-      "group": "core",
-      "source": {"repo": "AutomatosAI/automatos-ai", "root_dir": "/services/agent-opt-worker"},
-      "builder": "RAILPACK",
-      "dockerfile": null,
-      "start_command": null,
-      "port": 8080,
-      "healthcheck": null,
-      "restart_policy": {"type": "ON_FAILURE", "max_retries": 10},
-      "sleep": false,
-      "replicas": null,
-      "domains": {
-        "railway": ["agent-opt-worker-production.up.railway.app"],
-        "custom": []
+      "restart_policy": {
+        "type": "ON_FAILURE",
+        "max_retries": 10
       },
-      "volumes": [],
-      "env_keys": [
-        "FI_API_KEY", "FI_SECRET_KEY", "FUTUREAGI_API_KEY", "FUTUREAGI_SECRET_KEY",
-        "LOG_RELAY_ENABLED", "MAX_OPTIMIZE_TIMEOUT", "OPENAI_API_KEY",
-        "PORT", "QDRANT_URL", "SERVICE_NAME"
-      ]
-    },
-
-    "voice-service": {
-      "group": "voice",
-      "source": {"repo": "AutomatosAI/automatos-voice", "root_dir": "/"},
-      "builder": "RAILPACK",
-      "dockerfile": null,
-      "start_command": null,
-      "port": 8300,
-      "healthcheck": null,
-      "restart_policy": {"type": "ON_FAILURE", "max_retries": 10},
-      "sleep": false,
-      "replicas": null,
-      "domains": {
-        "railway": ["voice-service-production-bb28.up.railway.app"],
-        "custom": []
-      },
-      "volumes": [],
-      "env_keys": [
-        "ENVIRONMENT", "HOST", "LOG_LEVEL", "METRICS_ENABLED", "PORT",
-        "TTS_DEFAULT_MODEL", "TTS_DEFAULT_VOICE", "TTS_ENGINE",
-        "WHISPER_COMPUTE_TYPE", "WHISPER_DEVICE", "WHISPER_MODEL"
-      ]
-    },
-
-    "voice-pipeline": {
-      "group": "voice",
-      "source": {"repo": "AutomatosAI/automatos-voice", "root_dir": "/"},
-      "builder": "RAILPACK",
-      "dockerfile": null,
-      "start_command": null,
-      "port": 8301,
-      "healthcheck": null,
-      "restart_policy": {"type": "ON_FAILURE", "max_retries": 10},
-      "sleep": false,
-      "replicas": null,
-      "domains": {
-        "railway": ["voice-pipeline-production.up.railway.app"],
-        "custom": []
-      },
-      "volumes": [],
-      "env_keys": [
-        "HOST", "LOG_LEVEL", "MAX_CONCURRENT_SESSIONS", "METRICS_ENABLED",
-        "ORCHESTRATOR_URL", "PORT", "STT_MODEL", "TTS_MODEL", "TTS_VOICE",
-        "VOICE_SERVICE_URL"
-      ]
-    },
-
-    "automatos-ai-mem0-Server": {
-      "group": "memory",
-      "source": {"repo": "AutomatosAI/automatos-mem0", "root_dir": "/openmemory/api"},
-      "builder": "RAILPACK",
-      "dockerfile": "/openmemory/api/Dockerfile",
-      "start_command": null,
-      "port": 8765,
-      "healthcheck": null,
-      "restart_policy": {"type": "ON_FAILURE", "max_retries": 10},
-      "sleep": false,
-      "replicas": null,
-      "domains": {"railway": [], "custom": []},
-      "volumes": [],
-      "env_keys": [
-        "DATABASE_URL", "ELASTICSEARCH_PASSWORD", "LOG_RELAY_ENABLED",
-        "OPENAI_API_KEY", "PG_DB", "PG_HOST", "PG_PASSWORD", "PG_PORT",
-        "PG_USER", "SERVICE_NAME"
-      ]
-    },
-
-    "automatos-ai-mem0-pgvector": {
-      "group": "memory",
-      "source": {"image": "pgvector/pgvector:pg18"},
-      "builder": "RAILPACK",
-      "dockerfile": null,
-      "start_command": null,
-      "port": 5432,
-      "healthcheck": null,
-      "restart_policy": {"type": "ON_FAILURE", "max_retries": 10},
-      "sleep": false,
-      "replicas": null,
-      "domains": {"railway": [], "custom": []},
-      "volumes": [
-        {"name": "automatos-ai-mem0-pgvector-volume", "mount": "/var/lib/postgresql/data/", "size_mb": 50000}
-      ],
-      "env_keys": []
-    },
-
-    "prometheus": {
-      "group": "monitoring",
-      "source": {"repo": "AutomatosAI/automatos-monitoring", "root_dir": "/services/prometheus"},
-      "builder": "RAILPACK",
-      "dockerfile": null,
-      "start_command": null,
-      "port": 9090,
-      "healthcheck": null,
-      "restart_policy": {"type": "ON_FAILURE", "max_retries": 10},
-      "sleep": false,
-      "replicas": null,
-      "domains": {"railway": [], "custom": []},
-      "volumes": [
-        {"name": "prometheus-volume", "mount": "/prometheus", "size_mb": 50000}
-      ],
-      "env_keys": ["PORT"]
-    },
-
-    "grafana": {
-      "group": "monitoring",
-      "source": {"repo": "AutomatosAI/automatos-monitoring", "root_dir": "/services/grafana"},
-      "builder": "RAILPACK",
-      "dockerfile": null,
-      "start_command": null,
-      "port": 3000,
-      "healthcheck": null,
-      "restart_policy": {"type": "ON_FAILURE", "max_retries": 10},
-      "sleep": false,
-      "replicas": null,
-      "domains": {
-        "railway": ["grafana-production-5f61.up.railway.app"],
-        "custom": []
-      },
-      "volumes": [
-        {"name": "grafana-volume", "mount": "/var/lib/grafana", "size_mb": 50000}
-      ],
-      "env_keys": [
-        "GF_AUTH_ANONYMOUS_ENABLED", "GF_SECURITY_ADMIN_PASSWORD",
-        "GF_SECURITY_ADMIN_USER", "GF_SERVER_ROOT_URL",
-        "GF_USERS_ALLOW_SIGN_UP", "PORT"
-      ]
-    },
-
-    "loki": {
-      "group": "monitoring",
-      "source": {"repo": "AutomatosAI/automatos-monitoring", "root_dir": "/services/loki"},
-      "builder": "RAILPACK",
-      "dockerfile": null,
-      "start_command": null,
-      "port": 3100,
-      "healthcheck": null,
-      "restart_policy": {"type": "ON_FAILURE", "max_retries": 10},
-      "sleep": false,
-      "replicas": null,
-      "domains": {"railway": [], "custom": []},
-      "volumes": [
-        {"name": "loki-volume", "mount": "/loki", "size_mb": 50000}
-      ],
-      "env_keys": ["PORT"]
-    },
-
-    "log-relay": {
-      "group": "monitoring",
-      "source": {"repo": "AutomatosAI/automatos-monitoring", "root_dir": "/services/log-relay"},
-      "builder": "RAILPACK",
-      "dockerfile": null,
-      "start_command": null,
-      "port": 8080,
-      "healthcheck": null,
-      "restart_policy": {"type": "ON_FAILURE", "max_retries": 10},
-      "sleep": false,
-      "replicas": null,
-      "domains": {
-        "railway": ["log-relay-production.up.railway.app"],
-        "custom": []
-      },
-      "volumes": [],
-      "env_keys": [
-        "ENVIRONMENT", "LOG_RELAY_SECRET", "LOKI_PUSH_URL", "PORT"
-      ]
-    },
-
-    "alertmanager": {
-      "group": "monitoring",
-      "source": {"repo": "AutomatosAI/automatos-monitoring", "root_dir": "/services/alertmanager"},
-      "builder": "RAILPACK",
-      "dockerfile": null,
-      "start_command": null,
-      "port": 9093,
-      "healthcheck": null,
-      "restart_policy": {"type": "ON_FAILURE", "max_retries": 10},
-      "sleep": false,
-      "replicas": null,
-      "domains": {"railway": [], "custom": []},
-      "volumes": [
-        {"name": "alertmanager-volume", "mount": "/alertmanager", "size_mb": 50000}
-      ],
-      "env_keys": ["ALERT_INGEST_TOKEN", "PORT"]
-    },
-
-    "postgres-exporter": {
-      "group": "monitoring",
-      "source": {"image": "prometheuscommunity/postgres-exporter:v0.19.1"},
-      "builder": "RAILPACK",
-      "dockerfile": null,
-      "start_command": null,
-      "port": 9187,
-      "healthcheck": null,
-      "restart_policy": {"type": "ON_FAILURE", "max_retries": 10},
-      "sleep": false,
-      "replicas": null,
-      "domains": {"railway": [], "custom": []},
-      "volumes": [],
-      "env_keys": ["DATA_SOURCE_NAME"]
-    },
-
-    "redis-exporter": {
-      "group": "monitoring",
-      "source": {"image": "oliver006/redis_exporter:v1.82.0"},
-      "builder": "RAILPACK",
-      "dockerfile": null,
-      "start_command": null,
-      "port": 9121,
-      "healthcheck": null,
-      "restart_policy": {"type": "ON_FAILURE", "max_retries": 10},
-      "sleep": false,
-      "replicas": null,
-      "domains": {"railway": [], "custom": []},
-      "volumes": [],
-      "env_keys": ["REDIS_ADDR"]
-    },
-
-    "automatos-ai-pgvector": {
-      "group": "data",
-      "source": {"image": "pgvector/pgvector:pg18"},
-      "builder": "RAILPACK",
-      "dockerfile": null,
-      "start_command": "/bin/sh -c \"unset PGPORT; docker-entrypoint.sh postgres --port=5432\"",
-      "port": 5432,
-      "healthcheck": null,
-      "restart_policy": {"type": "ON_FAILURE", "max_retries": 10},
-      "sleep": false,
-      "replicas": null,
-      "domains": {"railway": [], "custom": []},
-      "volumes": [
-        {"name": "pgvector-volume", "mount": "/var/lib/postgresql/data/", "size_mb": 50000}
-      ],
-      "env_keys": [
-        "PGDATA", "PGDATABASE", "PGHOST", "PGPASSWORD", "PGPORT", "PGUSER",
-        "POSTGRES_DB", "POSTGRES_PASSWORD", "POSTGRES_USER",
-        "DATABASE_PUBLIC_URL", "DATABASE_URL"
-      ]
-    },
-
-    "Redis": {
-      "group": "data",
-      "source": {"image": "redis:8.2.1"},
-      "builder": "RAILPACK",
-      "dockerfile": null,
-      "start_command": "/bin/sh -c \"rm -rf $RAILWAY_VOLUME_MOUNT_PATH/lost+found/ && exec docker-entrypoint.sh redis-server --requirepass $REDIS_PASSWORD --save 60 1 --dir $RAILWAY_VOLUME_MOUNT_PATH\"",
-      "port": 6379,
-      "healthcheck": null,
-      "restart_policy": {"type": "ON_FAILURE", "max_retries": 10},
-      "sleep": false,
-      "replicas": null,
-      "domains": {"railway": [], "custom": []},
-      "volumes": [
-        {"name": "redis-volume", "mount": "/data", "size_mb": 50000}
-      ],
-      "env_keys": [
-        "REDISHOST", "REDISPASSWORD", "REDISPORT", "REDISUSER",
-        "REDIS_PASSWORD", "REDIS_PUBLIC_URL", "REDIS_URL"
-      ]
-    },
-
-    "Qdrant": {
-      "group": "data",
-      "source": {"image": "qdrant/qdrant"},
-      "builder": "RAILPACK",
-      "dockerfile": null,
-      "start_command": null,
-      "port": 6333,
-      "healthcheck": null,
-      "restart_policy": {"type": "ON_FAILURE", "max_retries": 10},
-      "sleep": false,
-      "replicas": null,
-      "domains": {
-        "railway": ["qdrant-production-c691.up.railway.app"],
-        "custom": []
-      },
-      "volumes": [
-        {"name": "qdrant-volume", "mount": "/qdrant/storage", "size_mb": 50000}
-      ],
-      "env_keys": ["PORT"]
-    },
-
-    "automatos-ai-landing": {
-      "group": "landing",
-      "source": {"repo": "AutomatosAI/automatos-ai-landing"},
-      "builder": "RAILPACK",
-      "dockerfile": "/Dockerfile",
-      "start_command": null,
-      "port": 80,
-      "healthcheck": null,
-      "restart_policy": {"type": "ON_FAILURE", "max_retries": 10},
       "sleep": false,
       "replicas": null,
       "domains": {
         "railway": [],
-        "custom": ["automatos.app"]
+        "custom": []
+      },
+      "volumes": [
+        {
+          "name": "agent-workspace-data",
+          "mount": "/workspaces",
+          "size_mb": 50000
+        }
+      ],
+      "env_keys": [
+        "DATABASE_URL",
+        "ENVIRONMENT",
+        "LOG_LEVEL",
+        "LOG_RELAY_ENABLED",
+        "QDRANT_URL",
+        "REDIS_URL",
+        "SERVICE_NAME",
+        "WORKER_CONCURRENCY",
+        "WORKER_HEALTH_PORT",
+        "WORKER_INTERNAL_TOKEN",
+        "WORKSPACE_DEFAULT_QUOTA_GB",
+        "WORKSPACE_VOLUME_PATH"
+      ]
+    },
+    "agent-opt-worker": {
+      "group": "core",
+      "source": {
+        "repo": "AutomatosAI/automatos-ai",
+        "root_dir": "/services/agent-opt-worker"
+      },
+      "builder": "DOCKERFILE",
+      "dockerfile": null,
+      "start_command": null,
+      "port": 8080,
+      "healthcheck": null,
+      "restart_policy": {
+        "type": "ON_FAILURE",
+        "max_retries": 10
+      },
+      "sleep": false,
+      "replicas": null,
+      "domains": {
+        "railway": [
+          "agent-opt-worker-production.up.railway.app"
+        ],
+        "custom": []
       },
       "volumes": [],
       "env_keys": [
-        "CONTACT_EMAIL", "SMTP_HOST", "SMTP_PASS", "SMTP_PORT", "SMTP_USER",
-        "VITE_AUTOMATOS_WORKSPACE_ID", "VITE_CLERK_PUBLISHABLE_KEY"
+        "FI_API_KEY",
+        "FI_SECRET_KEY",
+        "FUTUREAGI_API_KEY",
+        "FUTUREAGI_SECRET_KEY",
+        "LOG_RELAY_ENABLED",
+        "MAX_OPTIMIZE_TIMEOUT",
+        "OPENAI_API_KEY",
+        "PORT",
+        "QDRANT_URL",
+        "SERVICE_NAME"
+      ]
+    },
+    "voice-service": {
+      "group": "voice",
+      "source": {
+        "repo": "AutomatosAI/automatos-voice",
+        "root_dir": "/"
+      },
+      "builder": "DOCKERFILE",
+      "dockerfile": null,
+      "start_command": null,
+      "port": 8300,
+      "healthcheck": null,
+      "restart_policy": {
+        "type": "ON_FAILURE",
+        "max_retries": 10
+      },
+      "sleep": false,
+      "replicas": null,
+      "domains": {
+        "railway": [
+          "voice-service-production-bb28.up.railway.app"
+        ],
+        "custom": []
+      },
+      "volumes": [],
+      "env_keys": [
+        "ENVIRONMENT",
+        "HOST",
+        "LOG_LEVEL",
+        "METRICS_ENABLED",
+        "PORT",
+        "TTS_DEFAULT_MODEL",
+        "TTS_DEFAULT_VOICE",
+        "TTS_ENGINE",
+        "WHISPER_COMPUTE_TYPE",
+        "WHISPER_DEVICE",
+        "WHISPER_MODEL"
+      ]
+    },
+    "voice-pipeline": {
+      "group": "voice",
+      "source": {
+        "repo": "AutomatosAI/automatos-voice",
+        "root_dir": "/"
+      },
+      "builder": "DOCKERFILE",
+      "dockerfile": null,
+      "start_command": null,
+      "port": 8301,
+      "healthcheck": null,
+      "restart_policy": {
+        "type": "ON_FAILURE",
+        "max_retries": 10
+      },
+      "sleep": false,
+      "replicas": null,
+      "domains": {
+        "railway": [
+          "voice-pipeline-production.up.railway.app"
+        ],
+        "custom": []
+      },
+      "volumes": [],
+      "env_keys": [
+        "HOST",
+        "LOG_LEVEL",
+        "MAX_CONCURRENT_SESSIONS",
+        "METRICS_ENABLED",
+        "ORCHESTRATOR_URL",
+        "PORT",
+        "STT_MODEL",
+        "TTS_MODEL",
+        "TTS_VOICE",
+        "VOICE_SERVICE_URL"
+      ]
+    },
+    "automatos-ai-mem0-Server": {
+      "group": "memory",
+      "source": {
+        "repo": "AutomatosAI/automatos-mem0",
+        "root_dir": "/openmemory/api"
+      },
+      "builder": "DOCKERFILE",
+      "dockerfile": "/openmemory/api/Dockerfile",
+      "start_command": null,
+      "port": 8765,
+      "healthcheck": null,
+      "restart_policy": {
+        "type": "ON_FAILURE",
+        "max_retries": 10
+      },
+      "sleep": false,
+      "replicas": null,
+      "domains": {
+        "railway": [],
+        "custom": []
+      },
+      "volumes": [],
+      "env_keys": [
+        "DATABASE_URL",
+        "ELASTICSEARCH_PASSWORD",
+        "LOG_RELAY_ENABLED",
+        "OPENAI_API_KEY",
+        "PG_DB",
+        "PG_HOST",
+        "PG_PASSWORD",
+        "PG_PORT",
+        "PG_USER",
+        "SERVICE_NAME"
+      ]
+    },
+    "automatos-ai-mem0-pgvector": {
+      "group": "memory",
+      "source": {
+        "image": "pgvector/pgvector:pg18"
+      },
+      "builder": "DOCKERFILE",
+      "dockerfile": null,
+      "start_command": null,
+      "port": 5432,
+      "healthcheck": null,
+      "restart_policy": {
+        "type": "ON_FAILURE",
+        "max_retries": 10
+      },
+      "sleep": false,
+      "replicas": null,
+      "domains": {
+        "railway": [],
+        "custom": []
+      },
+      "volumes": [
+        {
+          "name": "automatos-ai-mem0-pgvector-volume",
+          "mount": "/var/lib/postgresql/data/",
+          "size_mb": 50000
+        }
+      ],
+      "env_keys": []
+    },
+    "prometheus": {
+      "group": "monitoring",
+      "source": {
+        "repo": "AutomatosAI/automatos-monitoring",
+        "root_dir": "/services/prometheus"
+      },
+      "builder": "DOCKERFILE",
+      "dockerfile": null,
+      "start_command": null,
+      "port": 9090,
+      "healthcheck": null,
+      "restart_policy": {
+        "type": "ON_FAILURE",
+        "max_retries": 10
+      },
+      "sleep": false,
+      "replicas": null,
+      "domains": {
+        "railway": [],
+        "custom": []
+      },
+      "volumes": [
+        {
+          "name": "prometheus-volume",
+          "mount": "/prometheus",
+          "size_mb": 50000
+        }
+      ],
+      "env_keys": [
+        "PORT"
+      ]
+    },
+    "grafana": {
+      "group": "monitoring",
+      "source": {
+        "repo": "AutomatosAI/automatos-monitoring",
+        "root_dir": "/services/grafana"
+      },
+      "builder": "DOCKERFILE",
+      "dockerfile": null,
+      "start_command": null,
+      "port": 3000,
+      "healthcheck": null,
+      "restart_policy": {
+        "type": "ON_FAILURE",
+        "max_retries": 10
+      },
+      "sleep": false,
+      "replicas": null,
+      "domains": {
+        "railway": [
+          "grafana-production-5f61.up.railway.app"
+        ],
+        "custom": []
+      },
+      "volumes": [
+        {
+          "name": "grafana-volume",
+          "mount": "/var/lib/grafana",
+          "size_mb": 50000
+        }
+      ],
+      "env_keys": [
+        "GF_AUTH_ANONYMOUS_ENABLED",
+        "GF_SECURITY_ADMIN_PASSWORD",
+        "GF_SECURITY_ADMIN_USER",
+        "GF_SERVER_ROOT_URL",
+        "GF_USERS_ALLOW_SIGN_UP",
+        "PORT"
+      ]
+    },
+    "loki": {
+      "group": "monitoring",
+      "source": {
+        "repo": "AutomatosAI/automatos-monitoring",
+        "root_dir": "/services/loki"
+      },
+      "builder": "DOCKERFILE",
+      "dockerfile": null,
+      "start_command": null,
+      "port": 3100,
+      "healthcheck": null,
+      "restart_policy": {
+        "type": "ON_FAILURE",
+        "max_retries": 10
+      },
+      "sleep": false,
+      "replicas": null,
+      "domains": {
+        "railway": [],
+        "custom": []
+      },
+      "volumes": [
+        {
+          "name": "loki-volume",
+          "mount": "/loki",
+          "size_mb": 50000
+        }
+      ],
+      "env_keys": [
+        "PORT"
+      ]
+    },
+    "log-relay": {
+      "group": "monitoring",
+      "source": {
+        "repo": "AutomatosAI/automatos-monitoring",
+        "root_dir": "/services/log-relay"
+      },
+      "builder": "DOCKERFILE",
+      "dockerfile": null,
+      "start_command": null,
+      "port": 8080,
+      "healthcheck": null,
+      "restart_policy": {
+        "type": "ON_FAILURE",
+        "max_retries": 10
+      },
+      "sleep": false,
+      "replicas": null,
+      "domains": {
+        "railway": [
+          "log-relay-production.up.railway.app"
+        ],
+        "custom": []
+      },
+      "volumes": [],
+      "env_keys": [
+        "ENVIRONMENT",
+        "LOG_RELAY_SECRET",
+        "LOKI_PUSH_URL",
+        "PORT"
+      ]
+    },
+    "alertmanager": {
+      "group": "monitoring",
+      "source": {
+        "repo": "AutomatosAI/automatos-monitoring",
+        "root_dir": "/services/alertmanager"
+      },
+      "builder": "DOCKERFILE",
+      "dockerfile": null,
+      "start_command": null,
+      "port": 9093,
+      "healthcheck": null,
+      "restart_policy": {
+        "type": "ON_FAILURE",
+        "max_retries": 10
+      },
+      "sleep": false,
+      "replicas": null,
+      "domains": {
+        "railway": [],
+        "custom": []
+      },
+      "volumes": [
+        {
+          "name": "alertmanager-volume",
+          "mount": "/alertmanager",
+          "size_mb": 50000
+        }
+      ],
+      "env_keys": [
+        "ALERT_INGEST_TOKEN",
+        "PORT"
+      ]
+    },
+    "postgres-exporter": {
+      "group": "monitoring",
+      "source": {
+        "image": "prometheuscommunity/postgres-exporter:v0.19.1"
+      },
+      "builder": "DOCKERFILE",
+      "dockerfile": null,
+      "start_command": null,
+      "port": 9187,
+      "healthcheck": null,
+      "restart_policy": {
+        "type": "ON_FAILURE",
+        "max_retries": 10
+      },
+      "sleep": false,
+      "replicas": null,
+      "domains": {
+        "railway": [],
+        "custom": []
+      },
+      "volumes": [],
+      "env_keys": [
+        "DATA_SOURCE_NAME"
+      ]
+    },
+    "redis-exporter": {
+      "group": "monitoring",
+      "source": {
+        "image": "oliver006/redis_exporter:v1.82.0"
+      },
+      "builder": "DOCKERFILE",
+      "dockerfile": null,
+      "start_command": null,
+      "port": 9121,
+      "healthcheck": null,
+      "restart_policy": {
+        "type": "ON_FAILURE",
+        "max_retries": 10
+      },
+      "sleep": false,
+      "replicas": null,
+      "domains": {
+        "railway": [],
+        "custom": []
+      },
+      "volumes": [],
+      "env_keys": [
+        "REDIS_ADDR"
+      ]
+    },
+    "automatos-ai-pgvector": {
+      "group": "data",
+      "source": {
+        "image": "pgvector/pgvector:pg18"
+      },
+      "builder": "DOCKERFILE",
+      "dockerfile": null,
+      "start_command": "/bin/sh -c \"unset PGPORT; docker-entrypoint.sh postgres --port=5432\"",
+      "port": 5432,
+      "healthcheck": null,
+      "restart_policy": {
+        "type": "ON_FAILURE",
+        "max_retries": 10
+      },
+      "sleep": false,
+      "replicas": null,
+      "domains": {
+        "railway": [],
+        "custom": []
+      },
+      "volumes": [
+        {
+          "name": "pgvector-volume",
+          "mount": "/var/lib/postgresql/data/",
+          "size_mb": 50000
+        }
+      ],
+      "env_keys": [
+        "PGDATA",
+        "PGDATABASE",
+        "PGHOST",
+        "PGPASSWORD",
+        "PGPORT",
+        "PGUSER",
+        "POSTGRES_DB",
+        "POSTGRES_PASSWORD",
+        "POSTGRES_USER",
+        "DATABASE_PUBLIC_URL",
+        "DATABASE_URL"
+      ]
+    },
+    "Redis": {
+      "group": "data",
+      "source": {
+        "image": "redis:8.2.1"
+      },
+      "builder": "DOCKERFILE",
+      "dockerfile": null,
+      "start_command": "/bin/sh -c \"rm -rf $RAILWAY_VOLUME_MOUNT_PATH/lost+found/ && exec docker-entrypoint.sh redis-server --requirepass $REDIS_PASSWORD --save 60 1 --dir $RAILWAY_VOLUME_MOUNT_PATH\"",
+      "port": 6379,
+      "healthcheck": null,
+      "restart_policy": {
+        "type": "ON_FAILURE",
+        "max_retries": 10
+      },
+      "sleep": false,
+      "replicas": null,
+      "domains": {
+        "railway": [],
+        "custom": []
+      },
+      "volumes": [
+        {
+          "name": "redis-volume",
+          "mount": "/data",
+          "size_mb": 50000
+        }
+      ],
+      "env_keys": [
+        "REDISHOST",
+        "REDISPASSWORD",
+        "REDISPORT",
+        "REDISUSER",
+        "REDIS_PASSWORD",
+        "REDIS_PUBLIC_URL",
+        "REDIS_URL"
+      ]
+    },
+    "Qdrant": {
+      "group": "data",
+      "source": {
+        "image": "qdrant/qdrant"
+      },
+      "builder": "DOCKERFILE",
+      "dockerfile": null,
+      "start_command": null,
+      "port": 6333,
+      "healthcheck": null,
+      "restart_policy": {
+        "type": "ON_FAILURE",
+        "max_retries": 10
+      },
+      "sleep": false,
+      "replicas": null,
+      "domains": {
+        "railway": [
+          "qdrant-production-c691.up.railway.app"
+        ],
+        "custom": []
+      },
+      "volumes": [
+        {
+          "name": "qdrant-volume",
+          "mount": "/qdrant/storage",
+          "size_mb": 50000
+        }
+      ],
+      "env_keys": [
+        "PORT"
+      ]
+    },
+    "automatos-ai-landing": {
+      "group": "landing",
+      "source": {
+        "repo": "AutomatosAI/automatos-ai-landing"
+      },
+      "builder": "DOCKERFILE",
+      "dockerfile": "/Dockerfile",
+      "start_command": null,
+      "port": 80,
+      "healthcheck": null,
+      "restart_policy": {
+        "type": "ON_FAILURE",
+        "max_retries": 10
+      },
+      "sleep": false,
+      "replicas": null,
+      "domains": {
+        "railway": [],
+        "custom": [
+          "automatos.app"
+        ]
+      },
+      "volumes": [],
+      "env_keys": [
+        "CONTACT_EMAIL",
+        "SMTP_HOST",
+        "SMTP_PASS",
+        "SMTP_PORT",
+        "SMTP_USER",
+        "VITE_AUTOMATOS_WORKSPACE_ID",
+        "VITE_CLERK_PUBLISHABLE_KEY"
       ]
     }
   },
-
   "volumes_summary": {
-    "qdrant-volume":                    {"mount": "/qdrant/storage",             "service": "Qdrant",                    "size_mb": 50000},
-    "loki-volume":                      {"mount": "/loki",                       "service": "loki",                      "size_mb": 50000},
-    "pgvector-volume":                  {"mount": "/var/lib/postgresql/data/",   "service": "automatos-ai-pgvector",     "size_mb": 50000},
-    "agent-workspace-data":             {"mount": "/workspaces",                 "service": "agent-workspace-worker",    "size_mb": 50000},
-    "alertmanager-volume":              {"mount": "/alertmanager",               "service": "alertmanager",              "size_mb": 50000},
-    "prometheus-volume":                {"mount": "/prometheus",                 "service": "prometheus",                "size_mb": 50000},
-    "redis-volume":                     {"mount": "/data",                       "service": "Redis",                     "size_mb": 50000},
-    "automatos-ai-mem0-pgvector-volume":{"mount": "/var/lib/postgresql/data/",   "service": "automatos-ai-mem0-pgvector","size_mb": 50000},
-    "grafana-volume":                   {"mount": "/var/lib/grafana",            "service": "grafana",                   "size_mb": 50000}
+    "qdrant-volume": {
+      "mount": "/qdrant/storage",
+      "service": "Qdrant",
+      "size_mb": 50000
+    },
+    "loki-volume": {
+      "mount": "/loki",
+      "service": "loki",
+      "size_mb": 50000
+    },
+    "pgvector-volume": {
+      "mount": "/var/lib/postgresql/data/",
+      "service": "automatos-ai-pgvector",
+      "size_mb": 50000
+    },
+    "agent-workspace-data": {
+      "mount": "/workspaces",
+      "service": "agent-workspace-worker",
+      "size_mb": 50000
+    },
+    "alertmanager-volume": {
+      "mount": "/alertmanager",
+      "service": "alertmanager",
+      "size_mb": 50000
+    },
+    "prometheus-volume": {
+      "mount": "/prometheus",
+      "service": "prometheus",
+      "size_mb": 50000
+    },
+    "redis-volume": {
+      "mount": "/data",
+      "service": "Redis",
+      "size_mb": 50000
+    },
+    "automatos-ai-mem0-pgvector-volume": {
+      "mount": "/var/lib/postgresql/data/",
+      "service": "automatos-ai-mem0-pgvector",
+      "size_mb": 50000
+    },
+    "grafana-volume": {
+      "mount": "/var/lib/grafana",
+      "service": "grafana",
+      "size_mb": 50000
+    }
   },
-
   "network_topology": {
     "internal_dns": "*.railway.internal",
     "service_discovery": "Railway private networking — services reference each other via RAILWAY_SERVICE_<NAME>_URL env vars",
@@ -501,5 +874,6 @@
       "postgres-exporter",
       "redis-exporter"
     ]
-  }
+  },
+  "_builder_correction_2026-08-30": "railway.json is the truth: builder DOCKERFILE, dockerfileTarget production, for every service. This 2026-04-09 export said RAILPACK and misled the PRD-233 Docker slim pass into shipping the local edition's defaults to production (#650 -> Clerk outage -> #668). Dockerfile ARG defaults are production values; docker-compose.yml passes the local edition's choices explicitly."
 }

--- a/orchestrator/Dockerfile
+++ b/orchestrator/Dockerfile
@@ -34,11 +34,14 @@ COPY requirements.txt .
 # graphify.cluster documents its own fallback: "Tries Leiden (graspologic)
 # first… falls back to Louvain (built into networkx) if graspologic is not
 # installed", so the Knowledge Graph still clusters without it, at lower
-# partition quality. Local default: off. Want Leiden locally:
-#   docker compose build --build-arg INSTALL_GRAPH_EXTRAS=true backend
-# requirements.txt itself is UNCHANGED, so Railway (Railpack) still installs
-# the extra and SaaS clustering is untouched.
-ARG INSTALL_GRAPH_EXTRAS=false
+# partition quality.
+# THE DEFAULT IS THE PRODUCTION VALUE (true). Railway builds THIS file
+# (railway.json: builder DOCKERFILE, target production), so a Dockerfile default
+# is a production decision — a `false` here shipped degraded clustering to prod
+# on 2026-08-30 (#650). The local edition passes INSTALL_GRAPH_EXTRAS=false
+# explicitly via docker-compose.yml build args to stay slim; want Leiden
+# locally: docker compose build --build-arg INSTALL_GRAPH_EXTRAS=true backend
+ARG INSTALL_GRAPH_EXTRAS=true
 
 # futureagi is installed separately with --no-deps because it pins exact
 # versions of common packages (requests==2.32.3, pandas==2.2.2, etc.)

--- a/orchestrator/tests/test_dockerfile_prod_parity.py
+++ b/orchestrator/tests/test_dockerfile_prod_parity.py
@@ -1,0 +1,102 @@
+"""Dockerfile ARG defaults are PRODUCTION values; compose opts the local edition out.
+
+Railway builds the three Dockerfiles (railway.json: builder DOCKERFILE, target
+production). On 2026-08-30 a `NEXT_PUBLIC_AUTH_EDITION=local` default shipped the
+Clerk-less local edition to production (#650 -> #668), and the same slim pass
+left the graph-extras and browser installs defaulted OFF. This guard makes the
+rule mechanical: every build ARG with a default must be registered here with
+its production value, the local edition must pass its own choices explicitly in
+docker-compose.yml, and the deploy config must still say what we assume.
+"""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import yaml
+
+_ROOT = Path(__file__).resolve().parents[2]
+
+# Registered production defaults. Adding a defaulted ARG to a Dockerfile without
+# a row here fails on purpose: decide the PRODUCTION value first.
+PROD_DEFAULTS = {
+    "frontend/Dockerfile": {
+        "NEXT_PUBLIC_AUTH_EDITION": "saas",
+        "NEXT_PUBLIC_CLERK_SIGN_IN_URL": "/sign-in",
+        "NEXT_PUBLIC_CLERK_SIGN_UP_URL": "/sign-up",
+        "NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL": "/dashboard",
+        "NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL": "/dashboard",
+        "FRONTEND_CACHE_BUST": None,  # any value: a cache key, not behaviour
+    },
+    "orchestrator/Dockerfile": {"INSTALL_GRAPH_EXTRAS": "true"},
+    "services/workspace-worker/Dockerfile": {"INSTALL_BROWSER": "true"},
+}
+
+# What the LOCAL edition must pass explicitly (docker-compose.yml build args).
+LOCAL_BUILD_ARGS = {
+    "frontend": {"NEXT_PUBLIC_AUTH_EDITION": "local"},
+    "backend": {"INSTALL_GRAPH_EXTRAS": "false"},
+    "workspace-worker": {"INSTALL_BROWSER": "false"},
+}
+
+_ARG = re.compile(r"^ARG\s+([A-Z0-9_]+)(?:=(\S*))?\s*$", re.M)
+
+
+def _arg_defaults(dockerfile: str) -> dict[str, str]:
+    text = (_ROOT / dockerfile).read_text()
+    # `ARG NAME` (no default) matches with an empty group — that is NOT a default.
+    return {name: default for name, default in _ARG.findall(text) if default != ""}
+
+
+def test_every_defaulted_arg_is_registered_with_its_production_value():
+    for dockerfile, registered in PROD_DEFAULTS.items():
+        found = _arg_defaults(dockerfile)
+        unregistered = sorted(set(found) - set(registered))
+        assert not unregistered, (
+            f"{dockerfile}: ARG(s) {unregistered} have a default that is not registered in "
+            f"PROD_DEFAULTS — a Dockerfile default is a PRODUCTION decision (Railway builds this file)."
+        )
+        for name, expected in registered.items():
+            if expected is None or name not in found:
+                continue
+            assert found[name] == expected, (
+                f"{dockerfile}: ARG {name} defaults to {found[name]!r}; production requires {expected!r}. "
+                f"The local edition opts out in docker-compose.yml, never here."
+            )
+
+
+def test_the_local_edition_passes_its_choices_explicitly():
+    compose = yaml.safe_load((_ROOT / "docker-compose.yml").read_text())
+    for service, args in LOCAL_BUILD_ARGS.items():
+        build = compose["services"][service].get("build") or {}
+        got = {k: str(v) for k, v in (build.get("args") or {}).items()}
+        for name, expected in args.items():
+            assert name in got, f"docker-compose.yml: {service}.build.args must set {name} explicitly"
+            value = got[name]
+            # `${VAR:-local}` style is fine as long as the fallback is the local value.
+            assert expected in value, f"docker-compose.yml: {service}.build.args.{name}={value!r}, expected the local value {expected!r}"
+
+
+def test_deploy_config_builds_the_dockerfiles():
+    railway = json.loads((_ROOT / "railway.json").read_text())
+    assert railway["build"]["builder"] == "DOCKERFILE"
+    assert railway["build"]["dockerfileTarget"] == "production"
+    manifest = json.loads((_ROOT / "infrastructure" / "railway-manifest.json").read_text())
+    builders = set()
+
+    def walk(o):
+        if isinstance(o, dict):
+            if "builder" in o:
+                builders.add(o["builder"])
+            for v in o.values():
+                walk(v)
+        elif isinstance(o, list):
+            for v in o:
+                walk(v)
+
+    walk(manifest)
+    assert builders <= {"DOCKERFILE"}, (
+        f"infrastructure/railway-manifest.json declares builders {sorted(builders)} — the stale RAILPACK "
+        "claim caused the 2026-08-30 outage; railway.json (DOCKERFILE) is the truth"
+    )

--- a/services/workspace-worker/Dockerfile
+++ b/services/workspace-worker/Dockerfile
@@ -38,14 +38,16 @@ RUN useradd -m -u 1000 worker \
     && mkdir -p /workspaces \
     && chown -R worker:worker /app /workspaces
 
-# Headless Chromium for the workspace_html_to_png tool — OPT-IN (PRD-233 slim
-# pass). Chromium plus its X11/font stack is 1.18 GB, for one tool; installing
-# it in every local edition made the worker image 2.9 GB. Enable with:
-#   docker compose build --build-arg INSTALL_BROWSER=true workspace-worker
-# Without it the tool fails with Playwright's own "Executable doesn't exist"
-# message naming the install command — honest, not silent.
+# Headless Chromium for the workspace_html_to_png tool. THE DEFAULT IS THE
+# PRODUCTION VALUE (true): Railway builds THIS file (railway.json: builder
+# DOCKERFILE), so a `false` default here removed the browser from the prod
+# worker on 2026-08-30 (#650). The local edition passes INSTALL_BROWSER=false
+# explicitly via docker-compose.yml build args (Chromium + its X11/font stack
+# is 1.18 GB for one tool); without it the tool fails with Playwright's own
+# "Executable doesn't exist" message naming the install command — honest, not
+# silent. Want it locally: docker compose build --build-arg INSTALL_BROWSER=true workspace-worker
 # (Install deps manually: --with-deps fails on Debian Trixie due to renamed font pkgs.)
-ARG INSTALL_BROWSER=false
+ARG INSTALL_BROWSER=true
 ENV PLAYWRIGHT_BROWSERS_PATH=/opt/playwright-browsers
 RUN if [ "$INSTALL_BROWSER" = "true" ]; then \
         apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Root cause (owner asked for it)
The PRD-233 Docker slim pass assumed the three Dockerfiles were local-only because `infrastructure/railway-manifest.json` (a 2026-04 export) says every service uses RAILPACK. **`railway.json` says `builder: DOCKERFILE, dockerfileTarget: production`** — Railway builds these files. Three ARG defaults were set to the local edition's values: `NEXT_PUBLIC_AUTH_EDITION=local` (shipped the Clerk-less frontend to prod → #668 fixed), `INSTALL_GRAPH_EXTRAS=false` (prod Knowledge Graph clustering degraded to Louvain — **still live**), `INSTALL_BROWSER=false` (prod worker without Chromium — **still live**).

## Fix
- Backend and worker defaults back to production values; `docker-compose.yml` passes the local edition's slim choices explicitly as build args — the local install is unchanged (verified: rebuilt, ran, edition local, extras/browser absent by choice).
- Manifest corrected (19 × RAILPACK → DOCKERFILE) with a note on the incident.

## So it cannot happen again
- `tests/test_dockerfile_prod_parity.py`: every defaulted ARG must be registered with its production value; compose must pass the local values; `railway.json` must still say DOCKERFILE/production.
- CI lane `prod-image-parity` (non-required until the admin flips it): builds all three images **with no build args, exactly as Railway does**, and checks what got baked (edition literal = saas; `import graspologic` works; Chromium present).

## Test plan
- Guard tests green locally; compose guards green.
- Local: `docker compose build` → same slim images, stack healthy, `/team` still shows the local-edition notice.
- CI: the new lane builds the production images and asserts the three behaviours.