### PR TITLE
fix(executor): hierarchy-gate warnings log the target position, not the caller-supplied id

### DIFF
--- a/orchestrator/modules/tools/discovery/platform_executor.py
+++ b/orchestrator/modules/tools/discovery/platform_executor.py
@@ -996,7 +996,8 @@ class PlatformActionExecutor:
                     actor_id = int(actor_id_raw) if actor_id_raw is not None else None
                 except (TypeError, ValueError):
                     actor_id = None
-                for target_id_raw in target_ids_raw:
+                n_targets = len(target_ids_raw)
+                for idx, target_id_raw in enumerate(target_ids_raw, 1):
                     try:
                         target_id = int(target_id_raw) if target_id_raw is not None else None
                     except (TypeError, ValueError):
@@ -1020,10 +1021,12 @@ class PlatformActionExecutor:
                         # and leave the write's fate to upstream handling. Deny locally
                         # and escalate to Auto — mirrors the registry-lookup fail-closed
                         # above.
+                        # The target id itself is caller-supplied data: it is returned
+                        # in the error below, never written to the log.
                         logger.warning(
                             "[PlatformExecutor] hierarchy_check_failed action=%s actor=%s "
-                            "target=%s/%s err=%s — denying (fail-closed)",
-                            action_name, actor_id, target_type, target_id, e,
+                            "target=%s (#%d of %d) err=%s — denying (fail-closed)",
+                            action_name, actor_id, target_type, idx, n_targets, e,
                         )
                         return {
                             "success": False,
@@ -1037,8 +1040,9 @@ class PlatformActionExecutor:
                         }
                     if not decision.allowed:
                         logger.warning(
-                            "[PlatformExecutor] hierarchy_denied action=%s actor=%s target=%s/%s reason=%s",
-                            action_name, actor_id, target_type, target_id, decision.reason,
+                            "[PlatformExecutor] hierarchy_denied action=%s actor=%s "
+                            "target=%s (#%d of %d) reason=%s",
+                            action_name, actor_id, target_type, idx, n_targets, decision.reason,
                         )
                         return {
                             "success": False,


### PR DESCRIPTION
Follow-up to #681, which merged before this commit reached the branch.

#681 re-indented the two hierarchy-gate warnings into the bulk loop, so CodeQL reported their pre-existing `py/clear-text-logging-sensitive-data` instances (the `target_id` argument; five such alerts already stand on main for this file) as new on the PR. This keeps caller-supplied ids out of the log sink — the warning names the target type and its position in the bulk call (`#k of n`) — and the id still travels in the returned error, which is what the model and the user see.

No behaviour change beyond the log text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved permission-check reporting for bulk operations by identifying each target’s position within the operation.
  * Updated denial and fail-closed logs to avoid exposing caller-provided target identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->