### PR TITLE
fix(settings): a system_settings row with NULL flags no longer 500s the Settings page

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -8,7 +8,9 @@
 7f653279595e32516ff1b182a620ffb1e1b258cd:orchestrator/tests/test_prd206_write_contract.py:generic-api-key:242
 
 # 2026-09-02 — test_system_settings_null_flags.py fixture: a system_settings row
-# key="trial_spend_2026-09-02" (a setting NAME, value "0.001") matched
-# generic-api-key by entropy alone. Defanged in the next commit (key="spend");
-# the original literal lives only in this historical blob.
+# whose setting NAME was a dated trial-spend string (value "0.001") matched
+# generic-api-key on entropy alone. Defanged in the next commit; the original
+# literal lives only in the first historical blob. The first version of THIS
+# comment quoted the literal and was flagged in turn, hence the second entry.
 8c4e5ccd804ee7cc6a2d8af7987aec0649c60bdb:orchestrator/tests/test_system_settings_null_flags.py:generic-api-key:30
+df73ed7f3fb55842818452019edf2f7270543c20:.gitleaksignore:generic-api-key:11

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -6,3 +6,9 @@
 # string concatenation) right after, but the original literal lives in this
 # one historical commit blob, which the range scan keeps re-reading.
 7f653279595e32516ff1b182a620ffb1e1b258cd:orchestrator/tests/test_prd206_write_contract.py:generic-api-key:242
+
+# 2026-09-02 — test_system_settings_null_flags.py fixture: a system_settings row
+# key="trial_spend_2026-09-02" (a setting NAME, value "0.001") matched
+# generic-api-key by entropy alone. Defanged in the next commit (key="spend");
+# the original literal lives only in this historical blob.
+8c4e5ccd804ee7cc6a2d8af7987aec0649c60bdb:orchestrator/tests/test_system_settings_null_flags.py:generic-api-key:30

--- a/orchestrator/core/models/system_settings.py
+++ b/orchestrator/core/models/system_settings.py
@@ -8,7 +8,7 @@ Replaces .env file with database-backed settings.
 
 from sqlalchemy import Column, Integer, String, Text, DateTime, Boolean, JSON, Float
 from sqlalchemy.sql import func
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from typing import Dict, Any, Optional, List
 from datetime import datetime
 from enum import Enum
@@ -91,14 +91,28 @@ class SystemSettingResponse(BaseModel):
     value: Optional[str]
     value_type: str
     description: Optional[str]
-    is_sensitive: bool
-    is_required: bool
+    is_sensitive: bool = False
+    is_required: bool = False
     default_value: Optional[str]
     validation_rules: Optional[Dict[str, Any]]
     created_at: datetime
     updated_at: datetime
-    created_by: str
-    
+    created_by: str = "system"
+
+    # A row written by raw SQL (no ORM defaults, no server defaults) may carry
+    # NULL in these three columns. The contract's defaults apply instead of the
+    # whole by-category response failing validation (one bad row = a 500 for
+    # the entire Settings page, 2026-09-02).
+    @field_validator("is_sensitive", "is_required", mode="before")
+    @classmethod
+    def _flag_none_is_false(cls, v):
+        return False if v is None else v
+
+    @field_validator("created_by", mode="before")
+    @classmethod
+    def _creator_none_is_system(cls, v):
+        return "system" if v is None else v
+
     class Config:
         from_attributes = True
 

