### PR TITLE
PRD-234 S4: Session mode UI — settings tab with pairing, agent runtime field group, session block on tickets (stacked on #677)

### DIFF
--- a/frontend/components/activity/board/board-task-viewer.tsx
+++ b/frontend/components/activity/board/board-task-viewer.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Bot, Clock, CheckCircle2, AlertCircle, RotateCcw, Loader2, FileText, ExternalLink, Tag, Calendar, User, Shield, Workflow, Play } from 'lucide-react'
+import { Bot, Clock, CheckCircle2, AlertCircle, RotateCcw, Loader2, FileText, ExternalLink, Tag, Calendar, User, Shield, Workflow, Play, TerminalSquare } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog'
 import { PremiumIcon } from '@/components/shared'
@@ -45,11 +45,63 @@ function useLiveTask(task: BoardTask | null) {
     started_at: data.started_at ?? task.started_at,
     completed_at: data.completed_at ?? task.completed_at,
     step_progress: data.step_progress ?? task.step_progress,
+    runtime_ref: data.runtime_ref ?? task.runtime_ref,
   } as BoardTask
 }
 
 function formatElapsed(startedAt: string): string {
   return formatDistanceToNow(new Date(startedAt), { addSuffix: false })
+}
+
+// ── PRD-234: the session behind a `runtime: cli` ticket ─────────────────────
+
+function SessionBlock({ task }: { task: BoardTask }) {
+  const ref = task.runtime_ref
+  if (!ref || ref.runtime !== 'cli') return null
+  const files: string[] = Array.isArray(ref.files_touched) ? ref.files_touched : []
+  const usage = ref.usage || {}
+  const takeover = ref.session_id
+    ? `${ref.cwd ? `cd ${ref.cwd} && ` : ''}claude --resume ${ref.session_id}`
+    : null
+  return (
+    <div>
+      <SectionLabel icon={<TerminalSquare className="w-3 h-3" />}>Claude Code session</SectionLabel>
+      <div className="glass-card rounded-lg p-4 text-sm space-y-2">
+        <div className="grid grid-cols-2 gap-x-6 gap-y-1 text-xs">
+          <span className="text-muted-foreground">Provider · model</span>
+          <span>{ref.provider || 'claude'}{ref.model ? ` · ${ref.model}` : ''}</span>
+          <span className="text-muted-foreground">State</span>
+          <span>{ref.exit_reason ? `finished (${ref.exit_reason})` : ref.live_tool ? `running · ${ref.live_tool}` : ref.last_event ? `running · ${ref.last_event}` : 'claimed'}</span>
+          {usage.total_tokens != null && (
+            <>
+              <span className="text-muted-foreground">Tokens</span>
+              <span>{Number(usage.total_tokens).toLocaleString()}{usage.model ? ` on ${usage.model}` : ''} · plan usage, no cost</span>
+            </>
+          )}
+          {typeof ref.denials === 'number' && ref.denials > 0 && (
+            <>
+              <span className="text-muted-foreground">Denied tool calls</span>
+              <span>{ref.denials}</span>
+            </>
+          )}
+        </div>
+        {files.length > 0 && (
+          <div>
+            <p className="text-xs text-muted-foreground mb-1">Files touched</p>
+            <ul className="text-xs font-mono space-y-0.5 max-h-32 overflow-y-auto">
+              {files.map((f) => <li key={f} className="truncate" title={f}>{f}</li>)}
+            </ul>
+          </div>
+        )}
+        {takeover && (
+          <div>
+            <p className="text-xs text-muted-foreground mb-1">Take over in your terminal</p>
+            <code className="block rounded bg-muted px-2 py-1.5 font-mono text-xs overflow-x-auto">{takeover}</code>
+          </div>
+        )}
+      </div>
+    </div>
+  )
 }
 
 // ── Metadata grid — shared across views ──────────────────────────────
@@ -185,6 +237,8 @@ function InProgressContent({ task }: { task: BoardTask }) {
       )}
 
       {/* Live output */}
