### PR TITLE
fix(prd-222): empty completions retry then speak; unknown model id names the way out

### DIFF
--- a/orchestrator/consumers/chatbot/empty_completion.py
+++ b/orchestrator/consumers/chatbot/empty_completion.py
@@ -1,0 +1,39 @@
+"""Empty completions — the provider returned nothing and the turn streamed blank.
+
+Live test 2026-09-02 (prod, Gemini 2.5 Flash via OpenRouter): mid-onboarding the
+LLM call logged ``input_tokens=0 output_tokens=0 status=success`` with
+``content_length: 0, finish_reason: stop`` and the chat service streamed it as a
+successful turn — to the user, Auto went silent. Two of ~60 turns that day.
+Policy: retry once, then an honest sentence. Never a blank.
+"""
+from __future__ import annotations
+
+import dataclasses
+from typing import Any
+
+EMPTY_COMPLETION_FALLBACK = (
+    "I didn't get a response through that time — could you send that again?"
+)
+
+
+def is_empty_completion(response: Any) -> bool:
+    """True when the model produced neither text nor a tool call."""
+    if response is None:
+        return True
+    if getattr(response, "tool_calls", None):
+        return False
+    return not (getattr(response, "content", None) or "").strip()
+
+
+def with_fallback_content(response: Any) -> Any:
+    """A COPY of ``response`` carrying the fallback sentence — never mutated in place."""
+    if response is None:
+        from core.llm.clients.base import LLMResponse
+
+        return LLMResponse(content=EMPTY_COMPLETION_FALLBACK, finish_reason="empty_completion")
+    if dataclasses.is_dataclass(response):
+        return dataclasses.replace(response, content=EMPTY_COMPLETION_FALLBACK)
+    clone = type(response).__new__(type(response))
+    clone.__dict__.update(getattr(response, "__dict__", {}))
+    clone.content = EMPTY_COMPLETION_FALLBACK
+    return clone

--- a/orchestrator/consumers/chatbot/service.py
+++ b/orchestrator/consumers/chatbot/service.py
@@ -59,6 +59,8 @@ from services.page_context import (
     page_actions_from_context as _page_actions_from_context,
 )
 
+from consumers.chatbot.empty_completion import is_empty_completion, with_fallback_content
+
 logger = logging.getLogger(__name__)
 
 # PRD-157 S3: token budget for a single tool result fed back into the LLM loop
@@ -2428,6 +2430,16 @@ class StreamingChatService:
             response = await agent_runtime.llm_manager.generate_response(
                 messages=llm_messages, tools=use_tools,
             )
