### PR TITLE
fix(prd-222): the veteran backfill never stamps a workspace created after PRD-222 (completes #688)

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -107,7 +107,10 @@ ensure_local_workspace() {
     echo "🏠 Ensuring local workspace ${DEFAULT_WORKSPACE_ID} exists..."
     export PGPASSWORD="$POSTGRES_PASSWORD"
     if psql -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" -U "$POSTGRES_USER" -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-        "INSERT INTO workspaces (id, name, slug, is_personal, is_active) VALUES ('${DEFAULT_WORKSPACE_ID}', 'Local Workspace', 'local', TRUE, TRUE) ON CONFLICT (id) DO NOTHING;"; then
+        # A brand-new install starts Auto-led onboarding: the row carries an explicit
+        # not_started document, so PRD-222's veteran backfill (stage-less ⇒ skipped),
+        # which the migration replay runs right after this, leaves it alone (2026-09-03).
+        "INSERT INTO workspaces (id, name, slug, is_personal, is_active, onboarding) VALUES ('${DEFAULT_WORKSPACE_ID}', 'Local Workspace', 'local', TRUE, TRUE, '{\"stage\": \"not_started\", \"stages\": {}, \"segment\": {}}'::jsonb) ON CONFLICT (id) DO NOTHING;"; then
         echo "✅ Local workspace present"
         # The single local operator (users id 1 — api/chat.py's own fallback).
         # Idempotent; PRD-233 S6 makes name/email editable in Settings → Profile.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -106,10 +106,10 @@ ensure_local_workspace() {
     echo ""
     echo "🏠 Ensuring local workspace ${DEFAULT_WORKSPACE_ID} exists..."
     export PGPASSWORD="$POSTGRES_PASSWORD"
+    # A brand-new install starts Auto-led onboarding: the row carries an explicit
+    # not_started document (PRD-222's veteran backfill matches only stage-less rows
+    # older than PRD-222 — see prd222_veteran_skip_backfill).
     if psql -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" -U "$POSTGRES_USER" -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c \
-        # A brand-new install starts Auto-led onboarding: the row carries an explicit
-        # not_started document, so PRD-222's veteran backfill (stage-less ⇒ skipped),
-        # which the migration replay runs right after this, leaves it alone (2026-09-03).
         "INSERT INTO workspaces (id, name, slug, is_personal, is_active, onboarding) VALUES ('${DEFAULT_WORKSPACE_ID}', 'Local Workspace', 'local', TRUE, TRUE, '{\"stage\": \"not_started\", \"stages\": {}, \"segment\": {}}'::jsonb) ON CONFLICT (id) DO NOTHING;"; then
         echo "✅ Local workspace present"
         # The single local operator (users id 1 — api/chat.py's own fallback).

--- a/orchestrator/alembic/versions/prd222_veteran_skip_backfill.py
+++ b/orchestrator/alembic/versions/prd222_veteran_skip_backfill.py
@@ -41,7 +41,12 @@ SET onboarding = COALESCE(onboarding, '{}'::jsonb)
                 to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD"T"HH24:MI:SS"Z"')
               )
        )
-WHERE onboarding IS NULL OR onboarding->>'stage' IS NULL
+WHERE (onboarding IS NULL OR onboarding->>'stage' IS NULL)
+  -- A veteran predates PRD-222. Anything created after it shipped (2026-08-28)
+  -- is a NEW workspace that has simply not started — never stamp it. Found
+  -- 2026-09-03: on a fresh local install the orphan-root chains re-run at the
+  -- container's `alembic upgrade heads` AFTER the operator workspace exists.
+  AND created_at < TIMESTAMP '2026-08-29'
 """
 
 _DOWNGRADE_SQL = """

--- a/orchestrator/tests/test_prd233_fresh_install_starts_onboarding.py
+++ b/orchestrator/tests/test_prd233_fresh_install_starts_onboarding.py
@@ -35,3 +35,14 @@ def test_existing_workspace_is_left_alone():
     db = _db(0)
     assert _ensure_workspace(db, uuid4()) == "present"
     assert "ON CONFLICT (id) DO NOTHING" in str(db.execute.call_args.args[0])
+
+
+def test_entrypoint_inserts_the_default_workspace_at_not_started():
+    """The entrypoint creates the default workspace BEFORE the migration replay
+    (found on the lab 2026-09-03: a fresh boot still read `skipped` after the
+    seed fix alone) — its INSERT must carry the stage too."""
+    import pathlib
+
+    src = (pathlib.Path(__file__).resolve().parents[2] / "docker-entrypoint.sh").read_text()
+    insert = next(line for line in src.splitlines() if "INSERT INTO workspaces" in line)
+    assert "onboarding" in insert and "not_started" in insert

--- a/orchestrator/tests/test_prd233_fresh_install_starts_onboarding.py
+++ b/orchestrator/tests/test_prd233_fresh_install_starts_onboarding.py
@@ -46,3 +46,12 @@ def test_entrypoint_inserts_the_default_workspace_at_not_started():
     src = (pathlib.Path(__file__).resolve().parents[2] / "docker-entrypoint.sh").read_text()
     insert = next(line for line in src.splitlines() if "INSERT INTO workspaces" in line)
     assert "onboarding" in insert and "not_started" in insert
+
+
+def test_veteran_backfill_never_touches_workspaces_created_after_prd222():
+    """The migration re-runs on fresh installs (orphan-root chains); a workspace
+    created after PRD-222 shipped cannot be a veteran."""
+    import pathlib
+
+    src = (pathlib.Path(__file__).resolve().parents[1] / "alembic/versions/prd222_veteran_skip_backfill.py").read_text()
+    assert "AND created_at < TIMESTAMP '2026-08-29'" in src


### PR DESCRIPTION
## Why #688 alone was not enough
#688 merged with its first commit only. A genuinely fresh local boot (isolated lab, 2026-09-03) still read `skipped`: the container's own `alembic upgrade heads` re-runs the forest's orphan-root migration chains AFTER seeds and entrypoint have created rows, so `prd222_veteran_skip_backfill` stamps whatever stage-less workspace exists by then — whichever step inserted it.

## Fix (the two commits pushed to the #688 branch after its merge)
- The backfill's UPDATE also requires `created_at < TIMESTAMP '2026-08-29'`: a veteran predates PRD-222 by definition; a workspace created after it shipped has simply not started. Prod is unaffected (already applied, idempotent); only fresh installs re-run it.
- The entrypoint's default-workspace INSERT carries the not_started document too (a comment placement in an intermediate commit had broken the `psql -c` continuation; fixed).

## Proven
Fresh lab boot: doc `{}` → backfill ran → not stamped → API `not_started`, zero restarts.

## Wider exposure (owner's call)
Every data-backfill migration re-runs on fresh installs until the 41 orphan-root revisions are re-chained (PRD-209 follow-on). The persona/doctrine backfills are worth checking next.

## Tests
`test_prd233_fresh_install_starts_onboarding.py`: entrypoint insert carries the stage; the backfill carries the created_at guard. CI only. Gerard's merge.