+      <SessionBlock task={task} />
+
       {task.result && (
         <div>
           <SectionLabel>Live Output</SectionLabel>
@@ -213,6 +267,8 @@ function ReviewContent({ task, onStatusChange, onApprove, onReject }: { task: Bo
           )}
         </div>
       </div>
+
+      <SessionBlock task={task} />
 
       {/* Agent result — the main attraction */}
       {task.result ? (

--- a/frontend/components/agents/__tests__/runtime-section.test.tsx
+++ b/frontend/components/agents/__tests__/runtime-section.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * PRD-234 S4 — the Runtime group shared by the create wizard and Configure.
+ *
+ * Local edition only; the fields round-trip through `Agent.configuration`
+ * (runtime / provider / model / working_directory) with blanks saved as null.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+async function load(edition: 'local' | 'saas') {
+  vi.resetModules()
+  vi.doMock('@/lib/auth-edition', () => ({
+    authEdition: edition,
+    isLocal: edition === 'local',
+    isSaaS: edition === 'saas',
+  }))
+  return import('../runtime-section')
+}
+
+afterEach(() => {
+  vi.doUnmock('@/lib/auth-edition')
+  vi.resetModules()
+})
+
+describe('runtime configuration helpers', () => {
+  it('an api agent saves only the runtime kind', async () => {
+    const { runtimeConfiguration, DEFAULT_RUNTIME_FIELDS } = await load('local')
+    expect(runtimeConfiguration(DEFAULT_RUNTIME_FIELDS)).toEqual({ runtime: 'api' })
+  })
+
+  it('a cli agent saves provider/model/working_directory with blanks as null, trimmed', async () => {
+    const { runtimeConfiguration } = await load('local')
+    expect(
+      runtimeConfiguration({ runtime: 'cli', cli_provider: 'claude', cli_model: '  ', cli_working_directory: '' }),
+    ).toEqual({ runtime: 'cli', provider: 'claude', model: null, working_directory: null })
+    expect(
+      runtimeConfiguration({ runtime: 'cli', cli_provider: '', cli_model: ' fable ', cli_working_directory: ' /w/repo ' }),
+    ).toEqual({ runtime: 'cli', provider: 'claude', model: 'fable', working_directory: '/w/repo' })
+  })
+
+  it('reads the fields back from an agent configuration, defaulting anything missing', async () => {
+    const { runtimeFieldsFromConfiguration, DEFAULT_RUNTIME_FIELDS } = await load('local')
+    expect(runtimeFieldsFromConfiguration(undefined)).toEqual(DEFAULT_RUNTIME_FIELDS)
+    expect(runtimeFieldsFromConfiguration({ runtime: 'api', model: 'gpt-4o' })).toEqual({
+      ...DEFAULT_RUNTIME_FIELDS,
+      cli_model: 'gpt-4o',
+    })
+    expect(
+      runtimeFieldsFromConfiguration({ runtime: 'cli', provider: 'claude', model: 'opus', working_directory: '/w' }),
+    ).toEqual({ runtime: 'cli', cli_provider: 'claude', cli_model: 'opus', cli_working_directory: '/w' })
+  })
+})
+
+describe('RuntimeSection', () => {
+  it('does not exist in the saas edition', async () => {
+    const { RuntimeSection, DEFAULT_RUNTIME_FIELDS } = await load('saas')
+    const { container } = render(<RuntimeSection value={DEFAULT_RUNTIME_FIELDS} onChange={vi.fn()} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders the runtime choice locally and hides the session fields for an api agent', async () => {
+    const { RuntimeSection, DEFAULT_RUNTIME_FIELDS } = await load('local')
+    render(<RuntimeSection value={DEFAULT_RUNTIME_FIELDS} onChange={vi.fn()} />)
+    expect(screen.getByLabelText('Runtime')).toBeInTheDocument()
+    expect(screen.queryByLabelText(/Working directory/)).not.toBeInTheDocument()
+  })
+
+  it('shows the session fields for a cli agent and reports edits field by field', async () => {
+    const { RuntimeSection } = await load('local')
+    const onChange = vi.fn()
+    render(
+      <RuntimeSection
+        value={{ runtime: 'cli', cli_provider: 'claude', cli_model: '', cli_working_directory: '' }}
+        onChange={onChange}
+      />,
+    )
+    fireEvent.change(screen.getByLabelText(/Model \(optional\)/), { target: { value: 'fable' } })
+    fireEvent.change(screen.getByLabelText(/Working directory/), { target: { value: '/w/repo' } })
+    expect(onChange).toHaveBeenCalledWith('cli_model', 'fable')
+    expect(onChange).toHaveBeenCalledWith('cli_working_directory', '/w/repo')
+  })
+})

--- a/frontend/components/agents/agent-configuration-modal.tsx
+++ b/frontend/components/agents/agent-configuration-modal.tsx
@@ -29,6 +29,7 @@ import {
   Activity,
   Loader2,
   Play,
+  TerminalSquare,
 } from 'lucide-react'
 import { InlineHelp } from '@/components/ui/help-tooltip'
 import { Button } from '@/components/ui/button'
@@ -61,6 +62,7 @@ import { useTools } from '@/hooks/use-tools-api'
 import { useSystemIcons } from '@/hooks/use-system-config-api'
 import { apiClient } from '@/lib/api-client'
 import { toast } from 'sonner'
+import { isLocal } from '@/lib/auth-edition'
 
 interface AgentConfigurationModalProps {
   agentId: number | null
@@ -419,7 +421,12 @@ export function AgentConfigurationModal({
         // PRD-15: Model configuration
         model_config: modelConfig,
         // Tools configuration — filter out null IDs (tools without cache entries)
-        assigned_tools: ((agent as any).tools || []).map((tool: any) => tool.id).filter((id: any) => id != null)
+        assigned_tools: ((agent as any).tools || []).map((tool: any) => tool.id).filter((id: any) => id != null),
+        // PRD-234: runtime — API model (default) or the user's own Claude Code session
+        runtime: ((agent as any).configuration?.runtime === 'cli') ? 'cli' : 'api',
+        cli_provider: (agent as any).configuration?.provider || 'claude',
+        cli_model: (agent as any).configuration?.model || '',
+        cli_working_directory: (agent as any).configuration?.working_directory || '',
       })
       setHasChanges(false)
     }
@@ -637,6 +644,15 @@ export function AgentConfigurationModal({
         tags,
         configuration: {
           category: selectedCategory,
+          // PRD-234: the runtime fields ride the same configuration JSON (backend validates)
+          runtime: formData.runtime === 'cli' ? 'cli' : 'api',
+          ...(formData.runtime === 'cli'
+            ? {
+                provider: formData.cli_provider || 'claude',
+                model: (formData.cli_model || '').trim() || null,
+                working_directory: (formData.cli_working_directory || '').trim() || null,
+              }
+            : {}),
           priority_level: formData.priority_level,
           max_concurrent_tasks: formData.max_concurrent_tasks,
           auto_start: formData.auto_start,
@@ -1516,6 +1532,72 @@ export function AgentConfigurationModal({
                       </p>
                     </CardHeader>
                     <CardContent className="space-y-6">
+                      {/* PRD-234 S4: where this agent runs — API model, or the user's own Claude Code session (local edition) */}
+                      {isLocal && (
+                        <div className="space-y-4 rounded-lg border border-border/40 p-4">
+                          <div className="flex items-center gap-2">
+                            <TerminalSquare className="h-4 w-4 text-[hsl(var(--agent))]" />
+                            <Label className="text-sm font-medium">Runtime</Label>
+                          </div>
+                          <Select
+                            value={formData.runtime || 'api'}
+                            onValueChange={(value) => updateFormData('runtime', value)}
+                          >
+                            <SelectTrigger aria-label="Runtime">
+                              <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                              <SelectItem value="api">API model (this workspace&apos;s keys or OpenRouter)</SelectItem>
+                              <SelectItem value="cli">Claude Code session (your own login, on your machine)</SelectItem>
+                            </SelectContent>
+                          </Select>
+                          {formData.runtime === 'cli' && (
+                            <div className="space-y-3">
+                              <p className="text-xs text-muted-foreground">
+                                Tickets for this agent are run by your paired CLI host as interactive Claude Code sessions.
+                                The model settings below do not apply to sessions.
+                              </p>
+                              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                                <div className="space-y-1">
+                                  <Label htmlFor="cli-provider" className="text-xs">CLI</Label>
+                                  <Select
+                                    value={formData.cli_provider || 'claude'}
+                                    onValueChange={(value) => updateFormData('cli_provider', value)}
+                                  >
+                                    <SelectTrigger id="cli-provider"><SelectValue /></SelectTrigger>
+                                    <SelectContent>
+                                      <SelectItem value="claude">Claude Code</SelectItem>
+                                      <SelectItem value="codex">Codex (S5 — not yet served by the host)</SelectItem>
+                                    </SelectContent>
+                                  </Select>
+                                </div>
+                                <div className="space-y-1">
+                                  <Label htmlFor="cli-model" className="text-xs">Model alias (optional)</Label>
+                                  <Input
+                                    id="cli-model"
+                                    placeholder="sonnet · opus · haiku · fable (blank = the CLI's default)"
+                                    value={formData.cli_model || ''}
+                                    onChange={(e) => updateFormData('cli_model', e.target.value)}
+                                  />
+                                </div>
+                              </div>
+                              <div className="space-y-1">
+                                <Label htmlFor="cli-working-directory" className="text-xs">Working directory (absolute path, inside a directory the host registered)</Label>
+                                <Input
+                                  id="cli-working-directory"
+                                  placeholder="/Users/you/Development/your-repo"
+                                  value={formData.cli_working_directory || ''}
+                                  onChange={(e) => updateFormData('cli_working_directory', e.target.value)}
+                                />
+                                <p className="text-xs text-muted-foreground">
+                                  Blank = the host&apos;s default <span className="font-mono">./workspaces</span>. Git repositories get their own worktree per session; sessions never push.
+                                </p>
+                              </div>
+                            </div>
+                          )}
+                        </div>
+                      )}
+
                       {/* Model Selection */}
                       <ModelSelector
                         value={formData.model_config?.model_id || LLM_DEFAULTS.model_id}

--- a/frontend/components/agents/agent-configuration-modal.tsx
+++ b/frontend/components/agents/agent-configuration-modal.tsx
@@ -29,7 +29,6 @@ import {
   Activity,
   Loader2,
   Play,
-  TerminalSquare,
 } from 'lucide-react'
 import { InlineHelp } from '@/components/ui/help-tooltip'
 import { Button } from '@/components/ui/button'
@@ -62,7 +61,7 @@ import { useTools } from '@/hooks/use-tools-api'
 import { useSystemIcons } from '@/hooks/use-system-config-api'
 import { apiClient } from '@/lib/api-client'
 import { toast } from 'sonner'
-import { isLocal } from '@/lib/auth-edition'
+import { RuntimeSection, normalizeRuntimeFields, runtimeConfiguration, runtimeFieldsFromConfiguration } from './runtime-section'
 
 interface AgentConfigurationModalProps {
   agentId: number | null
@@ -423,10 +422,7 @@ export function AgentConfigurationModal({
         // Tools configuration — filter out null IDs (tools without cache entries)
         assigned_tools: ((agent as any).tools || []).map((tool: any) => tool.id).filter((id: any) => id != null),
         // PRD-234: runtime — API model (default) or the user's own Claude Code session
-        runtime: ((agent as any).configuration?.runtime === 'cli') ? 'cli' : 'api',
-        cli_provider: (agent as any).configuration?.provider || 'claude',
-        cli_model: (agent as any).configuration?.model || '',
-        cli_working_directory: (agent as any).configuration?.working_directory || '',
+        ...runtimeFieldsFromConfiguration((agent as any).configuration),
       })
       setHasChanges(false)
     }
@@ -645,14 +641,7 @@ export function AgentConfigurationModal({
         configuration: {
           category: selectedCategory,
           // PRD-234: the runtime fields ride the same configuration JSON (backend validates)
-          runtime: formData.runtime === 'cli' ? 'cli' : 'api',
-          ...(formData.runtime === 'cli'
-            ? {
-                provider: formData.cli_provider || 'claude',
-                model: (formData.cli_model || '').trim() || null,
-                working_directory: (formData.cli_working_directory || '').trim() || null,
-              }
-            : {}),
+          ...runtimeConfiguration(normalizeRuntimeFields(formData)),
           priority_level: formData.priority_level,
           max_concurrent_tasks: formData.max_concurrent_tasks,
           auto_start: formData.auto_start,
@@ -1533,70 +1522,10 @@ export function AgentConfigurationModal({
                     </CardHeader>
                     <CardContent className="space-y-6">
                       {/* PRD-234 S4: where this agent runs — API model, or the user's own Claude Code session (local edition) */}
-                      {isLocal && (
-                        <div className="space-y-4 rounded-lg border border-border/40 p-4">
-                          <div className="flex items-center gap-2">
-                            <TerminalSquare className="h-4 w-4 text-[hsl(var(--agent))]" />
-                            <Label className="text-sm font-medium">Runtime</Label>
-                          </div>
-                          <Select
-                            value={formData.runtime || 'api'}
-                            onValueChange={(value) => updateFormData('runtime', value)}
-                          >
-                            <SelectTrigger aria-label="Runtime">
-                              <SelectValue />
-                            </SelectTrigger>
-                            <SelectContent>
-                              <SelectItem value="api">API model (this workspace&apos;s keys or OpenRouter)</SelectItem>
-                              <SelectItem value="cli">Claude Code session (your own login, on your machine)</SelectItem>
-                            </SelectContent>
-                          </Select>
-                          {formData.runtime === 'cli' && (
-                            <div className="space-y-3">
-                              <p className="text-xs text-muted-foreground">
-                                Tickets for this agent are run by your paired CLI host as interactive Claude Code sessions.
-                                The model settings below do not apply to sessions.
-                              </p>
-                              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                                <div className="space-y-1">
-                                  <Label htmlFor="cli-provider" className="text-xs">CLI</Label>
-                                  <Select
-                                    value={formData.cli_provider || 'claude'}
-                                    onValueChange={(value) => updateFormData('cli_provider', value)}
-                                  >
-                                    <SelectTrigger id="cli-provider"><SelectValue /></SelectTrigger>
-                                    <SelectContent>
-                                      <SelectItem value="claude">Claude Code</SelectItem>
-                                      <SelectItem value="codex">Codex (S5 — not yet served by the host)</SelectItem>
-                                    </SelectContent>
-                                  </Select>
-                                </div>
-                                <div className="space-y-1">
-                                  <Label htmlFor="cli-model" className="text-xs">Model alias (optional)</Label>
-                                  <Input
-                                    id="cli-model"
-                                    placeholder="sonnet · opus · haiku · fable (blank = the CLI's default)"
-                                    value={formData.cli_model || ''}
-                                    onChange={(e) => updateFormData('cli_model', e.target.value)}
-                                  />
-                                </div>
-                              </div>
-                              <div className="space-y-1">
-                                <Label htmlFor="cli-working-directory" className="text-xs">Working directory (absolute path, inside a directory the host registered)</Label>
-                                <Input
-                                  id="cli-working-directory"
-                                  placeholder="/Users/you/Development/your-repo"
-                                  value={formData.cli_working_directory || ''}
-                                  onChange={(e) => updateFormData('cli_working_directory', e.target.value)}
-                                />
-                                <p className="text-xs text-muted-foreground">
-                                  Blank = the host&apos;s default <span className="font-mono">./workspaces</span>. Git repositories get their own worktree per session; sessions never push.
-                                </p>
-                              </div>
-                            </div>
-                          )}
-                        </div>
-                      )}
+                      <RuntimeSection
+                        value={normalizeRuntimeFields(formData)}
+                        onChange={(field, value) => updateFormData(field, value)}
+                      />
 
                       {/* Model Selection */}
                       <ModelSelector

--- a/frontend/components/agents/create-agent-modal.tsx
+++ b/frontend/components/agents/create-agent-modal.tsx
@@ -37,6 +37,7 @@ import { useCreateAgent } from '@/hooks/use-agent-api'
 import { useModels, useUpdateAgentModelConfig } from '@/hooks/use-model-api'
 import { useSystemIcons } from '@/hooks/use-system-config-api'
 import { ModelSelector } from './model-selector'
+import { RuntimeSection, DEFAULT_RUNTIME_FIELDS, runtimeConfiguration, type RuntimeFields } from './runtime-section'
 import { ToolLogo } from '@/components/ui/tool-logo'
 import { apiClient } from '@/lib/api-client'
 
@@ -79,6 +80,9 @@ export function CreateAgentModal({ open, onClose, onSuccess }: CreateAgentModalP
 
   // PRD-15: Model configuration state
   const [modelConfig, setModelConfig] = useState(getDefaultModelConfig())
+
+  // PRD-234: runtime — API model (default) or the user's own Claude Code session (local edition)
+  const [runtimeFields, setRuntimeFields] = useState<RuntimeFields>(DEFAULT_RUNTIME_FIELDS)
 
   // Persona state (US-021)
   const [personaMode, setPersonaMode] = useState<PersonaMode>('none')
@@ -205,7 +209,9 @@ export function CreateAgentModal({ open, onClose, onSuccess }: CreateAgentModalP
         configuration: {
           category: agentData.category,
           specializations: agentData.specializations || [],
-          tags
+          tags,
+          // PRD-234: the runtime rides the same configuration JSON; the backend validates it
+          ...runtimeConfiguration(runtimeFields),
         }
       }
 
@@ -307,6 +313,7 @@ export function CreateAgentModal({ open, onClose, onSuccess }: CreateAgentModalP
         shareToMarketplace: false
       })
       setModelConfig(getDefaultModelConfig())
+      setRuntimeFields(DEFAULT_RUNTIME_FIELDS)
       setPersonaMode('none')
       setSelectedPersonaId(null)
       setCustomPersonaPrompt('')
@@ -742,6 +749,12 @@ export function CreateAgentModal({ open, onClose, onSuccess }: CreateAgentModalP
                         </p>
                       </CardHeader>
                       <CardContent className="space-y-6">
+
+                        {/* PRD-234 S4: where this agent runs — API model, or the user's own Claude Code session (local edition) */}
+                        <RuntimeSection
+                          value={runtimeFields}
+                          onChange={(field, value) => setRuntimeFields((prev) => ({ ...prev, [field]: value }))}
+                        />
 
                         <ModelSelector
                           value={modelConfig.model_id}

--- a/frontend/components/agents/runtime-section.tsx
+++ b/frontend/components/agents/runtime-section.tsx
@@ -1,0 +1,161 @@
+'use client'
+
+/**
+ * PRD-234 S4 — the Runtime group of an agent's Model step.
+ *
+ * Shared by the create wizard and the configuration modal so both offer the
+ * same choice: an API model (the default — this workspace's keys or OpenRouter)
+ * or the user's own Claude Code session on their machine. Local edition only:
+ * in saas the group does not render and every agent stays `api`.
+ *
+ * The fields ride `Agent.configuration` (runtime / provider / model /
+ * working_directory). The backend validates them (`core/cli_runtime.py`), so a
+ * bad alias is refused at save, not discovered at claim.
+ */
+
+import { TerminalSquare } from 'lucide-react'
+import { isLocal } from '@/lib/auth-edition'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+
+export type RuntimeKind = 'api' | 'cli'
+
+export interface RuntimeFields {
+  runtime: RuntimeKind
+  cli_provider: string
+  cli_model: string
+  cli_working_directory: string
+}
+
+const DEFAULT_CLI_PROVIDER = 'claude'
+
+export const DEFAULT_RUNTIME_FIELDS: RuntimeFields = {
+  runtime: 'api',
+  cli_provider: DEFAULT_CLI_PROVIDER,
+  cli_model: '',
+  cli_working_directory: '',
+}
+
+/** The aliases Claude Code itself resolves (`claude --model`); a full `claude-…` id also works. */
+export const CLAUDE_MODEL_ALIASES = ['fable', 'opus', 'sonnet', 'haiku'] as const
+
+function str(value: unknown): string {
+  return typeof value === 'string' ? value : ''
+}
+
+/** Coerce a loosely-typed source (a form state, a decoded JSON) into RuntimeFields. */
+export function normalizeRuntimeFields(source: object | null | undefined): RuntimeFields {
+  const src = (source ?? {}) as Record<string, unknown>
+  return {
+    runtime: src.runtime === 'cli' ? 'cli' : 'api',
+    cli_provider: str(src.cli_provider) || DEFAULT_CLI_PROVIDER,
+    cli_model: str(src.cli_model),
+    cli_working_directory: str(src.cli_working_directory),
+  }
+}
+
+/** The fields as stored on an agent's `configuration` JSON. */
+export function runtimeFieldsFromConfiguration(configuration: object | null | undefined): RuntimeFields {
+  const cfg = (configuration ?? {}) as Record<string, unknown>
+  return normalizeRuntimeFields({
+    runtime: cfg.runtime,
+    cli_provider: cfg.provider,
+    cli_model: cfg.model,
+    cli_working_directory: cfg.working_directory,
+  })
+}
+
+/**
+ * The configuration fragment to save. An api agent carries only `runtime: 'api'`;
+ * a cli agent carries provider/model/working_directory, blanks as null so the
+ * host falls back to the CLI's default model and its default directory.
+ */
+export function runtimeConfiguration(fields: RuntimeFields): Record<string, unknown> {
+  if (fields.runtime !== 'cli') return { runtime: 'api' }
+  return {
+    runtime: 'cli',
+    provider: fields.cli_provider || DEFAULT_CLI_PROVIDER,
+    model: fields.cli_model.trim() || null,
+    working_directory: fields.cli_working_directory.trim() || null,
+  }
+}
+
+interface RuntimeSectionProps {
+  value: RuntimeFields
+  onChange: <K extends keyof RuntimeFields>(field: K, value: RuntimeFields[K]) => void
+}
+
+export function RuntimeSection({ value, onChange }: RuntimeSectionProps) {
+  if (!isLocal) return null
+  return (
+    <div className="space-y-4 rounded-lg border border-border/40 p-4" data-testid="runtime-section">
+      <div className="flex items-center gap-2">
+        <TerminalSquare className="h-4 w-4 text-[hsl(var(--agent))]" />
+        <Label className="text-sm font-medium">Runtime</Label>
+      </div>
+      <Select
+        value={value.runtime}
+        onValueChange={(next) => onChange('runtime', next === 'cli' ? 'cli' : 'api')}
+      >
+        <SelectTrigger aria-label="Runtime">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="api">API model (this workspace&apos;s keys or OpenRouter)</SelectItem>
+          <SelectItem value="cli">Claude Code session (your own login, on your machine)</SelectItem>
+        </SelectContent>
+      </Select>
+      {value.runtime === 'cli' && (
+        <div className="space-y-3">
+          <p className="text-xs text-muted-foreground">
+            Tickets for this agent are run by your paired CLI host as interactive Claude Code sessions.
+            The model settings below do not apply to sessions.
+          </p>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div className="space-y-1">
+              <Label htmlFor="cli-provider" className="text-xs">CLI</Label>
+              <Select
+                value={value.cli_provider || DEFAULT_CLI_PROVIDER}
+                onValueChange={(next) => onChange('cli_provider', next)}
+              >
+                <SelectTrigger id="cli-provider"><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="claude">Claude Code</SelectItem>
+                  <SelectItem value="codex">Codex (S5 — not yet served by the host)</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="cli-model" className="text-xs">Model (optional)</Label>
+              <Input
+                id="cli-model"
+                placeholder={`${CLAUDE_MODEL_ALIASES.join(' · ')} · or a full id such as claude-opus-5`}
+                value={value.cli_model}
+                onChange={(e) => onChange('cli_model', e.target.value)}
+              />
+              <p className="text-xs text-muted-foreground">
+                Claude Code&apos;s own aliases, lowercase. Blank = the CLI&apos;s default. The model must be
+                available to your login; it is not one of the API models below.
+              </p>
+            </div>
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="cli-working-directory" className="text-xs">Working directory (absolute path, inside a directory the host registered)</Label>
+            <Input
+              id="cli-working-directory"
+              placeholder="/Users/you/Development/your-repo"
+              value={value.cli_working_directory}
+              onChange={(e) => onChange('cli_working_directory', e.target.value)}
+            />
+            <p className="text-xs text-muted-foreground">
+              Blank = the host&apos;s default <span className="font-mono">./workspaces</span>. Git repositories get their own worktree per session; sessions never push.
+            </p>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default RuntimeSection

--- a/frontend/components/settings/SessionModeTab.tsx
+++ b/frontend/components/settings/SessionModeTab.tsx
@@ -1,0 +1,220 @@
+'use client'
+
+/**
+ * PRD-234 S4 — Settings → Session mode (local edition only).
+ *
+ * The operator's view of the CLI host lane: is session mode on, which hosts are
+ * paired and online, and the one-time pairing code a new host needs. The code
+ * is shown ONCE with the exact command to run; the token it is exchanged for
+ * never reaches this UI.
+ */
+
+import { useState } from 'react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { TerminalSquare, Copy, Check, RefreshCw, Plug } from 'lucide-react'
+import { toast } from 'sonner'
+import { apiClient } from '@/lib/api-client'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+
+interface HostRow {
+  id: string
+  name: string
+  status: 'pending' | 'paired' | 'revoked'
+  online: boolean
+  last_seen_at?: string | null
+  paired_at?: string | null
+  capabilities?: { claude?: { version?: string | null; path?: string | null; onboarded?: boolean } | null } | null
+}
+
+interface PairingCode {
+  host_id: string
+  code: string
+  expires_at: string
+  pair_command: string
+}
+
+function useSessionModeHealth() {
+  return useQuery({
+    queryKey: ['health', 'session-mode'],
+    queryFn: () => apiClient.request<{ edition?: string; cli_runtime_enabled?: boolean }>('/health'),
+    staleTime: 10_000,
+    refetchInterval: 30_000,
+  })
+}
+
+function useCliHosts(enabled: boolean) {
+  return useQuery({
+    queryKey: ['cli-hosts'],
+    queryFn: () => apiClient.request<{ hosts: HostRow[] }>('/api/v1/cli-hosts'),
+    enabled,
+    refetchInterval: 15_000,
+  })
+}
+
+function CopyButton({ value, label }: { value: string; label: string }) {
+  const [copied, setCopied] = useState(false)
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      onClick={async () => {
+        try {
+          await navigator.clipboard.writeText(value)
+          setCopied(true)
+          setTimeout(() => setCopied(false), 1500)
+        } catch {
+          toast.error('Could not copy — select the text and copy it manually')
+        }
+      }}
+      aria-label={label}
+    >
+      {copied ? <Check className="w-3.5 h-3.5" /> : <Copy className="w-3.5 h-3.5" />}
+    </Button>
+  )
+}
+
+export function SessionModeTab() {
+  const queryClient = useQueryClient()
+  const health = useSessionModeHealth()
+  const enabled = health.data?.cli_runtime_enabled === true
+  const hosts = useCliHosts(enabled)
+  const [hostName, setHostName] = useState('')
+  const [pairing, setPairing] = useState<PairingCode | null>(null)
+  const [minting, setMinting] = useState(false)
+
+  const mintCode = async () => {
+    setMinting(true)
+    try {
+      const code = await apiClient.post<PairingCode>('/api/v1/cli-hosts/pairing-codes', {
+        name: hostName.trim() || undefined,
+      })
+      setPairing(code)
+      queryClient.invalidateQueries({ queryKey: ['cli-hosts'] })
+    } catch (err) {
+      toast.error(`Could not issue a pairing code: ${err instanceof Error ? err.message : String(err)}`)
+    } finally {
+      setMinting(false)
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <Card className="bg-secondary/30 border-border/30">
+        <CardHeader>
+          <CardTitle className="text-base flex items-center gap-2">
+            <TerminalSquare className="h-5 w-5 text-[hsl(var(--agent))]" />
+            Session mode
+            {health.isLoading ? null : enabled ? (
+              <Badge variant="outline" className="ml-2">on</Badge>
+            ) : (
+              <Badge variant="secondary" className="ml-2">off</Badge>
+            )}
+          </CardTitle>
+          <p className="text-sm text-muted-foreground">
+            Agents with the runtime <span className="font-mono">Claude Code session</span> run their tickets as
+            your own Claude Code sessions on your machine, under your own login. Automatos assigns the ticket,
+            tracks it on the board and records the result; nothing runs through an API key.
+          </p>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {!health.isLoading && !enabled && (
+            <div className="rounded-lg border border-border/40 p-4 text-sm space-y-2">
+              <p className="font-medium">Session mode is off on this instance.</p>
+              <p className="text-muted-foreground">
+                Add <span className="font-mono">CLI_RUNTIME_ENABLED=true</span> to <span className="font-mono">.env</span>,
+                run <span className="font-mono">make up</span>, then come back here to pair a host. Session mode exists in
+                the local edition only.
+              </p>
+            </div>
+          )}
+
+          {enabled && (
+            <>
+              <div>
+                <Label className="text-xs uppercase tracking-wide text-muted-foreground">Hosts</Label>
+                <div className="mt-2 space-y-2">
+                  {(hosts.data?.hosts ?? []).length === 0 && (
+                    <p className="text-sm text-muted-foreground">No host paired yet.</p>
+                  )}
+                  {(hosts.data?.hosts ?? []).map((h) => (
+                    <div key={h.id} className="flex items-center justify-between rounded-lg border border-border/40 px-3 py-2 text-sm">
+                      <div className="flex items-center gap-3">
+                        <span
+                          className={
+                            'inline-block h-2 w-2 rounded-full ' +
+                            (h.status !== 'paired' ? 'bg-muted-foreground' : h.online ? 'bg-[hsl(var(--success))]' : 'bg-[hsl(var(--warning))]')
+                          }
+                          aria-hidden
+                        />
+                        <span className="font-medium">{h.name}</span>
+                        <span className="text-muted-foreground">
+                          {h.status !== 'paired' ? h.status : h.online ? 'connected' : 'not running'}
+                          {h.capabilities?.claude?.version ? ` · Claude Code ${h.capabilities.claude.version}` : ''}
+                        </span>
+                      </div>
+                      <span className="font-mono text-xs text-muted-foreground">{h.id.slice(0, 8)}</span>
+                    </div>
+                  ))}
+                </div>
+                {hosts.data && hosts.data.hosts.some((h) => h.status === 'paired' && !h.online) && (
+                  <p className="mt-2 text-xs text-muted-foreground">
+                    A paired host that is not running: start it with <span className="font-mono">make cli-host</span> from the repository.
+                  </p>
+                )}
+              </div>
+
+              <div className="rounded-lg border border-border/40 p-4 space-y-3">
+                <div className="flex items-center gap-2">
+                  <Plug className="w-4 h-4" />
+                  <p className="text-sm font-medium">Pair a host</p>
+                </div>
+                <div className="flex flex-col sm:flex-row gap-2">
+                  <Input
+                    placeholder="Name for this machine (optional)"
+                    value={hostName}
+                    onChange={(e) => setHostName(e.target.value)}
+                    className="sm:max-w-xs"
+                  />
+                  <Button type="button" onClick={mintCode} disabled={minting}>
+                    {minting ? <RefreshCw className="w-4 h-4 animate-spin" /> : 'Get a pairing code'}
+                  </Button>
+                </div>
+                {pairing && (
+                  <div className="space-y-2 text-sm">
+                    <p className="text-muted-foreground">
+                      One-time code, valid for ten minutes. Run this on the machine that will run your sessions:
+                    </p>
+                    <div className="flex items-center gap-2">
+                      <code className="flex-1 rounded bg-muted px-3 py-2 font-mono text-xs overflow-x-auto">{pairing.pair_command}</code>
+                      <CopyButton value={pairing.pair_command} label="Copy the pair command" />
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                      From the repository root. The host registers <span className="font-mono">./workspaces</span>; add a real
+                      repository with <span className="font-mono">CLI_HOST_ARGS=&quot;--allow /path/to/repo&quot;</span>.
+                    </p>
+                  </div>
+                )}
+              </div>
+
+              <div className="text-xs text-muted-foreground space-y-1">
+                <p>
+                  A session uses the unmodified <span className="font-mono">claude</span> on your machine and your own login;
+                  no credential is read, copied or set, and sessions never use <span className="font-mono">-p</span>.
+                  Anthropic&apos;s terms permit signing in to the unmodified Claude Code binary with your own subscription and
+                  assume &quot;ordinary, individual usage&quot; — how many sessions you run in parallel is your choice.
+                </p>
+              </div>
+            </>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+export default SessionModeTab

--- a/frontend/components/settings/SettingsPanel.tsx
+++ b/frontend/components/settings/SettingsPanel.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react'
 import Link from 'next/link'
-import { Settings, Key, Webhook, KeyRound, Radio, Brain, Puzzle, Bell, UserCircle, ArrowRight } from 'lucide-react'
+import { Settings, Key, Webhook, KeyRound, Radio, Brain, Puzzle, Bell, UserCircle, ArrowRight, TerminalSquare } from 'lucide-react'
 import { CredentialsTab } from './CredentialsTab'
 import SystemSettingsTab from './SystemSettingsTab'
 import SystemLLMSettingsTab from './SystemLLMSettingsTab'
@@ -12,6 +12,7 @@ import { ChannelsSettingsTab } from './ChannelsSettingsTab'
 import { ApiKeyManager } from './ApiKeyManager'
 import { WidgetSdkTab } from './WidgetSdkTab'
 import { NotificationsSettingsTab } from './NotificationsSettingsTab'
+import { SessionModeTab } from './SessionModeTab'
 import { useSystemRole } from '@/contexts/role-context'
 import { isLocal } from '@/lib/auth-edition'
 import { PageHeader, FilterTabs, TabsContent } from '@/components/shared'
@@ -31,6 +32,7 @@ export const LOCAL_EDITION_SETTINGS_TABS: ReadonlySet<string> = new Set([
   'api-keys',
   'credentials',
   'notifications',
+  'session-mode',  // PRD-234 S4 — local only: the CLI host lane
 ])
 
 export function SettingsPanel() {
@@ -39,6 +41,7 @@ export function SettingsPanel() {
 
   const allTabs = [
     ...(isLocal ? [{ value: 'profile', label: 'Profile', icon: UserCircle }] : []),
+    ...(isLocal ? [{ value: 'session-mode', label: 'Session mode', icon: TerminalSquare }] : []),
     ...(isAdmin ? [{ value: 'system-settings', label: 'System Settings', icon: Settings }] : []),
     { value: 'orchestrator', label: 'Orchestrator', icon: Brain },
     { value: 'webhooks', label: 'Webhooks', icon: Webhook },
@@ -97,6 +100,13 @@ export function SettingsPanel() {
         )}
 
         {/* PRD-54/55: Orchestrator Tab (self-loading) */}
+        {/* PRD-234 S4: local edition — session mode (CLI host) status + pairing */}
+        {isLocal && (
+          <TabsContent value="session-mode">
+            <SessionModeTab />
+          </TabsContent>
+        )}
+
         <TabsContent value="orchestrator">
           <SystemLLMSettingsTab />
         </TabsContent>

--- a/frontend/components/settings/__tests__/settings-panel-edition.test.tsx
+++ b/frontend/components/settings/__tests__/settings-panel-edition.test.tsx
@@ -1,8 +1,8 @@
 /**
  * PRD-233 S6/S7 — the Settings tabs per edition.
  *
- * local → only what exists locally: Profile (S6), System Settings, Orchestrator,
- *         API Keys, Credentials, Notifications. Webhooks / Channels / Widget SDK
+ * local → only what exists locally: Profile (S6), Session mode (PRD-234 S4),
+ *         System Settings, Orchestrator, API Keys, Credentials, Notifications. Webhooks / Channels / Widget SDK
  *         (hosted-edition surfaces) are hidden by the explicit allowlist, not by
  *         role — the local operator is super_admin.
  * saas  → the eight tabs exactly as before; no Profile tab (Clerk owns it).
@@ -46,6 +46,7 @@ vi.mock('../ChannelsSettingsTab', () => ({ ChannelsSettingsTab: () => null }))
 vi.mock('../ApiKeyManager', () => ({ ApiKeyManager: () => null }))
 vi.mock('../WidgetSdkTab', () => ({ WidgetSdkTab: () => null }))
 vi.mock('../NotificationsSettingsTab', () => ({ NotificationsSettingsTab: () => null }))
+vi.mock('../SessionModeTab', () => ({ SessionModeTab: () => null }))  // PRD-234 S4 (local only)
 
 async function loadPanel(edition: 'local' | 'saas') {
   vi.doMock('@/lib/auth-edition', () => ({
@@ -73,6 +74,7 @@ describe('SettingsPanel edition gating (PRD-233 S6/S7)', () => {
 
     expect(tabLabels()).toEqual([
       'Profile',
+      'Session mode',
       'System Settings',
       'Orchestrator',
       'API Keys',
@@ -83,6 +85,8 @@ describe('SettingsPanel edition gating (PRD-233 S6/S7)', () => {
     for (const hidden of ['webhooks', 'channels', 'widget-sdk']) {
       expect(LOCAL_EDITION_SETTINGS_TABS.has(hidden)).toBe(false)
     }
+    // PRD-234 S4: session mode is a local-only surface (the CLI host lane)
+    expect(LOCAL_EDITION_SETTINGS_TABS.has('session-mode')).toBe(true)
   })
 
   it('saas: the eight tabs render exactly as before and there is no Profile tab', async () => {

--- a/frontend/hooks/use-board-tasks.ts
+++ b/frontend/hooks/use-board-tasks.ts
@@ -251,5 +251,6 @@ function mapTaskToBoardTask(item: any): BoardTask {
     blocked_at: item.blocked_at ?? undefined,
     blocked_reason: item.blocked_reason ?? undefined,
     result: item.result,
+    runtime_ref: item.runtime_ref ?? undefined,  // PRD-234
   }
 }

--- a/frontend/types/board.ts
+++ b/frontend/types/board.ts
@@ -45,6 +45,8 @@ export interface BoardTask {
   blocked_reason?: string
   planning_data?: { playbook_id?: number; execution_id?: string; step_progress?: { current: number; total: number }; approval_action?: { type: string; post_id?: string; [key: string]: any } }
   result?: any
+  // PRD-234: the session reference a `runtime: cli` ticket carries once a CLI host claims it
+  runtime_ref?: Record<string, any> | null
 }
 
 export interface BoardColumn {

--- a/orchestrator/core/models/system_settings.py
+++ b/orchestrator/core/models/system_settings.py
@@ -8,7 +8,7 @@ Replaces .env file with database-backed settings.
 
 from sqlalchemy import Column, Integer, String, Text, DateTime, Boolean, JSON, Float
 from sqlalchemy.sql import func
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from typing import Dict, Any, Optional, List
 from datetime import datetime
 from enum import Enum
@@ -91,14 +91,28 @@ class SystemSettingResponse(BaseModel):
     value: Optional[str]
     value_type: str
     description: Optional[str]
-    is_sensitive: bool
-    is_required: bool
+    is_sensitive: bool = False
+    is_required: bool = False
     default_value: Optional[str]
     validation_rules: Optional[Dict[str, Any]]
     created_at: datetime
     updated_at: datetime
-    created_by: str
-    
+    created_by: str = "system"
+
+    # A row written by raw SQL (no ORM defaults, no server defaults) may carry
+    # NULL in these three columns. The contract's defaults apply instead of the
+    # whole by-category response failing validation (one bad row = a 500 for
+    # the entire Settings page, 2026-09-02).
+    @field_validator("is_sensitive", "is_required", mode="before")
+    @classmethod
+    def _flag_none_is_false(cls, v):
+        return False if v is None else v
+
+    @field_validator("created_by", mode="before")
+    @classmethod
+    def _creator_none_is_system(cls, v):
+        return "system" if v is None else v
+
     class Config:
         from_attributes = True
 

--- a/orchestrator/services/trial_ledger.py
+++ b/orchestrator/services/trial_ledger.py
@@ -366,8 +366,14 @@ def _increment_daily_spend(db: Any, cost_usd: float, *, day: Optional[date] = No
     else:
         db.execute(
             text(
-                "INSERT INTO system_settings (category, key, value, value_type, description) "
-                "VALUES (:c, :k, :v, 'number', :d)"
+                # Raw SQL bypasses the ORM's Python-side defaults, and the columns
+                # carry no server default: a row inserted without is_sensitive /
+                # is_required / created_by lands as NULL and the settings API's
+                # response contract (bool/bool/str) then 500s the whole Settings
+                # page (seen 2026-09-02 on the first trial_spend_* row of a day).
+                "INSERT INTO system_settings "
+                "(category, key, value, value_type, description, is_sensitive, is_required, created_by) "
+                "VALUES (:c, :k, :v, 'number', :d, false, false, 'system')"
             ),
             {"c": DAILY_SPEND_CATEGORY, "k": key, "v": str(new_total), "d": "PRD-222 trial daily spend"},
         )

--- a/orchestrator/tests/test_system_settings_null_flags.py
+++ b/orchestrator/tests/test_system_settings_null_flags.py
@@ -1,0 +1,83 @@
+"""system_settings rows with NULL flag columns must not 500 the Settings page.
+
+Two halves of one fix (2026-09-02): the trial ledger's raw INSERT now names
+``is_sensitive`` / ``is_required`` / ``created_by``, and the response contract
+tolerates NULLs from any other raw writer with its documented defaults.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+
+os.environ.setdefault("POSTGRES_USER", "test")
+os.environ.setdefault("POSTGRES_PASSWORD", "test")
+os.environ.setdefault("POSTGRES_HOST", "127.0.0.1")
+os.environ.setdefault("POSTGRES_PORT", "59432")
+os.environ.setdefault("POSTGRES_DB", "test")
+
+_ORCH = Path(__file__).resolve().parents[1]
+if str(_ORCH) not in sys.path:
+    sys.path.insert(0, str(_ORCH))
+
+from core.models.system_settings import SystemSettingResponse, SystemSettingsByCategory  # noqa: E402
+
+
+def _row(**over):
+    base = dict(
+        id=100, category="llm_cost_audit", key="trial_spend_2026-09-02", value="0.001",
+        value_type="number", description="PRD-222 trial daily spend", is_sensitive=None,
+        is_required=None, default_value=None, validation_rules=None,
+        created_at=datetime.now(timezone.utc), updated_at=datetime.now(timezone.utc), created_by=None,
+    )
+    base.update(over)
+    return SimpleNamespace(**base)
+
+
+def test_response_contract_tolerates_null_flags_with_documented_defaults():
+    out = SystemSettingResponse.model_validate(_row(), from_attributes=True)
+    assert out.is_sensitive is False and out.is_required is False and out.created_by == "system"
+    # explicit values still win
+    out = SystemSettingResponse.model_validate(_row(is_sensitive=True, created_by="gerard"), from_attributes=True)
+    assert out.is_sensitive is True and out.created_by == "gerard"
+
+
+def test_by_category_group_survives_one_null_row():
+    grouped = SystemSettingsByCategory(category="llm_cost_audit", settings=[_row(), _row(id=101)], total_count=2)
+    assert len(grouped.settings) == 2 and all(s.is_required is False for s in grouped.settings)
+
+
+class _Result:
+    def __init__(self, row=None):
+        self._row = row
+
+    def fetchone(self):
+        return self._row
+
+
+class _CapturingDB:
+    """SELECTs find nothing (so the INSERT path runs); every statement is recorded."""
+
+    def __init__(self):
+        self.statements = []
+
+    def execute(self, clause, params=None):
+        sql = str(getattr(clause, "text", clause))
+        self.statements.append((sql, dict(params or {})))
+        return _Result(None)
+
+
+def test_trial_ledger_insert_names_the_flag_columns():
+    from services import trial_ledger
+
+    db = _CapturingDB()
+    total = trial_ledger._increment_daily_spend(db, 0.0025)
+    assert total == 0.0025
+    inserts = [s for s, _ in db.statements if s.lstrip().upper().startswith("INSERT INTO SYSTEM_SETTINGS")]
+    assert len(inserts) == 1, db.statements
+    sql = inserts[0]
+    for col in ("is_sensitive", "is_required", "created_by"):
+        assert col in sql, f"INSERT must set {col}: {sql}"
+    assert "false, false, 'system'" in sql


### PR DESCRIPTION
## PRD-234 Session Mode — S4: the UI (stacked on #677)

**Base is `feat/prd-234-s1b-cli-host` (#677)**; retarget after it merges. Local edition only (`isLocal`); the hosted edition renders exactly as before.

- **Settings → Session mode** (new tab): whether `CLI_RUNTIME_ENABLED` is on (from `/health`), the paired hosts with online state and Claude Code version, and **Pair a host** — a one-time code with the exact `make cli-host PAIR=…` command. The host token is minted server-side and never reaches the UI.
- **Agent settings → Model tab → Runtime**: *API model* (default, unchanged) or *Claude Code session* with CLI (Claude Code; Codex listed for S5), model alias, working directory. Saved into `Agent.configuration` (`runtime`/`provider`/`model`/`working_directory`), which the S1a API validates.
- **Ticket detail → Claude Code session block**: provider/model, live tool or exit reason, tokens (plan usage, no cost figure), denied calls, files touched, and the take-over command `claude --resume <session id>`. `runtime_ref` now flows through the board mapper and the live-task poll.

Tested by hand on the owner's machine against the live smoke tickets (66, 67). No new vitest yet; the frontend CI lane (tsc baselined, eslint, route-contract) covers the types.
