### PR TITLE
fix(prd-224/227): 'close all the blocked tickets' — no invented assignee, every board status visible, bulk close, honest cap

### DIFF
--- a/orchestrator/consumers/chatbot/auto.py
+++ b/orchestrator/consumers/chatbot/auto.py
@@ -747,6 +747,7 @@ Prefer an agent that already exists. Before an **assign** or **mission** implies
 - "What agents do I have?" → molecule / respond (platform query)
 - "Search my docs for the Q4 report" → molecule / delegate (search tool, inline)
 - "Have my accountant agent chase the overdue invoices" → assign (named agent, off-thread deliverable), target_agent "accountant"
+- "Can you close all the blocked tickets for VECTOR? It was a token issue" → molecule / respond (addressed to YOU — do it with your platform tools; VECTOR owns the tickets and is not an assignee. Never invent an assignee from the topic, e.g. a Jira agent because the user said "tickets")
 - "Get Jim to draft the board pack, no rush" → assign + deferred (named agent, defer phrasing), target_agent "Jim"
 - "Research competitors, write a report, build a deck, and email the team" → organ / mission (multi-agent project)
 
@@ -766,7 +767,7 @@ Return ONLY valid JSON:
 }}
 
 action mapping: "respond" for atom; "delegate" for inline molecule/cell/organ answers; "assign" for a named/single agent's off-thread board work; "mission" ONLY for a multi-agent project (organ/organism with 4+ agents in phases).
-target_agent: for "assign", the agent name the user named (or the role, e.g. "accountant"); empty otherwise.
+target_agent: for "assign", the agent name the user named (or the role, e.g. "accountant") — it MUST appear in the user's own words; a request addressed to you ("can you…", "please close…") with no named assignee is NOT assign; empty otherwise.
 tool_hints: short domain keywords like "email", "github", "code", "database", "platform". Use "platform" when the user wants to create/list/manage agents, skills, plugins, recipes, or workspace resources. Empty for atom."""
 
 
@@ -984,7 +985,9 @@ class AutoBrain:
             )
             return []
 
-    def _match_roster_agent(self, name: Optional[str], agents=None):
+    def _match_roster_agent(
+        self, name: Optional[str], agents=None, message: Optional[str] = None
+    ):
         """Resolve an agent name from the user's request against the active
         roster (PRD-224 US-004). Case-insensitive: exact name first, then a
         forgiving contains match ("my accountant agent" -> "Accountant"). BOTH
@@ -1003,6 +1006,14 @@ class AutoBrain:
         if not name or not name.strip():
             return None, None
         target = name.strip().lower()
+        # Grounding (2026-09-02, the "JIRA ADMIN" misfire): when the user's
+        # message is supplied, the proposed name must be something they actually
+        # wrote. The classifier inferred a Jira agent from the word "tickets" in
+        # "can you close all the blocked tickets for VECTOR", and the lane filed
+        # and started a ticket for an agent the user never named. An ungrounded
+        # name resolves to nothing — the ask-in-thread signal, never a guess.
+        if message is not None and target not in message.lower():
+            return None, None
         agents = agents if agents is not None else self._active_agents()
         # Exact match wins — but collect EVERY exact (case-insensitive) hit keyed
         # by agent id so two agents sharing a name don't collapse to a first-row
@@ -1122,7 +1133,7 @@ class AutoBrain:
                 if action == Action.ASSIGN:
                     proposed = (data.get("target_agent") or "").strip()
                     target_agent_id, target_agent_name = self._match_roster_agent(
-                        proposed, roster
+                        proposed, roster, message=message
                     )
                     if target_agent_name is None and proposed:
                         target_agent_name = proposed  # keep the name for the ask

