### PR TITLE
fix(marketplace): a not-found install names the closest real entries — never a dead end

### DIFF
--- a/orchestrator/modules/tools/discovery/handlers_marketplace.py
+++ b/orchestrator/modules/tools/discovery/handlers_marketplace.py
@@ -366,7 +366,11 @@ async def install_plugin(db: Session, workspace_id: UUID, params: Dict[str, Any]
 
     plugin = query.first()
     if not plugin:
-        return {"success": False, "error": "Plugin not found"}
+        from modules.tools.discovery.not_found_candidates import find_candidates, not_found_error
+
+        requested = str(plugin_slug or plugin_id)
+        candidates = await find_candidates(browse_marketplace_plugins, db, workspace_id, requested, list_key="plugins")
+        return not_found_error("Plugin", requested, candidates, search_tool="platform_browse_marketplace_plugins")
 
     if plugin.approval_status != "approved" or not plugin.is_active:
         return {"success": False, "error": "Plugin is not approved or inactive"}
@@ -505,7 +509,11 @@ async def install_skill(db: Session, workspace_id: UUID, params: Dict[str, Any])
 
     skill = query.first()
     if not skill:
-        return {"success": False, "error": "Marketplace skill not found"}
+        from modules.tools.discovery.not_found_candidates import find_candidates, not_found_error
+
+        requested = str(skill_name or skill_id)
+        candidates = await find_candidates(browse_marketplace_skills, db, workspace_id, requested, list_key="skills")
+        return not_found_error("Marketplace skill", requested, candidates, search_tool="platform_browse_marketplace_skills")
 
     if not skill.is_active:
         return {"success": False, "error": "Skill is inactive"}

--- a/orchestrator/modules/tools/discovery/handlers_packages.py
+++ b/orchestrator/modules/tools/discovery/handlers_packages.py
@@ -203,7 +203,15 @@ async def install_package_tool(db: Any, workspace_id: UUID, params: Dict[str, An
 
     package = get_by_slug(db, slug)
     if package is None:
-        return {"success": False, "error": f"Package not found: {slug}"}
+        # The catalogue is small: name what exists (live-test 2026-09-02 — Auto
+        # guessed 'shopify-store-manager' and retried other guesses).
+        from modules.tools.discovery.not_found_candidates import candidate_terms, not_found_error
+        from services.marketplace_packages import list_packages
+
+        catalogue = [{"slug": p.slug, "name": p.name} for p in list_packages(db)]
+        terms = candidate_terms(slug)
+        close = [c for c in catalogue if any(t in f"{c['slug']} {c['name']}".lower() for t in terms)]
+        return not_found_error("Package", slug, (close or catalogue)[:3], search_tool="platform_search_packages")
 
     # D9 — over-quota is an honest conversation, checked BEFORE any registration.
     quota = _check_quota(db, workspace, workspace_id, package)
@@ -253,6 +261,12 @@ async def install_marketplace_agent_tool(db: Any, workspace_id: UUID, params: Di
     try:
         manifest = await install_marketplace_agent(db, workspace_id, ref, user_id=None)
     except PackageInstallError as exc:
+        if "not found" in str(exc).lower():
+            from modules.tools.discovery.handlers_marketplace import browse_marketplace_agents
+            from modules.tools.discovery.not_found_candidates import find_candidates, not_found_error
+
+            candidates = await find_candidates(browse_marketplace_agents, db, workspace_id, ref, list_key="agents")
+            return not_found_error("Marketplace agent", ref, candidates, search_tool="platform_browse_marketplace_agents")
         return {"success": False, "error": str(exc)}
     db.commit()
 

--- a/orchestrator/modules/tools/discovery/not_found_candidates.py
+++ b/orchestrator/modules/tools/discovery/not_found_candidates.py
@@ -1,0 +1,69 @@
+"""Not-found errors that name the closest REAL marketplace entries.
+
+Live tests 2026-08-29 → 2026-09-02: Auto invented marketplace names
+('shopify-store-manager', 'shopify-tools', 'customer-support-agent-skill',
+'Restaurant Customer Service Agent'), got a bare "not found", and either
+guessed again or stalled the build. A dead-end error is the wrong shape for
+an LLM caller: the honest reply names what DOES exist so the next call can be
+right. Nothing here installs or chooses — it only tells the truth about the
+catalogue, and a failing lookup never turns a not-found into a crash.
+"""
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List
+
+_GENERIC = frozenset({
+    "agent", "agents", "tool", "tools", "plugin", "plugins", "skill", "skills",
+    "package", "packages", "service", "services", "manager", "management",
+    "assistant", "custom", "automatos", "the", "and", "for", "with", "app", "apps",
+})
+
+
+def candidate_terms(requested: str, *, max_terms: int = 4) -> List[str]:
+    """Distinctive words of a requested name, in order (generic words dropped)."""
+    tokens = [t for t in re.split(r"[^a-z0-9]+", (requested or "").lower()) if len(t) >= 3]
+    distinct = [t for t in tokens if t not in _GENERIC]
+    out: List[str] = []
+    for t in distinct or tokens:
+        if t not in out:
+            out.append(t)
+    return out[:max_terms]
+
+
+async def find_candidates(browse, db: Any, workspace_id: Any, requested: str, *,
+                          list_key: str, limit: int = 3) -> List[Dict[str, Any]]:
+    """Up to ``limit`` real entries from ``browse`` that share a word with the request."""
+    seen: Dict[str, Dict[str, Any]] = {}
+    for term in candidate_terms(requested):
+        try:
+            result = await browse(db, workspace_id, {"search": term, "limit": 5})
+        except Exception:  # noqa: BLE001 — candidates are a courtesy, never a crash
+            continue
+        for item in (result or {}).get(list_key) or []:
+            key = str(item.get("slug") or item.get("name") or item.get("id") or "")
+            if key and key not in seen:
+                seen[key] = {k: item.get(k) for k in ("id", "slug", "name") if item.get(k) is not None}
+        if len(seen) >= limit:
+            break
+    return list(seen.values())[:limit]
+
+
+def not_found_error(kind: str, requested: str, candidates: List[Dict[str, Any]], *,
+                    search_tool: str) -> Dict[str, Any]:
+    """The tool result for a miss: what was asked, what exists, what to do."""
+    if candidates:
+        named = ", ".join(
+            f"'{c.get('slug') or c.get('name')}'" + (f" ({c['name']})" if c.get("slug") and c.get("name") else "")
+            for c in candidates
+        )
+        error = (
+            f"{kind} not found: '{requested}'. Closest in the marketplace: {named}. "
+            f"Use one of those exactly, or search with {search_tool} first — never guess a name."
+        )
+    else:
+        error = (
+            f"{kind} not found: '{requested}', and nothing in the marketplace resembles it. "
+            f"Search with {search_tool} first — never guess a name."
+        )
+    return {"success": False, "error": error, "requested": requested, "candidates": list(candidates)}

--- a/orchestrator/tests/test_prd222_not_found_names_candidates.py
+++ b/orchestrator/tests/test_prd222_not_found_names_candidates.py
@@ -1,0 +1,130 @@
+"""PRD-222 — a marketplace miss names the closest real entries (live-test 2026-09-02).
+
+Auto invented names ('shopify-store-manager', 'shopify-tools',
+'customer-support-agent-skill', 'Restaurant Customer Service Agent'), got a bare
+"not found" and guessed again or stalled. The error now says what exists.
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from modules.tools.discovery import handlers_marketplace as hm
+from modules.tools.discovery import handlers_packages as hp
+from modules.tools.discovery.not_found_candidates import candidate_terms, find_candidates, not_found_error
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _db_first_none():
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = None
+    db.query.return_value.filter.return_value.filter.return_value.first.return_value = None
+    return db
+
+
+# ── helper ────────────────────────────────────────────────────────────────
+
+def test_terms_drop_generic_words_and_keep_order():
+    assert candidate_terms("shopify-store-manager") == ["shopify", "store"]
+    assert candidate_terms("Restaurant Customer Service Agent") == ["restaurant", "customer"]
+    assert candidate_terms("customer-support-agent-skill") == ["customer", "support"]
+    assert candidate_terms("agent") == ["agent"]  # only generic words → keep the tokens
+    assert candidate_terms("") == []
+
+
+def test_not_found_error_names_candidates_or_says_nothing_resembles():
+    out = not_found_error("Plugin", "shopify-tools", [{"slug": "shopify-plugin", "name": "Shopify"}],
+                          search_tool="platform_browse_marketplace_plugins")
+    assert out["success"] is False
+    assert "'shopify-plugin' (Shopify)" in out["error"] and "never guess a name" in out["error"]
+    assert out["candidates"][0]["slug"] == "shopify-plugin" and out["requested"] == "shopify-tools"
+    out = not_found_error("Plugin", "x", [], search_tool="t")
+    assert "nothing in the marketplace resembles it" in out["error"] and out["candidates"] == []
+
+
+def test_find_candidates_dedupes_and_survives_a_failing_browse():
+    calls = []
+
+    async def browse(db, ws, params):
+        calls.append(params["search"])
+        if params["search"] == "store":
+            raise RuntimeError("db down")
+        return {"plugins": [{"slug": "shopify-plugin", "name": "Shopify"},
+                            {"slug": "shopify-plugin", "name": "Shopify"}]}
+
+    out = _run(find_candidates(browse, None, uuid4(), "shopify-store-manager", list_key="plugins"))
+    assert out == [{"slug": "shopify-plugin", "name": "Shopify"}]
+    assert calls == ["shopify", "store"]
+
+
+# ── the four sites ─────────────────────────────────────────────────────────
+
+def test_install_plugin_miss_names_real_plugins(monkeypatch):
+    async def browse(db, ws, params):
+        return {"plugins": [{"slug": "shopify-plugin", "name": "Shopify"}]}
+
+    monkeypatch.setattr(hm, "browse_marketplace_plugins", browse)
+    out = _run(hm.install_plugin(_db_first_none(), uuid4(), {"plugin_slug": "shopify-tools"}))
+    assert out["success"] is False and "'shopify-plugin'" in out["error"]
+    assert out["requested"] == "shopify-tools"
+
+
+def test_install_skill_miss_names_real_skills(monkeypatch):
+    async def browse(db, ws, params):
+        return {"skills": [{"id": 7, "name": "shopify-support"}]}
+
+    monkeypatch.setattr(hm, "browse_marketplace_skills", browse)
+    out = _run(hm.install_skill(_db_first_none(), uuid4(), {"skill_name": "customer-support-agent-skill"}))
+    assert out["success"] is False and "'shopify-support'" in out["error"]
+
+
+def test_install_marketplace_agent_miss_names_real_agents(monkeypatch):
+    from services.package_installer import PackageInstallError
+
+    async def missing(db, ws, ref, user_id=None):
+        raise PackageInstallError(f"Marketplace agent not found: {ref}")
+
+    async def browse(db, ws, params):
+        return {"agents": [{"id": 12, "name": "Customer Support Agent"}]}
+
+    monkeypatch.setattr("services.package_installer.install_marketplace_agent", missing)
+    monkeypatch.setattr(hm, "browse_marketplace_agents", browse)
+    out = _run(hp.install_marketplace_agent_tool(MagicMock(), uuid4(), {"agent_name": "Restaurant Customer Service Agent"}))
+    assert out["success"] is False
+    assert "'Customer Support Agent'" in out["error"] and "platform_browse_marketplace_agents" in out["error"]
+
+
+def test_install_marketplace_agent_other_errors_are_unchanged(monkeypatch):
+    from services.package_installer import PackageInstallError
+
+    async def quota(db, ws, ref, user_id=None):
+        raise PackageInstallError("quota exceeded")
+
+    monkeypatch.setattr("services.package_installer.install_marketplace_agent", quota)
+    out = _run(hp.install_marketplace_agent_tool(MagicMock(), uuid4(), {"agent_id": 3}))
+    assert out == {"success": False, "error": "quota exceeded"}
+
+
+def test_install_package_miss_names_the_catalogue(monkeypatch):
+    class _WS:
+        def __init__(self):
+            self.id = uuid4()
+            self.onboarding = {}
+
+    class _Pkg:
+        def __init__(self, slug, name):
+            self.slug, self.name = slug, name
+
+    monkeypatch.setattr(hp, "_load_workspace", lambda db, wid: _WS())
+    monkeypatch.setattr("services.marketplace_packages.get_by_slug", lambda db, slug: None)
+    monkeypatch.setattr("services.marketplace_packages.list_packages",
+                        lambda db: [_Pkg("shopify-management", "Shopify Management"),
+                                    _Pkg("shopify-development", "Shopify Development")])
+    out = _run(hp.install_package_tool(MagicMock(), uuid4(), {"slug": "shopify-store-manager"}))
+    assert out["success"] is False
+    assert "'shopify-management' (Shopify Management)" in out["error"]
+    assert out["candidates"][0]["slug"] == "shopify-management"


### PR DESCRIPTION
## The stall class
Live tests 2026-08-29 → 2026-09-02 (prod and the local edition): Auto invented marketplace names — `shopify-store-manager`, `shopify-tools`, `customer-support-agent-skill`, `Restaurant Customer Service Agent` — got a bare *not found*, and either guessed again or stalled at `building`. The #653 rule (search first) is prompt-level and the model does not always follow it; a dead-end error is the wrong shape for an LLM caller.

## Fix
`modules/tools/discovery/not_found_candidates.py`:
- `candidate_terms` — the distinctive words of the request (generic words dropped)
- `find_candidates` — the existing browse queries, a word at a time, deduped; a failing lookup never turns a miss into a crash
- `not_found_error` — what was asked, what exists (up to 3, slug + name), what to do ("use one of those exactly, or search with … first — never guess a name")

Wired into the four install sites: `install_package_tool` (the small catalogue is named outright), `install_marketplace_agent_tool` (on the service's not-found), `install_plugin`, `install_skill`. Nothing installs or chooses.

## Tests
`test_prd222_not_found_names_candidates.py` — helper semantics (terms, wording, dedupe, failing browse), all four sites with stubbed lookups, other install errors unchanged.

## Verification
CI only. No settings, no routes. Under the merge freeze — Gerard's call.