### PR TITLE
feat(prd-232): the uplift gate reads production telemetry (--from-telemetry)

### DIFF
--- a/orchestrator/evals/operating_graph_uplift.py
+++ b/orchestrator/evals/operating_graph_uplift.py
@@ -31,6 +31,8 @@ Run:
     cd orchestrator
     python -m evals.operating_graph_uplift              # bundled fixture
     python -m evals.operating_graph_uplift --json       # machine-readable
+    python -m evals.operating_graph_uplift --from-telemetry --json   # the real gate
+                                                        # (inside the API environment)
 """
 from __future__ import annotations
 
@@ -42,7 +44,7 @@ import sys
 from collections import Counter, defaultdict
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, Sequence, Tuple
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
 
 # The pass band for the moat claim (points of top-1 accuracy uplift, per tenant,
 # averaged across tenants). Below this, do NOT flip TOOL_ROUTING_GRAPH on.
@@ -86,6 +88,10 @@ class TenantResult:
 @dataclass
 class UpliftReport:
     tenants: List[TenantResult] = field(default_factory=list)
+    # Where the cases came from ("fixture" | "telemetry") plus the loader's
+    # counts. Printed WITH the number so a fixture run can never be mistaken
+    # for the production gate (PRD-232 §6.4).
+    meta: Dict[str, Any] = field(default_factory=lambda: {"source": "fixture"})
 
     @property
     def mean_uplift_points(self) -> float:
@@ -99,6 +105,8 @@ class UpliftReport:
 
     def to_dict(self) -> Dict:
         return {
+            "source": self.meta.get("source", "fixture"),
+            "loader": {k: v for k, v in self.meta.items() if k != "source"},
             "uplift_threshold_points": UPLIFT_THRESHOLD_POINTS,
             "mean_uplift_points": round(self.mean_uplift_points, 2),
             "passes": self.passes,
@@ -391,8 +399,181 @@ def load_cases_from_eval_set(
 
 
 # ---------------------------------------------------------------------------
+# Telemetry loading — the REAL gate (PRD-232 §6.4)
+# ---------------------------------------------------------------------------
+#
+# One case per (tenant, distinct query) from tool_execution_logs, labelled with
+# the action that actually succeeded for it. Honesty rules, in order:
+#   * production rows only (telemetry_source 'production' / NULL) — eval and
+#     replay rows never grade themselves;
+#   * status == 'success' only — the ground truth is what served the intent;
+#   * the resolved inner action name must exist in the ActionRegistry — the
+#     `platform_execute` wrapper and unknown/retired names are dropped ("assert
+#     on effects, not tool names");
+#   * repeated identical queries collapse to ONE case labelled with the
+#     majority successful action (ties → lexicographically smallest), so a
+#     heartbeat loop cannot vote a hundred times;
+#   * a tenant with fewer than ``min_cases_per_tenant`` distinct cases is
+#     dropped — a three-case tenant makes the train/test split meaningless.
+# The pure half (``cases_from_log_rows``) is unit-tested with no database; the
+# thin wrapper (``load_cases_from_telemetry``) is the only place that imports
+# the ORM, lazily, so the stdlib-only CI lane stays stdlib-only.
+
+DEFAULT_TELEMETRY_WINDOW_DAYS = 30
+DEFAULT_MIN_CASES_PER_TENANT = 10
+_PRODUCTION_SOURCES = (None, "", "production")
+_DISPATCHER_WRAPPER = "platform_execute"
+
+
+def _normalise_query(query: str) -> str:
+    return " ".join(query.lower().split())
+
+
+def cases_from_log_rows(
+    rows: Sequence[Dict[str, Any]],
+    category_by_action: Dict[str, str],
+    *,
+    min_cases_per_tenant: int = DEFAULT_MIN_CASES_PER_TENANT,
+) -> Tuple[List[EvalCase], Dict[str, Any]]:
+    """Turn raw tool_execution_logs rows (dicts) into per-tenant eval cases.
+
+    ``rows`` carry ``workspace_id``, ``user_query``, ``action_name``, ``status``
+    and ``telemetry_source``; ``category_by_action`` is the registry's
+    action → category map and doubles as the "known action" filter. Returns
+    the cases plus the loader counts that explain everything that was dropped.
+    """
+    counts: Dict[str, Any] = {
+        "rows_loaded": len(rows),
+        "rows_non_production": 0,
+        "rows_not_success": 0,
+        "rows_without_query": 0,
+        "rows_unknown_action": 0,
+        "rows_without_workspace": 0,
+        "distinct_queries": 0,
+        "tenants_seen": 0,
+        "tenants_dropped_small": 0,
+        "tenants_evaluated": 0,
+        "cases": 0,
+        "min_cases_per_tenant": min_cases_per_tenant,
+    }
+    votes: Dict[Tuple[str, str], Counter] = defaultdict(Counter)
+    first_query: Dict[Tuple[str, str], str] = {}
+    for row in rows:
+        if row.get("telemetry_source") not in _PRODUCTION_SOURCES:
+            counts["rows_non_production"] += 1
+            continue
+        if row.get("status") != "success":
+            counts["rows_not_success"] += 1
+            continue
+        query = (row.get("user_query") or "").strip()
+        if not query:
+            counts["rows_without_query"] += 1
+            continue
+        action = row.get("action_name") or ""
+        if action == _DISPATCHER_WRAPPER or action not in category_by_action:
+            counts["rows_unknown_action"] += 1
+            continue
+        workspace_id = row.get("workspace_id")
+        if not workspace_id:
+            counts["rows_without_workspace"] += 1
+            continue
+        key = (str(workspace_id), _normalise_query(query))
+        votes[key][action] += 1
+        first_query.setdefault(key, query)
+
+    counts["distinct_queries"] = len(votes)
+    by_tenant: Dict[str, List[EvalCase]] = defaultdict(list)
+    for key, counter in votes.items():
+        workspace_id, _ = key
+        # Majority successful action; ties break to the lexicographically
+        # smallest name so the label is identical run to run.
+        action = min(counter.items(), key=lambda kv: (-kv[1], kv[0]))[0]
+        by_tenant[workspace_id].append(
+            EvalCase(
+                query=first_query[key],
+                correct_action=action,
+                category=category_by_action[action],
+                workspace_id=workspace_id,
+            )
+        )
+
+    counts["tenants_seen"] = len(by_tenant)
+    cases: List[EvalCase] = []
+    for workspace_id in sorted(by_tenant):
+        tenant_cases = by_tenant[workspace_id]
+        if len(tenant_cases) < min_cases_per_tenant:
+            counts["tenants_dropped_small"] += 1
+            continue
+        cases.extend(sorted(tenant_cases, key=lambda c: (c.category, c.query)))
+    counts["tenants_evaluated"] = counts["tenants_seen"] - counts["tenants_dropped_small"]
+    counts["cases"] = len(cases)
+    return cases, counts
+
+
+def load_cases_from_telemetry(
+    window_days: int = DEFAULT_TELEMETRY_WINDOW_DAYS,
+    min_cases_per_tenant: int = DEFAULT_MIN_CASES_PER_TENANT,
+) -> Tuple[List[EvalCase], Dict[str, Any]]:
+    """Read production tool_execution_logs for the last ``window_days`` and
+    build per-tenant cases. Imports the ORM lazily: the harness stays
+    importable (and the CI fixture lane runnable) without a database."""
+    from datetime import datetime, timedelta
+
+    from core.database.database import get_db_session
+    from core.models.composio_cache import ToolExecutionLog
+    from modules.tools.discovery import get_action_registry
+
+    registry = get_action_registry()
+    category_by_action = {a.name: a.category for a in registry.get_all()}
+
+    cutoff = datetime.utcnow() - timedelta(days=window_days)
+    with get_db_session() as db:
+        query = (
+            db.query(
+                ToolExecutionLog.workspace_id,
+                ToolExecutionLog.user_query,
+                ToolExecutionLog.action_name,
+                ToolExecutionLog.status,
+                ToolExecutionLog.telemetry_source,
+            )
+            .filter(ToolExecutionLog.executed_at >= cutoff)
+            .order_by(ToolExecutionLog.executed_at.asc())
+        )
+        rows = [
+            {
+                "workspace_id": str(ws) if ws else None,
+                "user_query": q,
+                "action_name": action,
+                "status": status,
+                "telemetry_source": source,
+            }
+            for ws, q, action, status, source in query.all()
+        ]
+    cases, counts = cases_from_log_rows(
+        rows, category_by_action, min_cases_per_tenant=min_cases_per_tenant
+    )
+    counts["window_days"] = window_days
+    counts["registry_actions"] = len(category_by_action)
+    return cases, counts
+
+
+# ---------------------------------------------------------------------------
 # Reporting
 # ---------------------------------------------------------------------------
+
+def _describe_source(meta: Dict[str, Any]) -> str:
+    if meta.get("source") == "telemetry":
+        return (
+            f"Source: PRODUCTION TELEMETRY — {meta.get('cases', 0)} cases across "
+            f"{meta.get('tenants_evaluated', 0)} tenant(s), window "
+            f"{meta.get('window_days', '?')} days; {meta.get('tenants_dropped_small', 0)} "
+            f"tenant(s) below the {meta.get('min_cases_per_tenant', '?')}-case minimum dropped."
+        )
+    return (
+        f"Source: bundled fixture ({meta.get('cases', 0)} cases sharded into "
+        f"{meta.get('tenants', '?')} synthetic tenants) — NOT the production gate."
+    )
+
 
 def render_report(report: UpliftReport) -> str:
     lines = [
@@ -400,6 +581,7 @@ def render_report(report: UpliftReport) -> str:
         "",
         f"Uplift threshold: {UPLIFT_THRESHOLD_POINTS:.1f} points of top-1 accuracy "
         "(learned-edge over best baseline, per tenant, mean across tenants).",
+        _describe_source(report.meta),
         "",
         "| tenant | n(test) | BM25 top-1 | embedding top-1 | learned top-1 | uplift (pts) |",
         "| --- | --- | --- | --- | --- | --- |",
@@ -422,24 +604,59 @@ def render_report(report: UpliftReport) -> str:
             "on is supported by this run."
         )
     else:
+        note = (
+            "this IS the production-telemetry gate number"
+            if report.meta.get("source") == "telemetry"
+            else "this is the bundled fixture, not the gate — run with "
+            "--from-telemetry inside the API environment for the real number"
+        )
         lines.append(
             "Recommendation: uplift is BELOW the gate — do NOT flip "
-            "`TOOL_ROUTING_GRAPH` on. This is an honest sub-threshold outcome "
-            "(note: run against production per-tenant telemetry for the real gate; "
-            "the bundled fixture + offline embedding proxy under-represents the "
-            "learned signal available in production)."
+            f"`TOOL_ROUTING_GRAPH` on. This is an honest sub-threshold outcome ({note})."
         )
     return "\n".join(lines)
 
 
-def main(argv: Optional[List[str]] = None) -> int:
+def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Operating-graph uplift eval (PRD-177 S6)")
     parser.add_argument("--json", action="store_true", help="emit machine-readable JSON")
-    parser.add_argument("--tenants", type=int, default=2, help="synthetic tenant shards")
-    args = parser.parse_args(argv)
+    parser.add_argument(
+        "--tenants", type=int, default=2, help="synthetic tenant shards (fixture mode)"
+    )
+    parser.add_argument(
+        "--from-telemetry",
+        action="store_true",
+        help="the real gate: build cases from production tool_execution_logs "
+        "(needs the app database — run inside the API environment)",
+    )
+    parser.add_argument(
+        "--window-days",
+        type=int,
+        default=DEFAULT_TELEMETRY_WINDOW_DAYS,
+        help="telemetry lookback in days (with --from-telemetry)",
+    )
+    parser.add_argument(
+        "--min-cases",
+        type=int,
+        default=DEFAULT_MIN_CASES_PER_TENANT,
+        help="drop tenants with fewer distinct cases (with --from-telemetry)",
+    )
+    return parser
 
-    cases = load_cases_from_eval_set(num_tenants=args.tenants)
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = _build_parser().parse_args(argv)
+
+    if args.from_telemetry:
+        cases, counts = load_cases_from_telemetry(
+            window_days=args.window_days, min_cases_per_tenant=args.min_cases
+        )
+        meta: Dict[str, Any] = {"source": "telemetry", **counts}
+    else:
+        cases = load_cases_from_eval_set(num_tenants=args.tenants)
+        meta = {"source": "fixture", "tenants": args.tenants, "cases": len(cases)}
     report = run_uplift_eval(cases)
+    report.meta = meta
 
     if args.json:
         print(json.dumps(report.to_dict(), indent=2))

--- a/orchestrator/tests/test_prd177_uplift_eval.py
+++ b/orchestrator/tests/test_prd177_uplift_eval.py
@@ -18,8 +18,11 @@ if _orchestrator_root not in sys.path:
 from evals.operating_graph_uplift import (  # noqa: E402
     EvalCase,
     UPLIFT_THRESHOLD_POINTS,
+    cases_from_log_rows,
     load_cases_from_eval_set,
+    render_report,
     run_uplift_eval,
+    _build_parser,
     _bm25_ranker,
     _embedding_proxy_ranker,
 )
@@ -107,3 +110,106 @@ def test_bundled_fixture_runs_and_emits_a_number():
     d = report.to_dict()
     assert isinstance(d["mean_uplift_points"], float)
     assert "tenants" in d and len(d["tenants"]) == 2
+    assert d["source"] == "fixture"  # a fixture run can never pass as the gate
+
+
+# ---------------------------------------------------------------------------
+# Telemetry loader — the real gate (PRD-232 §6.4), pure half, no database
+# ---------------------------------------------------------------------------
+
+_CATEGORIES = {
+    "platform_list_agents": "agents",
+    "platform_create_agent": "agents",
+    "platform_search_memory": "memory",
+}
+
+
+def _row(ws, query, action, status="success", source="production"):
+    return {
+        "workspace_id": ws,
+        "user_query": query,
+        "action_name": action,
+        "status": status,
+        "telemetry_source": source,
+    }
+
+
+def test_telemetry_cases_come_only_from_successful_production_rows_with_known_actions():
+    rows = [
+        _row("ws-a", "list my agents", "platform_list_agents"),
+        _row("ws-a", "list my agents", "platform_list_agents", status="error"),
+        _row("ws-a", "replay me", "platform_list_agents", source="replay"),
+        _row("ws-a", "eval me", "platform_list_agents", source="eval"),
+        _row("ws-a", "do the thing", "platform_execute"),  # the wrapper is not an effect
+        _row("ws-a", "retired", "platform_gone_action"),  # unknown to the registry
+        _row("ws-a", "   ", "platform_list_agents"),  # no query text
+        _row(None, "no tenant", "platform_list_agents"),  # no workspace
+    ]
+    cases, counts = cases_from_log_rows(rows, _CATEGORIES, min_cases_per_tenant=1)
+    assert [(c.workspace_id, c.query, c.correct_action, c.category) for c in cases] == [
+        ("ws-a", "list my agents", "platform_list_agents", "agents")
+    ]
+    assert counts["rows_loaded"] == 8
+    assert counts["rows_not_success"] == 1
+    assert counts["rows_non_production"] == 2
+    assert counts["rows_unknown_action"] == 2
+    assert counts["rows_without_query"] == 1
+    assert counts["rows_without_workspace"] == 1
+
+
+def test_telemetry_repeated_queries_collapse_to_the_majority_action():
+    rows = (
+        [_row("ws-a", "Find my agents", "platform_list_agents")] * 3
+        + [_row("ws-a", "find my  agents", "platform_create_agent")] * 2  # same after normalising
+        + [_row("ws-a", "remember this", "platform_search_memory")]
+    )
+    cases, counts = cases_from_log_rows(rows, _CATEGORIES, min_cases_per_tenant=1)
+    assert counts["distinct_queries"] == 2
+    by_query = {c.query: c.correct_action for c in cases}
+    assert by_query["Find my agents"] == "platform_list_agents"  # 3 votes beat 2; first text kept
+    assert by_query["remember this"] == "platform_search_memory"
+
+
+def test_telemetry_ties_break_deterministically():
+    rows = [
+        _row("ws-a", "q", "platform_list_agents"),
+        _row("ws-a", "q", "platform_create_agent"),
+    ]
+    cases, _ = cases_from_log_rows(rows, _CATEGORIES, min_cases_per_tenant=1)
+    assert cases[0].correct_action == "platform_create_agent"  # smallest name on a tie
+
+
+def test_telemetry_drops_tenants_below_the_minimum_and_reports_it():
+    rows = [_row("ws-big", f"query {i}", "platform_list_agents") for i in range(10)] + [
+        _row("ws-small", "one", "platform_list_agents"),
+        _row("ws-small", "two", "platform_search_memory"),
+    ]
+    cases, counts = cases_from_log_rows(rows, _CATEGORIES, min_cases_per_tenant=10)
+    assert {c.workspace_id for c in cases} == {"ws-big"}
+    assert counts["tenants_seen"] == 2
+    assert counts["tenants_dropped_small"] == 1
+    assert counts["tenants_evaluated"] == 1
+    assert counts["cases"] == 10
+
+
+def test_telemetry_cases_feed_the_harness_and_the_report_names_its_source():
+    rows = [_row("ws-a", f"list agents number {i}", "platform_list_agents") for i in range(6)] + [
+        _row("ws-a", f"search memory for item {i}", "platform_search_memory") for i in range(6)
+    ]
+    cases, counts = cases_from_log_rows(rows, _CATEGORIES, min_cases_per_tenant=10)
+    report = run_uplift_eval(cases)
+    report.meta = {"source": "telemetry", **counts}
+    d = report.to_dict()
+    assert d["source"] == "telemetry"
+    assert d["loader"]["cases"] == 12
+    assert d["tenants"][0]["workspace_id"] == "ws-a"
+    assert "PRODUCTION TELEMETRY" in render_report(report)
+
+
+def test_cli_exposes_the_telemetry_gate_flags():
+    ns = _build_parser().parse_args(
+        ["--from-telemetry", "--window-days", "7", "--min-cases", "5", "--json"]
+    )
+    assert ns.from_telemetry and ns.window_days == 7 and ns.min_cases == 5 and ns.json
+    defaults = _build_parser().parse_args([])
+    assert not defaults.from_telemetry and defaults.tenants == 2


### PR DESCRIPTION
## Why
PRD-232 §6.4 gates the `TOOL_ROUTING_GRAPH` flip on a per-tenant uplift number measured on **production telemetry**. The harness (`evals/operating_graph_uplift.py`) only had the bundled fixture: its two "tenants" are synthetic shards of `eval_set.jsonl`, so the gate number never existed. The fixture run reads −32.8 points and says nothing about prod.

## What
- `cases_from_log_rows(rows, category_by_action, min_cases_per_tenant)` — pure: production rows only (`telemetry_source` production/NULL), `status == 'success'`, resolved inner action must exist in the ActionRegistry (`platform_execute` and retired names dropped — effects, not tool names), repeated queries collapse to one case with the majority successful action (deterministic tie-break), tenants below the minimum dropped. Returns cases + every drop count.
- `load_cases_from_telemetry(window_days, min_cases_per_tenant)` — the only place that imports the ORM, lazily; the stdlib-only CI lane is unchanged.
- CLI: `--from-telemetry`, `--window-days` (30), `--min-cases` (10). JSON and Markdown output now carry `source` (`fixture` | `telemetry`) and the loader counts, and the below-gate text says which one it was.
- 6 new pure tests (12 total in the file, all green).

## First production number (2026-09-02, run inside the API container)
3,759 rows in 30 days → 24 distinct graded queries → 3 tenants seen, 2 below the 10-case minimum → **1 tenant evaluated, 22 cases / 11 held out: +9.09 points** (learned 45.5% vs 36.4% best baseline). Passes the 5-point gate; supports the flag being on. Caveat: one tenant, 11 cases — re-run as data accrues.

## Data-capture findings (not fixed here — owner's call)
- 3,180 of 3,759 rows have no `user_query`; the `PLATFORM` writer logs 3,685 rows with only 181 queries. Most executions are ungradeable until the executor carries the query.
- `routing_source` is NULL on every row, so nothing records whether a selection came via the graph.