--- a/orchestrator/consumers/chatbot/service.py
+++ b/orchestrator/consumers/chatbot/service.py
@@ -2125,9 +2125,12 @@ class StreamingChatService:
             llm_messages.append({
                 "role": "system",
                 "content": (
-                    f"STOP: `{tool_name}` has been called {_attempts} times. "
-                    "You MUST now synthesize a response from the results you have. "
-                    "Do NOT call any more tools."
+                    f"STOP: `{tool_name}` has been called {_attempts} times — this turn's "
+                    "tool budget is exhausted. You MUST now synthesize a response from the "
+                    "results you have and call NO more tools. Be exact about completeness: "
+                    "say what was actually done and what remains undone. If the request "
+                    "needed more calls than you could make, say so plainly and offer to "
+                    "continue — never report the request as done."
                 ),
             })
             logger.warning(f"[tool-loop] Multi-step tool {tool_name} hit hard cap ({_attempts} calls) — forcing synthesis")

--- a/orchestrator/modules/tools/discovery/actions_board_tasks.py
+++ b/orchestrator/modules/tools/discovery/actions_board_tasks.py
@@ -3,6 +3,20 @@
 from .action_registry import ActionDefinition, ActionRegistry
 
 
+def _board_statuses() -> list:
+    """The board's real status vocabulary, from the HTTP path's single source of
+    truth (api.board_tasks.VALID_STATUSES). PRD-227 gave the agent HANDLER parity
+    with it, but these SCHEMAS still listed five of seven: 'blocked' and 'failed'
+    were invisible to the model, so "close all the blocked tickets" could not even
+    list them (2026-09-02). Sorted for a stable schema; the fallback is the same
+    set spelled out, so a registry build never depends on the API module importing."""
+    try:
+        from api.board_tasks import VALID_STATUSES
+        return sorted(VALID_STATUSES)
+    except Exception:  # pragma: no cover — import-order safety only
+        return ["assigned", "blocked", "done", "failed", "in_progress", "inbox", "review"]
+
+
 def register_board_task_actions(registry: ActionRegistry) -> None:
     """Register board task actions (PRD-72)."""
 
@@ -84,7 +98,7 @@ def register_board_task_actions(registry: ActionRegistry) -> None:
             "properties": {
                 "status": {
                     "type": "string",
-                    "enum": ["inbox", "assigned", "in_progress", "review", "done"],
+                    "enum": _board_statuses(),
                     "description": "Filter by status (omit for all)",
                 },
                 "priority": {
@@ -98,7 +112,11 @@ def register_board_task_actions(registry: ActionRegistry) -> None:
                 },
                 "limit": {
                     "type": "integer",
-                    "description": "Max results (default 20)",
+                    "description": (
+                        "Max results (default 20, max 200). The result's "
+                        "'total_matching' says how many match in all — raise the "
+                        "limit when you need every one (e.g. to close all blocked tasks)."
+                    ),
                 },
             },
             "required": [],
