### PR TITLE
fix(prd-222): at 'building' the honest no-op names what is already registered

### DIFF
--- a/orchestrator/modules/tools/discovery/handlers_onboarding.py
+++ b/orchestrator/modules/tools/discovery/handlers_onboarding.py
@@ -20,6 +20,7 @@ from services.onboarding_state import (
     SEGMENT_KEYS,
     InvalidStageTransition,
     advance_onboarding_stage,
+    build_evidence,
     current_stage,
     get_onboarding,
     public_snapshot,
@@ -44,6 +45,29 @@ _SAME_STAGE_HINTS = {
     ),
     "boom": "Show the value on their business, then advance_to powerup.",
 }
+
+
+def _stage_hint(db: Any, workspace: Any) -> str:
+    """The current stage's next step. At 'building' it names what is ALREADY
+    registered (prod 2026-09-02, post-merge: two runs created a real agent or
+    installed the package, then re-asserted 'building' twice and never advanced
+    — the generic hint said "nothing is built yet", which was no longer true)."""
+    stage = current_stage(workspace)
+    if stage == "building" and db is not None:
+        ev = build_evidence(db, workspace)
+        if ev["any"]:
+            parts = []
+            if ev["package_installed"]:
+                parts.append("a package installed")
+            if ev["agents_built"]:
+                parts.append(f"{ev['agents_built']} agent(s) created")
+            if ev["missions"]:
+                parts.append(f"{ev['missions']} mission(s)")
+            return (
+                "Registered so far: " + ", ".join(parts) + ". If the build is complete, "
+                "advance_to boom now; otherwise keep building."
+            )
+    return _SAME_STAGE_HINTS.get(stage, "")
 
 
 def _usable_segment(segment: Any) -> Optional[Dict[str, Any]]:
@@ -224,7 +248,7 @@ async def update_onboarding(
             # installing nothing — a bare success read as progress. Say what
             # changed (nothing) and what the stage actually needs.
             snap = public_snapshot(workspace)
-            hint = _SAME_STAGE_HINTS.get(snap.get("stage"), "")
+            hint = _stage_hint(db, workspace)
             return {
                 "success": True,
                 "data": snap,
@@ -288,7 +312,7 @@ async def update_onboarding(
         # A refused move (backward, or the payoff without a build) names what the
         # CURRENT stage needs — local test 2026-09-02: Auto tried building →
         # proposal, was told "non-forward", and stalled.
-        hint = _SAME_STAGE_HINTS.get(current_stage(workspace), "")
+        hint = _stage_hint(db, workspace)
         return {"success": False, "error": f"{exc} {hint}".strip()}
     except ValueError as exc:
         # e.g. set_segment called with no recognised keys.

--- a/orchestrator/tests/test_prd222_segment_implied_advance.py
+++ b/orchestrator/tests/test_prd222_segment_implied_advance.py
@@ -182,3 +182,25 @@ def test_a_refused_move_names_what_the_current_stage_needs():
     assert r["success"] is False
     assert "non-forward" in r["error"] and "platform_install_package" in r["error"]
     assert current_stage(ws) == "building"
+
+
+# ── the building hint names what is already registered ────────────────────
+
+def test_building_noop_hint_names_the_registered_build():
+    ws = _Workspace("building")
+    r = asyncio.run(update_onboarding(_db(agents=2, workspace=ws), ws.id, {"advance_to": "building"}))
+    assert r["noop"] is True
+    assert "2 agent(s) created" in r["message"] and "advance_to boom now" in r["message"]
+    assert "Nothing is built yet" not in r["message"]
+
+
+def test_building_noop_hint_with_a_package_stamp():
+    ws = _Workspace("building", funnel={"package_installed": {"slug": "shopify-management", "at": "t"}})
+    r = asyncio.run(update_onboarding(_db(0, 0, workspace=ws), ws.id, {"advance_to": "building"}))
+    assert "a package installed" in r["message"] and "advance_to boom now" in r["message"]
+
+
+def test_building_noop_hint_with_nothing_built_is_unchanged():
+    ws = _Workspace("building")
+    r = asyncio.run(update_onboarding(_db(0, 0, workspace=ws), ws.id, {"advance_to": "building"}))
+    assert "Nothing is built yet" in r["message"]


### PR DESCRIPTION
## Prod, first run on the merged main (2026-09-02 13:35–13:47Z, 5 personas)
Every run walked `not_started → questions → teach → building` deterministically (the #674 inference held in prod; 14 shape WARNINGs, 0 freezes). Four of five then stalled at `building`. Two of those had **built something real** (waggle: an agent; lumen: the package) and still re-asserted `building` twice — the same-stage hint said *"Nothing is built yet"*, which was no longer true, and the model took it at its word.

## Fix
`_stage_hint(db, workspace)`: at `building` it reads `build_evidence` and says what is registered — *"Registered so far: 1 agent(s) created. If the build is complete, advance_to boom now; otherwise keep building."* — on both the honest no-op and a refused move. With nothing built the message is unchanged. Other stages keep their static hints.

## Tests
Three added to `test_prd222_segment_implied_advance.py` (agents, package stamp, nothing built).

CI only. No settings, no routes. Gerard's merge.