### PR TITLE
fix(prd-223): an unknown model id on agent creation uses the governed default and says so

### DIFF
--- a/orchestrator/modules/tools/discovery/handlers_agents.py
+++ b/orchestrator/modules/tools/discovery/handlers_agents.py
@@ -209,6 +209,7 @@ async def create_agent(db: Session, workspace_id: UUID, params: Dict[str, Any]) 
     # Build model_config from shared defaults (core.llm.defaults is the single source)
     from core.llm.defaults import get_default_model_config
     model_config: Dict[str, Any] = get_default_model_config()
+    model_note = None
     if model_id:
         # PRD-223 W1: this chat tool was an unvalidated model-write path —
         # any string became an agent's brain, provider guessed by substring.
@@ -219,24 +220,27 @@ async def create_agent(db: Session, workspace_id: UUID, params: Dict[str, Any]) 
 
         resolved = _get_or_create_from_cache(db, model_id)
         if resolved is None:
-            # Live-test 2026-08-29 + 09-02: Auto asked for a model id that is not
-            # in the catalog and retried the SAME id three times — the error named
-            # the problem but not the way out. Name it.
-            return {
-                "success": False,
-                "error": (
-                    f"Unknown model '{model_id}' — not found in the model catalog. "
-                    f"Omit model_id to use the workspace default "
-                    f"({model_config.get('model_id')}), or install the model first."
-                ),
-            }
-        allowed, reason = check_model_for_agent(
-            db, workspace_id, model_id, orchestrator_seat=False,
-        )
-        if not allowed:
-            return {"success": False, "error": f"Model rejected: {reason}"}
-        model_config["model_id"] = model_id
-        model_config["provider"] = resolved.provider
+            # Prod 2026-09-02 (post-#672): told "omit model_id to use the default",
+            # the model retried the SAME unknown id twice and the build stalled.
+            # An unknown id means the governed default in practice (PRD-223: the
+            # registry decides, never the caller's string) — use it and SAY so,
+            # in the result and in the log. The agent is still created.
+            default_id = model_config.get("model_id")
+            logger.warning(
+                "[create_agent] unknown model %r — using the workspace default %r", model_id, default_id
+            )
+            model_note = (
+                f"Model '{model_id}' is not in the catalog — the agent uses the workspace "
+                f"default ({default_id}) instead."
+            )
+        else:
+            allowed, reason = check_model_for_agent(
+                db, workspace_id, model_id, orchestrator_seat=False,
+            )
+            if not allowed:
+                return {"success": False, "error": f"Model rejected: {reason}"}
+            model_config["model_id"] = model_id
+            model_config["provider"] = resolved.provider
     if temperature is not None:
         model_config["temperature"] = max(0.0, min(2.0, float(temperature)))
 
@@ -289,7 +293,9 @@ async def create_agent(db: Session, workspace_id: UUID, params: Dict[str, Any]) 
             "has_system_prompt": bool(system_prompt),
             "tags": agent.tags or [],
         },
-        "message": f"Agent '{name}' created successfully with ID {agent.id}.",
+        "message": f"Agent '{name}' created successfully with ID {agent.id}."
+        + (f" {model_note}" if model_note else ""),
+        "model_note": model_note,
     }
 
 

--- a/orchestrator/tests/test_prd222_unknown_model_error_names_the_way_out.py
+++ b/orchestrator/tests/test_prd222_unknown_model_error_names_the_way_out.py
@@ -1,18 +1,44 @@
-"""PRD-222 — an unknown model id on agent creation names the way out (live-test 2026-09-02)."""
+"""PRD-223 — an unknown model id on agent creation uses the governed default and says so.
+
+Prod 2026-09-02 (post-#672): told "omit model_id to use the default", the model
+retried the SAME unknown id twice and the onboarding build stalled. The registry
+decides the model; an unknown id now means the workspace default, stated in the
+result and the log — the agent is still created. A known id still passes the
+PRD-223 policy gate.
+"""
 from __future__ import annotations
 
 import asyncio
+import logging
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 from uuid import uuid4
 
 import api.llm_marketplace as marketplace
+import core.llm.model_policy as policy
 from modules.tools.discovery.handlers_agents import create_agent
 
 
-def test_unknown_model_error_points_at_the_default(monkeypatch):
+def test_unknown_model_creates_the_agent_on_the_default_and_says_so(monkeypatch, caplog):
     monkeypatch.setattr(marketplace, "_get_or_create_from_cache", lambda db, model_id: None)
-    res = asyncio.run(create_agent(MagicMock(), uuid4(), {"name": "Booking Assistant", "model_id": "anthropic/claude-sonnet-4-20250514"}))
-    assert res["success"] is False
-    assert "not found in the model catalog" in res["error"]
-    assert "Omit model_id" in res["error"]
-    assert "workspace default (" in res["error"]
+    with caplog.at_level(logging.WARNING, logger="modules.tools.discovery.handlers_agents"):
+        res = asyncio.run(create_agent(MagicMock(), uuid4(), {"name": "Booking Assistant", "model_id": "anthropic/claude-sonnet-4-20250514"}))
+    assert res["success"] is True
+    assert "created successfully" in res["message"]
+    assert "not in the catalog" in res["model_note"] and "workspace default (" in res["model_note"]
+    assert res["model_note"] in res["message"]
+    assert any("unknown model" in r.getMessage() for r in caplog.records)
+
+
+def test_known_model_still_passes_the_policy_gate(monkeypatch):
+    monkeypatch.setattr(marketplace, "_get_or_create_from_cache", lambda db, model_id: SimpleNamespace(provider="openrouter"))
+    seen = {}
+
+    def gate(db, workspace_id, model_id, orchestrator_seat=False):
+        seen["model_id"] = model_id
+        return False, "not allowed on this plan"
+
+    monkeypatch.setattr(policy, "check_model_for_agent", gate)
+    res = asyncio.run(create_agent(MagicMock(), uuid4(), {"name": "X", "model_id": "google/gemini-2.5-pro"}))
+    assert res["success"] is False and "Model rejected" in res["error"]
+    assert seen["model_id"] == "google/gemini-2.5-pro"


### PR DESCRIPTION
## Prod, first run on the merged main (2026-09-02)
Told *"omit model_id to use the workspace default"* by #672, Auto retried the same unknown id (`anthropic/claude-sonnet-4-20250514`) twice and the onboarding build stalled at `building`. Refusing does not work with a caller that cannot take the hint.

## Fix
PRD-223 already makes the registry the authority. An unknown id now resolves to the workspace default: the agent is created on it, the result carries `model_note` (also appended to `message`), and the log carries a WARNING naming both ids. A known id still goes through `check_model_for_agent` exactly as before.

## Tests
`test_prd222_unknown_model_error_names_the_way_out.py` rewritten: unknown id → created on the default with the note + WARNING; known id → policy gate still enforced.

CI only. No settings, no routes. Gerard's merge.