### PR TITLE
fix(prd-233): a brand-new local install starts Auto-led onboarding

### DIFF
--- a/orchestrator/core/seeds/seed_local_first_run.py
+++ b/orchestrator/core/seeds/seed_local_first_run.py
@@ -524,14 +524,29 @@ def _refresh(
 
 # ── Workspace, operator, ledger ──────────────────────────────────────────────
 
+# A brand-new install starts Auto-led onboarding. Without an explicit stage the
+# operator workspace is created stage-less, and the container's own
+# `alembic upgrade heads` then runs PRD-222's veteran backfill over it, which
+# stamps every stage-less workspace `skipped` — so the onboarding chat never
+# appeared on a fresh local install (found 2026-09-03 on the isolated lab).
+# The backfill matches only stage-less docs; a document with a stage is left
+# alone. SaaS never enters this module.
+FRESH_INSTALL_ONBOARDING = '{"stage": "not_started", "stages": {}, "segment": {}}'
+
+
 def _ensure_workspace(db: Session, workspace_id: UUID) -> str:
     result = db.execute(
         text(
-            "INSERT INTO workspaces (id, name, slug, is_personal, is_active) "
-            "VALUES (CAST(:id AS uuid), :name, :slug, TRUE, TRUE) "
+            "INSERT INTO workspaces (id, name, slug, is_personal, is_active, onboarding) "
+            "VALUES (CAST(:id AS uuid), :name, :slug, TRUE, TRUE, CAST(:onboarding AS jsonb)) "
             "ON CONFLICT (id) DO NOTHING"
         ),
-        {"id": str(workspace_id), "name": LOCAL_WORKSPACE_NAME, "slug": LOCAL_WORKSPACE_SLUG},
+        {
+            "id": str(workspace_id),
+            "name": LOCAL_WORKSPACE_NAME,
+            "slug": LOCAL_WORKSPACE_SLUG,
+            "onboarding": FRESH_INSTALL_ONBOARDING,
+        },
     )
     return "created" if result.rowcount == 1 else "present"
 

--- a/orchestrator/tests/test_prd233_fresh_install_starts_onboarding.py
+++ b/orchestrator/tests/test_prd233_fresh_install_starts_onboarding.py
@@ -1,0 +1,37 @@
+"""PRD-233 — a brand-new local install starts Auto-led onboarding.
+
+Found 2026-09-03 on the isolated lab: the operator workspace was inserted
+stage-less, then the container's `alembic upgrade heads` ran PRD-222's veteran
+backfill (which stamps every stage-less workspace `skipped`) — so the onboarding
+chat never appeared on a fresh install. The seed now inserts the workspace with
+an explicit `not_started` document, which the backfill leaves alone.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from core.seeds.seed_local_first_run import FRESH_INSTALL_ONBOARDING, _ensure_workspace
+
+
+def _db(rowcount: int):
+    db = MagicMock()
+    db.execute.return_value.rowcount = rowcount
+    return db
+
+
+def test_fresh_workspace_is_inserted_at_not_started():
+    db = _db(1)
+    assert _ensure_workspace(db, uuid4()) == "created"
+    sql, params = db.execute.call_args.args
+    assert "onboarding" in str(sql) and "CAST(:onboarding AS jsonb)" in str(sql)
+    doc = json.loads(params["onboarding"])
+    assert doc == {"stage": "not_started", "stages": {}, "segment": {}}
+    assert json.loads(FRESH_INSTALL_ONBOARDING)["stage"] == "not_started"
+
+
+def test_existing_workspace_is_left_alone():
+    db = _db(0)
+    assert _ensure_workspace(db, uuid4()) == "present"
+    assert "ON CONFLICT (id) DO NOTHING" in str(db.execute.call_args.args[0])


### PR DESCRIPTION
## Why the onboarding chat never appeared locally
On a fresh database the local first-run seed inserts the operator workspace **stage-less**; the container's own `alembic upgrade heads` then runs PRD-222's veteran backfill (`prd222_veteran_skip_backfill`), which stamps every stage-less workspace `skipped`. A brand-new install was treated as a veteran. Found 2026-09-03 on the isolated lab; it is what Gerard saw on his local stack.

## Fix
`_ensure_workspace` inserts the workspace with an explicit `{"stage": "not_started", "stages": {}, "segment": {}}`. The backfill matches only stage-less documents and leaves it alone; an existing workspace is untouched (`ON CONFLICT (id) DO NOTHING`). SaaS never enters this module.

## Tests
`test_prd233_fresh_install_starts_onboarding.py`: the insert carries the not_started document; an existing workspace is left alone.

CI only. Gerard's merge.