+            if is_empty_completion(response):
+                # Live-test 2026-09-02: zero tokens, finish_reason=stop, streamed as
+                # a successful blank turn mid-onboarding. Retry once, then say so.
+                logger.warning("[chat] empty completion (no text, no tool calls) — retrying once")
+                response = await agent_runtime.llm_manager.generate_response(
+                    messages=llm_messages, tools=use_tools,
+                )
+                if is_empty_completion(response):
+                    logger.error("[chat] empty completion twice — streaming the fallback sentence")
+                    response = with_fallback_content(response)
 
             logger.info(
                 f"Agent LLM Response - has_tool_calls: {bool(response.tool_calls)}, "

--- a/orchestrator/modules/tools/discovery/handlers_agents.py
+++ b/orchestrator/modules/tools/discovery/handlers_agents.py
@@ -219,9 +219,16 @@ async def create_agent(db: Session, workspace_id: UUID, params: Dict[str, Any]) 
 
         resolved = _get_or_create_from_cache(db, model_id)
         if resolved is None:
+            # Live-test 2026-08-29 + 09-02: Auto asked for a model id that is not
+            # in the catalog and retried the SAME id three times — the error named
+            # the problem but not the way out. Name it.
             return {
                 "success": False,
-                "error": f"Unknown model '{model_id}' — not found in the model catalog",
+                "error": (
+                    f"Unknown model '{model_id}' — not found in the model catalog. "
+                    f"Omit model_id to use the workspace default "
+                    f"({model_config.get('model_id')}), or install the model first."
+                ),
             }
         allowed, reason = check_model_for_agent(
             db, workspace_id, model_id, orchestrator_seat=False,

--- a/orchestrator/tests/test_prd222_empty_completion.py
+++ b/orchestrator/tests/test_prd222_empty_completion.py
@@ -1,0 +1,47 @@
+"""PRD-222 — an empty completion never streams as a blank turn (live-test 2026-09-02)."""
+from __future__ import annotations
+
+import pathlib
+from types import SimpleNamespace
+
+from consumers.chatbot.empty_completion import (
+    EMPTY_COMPLETION_FALLBACK,
+    is_empty_completion,
+    with_fallback_content,
+)
+from core.llm.clients.base import LLMResponse
+
+
+def test_empty_when_neither_text_nor_tool_calls():
+    assert is_empty_completion(LLMResponse(content=""))
+    assert is_empty_completion(LLMResponse(content="   \n"))
+    assert is_empty_completion(LLMResponse(content=None))
+    assert is_empty_completion(None)
+
+
+def test_not_empty_with_text_or_a_tool_call():
+    assert not is_empty_completion(LLMResponse(content="hello"))
+    assert not is_empty_completion(LLMResponse(content="", tool_calls=[{"id": "t1"}]))
+
+
+def test_fallback_is_a_copy_carrying_the_sentence():
+    r = LLMResponse(content="", finish_reason="stop", model="google/gemini-2.5-flash")
+    out = with_fallback_content(r)
+    assert out is not r and r.content == ""            # never mutated in place
+    assert out.content == EMPTY_COMPLETION_FALLBACK
+    assert out.model == "google/gemini-2.5-flash"      # everything else preserved
+    assert not is_empty_completion(out)
+
+
+def test_fallback_handles_none_and_plain_objects():
+    assert with_fallback_content(None).content == EMPTY_COMPLETION_FALLBACK
+    r = SimpleNamespace(content="", tool_calls=None)
+    out = with_fallback_content(r)
+    assert out.content == EMPTY_COMPLETION_FALLBACK and r.content == ""
+
+
+def test_chat_service_retries_once_then_falls_back():
+    src = (pathlib.Path(__file__).resolve().parents[1] / "consumers/chatbot/service.py").read_text()
+    assert "if is_empty_completion(response):" in src
+    assert "retrying once" in src
+    assert "response = with_fallback_content(response)" in src

--- a/orchestrator/tests/test_prd222_unknown_model_error_names_the_way_out.py
+++ b/orchestrator/tests/test_prd222_unknown_model_error_names_the_way_out.py
@@ -1,0 +1,18 @@
+"""PRD-222 — an unknown model id on agent creation names the way out (live-test 2026-09-02)."""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import api.llm_marketplace as marketplace
+from modules.tools.discovery.handlers_agents import create_agent
+
+
+def test_unknown_model_error_points_at_the_default(monkeypatch):
+    monkeypatch.setattr(marketplace, "_get_or_create_from_cache", lambda db, model_id: None)
+    res = asyncio.run(create_agent(MagicMock(), uuid4(), {"name": "Booking Assistant", "model_id": "anthropic/claude-sonnet-4-20250514"}))
+    assert res["success"] is False
+    assert "not found in the model catalog" in res["error"]
+    assert "Omit model_id" in res["error"]
+    assert "workspace default (" in res["error"]


### PR DESCRIPTION
## Two onboarding failures from the 2026-09-02 live runs

**1. Empty completion streamed as a blank turn** (lumen 11:11Z, snip 12:17Z). Prod logged `LLM_CALL … input_tokens=0 output_tokens=0 status=success` → `content_length: 0, finish_reason: stop`, and the chat service streamed it as a successful turn — Auto went silent mid-onboarding. Fix: `consumers/chatbot/empty_completion.py` (`is_empty_completion`, `with_fallback_content` — a copy, never mutated in place); `service.py` retries `generate_response` once (WARNING), then streams an honest sentence (ERROR) instead of nothing.

**2. Unknown model id on agent creation** (three runs across 08-29/09-02). Auto asked for `anthropic/claude-sonnet-4-20250514`, was told *not found in the model catalog*, and retried the same id three times. The error now names the exit: omit `model_id` to use the workspace default (named), or install the model first.

## Tests
`test_prd222_empty_completion.py` (helper semantics, copy-not-mutate, service wiring guard) · `test_prd222_unknown_model_error_names_the_way_out.py` (handler error text with the registry lookup stubbed).

## Verification
CI only. No settings, no routes.

## Merge
Under the merge freeze — Gerard's call.