### PR TITLE
fix(prd-222): onboarding tool survives the argument shapes the model sends — the not_started freeze

### DIFF
--- a/orchestrator/modules/tools/discovery/actions_onboarding.py
+++ b/orchestrator/modules/tools/discovery/actions_onboarding.py
@@ -109,9 +109,10 @@ def register_onboarding_actions(registry: ActionRegistry) -> None:
                         },
                     },
                     "description": (
-                        "The onboarding answers — business, goal, comfort, and "
-                        "optional team_size. Any subset may be supplied; keys are "
-                        "merged into onboarding state. Omit to only advance."
+                        "The onboarding answers as a JSON object — business, goal, "
+                        "comfort, and optional team_size. Pass an object, never a "
+                        "string. Any subset may be supplied; keys are merged into "
+                        "onboarding state. Omit to only advance."
                     ),
                 },
                 "plan": {

--- a/orchestrator/modules/tools/discovery/handlers_onboarding.py
+++ b/orchestrator/modules/tools/discovery/handlers_onboarding.py
@@ -5,14 +5,16 @@ of the stage machine — and returns the client-safe ``{stage, trial}`` snapshot
 Invalid transitions are returned as clear errors, never raised as crashes.
 """
 
+import json
 import logging
-from typing import Any, Dict
+from typing import Any, Dict, List, Optional, Tuple
 from uuid import UUID
 
 from sqlalchemy.orm import Session
 
 from core.models.workspaces import Workspace
 from services.onboarding_state import (
+    ALL_STAGES,
     SEGMENT_KEYS,
     InvalidStageTransition,
     advance_onboarding_stage,
@@ -24,6 +26,82 @@ from services.onboarding_state import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _usable_segment(segment: Any) -> Optional[Dict[str, Any]]:
+    """The segment as a dict carrying at least one recognised key, else None.
+
+    A JSON-encoded string is parsed first: Gemini 2.5 Flash on prod stringifies
+    the nested ``segment`` object often enough to matter (live-test 2026-09-02).
+    """
+    if isinstance(segment, str):
+        try:
+            segment = json.loads(segment)
+        except ValueError:
+            return None
+    if isinstance(segment, dict) and any(segment.get(k) is not None for k in SEGMENT_KEYS):
+        return segment
+    return None
+
+
+def _normalise_params(params: Any) -> Tuple[Dict[str, Any], List[str]]:
+    """Coerce the LLM-supplied argument shapes seen in prod into the schema's.
+
+    Returns a NEW dict (the input is never mutated) plus notes of what was
+    coerced or dropped — types and keys only, never user text — for the
+    handler to log. The shapes, all observed on prod 2026-09-02 (Gemini 2.5
+    Flash) while a workspace sat frozen at ``not_started``:
+
+    * ``segment`` as a JSON-encoded string          -> parsed;
+    * the answers flat at top level
+      (business/goal/comfort/team_size)            -> folded into ``segment``;
+    * ``value`` carrying a stage name instead of
+      ``advance_to`` (the enum under the wrong key;
+      INFERRED from ``keys=['value', 'segment']``)  -> ``advance_to``, only when
+      it names a real stage;
+    * ``advance_to`` / ``plan`` with stray case or
+      whitespace ('Teach', ' Basic ')               -> lower-cased.
+
+    Anything still unusable is dropped with a note; the honest "at least one
+    is required" error then applies (2026-08-29 rule: a junk segment must never
+    fail a call that also carries a valid advance).
+    """
+    src = params if isinstance(params, dict) else {}
+    out: Dict[str, Any] = dict(src)
+    notes: List[str] = []
+
+    value = out.pop("value", None)
+    if not out.get("advance_to") and isinstance(value, str) and value.strip().lower() in ALL_STAGES:
+        out["advance_to"] = value.strip().lower()
+        notes.append("advance_to taken from 'value'")
+    elif value is not None:
+        notes.append(f"'value' ignored (type={type(value).__name__})")
+
+    advance_to = out.get("advance_to")
+    if isinstance(advance_to, str) and advance_to != advance_to.strip().lower():
+        out["advance_to"] = advance_to.strip().lower()
+        notes.append("advance_to case/whitespace normalised")
+
+    raw_segment = out.get("segment")
+    usable = _usable_segment(raw_segment)
+    if isinstance(raw_segment, str) and usable is not None:
+        notes.append("segment parsed from a JSON string")
+    flat = {k: out.pop(k) for k in SEGMENT_KEYS if out.get(k) is not None}
+    if flat:
+        notes.append(f"segment keys arrived flat: {sorted(flat)}")
+        usable = {**(usable or {}), **flat}
+    if raw_segment is not None and usable is None:
+        shape = f"type={type(raw_segment).__name__}"
+        if isinstance(raw_segment, dict):
+            shape += f", keys={sorted(map(str, raw_segment))[:6]}"
+        notes.append(f"segment carries nothing usable ({shape}) — dropped")
+    out["segment"] = usable
+
+    plan = out.get("plan")
+    if isinstance(plan, str) and plan != plan.strip().lower():
+        out["plan"] = plan.strip().lower()
+        notes.append("plan case/whitespace normalised")
+    return out, notes
 
 
 async def update_onboarding(
@@ -38,29 +116,21 @@ async def update_onboarding(
     to the proposal stamps ``plan_recommended``. Returns ``{success, data:
     {stage, trial}}``.
     """