--- a/orchestrator/services/trial_ledger.py
+++ b/orchestrator/services/trial_ledger.py
@@ -366,8 +366,14 @@ def _increment_daily_spend(db: Any, cost_usd: float, *, day: Optional[date] = No
     else:
         db.execute(
             text(
-                "INSERT INTO system_settings (category, key, value, value_type, description) "
-                "VALUES (:c, :k, :v, 'number', :d)"
+                # Raw SQL bypasses the ORM's Python-side defaults, and the columns
+                # carry no server default: a row inserted without is_sensitive /
+                # is_required / created_by lands as NULL and the settings API's
+                # response contract (bool/bool/str) then 500s the whole Settings
+                # page (seen 2026-09-02 on the first trial_spend_* row of a day).
+                "INSERT INTO system_settings "
+                "(category, key, value, value_type, description, is_sensitive, is_required, created_by) "
+                "VALUES (:c, :k, :v, 'number', :d, false, false, 'system')"
             ),
             {"c": DAILY_SPEND_CATEGORY, "k": key, "v": str(new_total), "d": "PRD-222 trial daily spend"},
         )

--- a/orchestrator/tests/test_system_settings_null_flags.py
+++ b/orchestrator/tests/test_system_settings_null_flags.py
@@ -1,0 +1,83 @@
+"""system_settings rows with NULL flag columns must not 500 the Settings page.
+
+Two halves of one fix (2026-09-02): the trial ledger's raw INSERT now names
+``is_sensitive`` / ``is_required`` / ``created_by``, and the response contract
+tolerates NULLs from any other raw writer with its documented defaults.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+
+os.environ.setdefault("POSTGRES_USER", "test")
+os.environ.setdefault("POSTGRES_PASSWORD", "test")
+os.environ.setdefault("POSTGRES_HOST", "127.0.0.1")
+os.environ.setdefault("POSTGRES_PORT", "59432")
+os.environ.setdefault("POSTGRES_DB", "test")
+
+_ORCH = Path(__file__).resolve().parents[1]
+if str(_ORCH) not in sys.path:
+    sys.path.insert(0, str(_ORCH))
+
+from core.models.system_settings import SystemSettingResponse, SystemSettingsByCategory  # noqa: E402
+
+
+def _row(**over):
+    base = dict(
+        id=100, category="llm_cost_audit", key="trial_spend_2026-09-02", value="0.001",
+        value_type="number", description="PRD-222 trial daily spend", is_sensitive=None,
+        is_required=None, default_value=None, validation_rules=None,
+        created_at=datetime.now(timezone.utc), updated_at=datetime.now(timezone.utc), created_by=None,
+    )
+    base.update(over)
+    return SimpleNamespace(**base)
+
+
+def test_response_contract_tolerates_null_flags_with_documented_defaults():
+    out = SystemSettingResponse.model_validate(_row(), from_attributes=True)
+    assert out.is_sensitive is False and out.is_required is False and out.created_by == "system"
+    # explicit values still win
+    out = SystemSettingResponse.model_validate(_row(is_sensitive=True, created_by="gerard"), from_attributes=True)
+    assert out.is_sensitive is True and out.created_by == "gerard"
+
+
+def test_by_category_group_survives_one_null_row():
+    grouped = SystemSettingsByCategory(category="llm_cost_audit", settings=[_row(), _row(id=101)], total_count=2)
+    assert len(grouped.settings) == 2 and all(s.is_required is False for s in grouped.settings)
+
+
+class _Result:
+    def __init__(self, row=None):
+        self._row = row
+
+    def fetchone(self):
+        return self._row
+
+
+class _CapturingDB:
+    """SELECTs find nothing (so the INSERT path runs); every statement is recorded."""
+
+    def __init__(self):
+        self.statements = []
+
+    def execute(self, clause, params=None):
+        sql = str(getattr(clause, "text", clause))
+        self.statements.append((sql, dict(params or {})))
+        return _Result(None)
+
+
+def test_trial_ledger_insert_names_the_flag_columns():
+    from services import trial_ledger
+
+    db = _CapturingDB()
+    total = trial_ledger._increment_daily_spend(db, 0.0025)
+    assert total == 0.0025
+    inserts = [s for s, _ in db.statements if s.lstrip().upper().startswith("INSERT INTO SYSTEM_SETTINGS")]
+    assert len(inserts) == 1, db.statements
+    sql = inserts[0]
+    for col in ("is_sensitive", "is_required", "created_by"):
+        assert col in sql, f"INSERT must set {col}: {sql}"
+    assert "false, false, 'system'" in sql

--- a/orchestrator/tests/test_system_settings_null_flags.py
+++ b/orchestrator/tests/test_system_settings_null_flags.py
@@ -27,7 +27,7 @@ from core.models.system_settings import SystemSettingResponse, SystemSettingsByC
 
 def _row(**over):
     base = dict(
-        id=100, category="llm_cost_audit", key="trial_spend_2026-09-02", value="0.001",
+        id=100, category="llm_cost_audit", key="spend", value="0.001",
         value_type="number", description="PRD-222 trial daily spend", is_sensitive=None,
         is_required=None, default_value=None, validation_rules=None,
         created_at=datetime.now(timezone.utc), updated_at=datetime.now(timezone.utc), created_by=None,


### PR DESCRIPTION
Found during the PRD-234 local test on 2026-09-02: the first `trial_spend_<day>` row (written by the trial ledger's raw INSERT, which bypasses ORM defaults; the columns have no server default) has NULL `is_sensitive` / `is_required` / `created_by`, and `GET /api/system-settings/by-category` fails response validation for the whole list → the Settings page shows *Internal server error*.

- `services/trial_ledger.py`: the INSERT names the three columns with their documented defaults.
- `SystemSettingResponse`: before-mode validators map NULL → `False` / `False` / `'system'`, so no other raw writer can take the page down.
- tests: contract tolerance, by-category grouping with a NULL row, and the INSERT names the columns.

No migration in this PR: server defaults are the durable third half, deferred only to avoid a second Alembic head while the PRD-234 stack (#673 → #677 → #682) is open. The one existing row on the owner's local DB was repaired by hand.

**SaaS**: prod runs the same writer — the same 500 will hit the Settings page there on any day a trial spend is recorded, so this is worth merging ahead of the stack.