### PR TITLE
fix(agents): saving an agent without renaming it no longer fails the name check

### DIFF
--- a/orchestrator/api/agents.py
+++ b/orchestrator/api/agents.py
@@ -849,6 +849,24 @@ async def remove_agent_skill(agent_id: int, skill_id: int, ctx: RequestContext =
         logger.error(f"Error removing skill from agent: {e}")
         raise HTTPException(status_code=500, detail="Internal server error")
 
+def _renamed_to_taken_name(db: Session, workspace_id, agent: Agent, new_name: str) -> bool:
+    """True only when ``new_name`` is a real rename AND another agent in the workspace holds it.
+
+    An unchanged name is never re-validated. Legacy data can hold two agents
+    with one name (two "Bob"s, 2026-08-29); the frontend sends the name on
+    every save, so re-checking it made every Configure -> Save of either agent
+    400 "already exists" for the name it had all along (2026-09-03).
+    """
+    if new_name == agent.name:
+        return False
+    return (
+        db.query(Agent)
+        .filter(Agent.workspace_id == workspace_id, Agent.name == new_name, Agent.id != agent.id)
+        .first()
+        is not None
+    )
+
+
 @router.put("/{agent_id}", response_model=AgentResponse, dependencies=[Depends(require_workspace_permission("agents:update"))])
 async def update_agent(agent_id: int, agent_update: AgentUpdate, ctx: RequestContext = Depends(get_request_context_hybrid), db: Session = Depends(get_db)):
     """Update an existing agent"""
@@ -859,9 +877,7 @@ async def update_agent(agent_id: int, agent_update: AgentUpdate, ctx: RequestCon
         
         # Update fields if provided
         if agent_update.name is not None:
-            # Check for name conflicts in workspace
-            existing = db.query(Agent).filter(Agent.workspace_id == ctx.workspace_id, Agent.name == agent_update.name, Agent.id != agent_id).first()
-            if existing:
+            if _renamed_to_taken_name(db, ctx.workspace_id, agent, agent_update.name):
                 raise HTTPException(status_code=400, detail="Agent with this name already exists")
             agent.name = agent_update.name
         

--- a/orchestrator/tests/test_agent_update_unchanged_name.py
+++ b/orchestrator/tests/test_agent_update_unchanged_name.py
@@ -1,0 +1,71 @@
+"""Saving an agent without renaming it must not trip the name-conflict check.
+
+2026-09-03: two agents named "Bob" existed in one workspace (legacy rows from
+2026-08-29). The frontend sends ``name`` on every save, and the update handler
+re-validated the unchanged name against the other row, so every
+Configure -> Save of either agent answered 400 "Agent with this name already
+exists" for the name it had all along. The check now runs only on a real rename.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+os.environ.setdefault("POSTGRES_USER", "test")
+os.environ.setdefault("POSTGRES_PASSWORD", "test")
+os.environ.setdefault("POSTGRES_HOST", "127.0.0.1")
+os.environ.setdefault("POSTGRES_PORT", "59432")
+os.environ.setdefault("POSTGRES_DB", "test")
+
+_ORCH = Path(__file__).resolve().parents[1]
+if str(_ORCH) not in sys.path:
+    sys.path.insert(0, str(_ORCH))
+
+from api.agents import _renamed_to_taken_name  # noqa: E402
+
+
+class _Query:
+    def __init__(self, hit):
+        self._hit = hit
+
+    def filter(self, *_clauses):
+        return self
+
+    def first(self):
+        return self._hit
+
+
+class _DB:
+    """Answers every conflict query with ``hit`` and counts how often it was asked."""
+
+    def __init__(self, hit=None):
+        self.hit = hit
+        self.queries = 0
+
+    def query(self, *_args, **_kwargs):
+        self.queries += 1
+        return _Query(self.hit)
+
+
+def test_unchanged_name_is_not_revalidated_even_with_a_legacy_duplicate():
+    other_bob = SimpleNamespace(id=14, name="Bob")
+    db = _DB(hit=other_bob)  # the duplicate WOULD be found if the handler asked
+    agent = SimpleNamespace(id=15, name="Bob")
+    assert _renamed_to_taken_name(db, "ws", agent, "Bob") is False
+    assert db.queries == 0
+
+
+def test_real_rename_to_a_taken_name_is_refused():
+    db = _DB(hit=SimpleNamespace(id=14, name="Alice"))
+    agent = SimpleNamespace(id=15, name="Bob")
+    assert _renamed_to_taken_name(db, "ws", agent, "Alice") is True
+    assert db.queries == 1
+
+
+def test_real_rename_to_a_free_name_is_allowed():
+    db = _DB(hit=None)
+    agent = SimpleNamespace(id=15, name="Bob")
+    assert _renamed_to_taken_name(db, "ws", agent, "Carol") is False
+    assert db.queries == 1


### PR DESCRIPTION
## Summary
- Legacy data can hold two agents with one name in a workspace (two "Bob"s, created 2026-08-29 41 s apart). The frontend sends `name` on every save, and `update_agent` re-validated the unchanged name against the other row, so **every Configure → Save of either agent answered 400 "Agent with this name already exists"** for the name it already had. Found by the owner on the local edition on 2026-09-03; the handler is shared, so SaaS behaves the same.
- The conflict check now runs only on a real rename (`_renamed_to_taken_name`). A rename to a taken name is still refused; an unchanged name is never queried.

Not part of PRD-234 — surfaced while testing it. The create paths are untouched (they already refuse duplicates; the two Bobs predate/bypassed them).

## Test plan
- [x] `tests/test_agent_update_unchanged_name.py`: unchanged name + legacy duplicate → no conflict query, no 400; rename to a taken name → refused; rename to a free name → allowed.
- [ ] CI `orchestrator-tests` green.
- [ ] Owner: Configure → Save on agent 15 "Bob" (local) succeeds without renaming.