+    # Argument shapes are external data (LLM-supplied) — coerced at this
+    # boundary, never assumed. 2026-08-29: a bare-string segment used to fail
+    # the whole call ("'str' object has no attribute 'get'", every onboarding
+    # stuck at teach); an unusable one is dropped, a valid advance proceeds.
+    # 2026-09-02: the shapes below froze a workspace at not_started — the model
+    # sent the stage under 'value' with a stringified segment, was told "at least
+    # one is required", retried identically and narrated on with nothing
+    # recorded. Every coercion or drop is a WARNING naming the shape (types and
+    # keys only, never the user's text) so the next variant names itself.
+    params, notes = _normalise_params(params)
+    if notes:
+        logger.warning("[update_onboarding] argument shape coerced: %s", "; ".join(notes))
     advance_to = params.get("advance_to")
     segment = params.get("segment")
     plan = params.get("plan")
-
-    # Normalize an UNUSABLE segment to absent (live-test 2026-08-29). ``segment``
-    # is LLM-supplied: it arrives as a bare string, or a dict of unrecognized
-    # keys, often enough to matter. ``_clean_segment`` already tolerates that at
-    # the state layer, but ``set_segment`` deliberately RAISES when nothing
-    # recognised survives (so a no-op write can't masquerade as a saved answer) —
-    # and the handler routed such calls straight into it, failing the whole tool
-    # call with "set_segment requires at least one of business/goal/comfort".
-    # Observed in prod paired with a same-stage advance: the advance is dropped
-    # as a no-op, then the junk segment raises, so a benign call errors.
-    # Treating unusable as absent makes each path correct: advance proceeds,
-    # a same-stage no-op returns success, and a call carrying NOTHING usable
-    # gets the honest "at least one is required" message below instead of an
-    # internal function name.
-    if segment is not None and not (
-        isinstance(segment, dict)
-        and any(segment.get(k) is not None for k in SEGMENT_KEYS)
-    ):
-        logger.info("[update_onboarding] segment carries nothing usable — ignoring")
-        segment = None
 
     if not advance_to and not segment and not plan:
         return {
@@ -96,11 +166,17 @@ async def update_onboarding(
         from services.plan_tiers import is_assignable
 
         if not is_assignable(plan):
+            # Honest copy: only enterprise is "coming soon"; anything else is not
+            # a tier at all (live-test 2026-09-02: 'Basic' was answered with
+            # "Enterprise is coming soon" — case is forgiven above, so this
+            # branch now only sees genuine non-tiers).
             return {
                 "success": False,
                 "error": (
-                    f"'{plan}' can't be assigned yet — Enterprise is coming soon. "
+                    "'enterprise' can't be assigned yet — Enterprise is coming soon. "
                     "Choose basic, pro, or business."
+                    if plan == "enterprise"
+                    else f"'{plan}' isn't a plan tier — choose basic, pro, or business."
                 ),
             }
 

--- a/orchestrator/tests/test_prd222_onboarding_tool_arg_shapes.py
+++ b/orchestrator/tests/test_prd222_onboarding_tool_arg_shapes.py
@@ -1,0 +1,170 @@
+"""PRD-222 — platform_update_onboarding survives the argument shapes the model
+actually sends (live-test 2026-09-02, prod, Gemini 2.5 Flash).
+
+The not_started freeze, trace-backed: the model called the spine tool with
+``keys=['value', 'segment']`` — the stage name under the wrong key and a
+stringified segment — was told "at least one is required", retried
+identically (dedup-skipped) and narrated on with nothing recorded. The same
+run answered a plan of 'Basic' with "Enterprise is coming soon".
+
+Pure normaliser tests + handler tests against a MagicMock session — no DB.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from modules.tools.discovery.handlers_onboarding import _normalise_params, update_onboarding
+
+_LOGGER = "modules.tools.discovery.handlers_onboarding"
+
+
+class _FakeWorkspace:
+    def __init__(self, stage: str = "not_started"):
+        self.id = uuid4()
+        self.onboarding = {"stage": stage, "stages": {}, "segment": {}}
+        self.plan = None
+        self.plan_limits = {}
+
+
+def _db_returning(workspace):
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = workspace
+    return db
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# --------------------------------------------------------------------------- #
+# The normaliser — pure, returns a new dict, names every coercion
+# --------------------------------------------------------------------------- #
+
+
+def test_normaliser_returns_a_new_dict_and_never_mutates_input():
+    params = {"segment": json.dumps({"comfort": "novice"}), "value": "teach", "plan": " Basic "}
+    before = dict(params)
+    out, notes = _normalise_params(params)
+    assert params == before and out is not params
+    assert out["advance_to"] == "teach"
+    assert out["segment"] == {"comfort": "novice"}
+    assert out["plan"] == "basic"
+    assert "value" not in out
+    assert len(notes) == 3  # every coercion is named
+
+
+def test_normaliser_value_only_counts_when_it_names_a_stage():
+    out, notes = _normalise_params({"value": "banana"})
+    assert "advance_to" not in out and "value" not in out
+    assert any("'value' ignored" in n for n in notes)
+    out, _ = _normalise_params({"advance_to": "proposal", "value": "teach"})
+    assert out["advance_to"] == "proposal"  # an explicit advance_to always wins
+
+
+def test_normaliser_folds_flat_answer_keys_into_segment():
+    out, notes = _normalise_params({"business": "a barber shop", "goal": "bookings"})
+    assert out["segment"] == {"business": "a barber shop", "goal": "bookings"}
+    assert "business" not in out and "goal" not in out
+    assert any("arrived flat" in n for n in notes)
+
+
+def test_normaliser_drops_junk_segment_with_a_shape_note_and_no_user_text():
+    out, notes = _normalise_params({"segment": "We are Lumen & Lark, a jewellery brand"})
+    assert out["segment"] is None
+    note = next(n for n in notes if "nothing usable" in n)
+    assert "type=str" in note and "Lumen" not in note
+    out, notes = _normalise_params({"segment": {"industry": "dental", "notes": "x"}})
+    assert out["segment"] is None
+    assert "keys=['industry', 'notes']" in next(n for n in notes if "nothing usable" in n)
+
+
+def test_normaliser_lowercases_advance_to():
+    out, notes = _normalise_params({"advance_to": "Teach "})
+    assert out["advance_to"] == "teach"
+    assert any("advance_to case" in n for n in notes)
+
+
+def test_normaliser_tolerates_non_dict_params():
+    out, notes = _normalise_params("garbage")
+    assert not out.get("advance_to") and out.get("segment") is None and notes == []
+
+
+# --------------------------------------------------------------------------- #
+# Handler — the shapes that froze prod now record, junk is still honest
+# --------------------------------------------------------------------------- #
+
+
+def test_handler_records_a_json_string_segment():
+    ws = _FakeWorkspace("questions")
+    res = _run(update_onboarding(_db_returning(ws), ws.id, {"segment": json.dumps({"comfort": "novice"})}))
+    assert res["success"] is True
+    assert ws.onboarding["segment"]["comfort"] == "novice"
+
+
+def test_handler_advances_when_the_stage_arrives_under_value():
+    # The exact prod shape: keys=['value', 'segment'] with an unusable segment.
+    ws = _FakeWorkspace("questions")
+    res = _run(update_onboarding(_db_returning(ws), ws.id, {"value": "teach", "segment": "junk"}))
+    assert res["success"] is True
+    assert res["data"]["stage"] == "teach"
+
+
+def test_handler_folds_flat_answers():
+    ws = _FakeWorkspace("not_started")
+    res = _run(update_onboarding(_db_returning(ws), ws.id, {"business": "a barber shop in Leeds"}))
+    assert res["success"] is True
+    assert ws.onboarding["segment"]["business"] == "a barber shop in Leeds"
+
+
+def test_handler_junk_segment_alone_is_still_the_honest_error_and_is_logged(caplog):
+    ws = _FakeWorkspace("not_started")
+    with caplog.at_level(logging.WARNING, logger=_LOGGER):
+        res = _run(update_onboarding(_db_returning(ws), ws.id, {"segment": "We are Lumen & Lark"}))
+    assert res["success"] is False
+    assert "at least one is required" in res["error"]
+    warned = [r.getMessage() for r in caplog.records if "argument shape coerced" in r.getMessage()]
+    assert warned and "type=str" in warned[0]
+    assert "Lumen" not in warned[0]  # never the user's text
+
+
+def test_handler_is_silent_when_the_shape_is_already_right(caplog):
+    ws = _FakeWorkspace("not_started")
+    with caplog.at_level(logging.WARNING, logger=_LOGGER):
+        res = _run(update_onboarding(_db_returning(ws), ws.id, {"advance_to": "questions"}))
+    assert res["success"] is True
+    assert not [r for r in caplog.records if "argument shape coerced" in r.getMessage()]
+
+
+def test_handler_plan_case_is_forgiven():
+    ws = _FakeWorkspace("proposal")
+    res = _run(update_onboarding(_db_returning(ws), ws.id, {"plan": " Basic "}))
+    assert res["success"] is True
+    assert ws.plan == "basic"
+
+
+def test_handler_enterprise_copy_is_only_for_enterprise():
+    ws = _FakeWorkspace("proposal")
+    res = _run(update_onboarding(_db_returning(ws), ws.id, {"plan": "Gold"}))
+    assert res["success"] is False
+    assert "isn't a plan tier" in res["error"] and "coming soon" not in res["error"]
+    res = _run(update_onboarding(_db_returning(ws), ws.id, {"plan": "Enterprise"}))
+    assert res["success"] is False and "coming soon" in res["error"]
+
+
+# --------------------------------------------------------------------------- #
+# Schema — the model is told an object, never a string
+# --------------------------------------------------------------------------- #
+
+
+def test_schema_says_object_never_string():
+    from modules.tools.discovery.action_registry import ActionRegistry
+    from modules.tools.discovery.actions_onboarding import register_onboarding_actions
+
+    reg = ActionRegistry()
+    register_onboarding_actions(reg)
+    desc = reg._actions["platform_update_onboarding"].parameters["properties"]["segment"]["description"].lower()
+    assert "json object" in desc and "never a string" in desc


### PR DESCRIPTION
## The freeze, trace-backed

Reproduced on prod 2026-09-02 12:11 (persona run, #662 logging live). Stage frozen at `not_started` while Auto recited the three questions:

| turn | what the API logged |
|---|---|
| 1, 2 | text only, no tool call |
| 3 | `LLM_CALL … input_tokens=0 output_tokens=0 status=success` → `content_length: 0, finish_reason: stop` — an **empty completion streamed as nothing** (separate finding, not fixed here) |
| 4 | `execute_and_format tool=platform_update_onboarding args=dict keys=['value', 'segment']` → `segment carries nothing usable` → `"Provide advance_to, segment, or plan — at least one is required."` → identical retry **dedup-skipped** → Auto narrates a proposal with nothing recorded |

A third run the same minute needed three failed calls (`segment carries nothing usable`) before one landed. A snip run was refused `plan='Basic'` with *"Enterprise is coming soon"*.

Tool parameters are recorded as key names only (`telemetry.py` stores `{"keys": [...]}`), so the values are inferred from the keys: the stage name under `value`, the segment as a string.

## Fix — at the boundary, in `handlers_onboarding.py`

- `_normalise_params(params)` — pure, returns a **new** dict plus notes:
  - `segment` as a JSON-encoded string → parsed
  - answers flat at top level (`business/goal/comfort/team_size`) → folded into `segment`
  - `value` carrying a real stage name and no `advance_to` → `advance_to` (INFERRED shape; guarded by `ALL_STAGES`)
  - `advance_to` / `plan` case and whitespace forgiven
  - anything still unusable is dropped so a valid advance in the same call proceeds (the 2026-08-29 rule stands)
- Every coercion or drop is a **WARNING** naming the shape — types and keys only, never user text.
- Plan error copy is honest: only `enterprise` is "coming soon"; anything else "isn't a plan tier".
- `actions_onboarding.py`: the `segment` description says *a JSON object, never a string*.

No new settings, no new routes, no schema shape change (the enum and `required: []` are untouched).

## Not in this PR

The empty completion (turn 3): `generate_response` returned zero tokens with `finish_reason: stop` and the chat service streamed it as a successful empty turn. That is a chat-pipeline retry/surface decision and is reported separately.

## Tests

`orchestrator/tests/test_prd222_onboarding_tool_arg_shapes.py` — normaliser (immutability, every shape, no user text in notes), handler (the exact prod shape advances; junk alone is still the honest error and is logged; silent when the shape is right; plan case; enterprise copy), schema wording.

## Verification

CI only (nothing runs locally per workspace convention).

## Merge

Under the merge freeze: **do not auto-merge** — Gerard's call.
