### PR TITLE
fix(prd-222): boom is refused until the workspace actually holds a build

### DIFF
--- a/orchestrator/modules/context/sections/onboarding.py
+++ b/orchestrator/modules/context/sections/onboarding.py
@@ -157,7 +157,9 @@ request the connections the setup needs through the chat connect card (never \
 auto-connect); for Shopify, the two-step honestly — connect now for store data, \
 then the Automatos app adds a Site under Settings → Widget SDK → sync. Narrate as \
 you go ("Created your Marketing helper — it's on your Agents page"). When the build \
-is complete and verified, advance_to `boom`.
+is complete and verified, advance_to `boom` — it is refused until the workspace \
+actually holds the build (an installed package, created agents, or a mission), so \
+never announce a team before it exists.
 """
 
 _STAGE_BOOM = """\

--- a/orchestrator/services/onboarding_state.py
+++ b/orchestrator/services/onboarding_state.py
@@ -202,6 +202,17 @@ def advance_onboarding_stage(
     current = doc.get("stage", INITIAL_STAGE)
     _validate_transition(current, to_stage)
 
+    # Honesty gate: the payoff stage needs a build to show. With no session
+    # (pure-document logic path) there is nothing to count against — the
+    # ordering validator alone applies, as before.
+    if to_stage == BUILD_EVIDENCE_STAGE and db is not None:
+        if not build_evidence(db, workspace)["any"]:
+            raise InvalidStageTransition(
+                "boom needs a build first: nothing is registered to this workspace "
+                "yet (no package installed, no agents created, no mission). Install "
+                "the matched package or create the agents, then advance to boom."
+            )
+
     # W1S2/US-002 funnel decision — the JSONB per-stage timestamps below ARE the
     # Wave-1 funnel record. There is no generic analytics/funnel event sink to
     # emit an ``onboarding_stage_changed`` event into: grepping
@@ -355,6 +366,65 @@ def onboarding_package_installed(workspace: Any) -> bool:
     """True once a package has been installed during THIS onboarding (D6 gate)."""
     doc = get_onboarding(workspace) or {}
     return bool((doc.get("funnel") or {}).get("package_installed"))
+
+
+# =========================================================================== #
+# Build evidence — the honesty gate on ``boom`` (live test 2026-08-29)
+# =========================================================================== #
+#
+# Two personas (Saffron, Waggle) reached the payoff stage having built NOTHING:
+# ``_validate_transition`` checks ordering only, so ``advance_to="boom"`` from
+# ``building`` always succeeded and Auto presented a team that did not exist.
+# ``boom`` is "here is your team" — it is reachable only once the workspace
+# actually holds a build. "Built" reuses the purge's definition
+# (``services.workspace_purge._AGENT_SURVIVOR_SQL``, inverted): a workspace-owned
+# agent that is neither a platform system agent nor a hidden onboarding-role
+# agent. The package funnel stamp and a mission (the larger-build path, which
+# awaits approval) count too. Read-only — no new table, no new stamp: only the
+# rows onboarding already writes.
+
+BUILD_EVIDENCE_STAGE = "boom"
+
+
+def build_evidence(db: Any, workspace: Any) -> dict[str, Any]:
+    """What this workspace holds that onboarding could have built.
+
+    Returns ``{package_installed, agents_built, missions, any}``. With ``db``
+    None (the pure-document logic path) the live counts are 0 and only the
+    funnel stamp can supply evidence.
+    """
+    package_installed = onboarding_package_installed(workspace)
+    agents_built = 0
+    missions = 0
+    workspace_id = getattr(workspace, "id", None)
+    if db is not None and workspace_id is not None:
+        from sqlalchemy import or_
+
+        from core.models.core import Agent
+        from core.models.orchestration import OrchestrationRun
+
+        agents_built = int(
+            db.query(Agent)
+            .filter(
+                Agent.workspace_id == workspace_id,
+                Agent.is_system_agent.isnot(True),
+                or_(Agent.required_role.is_(None), Agent.required_role != "onboarding"),
+            )
+            .count()
+            or 0
+        )
+        missions = int(
+            db.query(OrchestrationRun)
+            .filter(OrchestrationRun.workspace_id == workspace_id)
+            .count()
+            or 0
+        )
+    return {
+        "package_installed": bool(package_installed),
+        "agents_built": agents_built,
+        "missions": missions,
+        "any": bool(package_installed or agents_built or missions),
+    }
 
 
 # =========================================================================== #

--- a/orchestrator/tests/test_prd222_boom_build_evidence.py
+++ b/orchestrator/tests/test_prd222_boom_build_evidence.py
@@ -1,0 +1,203 @@
+"""PRD-222 honesty gate — ``boom`` requires build evidence.
+
+Live test 2026-08-29: two personas (Saffron, Waggle) advanced to the payoff
+stage having built NOTHING, because the stage machine validated ORDERING only.
+``boom`` is "here is your team", so it now needs the workspace to actually hold
+a build: the package funnel stamp, a built agent, or a mission.
+
+Pure-logic tests against a MagicMock session — no DB. The "built agent"
+definition is pinned to the purge's survivor predicate (a workspace-owned agent
+that is neither a system agent nor a hidden onboarding-role agent).
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+from core.models.core import Agent
+from core.models.orchestration import OrchestrationRun
+from modules.tools.discovery.handlers_onboarding import update_onboarding
+from services.onboarding_state import (
+    BUILD_EVIDENCE_STAGE,
+    InvalidStageTransition,
+    advance_onboarding_stage,
+    build_evidence,
+    current_stage,
+)
+
+_PACKAGE_STAMP = {"package_installed": {"slug": "shopify-management", "at": "2026-08-29T00:00:00Z"}}
+
+
+class _Workspace:
+    def __init__(self, stage: str = "building", funnel: dict | None = None):
+        self.id = uuid4()
+        self.onboarding = {"stage": stage, "stages": {}, "segment": {}}
+        if funnel:
+            self.onboarding["funnel"] = funnel
+
+
+def _db(agents: int = 0, missions: int = 0, workspace=None):
+    """MagicMock session with per-model ``.count()`` and a ``.first()`` for the
+    handler's workspace load. ``made`` keeps each query object so a test can
+    inspect the filter clauses it was given."""
+    counts = {Agent: agents, OrchestrationRun: missions}
+    db = MagicMock()
+    db.made = {}
+
+    def _query(model):
+        q = MagicMock()
+        q.filter.return_value.count.return_value = counts.get(model, 0)
+        q.filter.return_value.first.return_value = workspace
+        db.made[model] = q
+        return q
+
+    db.query.side_effect = _query
+    return db
+
+
+# --------------------------------------------------------------------------- #
+# State layer — the single writer refuses an empty payoff
+# --------------------------------------------------------------------------- #
+
+
+def test_gate_is_on_boom():
+    assert BUILD_EVIDENCE_STAGE == "boom"
+
+
+def test_boom_refused_when_nothing_was_built():
+    ws = _Workspace("building")
+    with pytest.raises(InvalidStageTransition, match="needs a build"):
+        advance_onboarding_stage(_db(0, 0), ws, "boom")
+    assert current_stage(ws) == "building"  # nothing written
+
+
+def test_boom_allowed_on_the_package_funnel_stamp():
+    ws = _Workspace("building", funnel=_PACKAGE_STAMP)
+    advance_onboarding_stage(_db(0, 0), ws, "boom")
+    assert current_stage(ws) == "boom"
+
+
+def test_boom_allowed_on_a_built_agent():
+    ws = _Workspace("building")
+    advance_onboarding_stage(_db(agents=1), ws, "boom")
+    assert current_stage(ws) == "boom"
+
+
+def test_boom_allowed_on_a_mission():
+    ws = _Workspace("building")
+    advance_onboarding_stage(_db(missions=1), ws, "boom")
+    assert current_stage(ws) == "boom"
+
+
+def test_other_stages_never_consult_evidence():
+    ws = _Workspace("proposal")
+    db = _db(0, 0)
+    advance_onboarding_stage(db, ws, "building")
+    assert current_stage(ws) == "building"
+    assert Agent not in db.made and OrchestrationRun not in db.made
+
+
+def test_pure_document_path_keeps_ordering_only():
+    # db=None is the logic-test path: no session to count against, so the
+    # ordering validator alone applies, exactly as before this gate.
+    ws = _Workspace("building")
+    advance_onboarding_stage(None, ws, "boom")
+    assert current_stage(ws) == "boom"
+
+
+def test_ordering_still_validated_before_evidence():
+    # A backward move is refused for ordering, never reaches the evidence read.
+    ws = _Workspace("boom")
+    db = _db(agents=5)
+    with pytest.raises(InvalidStageTransition, match="non-forward"):
+        advance_onboarding_stage(db, ws, "building")
+    assert Agent not in db.made
+
+
+# --------------------------------------------------------------------------- #
+# The evidence read — shape + the "built agent" definition
+# --------------------------------------------------------------------------- #
+
+
+def test_build_evidence_shape():
+    ws = _Workspace("building")
+    assert build_evidence(_db(agents=2, missions=1), ws) == {
+        "package_installed": False,
+        "agents_built": 2,
+        "missions": 1,
+        "any": True,
+    }
+    assert build_evidence(_db(0, 0), ws)["any"] is False
+    assert build_evidence(None, _Workspace("building", funnel=_PACKAGE_STAMP)) == {
+        "package_installed": True,
+        "agents_built": 0,
+        "missions": 0,
+        "any": True,
+    }
+
+
+def test_built_agent_definition_matches_the_purge_survivor_predicate():
+    """Scoped to the workspace; excludes system agents and onboarding-role agents
+    (NULL-safe, like ``workspace_purge._AGENT_SURVIVOR_SQL``)."""
+    ws = _Workspace("building")
+    db = _db(agents=1)
+    build_evidence(db, ws)
+    clauses = " | ".join(str(c) for c in db.made[Agent].filter.call_args.args).lower()
+    assert "agents.workspace_id" in clauses
+    assert "agents.is_system_agent is not true" in clauses
+    assert "agents.required_role is null" in clauses
+    assert "agents.required_role !=" in clauses
+    mission_clauses = " | ".join(
+        str(c) for c in db.made[OrchestrationRun].filter.call_args.args
+    ).lower()
+    assert "orchestration_runs.workspace_id" in mission_clauses
+
+
+# --------------------------------------------------------------------------- #
+# Tool handler — the refusal reaches Auto as a clean, honest error
+# --------------------------------------------------------------------------- #
+
+
+def test_handler_returns_the_honest_error_and_moves_nothing():
+    ws = _Workspace("building")
+    db = _db(0, 0, workspace=ws)
+    res = asyncio.run(update_onboarding(db, ws.id, {"advance_to": "boom"}))
+    assert res["success"] is False
+    assert "needs a build" in res["error"]
+    assert "package" in res["error"] and "agents" in res["error"]
+    assert current_stage(ws) == "building"
+    db.rollback.assert_called_once()
+    db.commit.assert_not_called()
+
+
+def test_handler_advances_to_boom_once_a_package_is_installed():
+    ws = _Workspace("building", funnel=_PACKAGE_STAMP)
+    db = _db(0, 0, workspace=ws)
+    res = asyncio.run(update_onboarding(db, ws.id, {"advance_to": "boom"}))
+    assert res["success"] is True
+    assert res["data"]["stage"] == "boom"
+    db.commit.assert_called_once()
+
+
+def test_handler_advances_to_boom_on_built_agents():
+    ws = _Workspace("building")
+    res = asyncio.run(
+        update_onboarding(_db(agents=3, workspace=ws), ws.id, {"advance_to": "boom"})
+    )
+    assert res["success"] is True and res["data"]["stage"] == "boom"
+
+
+# --------------------------------------------------------------------------- #
+# Prompt — Auto is told the rule up front
+# --------------------------------------------------------------------------- #
+
+
+def test_building_prompt_states_the_refusal():
+    from modules.context.sections.onboarding import _STAGE_BUILDING
+
+    low = _STAGE_BUILDING.lower()
+    assert "refused until the workspace" in low
+    assert "never announce a team before it exists" in low


### PR DESCRIPTION
## What was broken

`advance_onboarding_stage` validated **ordering only**. `advance_to="boom"` from `building` always succeeded, whatever the workspace held. In the 2026-08-29 live persona run, Saffron and Waggle reached the payoff stage with nothing built and Auto presented a team that did not exist (the last member of that evening's honesty family, see the onboarding handoff).

## Fix

Inside the single stage writer, `services/onboarding_state.py`:

- `build_evidence(db, workspace)` — read-only: the package funnel stamp, the count of **built** agents using the purge's own definition (workspace-owned, `is_system_agent IS NOT TRUE`, `required_role IS DISTINCT FROM 'onboarding'`, NULL-safe), and the mission count (the larger-build path, which awaits approval). No new table, no new stamp.
- `advance_onboarding_stage` raises `InvalidStageTransition` for `boom` when the evidence is empty. The `platform_update_onboarding` handler already maps that to `success: False` with the message, so Auto is told *what to do* rather than blocked silently. The pure-document path (`db=None`, logic tests) is untouched.
- `_STAGE_BUILDING` states the rule up front so Auto does not spend a turn discovering it.

## Tests

`orchestrator/tests/test_prd222_boom_build_evidence.py`:
- refused with nothing built, stage unchanged, session rolled back
- allowed on the package stamp / a built agent / a mission
- other stages never consult evidence; ordering is still validated first
- the "built agent" filter is pinned to the purge survivor predicate
- handler returns the honest error; prompt carries the rule

## Verification

CI only (nothing runs locally per workspace convention). No new settings (config-surface guard unaffected), no new routes.

## Merge

Under the merge freeze: **do not auto-merge** — Gerard's call.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Onboarding now requires verifiable build progress—such as an installed package, created agent, or mission—before advancing to the final “boom” stage.
  * Onboarding guidance now avoids announcing a team before it has actually been created.

* **Bug Fixes**
  * Prevented onboarding from reporting successful advancement when no build evidence exists.
  * Added honest error handling and rollback when the advancement requirement is not met.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->