@@ -200,8 +218,11 @@ def register_board_task_actions(registry: ActionRegistry) -> None:
     registry.register(ActionDefinition(
         name="platform_update_task_status",
         description=(
-            "Change a task's status. Moving to 'in_progress' triggers immediate "
-            "agent execution if an agent is assigned. Moving to 'done' completes it."
+            "Change a task's status — one task via task_id, or MANY tasks to the "
+            "same status in ONE call via task_ids (use this for 'close all …'; "
+            "never loop one call per task). Moving to 'in_progress' triggers "
+            "immediate agent execution if an agent is assigned. Moving to 'done' "
+            "completes it. 'blocked' requires blocked_reason."
         ),
         category="tasks",
         parameters={
@@ -209,15 +230,28 @@ def register_board_task_actions(registry: ActionRegistry) -> None:
             "properties": {
                 "task_id": {
                     "type": "integer",
-                    "description": "The task ID",
+                    "description": "The task ID (single task)",
+                },
+                "task_ids": {
+                    "type": "array",
+                    "items": {"type": "integer"},
+                    "description": (
+                        "Several task IDs to move to the same status in one call "
+                        "(max 100). The result lists 'updated' and 'failed' ids — "
+                        "report both to the user."
+                    ),
                 },
                 "status": {
                     "type": "string",
-                    "enum": ["inbox", "assigned", "in_progress", "review", "done"],
+                    "enum": _board_statuses(),
                     "description": "New status",
                 },
+                "blocked_reason": {
+                    "type": "string",
+                    "description": "Why the task is blocked (required when status is 'blocked')",
+                },
             },
-            "required": ["task_id", "status"],
+            "required": ["status"],
         },
         permission_level="write",
         requires_confirmation=False,

--- a/orchestrator/modules/tools/discovery/handlers_board_tasks.py
+++ b/orchestrator/modules/tools/discovery/handlers_board_tasks.py
@@ -7,6 +7,14 @@ from uuid import UUID
 
 from sqlalchemy.orm import Session
 
+# list_board_tasks: the page size the model may ask for. "Close all the blocked
+# tasks" needs to SEE them all; 50 hid 121 blocked tasks behind a page (2026-09-02).
+MAX_LIST_TASKS_LIMIT = 200
+# update_board_task_status: how many task_ids one bulk call may carry. The chat
+# loop caps a tool at 8 calls per turn, so one-id-per-call could never close more
+# than eight tasks — the bulk path exists so "close all …" is one honest call.
+MAX_BULK_TASK_IDS = 100
+
 logger = logging.getLogger(__name__)
 
 
@@ -300,7 +308,13 @@ async def list_board_tasks(db: Session, workspace_id: UUID, params: Dict[str, An
         else:
             return {"success": True, "tasks": [], "total": 0, "note": f"No agent named '{agent_name}' found"}
 
-    limit = min(int(params.get("limit", 20)), 50)
+    limit = min(int(params.get("limit", 20)), MAX_LIST_TASKS_LIMIT)
+    # How many match in all, so the model knows whether it saw everything
+    # (the page is the sample, total_matching is the truth).
+    try:
+        total_matching = int(query.count())
+    except Exception:  # noqa: BLE001 — a count failure never fails the listing
+        total_matching = None
     tasks = query.order_by(BoardTask.created_at.desc()).limit(limit).all()
 
     # Enrich with agent names
@@ -327,7 +341,13 @@ async def list_board_tasks(db: Session, workspace_id: UUID, params: Dict[str, An
             "error_message": t.error_message,
         })
 
-    return {"success": True, "tasks": result, "total": len(result)}
+    return {
+        "success": True,
+        "tasks": result,
+        "total": len(result),
+        "total_matching": total_matching if total_matching is not None else len(result),
+        "limit": limit,
+    }
 
 
 async def get_board_task(db: Session, workspace_id: UUID, params: Dict[str, Any]) -> Dict[str, Any]:
@@ -421,14 +441,67 @@ async def assign_board_task(db: Session, workspace_id: UUID, params: Dict[str, A
     }
 
 
+async def _update_many_board_task_statuses(
+    db: Session, workspace_id: UUID, params: Dict[str, Any], task_ids: Any
+) -> Dict[str, Any]:
+    """Bulk form of update_board_task_status: every id goes through the SAME
+    single-task path (validation, blocked_reason rule, atomic in_progress claim,
+    board NOTIFY), so nothing is bypassed — this only removes the one-call-per-task
+    round trip that the per-turn tool cap turned into "closed the ones I could see".
+    Reports success only when EVERY id updated; the failed list names the rest."""
+    if not isinstance(task_ids, (list, tuple)):
+        return {"success": False, "error": "task_ids must be a list of task IDs"}
+    if len(task_ids) > MAX_BULK_TASK_IDS:
+        return {
+            "success": False,
+            "error": (
+                f"task_ids carries {len(task_ids)} ids; the maximum is {MAX_BULK_TASK_IDS} "
+                "per call — split the request and report progress to the user"
+            ),
+        }
+    new_status = params.get("status")
+    if not new_status:
+        return {"success": False, "error": "task_id (or task_ids) and status are required"}
+
+    single = {k: v for k, v in params.items() if k != "task_ids"}
+    updated = []
+    failed = []
+    for raw_id in task_ids:
+        try:
+            tid = int(raw_id)
+        except (TypeError, ValueError):
+            failed.append({"task_id": raw_id, "error": "not an integer task id"})
+            continue
+        result = await update_board_task_status(db, workspace_id, {**single, "task_id": tid})
+        if result.get("success"):
+            updated.append(tid)
+        else:
+            failed.append({"task_id": tid, "error": result.get("error", "unknown error")})
+    return {
+        "success": not failed,
+        "partial": bool(updated) and bool(failed),
+        "status": new_status,
+        "requested": len(task_ids),
+        "updated_count": len(updated),
+        "updated": updated,
+        "failed": failed,
+    }
+
+
 async def update_board_task_status(db: Session, workspace_id: UUID, params: Dict[str, Any]) -> Dict[str, Any]:
-    """Update a board task's status. Moving to in_progress triggers execution."""
+    """Update a board task's status. Moving to in_progress triggers execution.
+    With ``task_ids`` (a list) every id is updated to the same status — see
+    ``_update_many_board_task_statuses``."""
     from core.models.core import BoardTask
+
+    task_ids = params.get("task_ids")
+    if task_ids is not None and task_ids != []:
+        return await _update_many_board_task_statuses(db, workspace_id, params, task_ids)
 
     task_id = params.get("task_id")
     new_status = params.get("status")
     if not task_id or not new_status:
-        return {"success": False, "error": "task_id and status are required"}
+        return {"success": False, "error": "task_id (or task_ids) and status are required"}
 
     # PRD-227 US-001: agent-side vocabulary reaches parity with the HTTP path by
     # reusing its VALID_STATUSES set — so 'blocked'/'failed' are accepted and any

--- a/orchestrator/modules/tools/discovery/platform_executor.py
+++ b/orchestrator/modules/tools/discovery/platform_executor.py
@@ -974,73 +974,87 @@ class PlatformActionExecutor:
             if target_spec is not None:
                 target_type, target_param = target_spec
                 actor_id_raw = params.get("_agent_id") if isinstance(params, dict) else None
-                target_id_raw = (
-                    params.get(target_param)
-                    if (target_param and isinstance(params, dict))
+                # A bulk call carries its targets as ``<target_param>s`` (e.g.
+                # platform_update_task_status task_ids) — EVERY id is gated, and
+                # one denial denies the whole call. A missing/None target keeps
+                # the pre-bulk behaviour (one check with target_id=None).
+                bulk_key = f"{target_param}s" if target_param else None
+                bulk_raw = (
+                    params.get(bulk_key)
+                    if (bulk_key and isinstance(params, dict))
                     else None
                 )
+                if isinstance(bulk_raw, (list, tuple)) and bulk_raw:
+                    target_ids_raw = list(bulk_raw)
+                else:
+                    target_ids_raw = [
+                        params.get(target_param)
+                        if (target_param and isinstance(params, dict))
+                        else None
+                    ]
                 try:
                     actor_id = int(actor_id_raw) if actor_id_raw is not None else None
                 except (TypeError, ValueError):
                     actor_id = None
-                try:
-                    target_id = int(target_id_raw) if target_id_raw is not None else None
-                except (TypeError, ValueError):
-                    target_id = target_id_raw  # leave string IDs alone (UUIDs etc.)
+                for target_id_raw in target_ids_raw:
+                    try:
+                        target_id = int(target_id_raw) if target_id_raw is not None else None
+                    except (TypeError, ValueError):
+                        target_id = target_id_raw  # leave string IDs alone (UUIDs etc.)
 
-                try:
-                    decision = can_actor_modify(
-                        self.db,
-                        actor_agent_id=actor_id,
-                        target_type=target_type,
-                        workspace_id=self.workspace_id,
-                        target_id=target_id,
-                        change_type="update" if action_def.permission_level == "write" else "delete",
-                        source="platform_tool",
-                    )
-                except Exception as e:
-                    # Fail closed: a permission check that errors must DENY, never
-                    # fall through to execution. can_actor_modify's DB probes
-                    # (_agent_row / _reports_to_id) aren't all savepoint-guarded,
-                    # so a transient DB error would otherwise raise out of the gate
-                    # and leave the write's fate to upstream handling. Deny locally
-                    # and escalate to Auto — mirrors the registry-lookup fail-closed
-                    # above.
-                    logger.warning(
-                        "[PlatformExecutor] hierarchy_check_failed action=%s actor=%s "
-                        "target=%s/%s err=%s — denying (fail-closed)",
-                        action_name, actor_id, target_type, target_id, e,
-                    )
-                    return {
-                        "success": False,
-                        "permission_denied": True,
-                        "reason": "permission_check_failed",
-                        "escalation_target": "auto",
-                        "error": (
-                            f"Action '{action_name}' denied — permission check could not be "
-                            "completed. Route this through the auto for arbitration."
-                        ),
-                    }
-                if not decision.allowed:
-                    logger.warning(
-                        "[PlatformExecutor] hierarchy_denied action=%s actor=%s target=%s/%s reason=%s",
-                        action_name, actor_id, target_type, target_id, decision.reason,
-                    )
-                    return {
-                        "success": False,
-                        "permission_denied": True,
-                        "reason": decision.reason,
-                        "escalation_target": decision.escalation_target,
-                        "error": (
-                            f"Action '{action_name}' denied — {decision.reason}. "
-                            + (
-                                f"Route this through the {decision.escalation_target} "
-                                "for arbitration."
-                                if decision.escalation_target
-                                else ""
-                            )
-                        ).strip(),
-                    }
+                    try:
+                        decision = can_actor_modify(
+                            self.db,
+                            actor_agent_id=actor_id,
+                            target_type=target_type,
+                            workspace_id=self.workspace_id,
+                            target_id=target_id,
+                            change_type="update" if action_def.permission_level == "write" else "delete",
+                            source="platform_tool",
+                        )
+                    except Exception as e:
+                        # Fail closed: a permission check that errors must DENY, never
+                        # fall through to execution. can_actor_modify's DB probes
+                        # (_agent_row / _reports_to_id) aren't all savepoint-guarded,
+                        # so a transient DB error would otherwise raise out of the gate
+                        # and leave the write's fate to upstream handling. Deny locally
+                        # and escalate to Auto — mirrors the registry-lookup fail-closed
+                        # above.
+                        logger.warning(
+                            "[PlatformExecutor] hierarchy_check_failed action=%s actor=%s "
+                            "target=%s/%s err=%s — denying (fail-closed)",
+                            action_name, actor_id, target_type, target_id, e,
+                        )
+                        return {
+                            "success": False,
+                            "permission_denied": True,
+                            "reason": "permission_check_failed",
+                            "escalation_target": "auto",
+                            "error": (
+                                f"Action '{action_name}' denied — permission check could not be "
+                                "completed. Route this through the auto for arbitration."
+                            ),
+                        }
+                    if not decision.allowed:
+                        logger.warning(
+                            "[PlatformExecutor] hierarchy_denied action=%s actor=%s target=%s/%s reason=%s",
+                            action_name, actor_id, target_type, target_id, decision.reason,
+                        )
+                        return {
+                            "success": False,
+                            "permission_denied": True,
+                            "reason": decision.reason,
+                            "escalation_target": decision.escalation_target,
+                            "error": (
+                                f"Action '{action_name}' denied — {decision.reason}. "
+                                + (
+                                    f"Route this through the {decision.escalation_target} "
+                                    "for arbitration."
+                                    if decision.escalation_target
+                                    else ""
+                                )
+                            ).strip(),
+                        }
 
         # Rate limit write/destructive actions — scoped per (workspace, agent)
         # so a chatty Auto session doesn't starve mission tasks of headroom.

--- a/orchestrator/tests/test_board_task_handlers.py
+++ b/orchestrator/tests/test_board_task_handlers.py
@@ -1530,3 +1530,154 @@ def test_rvw4_single_active_match_still_resolves(monkeypatch):
     assert result["status"] == "assigned"
     assert db._task.assigned_agent_id == 7
     assert len(dispatch) == 1
+
+
+# ---------------------------------------------------------------------------
+# 2026-09-02 -- "close ALL blocked tasks": bulk status updates, a listing that
+# says how many match, and schemas that expose every real board status.
+# ---------------------------------------------------------------------------
+
+
+class _MultiQ:
+    """A query over several tasks that honours ``BoardTask.id == N`` filters."""
+
+    def __init__(self, tasks_by_id):
+        self._tasks = tasks_by_id
+        self._id = None
+
+    def filter(self, *exprs, **kw):
+        for expr in exprs:
+            left, right = getattr(expr, "left", None), getattr(expr, "right", None)
+            if getattr(left, "key", None) == "id" and hasattr(right, "value"):
+                self._id = right.value
+        return self
+
+    def order_by(self, *a, **k):
+        return self
+
+    def limit(self, *a, **k):
+        return self
+
+    def first(self):
+        return self._tasks.get(self._id) if self._id is not None else None
+
+    def all(self):
+        return list(self._tasks.values())
+
+    def count(self):
+        return len(self._tasks)
+
+
+class _MultiSession:
+    def __init__(self, tasks):
+        self.tasks = {t.id: t for t in tasks}
+        self.commits = 0
+
+    def query(self, model):
+        return _MultiQ(self.tasks)
+
+    def commit(self):
+        self.commits += 1
+
+
+def test_bulk_status_update_closes_every_id_in_one_call(monkeypatch):
+    calls = _patch_notify(monkeypatch)
+    tasks = [_fresh_task(id=i, status="blocked", blocked_at=1, blocked_reason="x") for i in (11, 12, 13)]
+    db = _MultiSession(tasks)
+
+    result = asyncio.run(
+        _HANDLER.update_board_task_status(db, _WS_ID, {"task_ids": [11, 12, 13], "status": "done"})
+    )
+
+    assert result["success"] is True and result["partial"] is False
+    assert result["updated"] == [11, 12, 13] and result["updated_count"] == 3
+    assert result["failed"] == [] and result["requested"] == 3
+    assert all(t.status == "done" for t in tasks)
+    assert all(t.blocked_reason is None and t.blocked_at is None for t in tasks)
+    assert [c["task_id"] for c in calls] == [11, 12, 13]  # one board NOTIFY per task
+
+
+def test_bulk_status_update_reports_the_ids_it_could_not_update(monkeypatch):
+    _patch_notify(monkeypatch)
+    db = _MultiSession([_fresh_task(id=11, status="blocked", blocked_reason="x")])
+
+    result = asyncio.run(
+        _HANDLER.update_board_task_status(db, _WS_ID, {"task_ids": [11, 999, "nope"], "status": "done"})
+    )
+
+    assert result["success"] is False and result["partial"] is True
+    assert result["updated"] == [11]
+    assert [f["task_id"] for f in result["failed"]] == [999, "nope"]
+    assert "not found" in result["failed"][0]["error"]
+
+
+def test_bulk_status_update_refuses_more_than_the_cap(monkeypatch):
+    _patch_notify(monkeypatch)
+    ids = list(range(1, _HANDLER.MAX_BULK_TASK_IDS + 2))
+    result = asyncio.run(
+        _HANDLER.update_board_task_status(_MultiSession([]), _WS_ID, {"task_ids": ids, "status": "done"})
+    )
+    assert result["success"] is False and "maximum" in result["error"]
+
+
+def test_bulk_status_update_keeps_the_single_path_rules(monkeypatch):
+    """'blocked' still needs blocked_reason — per id, through the same validation."""
+    _patch_notify(monkeypatch)
+    db = _MultiSession([_fresh_task(id=11, status="in_progress")])
+    result = asyncio.run(
+        _HANDLER.update_board_task_status(db, _WS_ID, {"task_ids": [11], "status": "blocked"})
+    )
+    assert result["success"] is False
+    assert "blocked_reason" in result["failed"][0]["error"]
+
+
+def test_single_status_update_without_any_id_names_both_forms():
+    result = asyncio.run(
+        _HANDLER.update_board_task_status(_MultiSession([]), _WS_ID, {"status": "done"})
+    )
+    assert result["success"] is False and "task_ids" in result["error"]
+
+
+def test_list_tasks_reports_total_matching_beyond_the_page():
+    tasks = [_fresh_task(id=i, status="blocked", tags=[], description="d", priority="low",
+                         assigned_agent_id=None, created_at=None, error_message=None)
+             for i in range(1, 8)]
+    result = asyncio.run(
+        _HANDLER.list_board_tasks(_MultiSession(tasks), _WS_ID, {"status": "blocked", "limit": 3})
+    )
+    assert result["success"] is True
+    assert result["total_matching"] == 7 and result["limit"] == 3
+    assert result["total"] == len(result["tasks"])
+
+
+def test_list_tasks_limit_is_capped_at_the_module_maximum():
+    result = asyncio.run(
+        _HANDLER.list_board_tasks(_MultiSession([]), _WS_ID, {"limit": 10_000})
+    )
+    assert result["limit"] == _HANDLER.MAX_LIST_TASKS_LIMIT
+
+
+class _StubRegistry:
+    def __init__(self):
+        self.actions = {}
+
+    def register(self, action):
+        self.actions[action.name] = action
+
+
+def test_task_tool_schemas_expose_every_board_status_and_the_bulk_form():
+    """The schemas the model sees must carry the HTTP path's full status set
+    (PRD-227 fixed only the handler): 'blocked' was invisible, so 'close all the
+    blocked tickets' could not even list them."""
+    from api.board_tasks import VALID_STATUSES
+    from modules.tools.discovery.actions_board_tasks import register_board_task_actions
+
+    reg = _StubRegistry()
+    register_board_task_actions(reg)
+    list_props = reg.actions["platform_list_tasks"].parameters["properties"]
+    upd = reg.actions["platform_update_task_status"].parameters
+    assert list_props["status"]["enum"] == sorted(VALID_STATUSES)
+    assert upd["properties"]["status"]["enum"] == sorted(VALID_STATUSES)
+    assert upd["properties"]["task_ids"]["type"] == "array"
+    assert "blocked_reason" in upd["properties"]
+    assert upd["required"] == ["status"]  # task_id OR task_ids, validated by the handler

--- a/orchestrator/tests/test_prd224_assign_lane.py
+++ b/orchestrator/tests/test_prd224_assign_lane.py
@@ -354,3 +354,51 @@ def test_service_py_injects_the_assign_directive():
         src = f.read()
     assert 'getattr(complexity_assessment, "context_directive", None)' in src
     assert "_assign_directive" in src
+
+
+# ---------------------------------------------------------------------------
+# 2026-09-02 -- the "JIRA ADMIN" misfire: a target agent must be grounded in
+# the user's own words. "Can you close all the blocked tickets for VECTOR" was
+# classified assign with target_agent "JIRA ADMIN" (inferred from "tickets"),
+# and the lane filed + started a ticket for an agent the user never named.
+# ---------------------------------------------------------------------------
+
+
+def test_match_roster_ungrounded_name_is_ask_signal():
+    """The classifier proposes a roster agent the user never mentioned →
+    unresolved (ask-in-thread), even though the name is a perfect roster hit."""
+    roster = [_agent(93, "JIRA ADMIN"), _agent(577, "VECTOR")]
+    message = "Hey Auto, Can you close all the blocked tickets for VECTOR as it was a token issue?"
+    assert _brain()._match_roster_agent("JIRA ADMIN", roster, message=message) == (None, None)
+
+
+def test_match_roster_grounded_partial_name_still_resolves():
+    """A name the user DID write keeps resolving, including the partial-name
+    contains path ('Jim' → 'Jim Whitfield')."""
+    roster = [_agent(3, "Jim Whitfield"), _agent(7, "Accountant")]
+    assert _brain()._match_roster_agent(
+        "Jim", roster, message="Get Jim to draft the board pack, no rush"
+    ) == (3, "Jim Whitfield")
+    assert _brain()._match_roster_agent(
+        "accountant", roster, message="Have my accountant agent chase the overdue invoices"
+    ) == (7, "Accountant")
+
+
+def test_match_roster_grounding_is_case_insensitive():
+    roster = [_agent(577, "VECTOR")]
+    assert _brain()._match_roster_agent(
+        "vector", roster, message="have VECTOR review the growth pulse"
+    ) == (577, "VECTOR")
+
+
+def test_match_roster_without_message_keeps_old_behaviour():
+    """Callers that cannot supply the message (none today) are unchanged."""
+    roster = [_agent(93, "JIRA ADMIN")]
+    assert _brain()._match_roster_agent("JIRA ADMIN", roster) == (93, "JIRA ADMIN")
+
+
+def test_prompt_forbids_inventing_an_assignee_from_the_topic():
+    prompt = build_assessment_prompt("hi", 0, "")
+    assert "MUST appear in the user's own words" in prompt
+    assert "close all the blocked tickets for VECTOR" in prompt
+    assert "Never invent an assignee from the topic" in prompt


### PR DESCRIPTION
## What the owner saw (2026-09-02 13:36Z, workspace ae8320bc)
1. *"Can you close all the blocked tickets for VECTOR as it was a token issue?"* → Auto **created ticket #2303 and started JIRA ADMIN on it**. Trace: `[Auto] ASSIGN lane — agent='JIRA ADMIN' resolved=True`. The classifier inferred a Jira agent from the word *tickets*; the user named nobody as assignee (VECTOR owns the tickets). The lane's directive then forbids answering directly.
2. *"I asked YOU to close all the tickets that are BLOCKED and assigned to VECTOR"* → tool gap, then `platform_list_tasks` + one `platform_update_task_status` (#1813 — correct: VECTOR had exactly one).
3. *"Please close ALL BLOCKED tasks/tickets"* → 2× list, 6× update, then `[tool-loop] platform_execute hit hard cap (8 calls)` → **"Done — I closed the blocked tasks I could see."** 121 blocked tasks remained.

## Root causes → fixes
| Cause | Fix |
|---|---|
| ASSIGN lane accepts a roster agent the user never mentioned | `_match_roster_agent(..., message=)`: the proposed name must appear in the user's words, else unresolved → ask-in-thread. Prompt rule + counter-example added. |
| `platform_list_tasks` status enum lacked `blocked` and `failed` (PRD-227 fixed the handler, not the schema) | Both task-tool enums derive from `api.board_tasks.VALID_STATUSES`. |
| One task per update call × 8-call turn cap = can never close more than eight | `platform_update_task_status` takes `task_ids` (bulk, max 100; every id goes through the single-task path incl. blocked_reason + atomic in_progress claim); `blocked_reason` added to the schema; `required` → `['status']`. Hierarchy gate checks **every** id of a bulk call. |
| Page of 20 (max 50) with no total → "the ones I could see" | `list_board_tasks` returns `total_matching` + `limit`; cap 200; schema text says to raise the limit when you need every one. |
| Cap STOP message never asks for honesty | Message now requires an exact done/undone report and forbids "done" when work remains. |

## Not fixed here (owner's call)
- `composio_execute` was offered ("Enriched with 50 actions from 23 apps") while `ComposioToolService` logged *No tools resolved*; Auto's first move was `composio_execute action=execute` → blocked as unknown. A no-tools-resolved app set should not be offered.
- 76 of the 121 blocked tasks are Auto's own "Review VECTOR/FIXER heartbeat" tickets — the blocked pile is heartbeat-generated.

## Tests
13 new pure tests (assign-lane grounding ×5, bulk/list/schema ×8); `test_prd224_assign_lane.py` + `test_board_task_handlers.py` = 123 passed locally on the current main tip; the corpus lint also passed.