### PR TITLE
feat(local): onboarding replay enabled by default in the local edition

### DIFF
--- a/envs/api.defaults
+++ b/envs/api.defaults
@@ -137,3 +137,10 @@ PROMETHEUS_URL=
 AGENT_OPT_WORKER_URL=
 # Observability (Loki/Prometheus/Grafana) is not part of this compose file — see the
 # automatos-monitoring repo; envs/observability.defaults documents the variables.
+
+# -----------------------------------------------------------------------------
+# Onboarding replay [ACTIVE] — local edition only
+# -----------------------------------------------------------------------------
+# POST /api/workspaces/current/onboarding/reset rewinds the operator workspace
+# to not_started so Auto-led onboarding can be run again (SaaS keeps this off).
+ONBOARDING_RESET_ENABLED=true


### PR DESCRIPTION
`ONBOARDING_RESET_ENABLED=true` in `envs/api.defaults` — the local topology file Railway never reads — so the operator can rewind Auto-led onboarding to `not_started` and run it again (`POST /api/workspaces/current/onboarding/reset`). SaaS keeps the config default (off). This is what makes the onboarding persona harness runnable against a local stack (verified 2026-09-02: reset → nine-turn run to completed on the local edition).

Under the merge freeze — Gerard's call.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a local-edition-only option to reset onboarding progress and replay the Auto-led onboarding experience.
  * Onboarding can be returned to its initial “not started” state through the workspace settings API.
  * This capability remains disabled in the SaaS edition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->