### PR TITLE
fix(prd-222): recorded answers move the onboarding stage; the payoff gate cannot be skipped around

### DIFF
--- a/orchestrator/modules/tools/discovery/handlers_onboarding.py
+++ b/orchestrator/modules/tools/discovery/handlers_onboarding.py
@@ -15,6 +15,7 @@ from sqlalchemy.orm import Session
 from core.models.workspaces import Workspace
 from services.onboarding_state import (
     ALL_STAGES,
+    INITIAL_STAGE,
     QUESTION_KEYS,
     SEGMENT_KEYS,
     InvalidStageTransition,
@@ -186,7 +187,9 @@ async def update_onboarding(
     # key the model named). The questions are asked in QUESTION order, so the
     # document says which one this is; dropping the text was the freeze.
     bare = params.get("_bare_answer")
-    if bare and not segment and not advance_to:
+    if bare and not segment and not advance_to and current_stage(workspace) in (INITIAL_STAGE, "questions"):
+        # Only while the questions are open: past 'questions' a bare sentence is
+        # not an answer to anything (the #656 rule — honest error — still holds).
         key, text = bare
         answered = get_onboarding(workspace).get("segment") or {}
         if not key:

--- a/orchestrator/modules/tools/discovery/handlers_onboarding.py
+++ b/orchestrator/modules/tools/discovery/handlers_onboarding.py
@@ -130,6 +130,8 @@ def _normalise_params(params: Any) -> Tuple[Dict[str, Any], List[str]]:
         shape = f"type={type(raw_segment).__name__}"
         if isinstance(raw_segment, dict):
             shape += f", keys={sorted(map(str, raw_segment))[:6]}"
+        elif isinstance(raw_segment, str):
+            shape += f", len={len(raw_segment.strip())}"  # 0 = an empty string, not an answer
         notes.append(f"segment carries nothing usable ({shape}) — dropped")
     out["segment"] = usable
 
@@ -280,7 +282,11 @@ async def update_onboarding(
     except InvalidStageTransition as exc:
         if db is not None:
             db.rollback()
-        return {"success": False, "error": str(exc)}
+        # A refused move (backward, or the payoff without a build) names what the
+        # CURRENT stage needs — local test 2026-09-02: Auto tried building →
+        # proposal, was told "non-forward", and stalled.
+        hint = _SAME_STAGE_HINTS.get(current_stage(workspace), "")
+        return {"success": False, "error": f"{exc} {hint}".strip()}
     except ValueError as exc:
         # e.g. set_segment called with no recognised keys.
         if db is not None:

--- a/orchestrator/modules/tools/discovery/handlers_onboarding.py
+++ b/orchestrator/modules/tools/discovery/handlers_onboarding.py
@@ -15,6 +15,7 @@ from sqlalchemy.orm import Session
 from core.models.workspaces import Workspace
 from services.onboarding_state import (
     ALL_STAGES,
+    QUESTION_KEYS,
     SEGMENT_KEYS,
     InvalidStageTransition,
     advance_onboarding_stage,
@@ -74,7 +75,7 @@ def _normalise_params(params: Any) -> Tuple[Dict[str, Any], List[str]]:
     if not out.get("advance_to") and isinstance(value, str) and value.strip().lower() in ALL_STAGES:
         out["advance_to"] = value.strip().lower()
         notes.append("advance_to taken from 'value'")
-    elif value is not None:
+    elif value is not None and not isinstance(value, str):
         notes.append(f"'value' ignored (type={type(value).__name__})")
 
     advance_to = out.get("advance_to")
@@ -86,11 +87,30 @@ def _normalise_params(params: Any) -> Tuple[Dict[str, Any], List[str]]:
     usable = _usable_segment(raw_segment)
     if isinstance(raw_segment, str) and usable is not None:
         notes.append("segment parsed from a JSON string")
+    # Bare text (live-test 2026-09-02, local + prod: the model sends the user's
+    # ANSWER as the segment string, sometimes with the question's key name under
+    # 'value' — e.g. segment="Fairly comfortable…", value="comfort"). Keep the
+    # text aside for the handler, which knows which question is still unanswered.
+    bare_text = None
+    bare_key = None
+    strings = {k: v.strip() for k, v in ((("segment", raw_segment), ("value", value))) if isinstance(v, str) and v.strip()}
+    if usable is None and strings:
+        keyed = {k: v for k, v in strings.items() if v.lower() in SEGMENT_KEYS}
+        texts = {k: v for k, v in strings.items() if v.lower() not in SEGMENT_KEYS and v.lower() not in ALL_STAGES}
+        if keyed and texts:
+            bare_key = next(iter(keyed.values())).lower()
+            bare_text = next(iter(texts.values()))
+        elif texts:
+            bare_text = next(iter(texts.values()))
+    if bare_text:
+        out["_bare_answer"] = (bare_key, bare_text)
     flat = {k: out.pop(k) for k in SEGMENT_KEYS if out.get(k) is not None}
     if flat:
         notes.append(f"segment keys arrived flat: {sorted(flat)}")
         usable = {**(usable or {}), **flat}
-    if raw_segment is not None and usable is None:
+    if bare_text:
+        notes.append("bare-text answer kept for the handler to map onto a question")
+    elif raw_segment is not None and usable is None:
         shape = f"type={type(raw_segment).__name__}"
         if isinstance(raw_segment, dict):
             shape += f", keys={sorted(map(str, raw_segment))[:6]}"
@@ -132,7 +152,7 @@ async def update_onboarding(
     segment = params.get("segment")
     plan = params.get("plan")
 
-    if not advance_to and not segment and not plan:
+    if not advance_to and not segment and not plan and not params.get("_bare_answer"):
         return {
             "success": False,
             "error": "Provide advance_to, segment, or plan — at least one is required.",
@@ -143,6 +163,25 @@ async def update_onboarding(
     )
     if not workspace:
         return {"success": False, "error": "workspace not found"}
+
+    # A bare-text answer becomes the first question still unanswered (or the
+    # key the model named). The questions are asked in QUESTION order, so the
+    # document says which one this is; dropping the text was the freeze.
+    bare = params.get("_bare_answer")
+    if bare and not segment and not advance_to:
+        key, text = bare
+        answered = get_onboarding(workspace).get("segment") or {}
+        if not key:
+            key = next((k for k in QUESTION_KEYS if answered.get(k) is None), None)
+        if key:
+            segment = {key: text}
+            logger.warning("[update_onboarding] bare-text answer recorded as '%s' (%s)", key,
+                           "key named by the model" if bare[0] else "first unanswered question")
+    if not advance_to and not segment and not plan:
+        return {
+            "success": False,
+            "error": "Provide advance_to, segment, or plan — at least one is required.",
+        }
 
     # Idempotent same-stage advance (live-test 2026-08-29): the LLM routinely
     # re-asserts the stage it is already in — e.g. calling advance_to="building"

--- a/orchestrator/modules/tools/discovery/handlers_onboarding.py
+++ b/orchestrator/modules/tools/discovery/handlers_onboarding.py
@@ -29,6 +29,22 @@ from services.onboarding_state import (
 logger = logging.getLogger(__name__)
 
 
+# What each stage needs before the NEXT advance — returned on a same-stage
+# re-assert so a no-op never reads as progress (short: this rides every such
+# tool result).
+_SAME_STAGE_HINTS = {
+    "questions": "Record the answers via segment; the third answer moves the stage to teach.",
+    "teach": "Call platform_search_packages, then advance_to proposal with what it returned.",
+    "proposal": "Wait for the user's explicit yes, then advance_to building.",
+    "building": (
+        "Nothing is built yet: install the matched package (platform_install_package) or "
+        "create the agents (platform_create_agent / platform_install_marketplace_agent); "
+        "advance_to boom only after that succeeds."
+    ),
+    "boom": "Show the value on their business, then advance_to powerup.",
+}
+
+
 def _usable_segment(segment: Any) -> Optional[Dict[str, Any]]:
     """The segment as a dict carrying at least one recognised key, else None.
 
@@ -198,7 +214,18 @@ async def update_onboarding(
         )
         advance_to = None
         if not segment and not plan:
-            return {"success": True, "data": public_snapshot(workspace)}
+            # Honest no-op (local test 2026-09-02): Auto re-asserted 'building'
+            # twice while SAYING "I'm proceeding with the installation" and
+            # installing nothing — a bare success read as progress. Say what
+            # changed (nothing) and what the stage actually needs.
+            snap = public_snapshot(workspace)
+            hint = _SAME_STAGE_HINTS.get(snap.get("stage"), "")
+            return {
+                "success": True,
+                "data": snap,
+                "noop": True,
+                "message": f"Already at '{snap.get('stage')}' — nothing changed. {hint}".strip(),
+            }
 
     # Reject a non-assignable plan BEFORE any write — honest coming-soon copy.
     if plan is not None:

--- a/orchestrator/services/onboarding_state.py
+++ b/orchestrator/services/onboarding_state.py
@@ -205,10 +205,14 @@ def advance_onboarding_stage(
     # Honesty gate: the payoff stage needs a build to show. With no session
     # (pure-document logic path) there is nothing to count against — the
     # ordering validator alone applies, as before.
-    if to_stage == BUILD_EVIDENCE_STAGE and db is not None:
+    if (
+        to_stage in BUILD_EVIDENCE_STAGES
+        and _stage_index(current) < _stage_index(BUILD_EVIDENCE_STAGE)
+        and db is not None
+    ):
         if not build_evidence(db, workspace)["any"]:
             raise InvalidStageTransition(
-                "boom needs a build first: nothing is registered to this workspace "
+                f"{to_stage} needs a build first: nothing is registered to this workspace "
                 "yet (no package installed, no agents created, no mission). Install "
                 "the matched package or create the agents, then advance to boom."
             )
@@ -259,9 +263,42 @@ def set_segment(
     doc = get_onboarding(workspace)
     merged = dict(doc.get("segment") or {})
     merged.update(cleaned)
+    implied = implied_stage(doc.get("stage", INITIAL_STAGE), merged)
+    if implied:
+        # The recorded answers prove the stage (see implied_stage) — one write
+        # advances and merges, exactly as an explicit advance_to would.
+        return advance_onboarding_stage(db, workspace, implied, segment=cleaned, commit=commit)
     doc["segment"] = merged
     doc["updated_at"] = _now_iso()
     return _persist(db, workspace, doc, commit=commit)
+
+
+# The three answers the questions stage exists to collect.
+QUESTION_KEYS: tuple[str, ...] = ("business", "goal", "comfort")
+
+
+def implied_stage(current: str, segment: dict) -> Optional[str]:
+    """The stage the RECORDED answers prove, or None.
+
+    Live test 2026-09-02 (prod, Gemini 2.5 Flash): the model saved answers
+    through the tool — ``platform_update_onboarding success=True`` twice — but
+    never sent ``advance_to``, so the stage sat at ``not_started`` while Auto
+    recited the questions; the user saw ordinary chat. The facts are in the
+    document: an answer being recorded means the questions are underway; all
+    three recorded means they are done. Inferring from those facts is honest,
+    deterministic, and still tool-driven (nothing moves without the call).
+    Explicit ``advance_to`` targets are never overridden — this only applies
+    to segment-only writes.
+    """
+    if current == INITIAL_STAGE and any(segment.get(k) is not None for k in QUESTION_KEYS):
+        implied = "questions"
+    else:
+        implied = None
+    if current in (INITIAL_STAGE, "questions") and all(
+        segment.get(k) is not None for k in QUESTION_KEYS
+    ):
+        implied = "teach"
+    return implied
 
 
 # The funnel-timestamp key stamped by the first integration a workspace connects
@@ -384,6 +421,10 @@ def onboarding_package_installed(workspace: Any) -> bool:
 # rows onboarding already writes.
 
 BUILD_EVIDENCE_STAGE = "boom"
+# Reaching ANY stage at or past the payoff from before it needs the build — the
+# validator allows forward skips, so ``advance_to="completed"`` from ``building``
+# would otherwise walk around the boom gate (found 2026-09-02).
+BUILD_EVIDENCE_STAGES: frozenset[str] = frozenset({"boom", "powerup", "completed"})
 
 
 def build_evidence(db: Any, workspace: Any) -> dict[str, Any]:

--- a/orchestrator/tests/test_prd222_onboarding_tool_arg_shapes.py
+++ b/orchestrator/tests/test_prd222_onboarding_tool_arg_shapes.py
@@ -60,7 +60,10 @@ def test_normaliser_returns_a_new_dict_and_never_mutates_input():
 def test_normaliser_value_only_counts_when_it_names_a_stage():
     out, notes = _normalise_params({"value": "banana"})
     assert "advance_to" not in out and "value" not in out
-    assert any("'value' ignored" in n for n in notes)
+    assert out["_bare_answer"] == (None, "banana")  # free text is kept for the handler to place
+    assert any("bare-text" in n for n in notes)
+    out, notes = _normalise_params({"value": 42})
+    assert any("'value' ignored (type=int)" in n for n in notes)
     out, _ = _normalise_params({"advance_to": "proposal", "value": "teach"})
     assert out["advance_to"] == "proposal"  # an explicit advance_to always wins
 

--- a/orchestrator/tests/test_prd222_onboarding_tool_arg_shapes.py
+++ b/orchestrator/tests/test_prd222_onboarding_tool_arg_shapes.py
@@ -72,11 +72,12 @@ def test_normaliser_folds_flat_answer_keys_into_segment():
     assert any("arrived flat" in n for n in notes)
 
 
-def test_normaliser_drops_junk_segment_with_a_shape_note_and_no_user_text():
+def test_normaliser_keeps_bare_text_for_mapping_and_drops_junk_dicts_with_a_shape_note():
     out, notes = _normalise_params({"segment": "We are Lumen & Lark, a jewellery brand"})
     assert out["segment"] is None
-    note = next(n for n in notes if "nothing usable" in n)
-    assert "type=str" in note and "Lumen" not in note
+    assert out["_bare_answer"] == (None, "We are Lumen & Lark, a jewellery brand")
+    note = next(n for n in notes if "bare-text" in n)
+    assert "Lumen" not in note
     out, notes = _normalise_params({"segment": {"industry": "dental", "notes": "x"}})
     assert out["segment"] is None
     assert "keys=['industry', 'notes']" in next(n for n in notes if "nothing usable" in n)
@@ -120,15 +121,24 @@ def test_handler_folds_flat_answers():
     assert ws.onboarding["segment"]["business"] == "a barber shop in Leeds"
 
 
-def test_handler_junk_segment_alone_is_still_the_honest_error_and_is_logged(caplog):
+def test_handler_bare_text_segment_is_recorded_as_the_first_unanswered_question(caplog):
     ws = _FakeWorkspace("not_started")
     with caplog.at_level(logging.WARNING, logger=_LOGGER):
         res = _run(update_onboarding(_db_returning(ws), ws.id, {"segment": "We are Lumen & Lark"}))
+    assert res["success"] is True
+    assert ws.onboarding["segment"] == {"business": "We are Lumen & Lark"}
+    warned = [r.getMessage() for r in caplog.records if "bare-text answer recorded as 'business'" in r.getMessage()]
+    assert warned and "Lumen" not in warned[0]  # never the user's text
+
+
+def test_handler_junk_dict_segment_alone_is_still_the_honest_error_and_is_logged(caplog):
+    ws = _FakeWorkspace("not_started")
+    with caplog.at_level(logging.WARNING, logger=_LOGGER):
+        res = _run(update_onboarding(_db_returning(ws), ws.id, {"segment": {"industry": "jewellery"}}))
     assert res["success"] is False
     assert "at least one is required" in res["error"]
     warned = [r.getMessage() for r in caplog.records if "argument shape coerced" in r.getMessage()]
-    assert warned and "type=str" in warned[0]
-    assert "Lumen" not in warned[0]  # never the user's text
+    assert warned and "keys=['industry']" in warned[0]
 
 
 def test_handler_is_silent_when_the_shape_is_already_right(caplog):

--- a/orchestrator/tests/test_prd222_segment_implied_advance.py
+++ b/orchestrator/tests/test_prd222_segment_implied_advance.py
@@ -134,3 +134,32 @@ def test_skipped_is_untouched_by_the_gate():
     ws = _Workspace("building")
     advance_onboarding_stage(_db(0, 0), ws, "skipped")
     assert current_stage(ws) == "skipped"
+
+
+# ── bare-text answers (the local + prod freeze shape) ─────────────────────
+
+def test_bare_text_answer_fills_the_first_unanswered_question():
+    ws = _Workspace()
+    db = _db(workspace=ws)
+    r = asyncio.run(update_onboarding(db, ws.id, {"segment": "We're Snip & Fade, a barber shop in Leeds"}))
+    assert r["success"] is True and r["data"]["stage"] == "questions"
+    assert ws.onboarding["segment"] == {"business": "We're Snip & Fade, a barber shop in Leeds"}
+    asyncio.run(update_onboarding(db, ws.id, {"segment": "appointment booking"}))
+    assert ws.onboarding["segment"]["goal"] == "appointment booking"
+    r3 = asyncio.run(update_onboarding(db, ws.id, {"value": "Brand new to this", "segment": "comfort"}))
+    assert ws.onboarding["segment"]["comfort"] == "Brand new to this"   # key named by the model
+    assert r3["data"]["stage"] == "teach"                                  # third answer → teach
+
+
+def test_bare_text_with_all_questions_answered_is_still_the_honest_error():
+    ws = _Workspace("teach", segment={"business": "a", "goal": "b", "comfort": "c"})
+    r = asyncio.run(update_onboarding(_db(workspace=ws), ws.id, {"segment": "some extra chat"}))
+    assert r["success"] is False and "at least one is required" in r["error"]
+    assert ws.onboarding["segment"] == {"business": "a", "goal": "b", "comfort": "c"}
+
+
+def test_bare_text_never_overrides_a_real_segment_or_advance():
+    ws = _Workspace()
+    r = asyncio.run(update_onboarding(_db(workspace=ws), ws.id, {"advance_to": "questions", "segment": "junk"}))
+    assert r["success"] is True and r["data"]["stage"] == "questions"
+    assert ws.onboarding["segment"] == {}   # an explicit advance with junk text records nothing invented

--- a/orchestrator/tests/test_prd222_segment_implied_advance.py
+++ b/orchestrator/tests/test_prd222_segment_implied_advance.py
@@ -163,3 +163,14 @@ def test_bare_text_never_overrides_a_real_segment_or_advance():
     r = asyncio.run(update_onboarding(_db(workspace=ws), ws.id, {"advance_to": "questions", "segment": "junk"}))
     assert r["success"] is True and r["data"]["stage"] == "questions"
     assert ws.onboarding["segment"] == {}   # an explicit advance with junk text records nothing invented
+
+
+# ── a same-stage re-assert says what changed (nothing) and what is needed ──
+
+def test_same_stage_reassert_is_an_honest_noop_with_the_next_step():
+    ws = _Workspace("building")
+    r = asyncio.run(update_onboarding(_db(workspace=ws), ws.id, {"advance_to": "building"}))
+    assert r["success"] is True and r["noop"] is True
+    assert "nothing changed" in r["message"]
+    assert "platform_install_package" in r["message"] and "advance_to boom only after" in r["message"]
+    assert current_stage(ws) == "building"

--- a/orchestrator/tests/test_prd222_segment_implied_advance.py
+++ b/orchestrator/tests/test_prd222_segment_implied_advance.py
@@ -174,3 +174,11 @@ def test_same_stage_reassert_is_an_honest_noop_with_the_next_step():
     assert "nothing changed" in r["message"]
     assert "platform_install_package" in r["message"] and "advance_to boom only after" in r["message"]
     assert current_stage(ws) == "building"
+
+
+def test_a_refused_move_names_what_the_current_stage_needs():
+    ws = _Workspace("building")
+    r = asyncio.run(update_onboarding(_db(workspace=ws), ws.id, {"advance_to": "proposal"}))
+    assert r["success"] is False
+    assert "non-forward" in r["error"] and "platform_install_package" in r["error"]
+    assert current_stage(ws) == "building"

--- a/orchestrator/tests/test_prd222_segment_implied_advance.py
+++ b/orchestrator/tests/test_prd222_segment_implied_advance.py
@@ -1,0 +1,136 @@
+"""PRD-222 — the recorded answers move the stage; the payoff gate cannot be skipped.
+
+Live test 2026-09-02 (prod): the model saved answers through the tool twice
+(success=True) but never sent advance_to — stage frozen at not_started while Auto
+recited the questions. Now a segment-only write advances to what the answers
+prove: any answer → questions; all three → teach. Explicit targets still win.
+Also: advance_to="completed" from building walked around the boom gate.
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+from core.models.core import Agent
+from core.models.orchestration import OrchestrationRun
+from modules.tools.discovery.handlers_onboarding import update_onboarding
+from services.onboarding_state import (
+    InvalidStageTransition,
+    advance_onboarding_stage,
+    current_stage,
+    implied_stage,
+    set_segment,
+)
+
+
+class _Workspace:
+    def __init__(self, stage="not_started", segment=None, funnel=None):
+        self.id = uuid4()
+        self.onboarding = {"stage": stage, "stages": {}, "segment": dict(segment or {})}
+        if funnel:
+            self.onboarding["funnel"] = funnel
+
+
+def _db(agents=0, missions=0, workspace=None):
+    counts = {Agent: agents, OrchestrationRun: missions}
+    db = MagicMock()
+
+    def _query(model):
+        q = MagicMock()
+        q.filter.return_value.count.return_value = counts.get(model, 0)
+        q.filter.return_value.first.return_value = workspace
+        return q
+
+    db.query.side_effect = _query
+    return db
+
+
+# ── implied_stage (pure) ────────────────────────────────────────────────────
+
+def test_any_answer_implies_questions_and_all_three_imply_teach():
+    assert implied_stage("not_started", {}) is None
+    assert implied_stage("not_started", {"business": "a barber"}) == "questions"
+    assert implied_stage("questions", {"business": "a barber", "goal": "bookings"}) is None
+    full = {"business": "a barber", "goal": "bookings", "comfort": "novice"}
+    assert implied_stage("not_started", full) == "teach"
+    assert implied_stage("questions", full) == "teach"
+
+
+def test_later_stages_never_move_on_answers():
+    full = {"business": "a", "goal": "b", "comfort": "c"}
+    for stage in ("teach", "proposal", "building", "boom", "powerup"):
+        assert implied_stage(stage, full) is None
+
+
+# ── set_segment advances on what the answers prove ─────────────────────────
+
+def test_first_answer_moves_not_started_to_questions():
+    ws = _Workspace()
+    set_segment(None, ws, {"business": "Snip & Fade, a barber shop"})
+    assert current_stage(ws) == "questions"
+    assert ws.onboarding["segment"]["business"] == "Snip & Fade, a barber shop"
+    assert "questions" in ws.onboarding["stages"]  # funnel stamp, like any advance
+
+
+def test_answers_accumulate_and_the_third_moves_to_teach():
+    ws = _Workspace()
+    set_segment(None, ws, {"business": "a barber"})
+    set_segment(None, ws, {"goal": "bookings"})
+    assert current_stage(ws) == "questions"
+    set_segment(None, ws, {"comfort": "brand new"})
+    assert current_stage(ws) == "teach"
+    assert ws.onboarding["segment"] == {"business": "a barber", "goal": "bookings", "comfort": "brand new"}
+
+
+def test_answers_at_a_later_stage_merge_without_moving():
+    ws = _Workspace("proposal", segment={"business": "a", "goal": "b", "comfort": "c"})
+    set_segment(None, ws, {"team_size": 4})
+    assert current_stage(ws) == "proposal"
+    assert ws.onboarding["segment"]["team_size"] == 4
+
+
+def test_explicit_advance_target_is_never_overridden():
+    ws = _Workspace()
+    full = {"business": "a", "goal": "b", "comfort": "c"}
+    advance_onboarding_stage(None, ws, "questions", segment=full)
+    assert current_stage(ws) == "questions"  # the model asked for questions; it gets questions
+
+
+# ── through the tool handler ───────────────────────────────────────────────
+
+def test_handler_segment_only_calls_walk_the_stage_forward():
+    ws = _Workspace()
+    db = _db(workspace=ws)
+    r1 = asyncio.run(update_onboarding(db, ws.id, {"segment": {"business": "a barber"}}))
+    assert r1["success"] is True and r1["data"]["stage"] == "questions"
+    asyncio.run(update_onboarding(db, ws.id, {"segment": {"goal": "bookings"}}))
+    r3 = asyncio.run(update_onboarding(db, ws.id, {"segment": {"comfort": "novice"}}))
+    assert r3["data"]["stage"] == "teach"
+
+
+# ── the payoff gate cannot be skipped around ───────────────────────────────
+
+def test_completed_from_building_needs_the_build_too():
+    ws = _Workspace("building")
+    with pytest.raises(InvalidStageTransition, match="completed needs a build"):
+        advance_onboarding_stage(_db(0, 0), ws, "completed")
+    with pytest.raises(InvalidStageTransition, match="powerup needs a build"):
+        advance_onboarding_stage(_db(0, 0), ws, "powerup")
+    assert current_stage(ws) == "building"
+
+
+def test_past_the_payoff_the_gate_does_not_re_run():
+    ws = _Workspace("boom")
+    advance_onboarding_stage(_db(0, 0), ws, "powerup")   # already past boom: no re-check
+    assert current_stage(ws) == "powerup"
+    advance_onboarding_stage(_db(0, 0), ws, "completed")
+    assert current_stage(ws) == "completed"
+
+
+def test_skipped_is_untouched_by_the_gate():
+    ws = _Workspace("building")
+    advance_onboarding_stage(_db(0, 0), ws, "skipped")
+    assert current_stage(ws) == "skipped"


### PR DESCRIPTION
## The residual not_started freeze (post-#671, trace-backed)

Post-merge run 2026-09-02 11:57Z (snip, resets=78), read with per-turn log windows: `platform_execute -> platform_update_onboarding success=True` on turns 1 and 3 — answers saved — and **no `advance_to` ever sent**. Stage stayed `not_started` while Auto recited the three questions. #671 fixed malformed calls; this is the well-formed call that never carries a target.

## Fixes (all in the onboarding state layer + tool handler)

1. **Recorded answers move the stage** — `implied_stage(current, segment)`: any of business/goal/comfort at `not_started` → `questions`; all three at `not_started`/`questions` → `teach`. `set_segment` advances through `advance_onboarding_stage` (same validation, same funnel stamps). Explicit `advance_to` targets are never overridden.
2. **The payoff gate cannot be skipped around** — `advance_to="completed"`/`powerup` from `building` needed no build (forward skips are allowed). Any stage at or past the payoff, reached from before it, needs the build; past `boom` the gate does not re-run; `skipped` untouched.
3. **A bare-text answer is recorded, not dropped** (local + prod, #671's WARNING made it visible: five of six coerced shapes were `segment=<the user's sentence>`, sometimes with the key under `value`). Bare text fills the first unanswered of business/goal/comfort, or the key the model named. Segment-only calls only; with every question answered the honest 'at least one is required' stands.
4. **A same-stage re-assert is an honest no-op** — `noop: true` + "Already at building — nothing changed. Nothing is built yet: install the matched package or create the agents; advance_to boom only after that succeeds." (local test: Auto re-asserted `building` twice while saying it was installing, and installed nothing.)

## Tests
`test_prd222_segment_implied_advance.py` (implied stage, accumulation, explicit target wins, handler walk-through, completed/powerup gated, no re-check past boom, skipped untouched, bare-text mapping ×3, honest no-op). `test_prd222_onboarding_tool_arg_shapes.py` updated for the bare-text case.

## Verified locally
Local edition on a wiped empty workspace (2026-09-02 ~13:40): each recorded answer moved the stage (business → questions, comfort → teach); no fake payoff.

## Verification
CI only. No settings, no routes. Branch is off main after the PRD-232 merge. Under the merge freeze — Gerard's call.
