### PR TITLE
fix(prd-222): the spine tool refuses to be a progress simulator at 'building'

### DIFF
--- a/orchestrator/modules/context/sections/onboarding.py
+++ b/orchestrator/modules/context/sections/onboarding.py
@@ -159,7 +159,9 @@ then the Automatos app adds a Site under Settings → Widget SDK → sync. Narra
 you go ("Created your Marketing helper — it's on your Agents page"). When the build \
 is complete and verified, advance_to `boom` — it is refused until the workspace \
 actually holds the build (an installed package, created agents, or a mission), so \
-never announce a team before it exists.
+never announce a team before it exists. While building, call `platform_update_onboarding` \
+only to advance_to boom — re-asserting `building` records nothing and, three times with \
+nothing built, is refused.
 """
 
 _STAGE_BOOM = """\

--- a/orchestrator/modules/tools/discovery/handlers_onboarding.py
+++ b/orchestrator/modules/tools/discovery/handlers_onboarding.py
@@ -22,6 +22,7 @@ from services.onboarding_state import (
     advance_onboarding_stage,
     build_evidence,
     current_stage,
+    record_same_stage_reassert,
     get_onboarding,
     public_snapshot,
     record_plan_event,
@@ -45,6 +46,10 @@ _SAME_STAGE_HINTS = {
     ),
     "boom": "Show the value on their business, then advance_to powerup.",
 }
+
+
+# The third same-stage re-assert at 'building' with nothing built is refused.
+BUILDING_REASSERT_LIMIT = 3
 
 
 def _stage_hint(db: Any, workspace: Any) -> str:
@@ -248,12 +253,36 @@ async def update_onboarding(
             # installing nothing — a bare success read as progress. Say what
             # changed (nothing) and what the stage actually needs.
             snap = public_snapshot(workspace)
+            stage = snap.get("stage")
+            n = record_same_stage_reassert(db, workspace, stage, commit=False)
+            if db is not None:
+                db.commit()  # the only write on this path
+            if (
+                stage == "building"
+                and n >= BUILDING_REASSERT_LIMIT
+                and not build_evidence(db, workspace)["any"]
+            ):
+                # Prod 2026-09-02: saffron re-asserted 'building' four times while
+                # narrating a build that never happened. The tool records progress
+                # — it cannot make it — and now says so as a refusal, which this
+                # model reacts to; a success-with-message it ignores.
+                return {
+                    "success": False,
+                    "noop": True,
+                    "data": snap,
+                    "error": (
+                        f"Refused: 'building' re-asserted {n} times with nothing built. This tool "
+                        "records progress — it cannot make it. Do not call it again until you have "
+                        "installed the matched package (platform_install_package) or created an "
+                        "agent (platform_create_agent); then advance_to boom."
+                    ),
+                }
             hint = _stage_hint(db, workspace)
             return {
                 "success": True,
                 "data": snap,
                 "noop": True,
-                "message": f"Already at '{snap.get('stage')}' — nothing changed. {hint}".strip(),
+                "message": f"Already at '{stage}' — nothing changed (re-assert {n}). {hint}".strip(),
             }
 
     # Reject a non-assignable plan BEFORE any write — honest coming-soon copy.

--- a/orchestrator/services/onboarding_state.py
+++ b/orchestrator/services/onboarding_state.py
@@ -405,6 +405,23 @@ def onboarding_package_installed(workspace: Any) -> bool:
     return bool((doc.get("funnel") or {}).get("package_installed"))
 
 
+def record_same_stage_reassert(db: Any, workspace: Any, stage: str, *, commit: bool = True) -> int:
+    """Count a same-stage ``advance_to`` re-assert in ``onboarding.reasserts[stage]``.
+
+    Prod 2026-09-02: eight "nothing changed" no-ops across four stalled runs — the
+    model used the spine tool as a progress simulator. The count lets the tool
+    refuse the habit (see handlers_onboarding). Per stage, so a new stage starts
+    at zero; a reset drops it with the document. Rebuild-don't-mutate.
+    """
+    doc = get_onboarding(workspace)  # deep copy
+    counts = dict(doc.get("reasserts") or {})
+    counts[stage] = int(counts.get(stage) or 0) + 1
+    doc["reasserts"] = counts
+    doc["updated_at"] = _now_iso()
+    _persist(db, workspace, doc, commit=commit)
+    return counts[stage]
+
+
 # =========================================================================== #
 # Build evidence — the honesty gate on ``boom`` (live test 2026-08-29)
 # =========================================================================== #

--- a/orchestrator/tests/test_prd222_segment_implied_advance.py
+++ b/orchestrator/tests/test_prd222_segment_implied_advance.py
@@ -204,3 +204,41 @@ def test_building_noop_hint_with_nothing_built_is_unchanged():
     ws = _Workspace("building")
     r = asyncio.run(update_onboarding(_db(0, 0, workspace=ws), ws.id, {"advance_to": "building"}))
     assert "Nothing is built yet" in r["message"]
+
+
+# ── the tool refuses to be a progress simulator ───────────────────────────
+
+def test_third_building_reassert_with_nothing_built_is_refused():
+    ws = _Workspace("building")
+    db = _db(0, 0, workspace=ws)
+    r1 = asyncio.run(update_onboarding(db, ws.id, {"advance_to": "building"}))
+    r2 = asyncio.run(update_onboarding(db, ws.id, {"advance_to": "building"}))
+    assert r1["success"] and r2["success"] and "(re-assert 2)" in r2["message"]
+    r3 = asyncio.run(update_onboarding(db, ws.id, {"advance_to": "building"}))
+    assert r3["success"] is False and r3["noop"] is True
+    assert "re-asserted 3 times" in r3["error"] and "platform_create_agent" in r3["error"]
+    assert ws.onboarding["reasserts"]["building"] == 3
+    assert current_stage(ws) == "building"
+
+
+def test_reasserts_with_a_real_build_are_never_refused():
+    ws = _Workspace("building")
+    db = _db(agents=1, workspace=ws)
+    for _ in range(4):
+        r = asyncio.run(update_onboarding(db, ws.id, {"advance_to": "building"}))
+    assert r["success"] is True and "advance_to boom now" in r["message"]
+    assert ws.onboarding["reasserts"]["building"] == 4
+
+
+def test_reassert_counter_is_per_stage_and_rebuilt_not_mutated():
+    ws = _Workspace("questions")
+    before = ws.onboarding
+    asyncio.run(update_onboarding(_db(workspace=ws), ws.id, {"advance_to": "questions"}))
+    assert ws.onboarding is not before
+    assert ws.onboarding["reasserts"] == {"questions": 1}
+
+
+def test_building_prompt_forbids_reasserting():
+    from modules.context.sections.onboarding import _STAGE_BUILDING
+
+    assert "only to advance_to boom" in _STAGE_BUILDING


### PR DESCRIPTION
## Prod, first run on the merged main (2026-09-02, 5 personas)
Four runs stalled at `building`; across them the model re-asserted `advance_to=building` **eight times** ("nothing changed" no-ops) while narrating builds that never happened. A success-with-message it ignores; a refusal it reacts to (it apologises and does something else).

## Fix
- `services.onboarding_state.record_same_stage_reassert`: a per-stage counter in `onboarding.reasserts` (rebuild-don't-mutate; a new stage starts at 0; a reset drops it with the document).
- The honest no-op carries the count (`(re-assert N)`). The **third** re-assert of `building` with no build evidence is refused: *"This tool records progress — it cannot make it. Do not call it again until you have installed the matched package (platform_install_package) or created an agent (platform_create_agent); then advance_to boom."* With a real build the no-op stays a success naming what is registered (#679).
- `_STAGE_BUILDING`: call `platform_update_onboarding` only to advance_to boom.

## Tests
Four added to `test_prd222_segment_implied_advance.py`: third re-assert refused with nothing built; never refused with a real build; counter per stage + rebuilt not mutated; prompt sentence.

## Live exercise
Not yet — the isolated local lab is waiting on an OpenRouter key; prod exercise after merge via the persona suite.

CI only. No settings, no routes. Gerard's merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Onboarding now advances from **building** to **boom** only after a build is available.
  * Repeated attempts to remain in **building** without a build are tracked and refused after three attempts.
  * Guidance now clearly directs users to install a package or create an agent before advancing.

* **Tests**
  * Added coverage for repeated onboarding attempts, build-dependent progression, and stage tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->