### PR TITLE
PRD-236 W1: provider tabs, one card per route, NVIDIA catalogue sync

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -50,9 +50,12 @@ internal testing and evaluation, not production, and no personal, financial or
 health data (NVIDIA API Trial Terms §1.2, §1.4, §4.3); the free tier allows about
 40 requests per minute per key. The key is your own agreement with NVIDIA —
 Automatos only routes to it. A model run on NVIDIA is recorded at zero cost and
-is never silently rerouted to a paid provider when the limit is hit. Pick the
-provider in **Settings → Orchestrator** (or on any agent): provider *NVIDIA*,
-model e.g. `moonshotai/kimi-k3`. (PRD-236)
+is never silently rerouted to a paid provider when the limit is hit. In
+**Marketplace → LLMs** open the *NVIDIA* tab, press *Sync NVIDIA* once, and add
+the models you want — "Kimi K3 · NVIDIA" is a different route from
+"Kimi K3 · OpenRouter" and installs with its own (zero) price. Then pick the
+route in **Settings → Orchestrator** (or on any agent): provider *NVIDIA*, model
+*Kimi K3*. (PRD-236)
 
 ## 2. Start the platform
 

--- a/docs/PRDS/PRD-236-PROVIDER-REGISTRY-PER-PROVIDER-MODELS.md
+++ b/docs/PRDS/PRD-236-PROVIDER-REGISTRY-PER-PROVIDER-MODELS.md
@@ -1,6 +1,6 @@
 # PRD-236: Provider registry + per-provider models — "Kimi via NVIDIA is free, Kimi via OpenRouter is paid, and the system routes to the one you picked"
 
-> **Status:** DRAFT 2026-09-03 (owner's ask of the same day). **Depends on:** PRD-54 (LLM marketplace, live), PRD-222 (BYOK validate-on-save, live), PRD-223 W0/W1 (model policy + `workspace_models` approval columns, live), PRD-233 (local edition, live). **Both editions.** **Build:** W0 first (this branch), W1/W2 after the owner's W0 test in both editions (feedback 2026-08-30: a phase is done when it is CI-green, merged and tested by him in both editions).
+> **Status:** W0 BUILT (PR #699, CI green, owner's local test: NVIDIA key added and validated 2026-09-03) · **W1 BUILT** (branch `feat/prd-236-w1`, stacked on W0; owner's go-ahead 2026-09-03: "separate tabs in marketplace for OpenRouter and NVIDIA… so Kimi K3 on OpenRouter is different from NVIDIA Kimi K3"). **Depends on:** PRD-54 (LLM marketplace, live), PRD-222 (BYOK validate-on-save, live), PRD-223 W0/W1 (model policy + `workspace_models` approval columns, live), PRD-233 (local edition, live). **Both editions.** **Build:** W0 first (this branch), W1/W2 after the owner's W0 test in both editions (feedback 2026-08-30: a phase is done when it is CI-green, merged and tested by him in both editions).
 
 ---
 
@@ -78,7 +78,9 @@ This section describes the design, not legal advice.
 
 **Known W0 limitation (fixed by W1):** the marketplace still shows one Kimi K3 card with OpenRouter's price; choosing NVIDIA is done through the provider field (Orchestrator settings / agent config), not through the card. The cost booked is already honest (S0.5).
 
-### W1 — the catalogue knows who serves what
+### W1 — the catalogue knows who serves what (BUILT 2026-09-03)
+
+**As built:** one migration (`prd236_w1_serving_provider`: `serving_provider`, UNIQUE `(serving_provider, model_id)`, `tier`→`sourcing`, data rule direct-keeps-provider / everything-else-OpenRouter); `core/services/provider_catalog_sync.py` (OpenRouter cache → `llm_models` projection; NVIDIA public list → rows at price 0 with metadata borrowed from the same vendor id's OpenRouter row, alias-aware, non-chat ids skipped; job history on `openrouter_sync_jobs.job_type`); `GET /api/marketplace/llm/catalog` (facets: serving provider + vendor + price tier), install/uninstall/detail take `?provider=`, `installed-ids` returns `routes`; `POST /sync/{provider}` + `GET /sync/status`; governance (`check_model_for_agent`), pricing (`price_per_1k`/`ModelRegistry.get_model`) and `UsageTracker` judge/price the tagged route; every write path stores the ROUTE's serving provider (never the vendor); seeding keys on `serving_provider`. UI: provider **tabs** inside Marketplace → LLMs (All · OpenRouter · NVIDIA · OpenAI …) with vendor chips beneath, one card per route with its own price / Free / "add a key" badge, per-provider Sync buttons (admin), route-aware install; Orchestrator settings list the selected provider's installed routes and the auto-switch is gone.
 
 | Story | What ships | Acceptance |
 |---|---|---|

--- a/frontend/components/marketplace/llm-model-card.tsx
+++ b/frontend/components/marketplace/llm-model-card.tsx
@@ -25,7 +25,19 @@ import { toast } from 'sonner'
 
 export interface LLMModel {
   id: number
+  /** The VENDOR of the model ('openai', 'moonshotai', 'deepseek-ai'…). */
   provider: string
+  vendor?: string
+  /** PRD-236 W1: the ROUTE that serves this row ('openrouter', 'nvidia', 'openai'…). */
+  serving_provider?: string
+  serving_provider_label?: string
+  route_label?: string
+  is_free?: boolean
+  price_tier?: string
+  key_available?: boolean
+  sourcing?: string | null
+  terms_note?: string | null
+  rate_limit_note?: string | null
   model_id: string
   display_name: string
   model_family: string | null
@@ -40,7 +52,8 @@ export interface LLMModel {
   supports_vision: boolean
   supports_streaming: boolean
   status: string
-  tier: string | null
+  /** Legacy name of `sourcing`; W1 responses no longer send it. */
+  tier?: string | null
   category: string | null
   tags: string[]
   is_featured: boolean
@@ -68,6 +81,9 @@ const PROVIDER_COLORS: Record<string, string> = {
   anthropic: 'bg-warning/15 text-warning border-warning/30',
   google: 'bg-info/15 text-info border-info/30',
   openrouter: 'bg-agent/15 text-agent border-agent/30',
+  nvidia: 'bg-lime-500/15 text-lime-400 border-lime-500/30',
+  deepseek: 'bg-indigo-500/15 text-indigo-400 border-indigo-500/30',
+  moonshotai: 'bg-violet-500/15 text-violet-400 border-violet-500/30',
   meta: 'bg-sky-500/15 text-sky-400 border-sky-500/30',
   mistral: 'bg-warning/15 text-warning border-warning/30',
   cohere: 'bg-pink-500/15 text-pink-400 border-pink-500/30',
@@ -106,6 +122,34 @@ function providerBadgeClass(provider: string): string {
   return PROVIDER_COLORS[key] || 'bg-secondary text-muted-foreground border-border'
 }
 
+/** PRD-236 W1: the route badge — who serves the call — plus the vendor when it differs. */
+export function routeBadges(model: LLMModel): { route: string; routeKey: string; vendor: string | null } {
+  const routeKey = model.serving_provider || model.provider
+  const route = model.serving_provider_label || routeKey
+  const vendor = model.serving_provider && model.provider !== model.serving_provider ? model.provider : null
+  return { route, routeKey, vendor }
+}
+
+const SOURCING_LABELS: Record<string, string> = {
+  direct: 'Direct API',
+  aggregator: 'Aggregator',
+  hosted_open: 'Hosted open model',
+  byok_only: 'BYO key',
+}
+
+export function sourcingLabel(model: LLMModel): string | null {
+  const key = model.sourcing ?? model.tier ?? null
+  if (!key) return null
+  return SOURCING_LABELS[key] || key
+}
+
+/** The install/uninstall path for THIS route (the provider query pins the row). */
+export function routeActionPath(model: LLMModel, action: 'install' | 'uninstall'): string {
+  const encodedId = encodeURIComponent(model.model_id)
+  const provider = model.serving_provider ? `?provider=${encodeURIComponent(model.serving_provider)}` : ''
+  return `/api/marketplace/llm/models/${encodedId}/${action}${provider}`
+}
+
 // ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
@@ -125,13 +169,12 @@ export function LLMModelCard({
     e.stopPropagation()
     setInstalling(true)
     try {
-      const encodedId = encodeURIComponent(model.model_id)
       if (model.is_installed) {
-        await apiClient.post(`/api/marketplace/llm/models/${encodedId}/uninstall`)
-        toast.success(`${model.display_name} removed`)
+        await apiClient.post(routeActionPath(model, 'uninstall'))
+        toast.success(`${model.route_label || model.display_name} removed`)
       } else {
-        await apiClient.post(`/api/marketplace/llm/models/${encodedId}/install`)
-        toast.success(`${model.display_name} installed`)
+        await apiClient.post(routeActionPath(model, 'install'))
+        toast.success(`${model.route_label || model.display_name} installed`)
       }
       queryClient.invalidateQueries({ queryKey: ['marketplaceLlmModels'] })
       queryClient.invalidateQueries({ queryKey: ['workspace-models'] })
@@ -167,15 +210,21 @@ export function LLMModelCard({
                 <span className="font-semibold text-sm truncate">{model.display_name}</span>
                 <Badge
                   variant="outline"
-                  className={`text-[9px] uppercase font-bold tracking-wider shrink-0 ${providerBadgeClass(model.provider)}`}
+                  className={`text-[9px] uppercase font-bold tracking-wider shrink-0 ${providerBadgeClass(routeBadges(model).routeKey)}`}
                 >
-                  {model.provider}
+                  {routeBadges(model).route}
                 </Badge>
+                {routeBadges(model).vendor && (
+                  <span className="text-[10px] text-muted-foreground shrink-0">{routeBadges(model).vendor}</span>
+                )}
               </div>
               <div className="flex items-center gap-2 text-xs text-muted-foreground mt-0.5">
                 <span>{formatTokenCount(model.context_window)} ctx</span>
                 <span>&middot;</span>
-                <span>In: {formatCostPer1M(model.input_cost_per_1k)}/1M</span>
+                <span>{model.is_free ? 'Free' : `In: ${formatCostPer1M(model.input_cost_per_1k)}/1M`}</span>
+                {model.key_available === false && (
+                  <span className="text-[10px] text-warning">· add a {routeBadges(model).route} key</span>
+                )}
               </div>
             </div>
             {model.is_installed ? (
@@ -215,12 +264,12 @@ export function LLMModelCard({
 
       <CardHeader className="pb-3">
         <div className="flex items-start gap-3">
-          {/* Provider badge */}
+          {/* Route badge — who serves the call (PRD-236 W1) */}
           <Badge
             variant="outline"
-            className={`text-[10px] uppercase font-bold tracking-wider shrink-0 ${providerBadgeClass(model.provider)}`}
+            className={`text-[10px] uppercase font-bold tracking-wider shrink-0 ${providerBadgeClass(routeBadges(model).routeKey)}`}
           >
-            {model.provider}
+            {routeBadges(model).route}
           </Badge>
 
           <div className="flex-1 min-w-0">
@@ -235,16 +284,31 @@ export function LLMModelCard({
 
         {/* Tier + Default + Plan badges */}
         <div className="flex flex-wrap gap-1.5 mt-2">
-          {model.tier && (
+          {routeBadges(model).vendor && (
+            <Badge variant="outline" className="text-[10px] border-border/60 text-muted-foreground">
+              by {routeBadges(model).vendor}
+            </Badge>
+          )}
+          {sourcingLabel(model) && (
             <Badge
               variant="outline"
               className={
-                model.tier === 'direct'
+                (model.sourcing ?? model.tier) === 'direct'
                   ? 'text-[10px] border-[hsl(var(--success))]/30 text-[hsl(var(--success))]'
                   : 'text-[10px] border-[hsl(var(--info))]/30 text-[hsl(var(--info))]'
               }
             >
-              {model.tier === 'direct' ? 'Direct' : 'Aggregator'}
+              {sourcingLabel(model)}
+            </Badge>
+          )}
+          {model.is_free && (
+            <Badge variant="outline" className="text-[10px] border-lime-500/40 text-lime-400">
+              Free
+            </Badge>
+          )}
+          {model.key_available === false && (
+            <Badge variant="outline" className="text-[10px] border-warning/40 text-warning">
+              Add a {routeBadges(model).route} key
             </Badge>
           )}
           {model.is_default && (
@@ -291,18 +355,24 @@ export function LLMModelCard({
           </div>
         </div>
 
-        {/* Cost per 1M tokens */}
+        {/* Cost per 1M tokens — per ROUTE (PRD-236 W1) */}
         <div className="flex items-center justify-between text-xs">
           <span className="text-muted-foreground">Cost / 1M tokens</span>
-          <div className="flex items-center gap-2">
-            <span className="text-[hsl(var(--success))] font-medium">
-              In: {formatCostPer1M(model.input_cost_per_1k)}
+          {model.is_free ? (
+            <span className="text-lime-400 font-medium" title={model.terms_note || undefined}>
+              Free{model.rate_limit_note ? ' · rate-limited' : ''}
             </span>
-            <span className="text-muted-foreground">/</span>
-            <span className="text-[hsl(var(--primary))] font-medium">
-              Out: {formatCostPer1M(model.output_cost_per_1k)}
-            </span>
-          </div>
+          ) : (
+            <div className="flex items-center gap-2">
+              <span className="text-[hsl(var(--success))] font-medium">
+                In: {formatCostPer1M(model.input_cost_per_1k)}
+              </span>
+              <span className="text-muted-foreground">/</span>
+              <span className="text-[hsl(var(--primary))] font-medium">
+                Out: {formatCostPer1M(model.output_cost_per_1k)}
+              </span>
+            </div>
+          )}
         </div>
 
         {/* Capability bars */}

--- a/frontend/components/marketplace/llm-model-detail-modal.tsx
+++ b/frontend/components/marketplace/llm-model-detail-modal.tsx
@@ -31,6 +31,7 @@ import { apiClient } from '@/lib/api-client'
 import { useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 import type { LLMModel } from './llm-model-card'
+import { routeActionPath, routeBadges, sourcingLabel } from './llm-model-card'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -116,11 +117,11 @@ export function LLMModelDetailModal({
     setInstalling(true)
     try {
       if (model.is_installed) {
-        await apiClient.post(`/api/marketplace/llm/models/${model.model_id}/uninstall`)
-        toast.success(`${model.display_name} removed`)
+        await apiClient.post(routeActionPath(model, 'uninstall'))
+        toast.success(`${model.route_label || model.display_name} removed`)
       } else {
-        await apiClient.post(`/api/marketplace/llm/models/${model.model_id}/install`)
-        toast.success(`${model.display_name} installed`)
+        await apiClient.post(routeActionPath(model, 'install'))
+        toast.success(`${model.route_label || model.display_name} installed`)
       }
       queryClient.invalidateQueries({ queryKey: ['marketplaceLlmModels'] })
       queryClient.invalidateQueries({ queryKey: ['workspace-models'] })
@@ -152,9 +153,9 @@ export function LLMModelDetailModal({
           <div className="flex items-start gap-3">
             <Badge
               variant="outline"
-              className={`text-[10px] uppercase font-bold tracking-wider shrink-0 mt-1 ${providerBadgeClass(model.provider)}`}
+              className={`text-[10px] uppercase font-bold tracking-wider shrink-0 mt-1 ${providerBadgeClass(routeBadges(model).routeKey)}`}
             >
-              {model.provider}
+              {routeBadges(model).route}
             </Badge>
             <div className="flex-1 min-w-0">
               <DialogTitle className="flex items-center gap-2 flex-wrap">
@@ -171,16 +172,16 @@ export function LLMModelDetailModal({
 
           {/* Tier + Default + Plan badges */}
           <div className="flex flex-wrap gap-1.5 mt-3">
-            {model.tier && (
+            {sourcingLabel(model) && (
               <Badge
                 variant="outline"
                 className={
-                  model.tier === 'direct'
+                  (model.sourcing ?? model.tier) === 'direct'
                     ? 'text-[10px] border-[hsl(var(--success))]/30 text-[hsl(var(--success))]'
                     : 'text-[10px] border-[hsl(var(--info))]/30 text-[hsl(var(--info))]'
                 }
               >
-                {model.tier === 'direct' ? 'Direct API' : 'Aggregator'}
+                {sourcingLabel(model)}
               </Badge>
             )}
             {model.is_default && (

--- a/frontend/components/marketplace/marketplace-llms-tab.tsx
+++ b/frontend/components/marketplace/marketplace-llms-tab.tsx
@@ -28,7 +28,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
-import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { apiClient } from '@/lib/api-client'
 import { toast } from 'sonner'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -36,7 +36,7 @@ import { ArrowRightLeft, CheckCircle } from 'lucide-react'
 import { LLMModelCard } from './llm-model-card'
 import { LLMModelDetailModal } from './llm-model-detail-modal'
 import type { LLMModel } from './llm-model-card'
-import { useSyncOpenRouterCache } from '@/hooks/use-openrouter-api'
+import { useProviderRegistry, providerLabel } from '@/hooks/use-provider-registry'
 import { useSystemRole } from '@/contexts/role-context'
 
 // ---------------------------------------------------------------------------
@@ -55,7 +55,7 @@ const CATEGORY_OPTIONS = [
 ]
 
 const TIER_OPTIONS = [
-  { value: 'all', label: 'All Tiers' },
+  { value: 'all', label: 'All Prices' },
   { value: 'free', label: 'Free' },
   { value: 'budget', label: 'Budget' },
   { value: 'mid', label: 'Mid-range' },
@@ -73,77 +73,17 @@ const SORT_OPTIONS: { value: SortKey; label: string }[] = [
 ]
 
 // ---------------------------------------------------------------------------
-// Types for OpenRouter cache response
+// Catalog response (PRD-236 W1): one row per ROUTE — (serving provider, model)
 // ---------------------------------------------------------------------------
 
-interface OpenRouterModel {
-  id: number
-  model_id: string
-  slug: string | null
-  display_name: string
-  description: string | null
-  provider: string
-  prompt_cost: number
-  completion_cost: number
-  image_cost: number
-  request_cost: number
-  cache_read_cost: number
-  cache_write_cost: number
-  context_length: number
-  max_completion_tokens: number
-  modality: string | null
-  input_modalities: string[]
-  output_modalities: string[]
-  tokenizer: string | null
-  supports_tools: boolean
-  supports_vision: boolean
-  supports_streaming: boolean
-  supports_json_mode: boolean
-  supports_reasoning: boolean
-  category: string | null
-  tier: string | null
-  tags: string[]
-  status: string
-  is_moderated: boolean
-  last_synced_at: string | null
-}
-
-interface OpenRouterMarketplaceResponse {
-  models: OpenRouterModel[]
+interface CatalogResponse {
+  models: LLMModel[]
   total: number
   providers: Record<string, number>
-  last_synced: string | null
-}
-
-// Adapt OpenRouter model to the existing LLMModel card interface
-function adaptToLLMModel(m: OpenRouterModel, installedIds?: Set<string>): LLMModel {
-  return {
-    id: m.id,
-    provider: m.provider,
-    model_id: m.model_id,
-    display_name: m.display_name,
-    model_family: null,
-    description: m.description,
-    context_window: m.context_length,
-    max_output_tokens: m.max_completion_tokens,
-    // Convert per-token cost to per-1K-token cost
-    input_cost_per_1k: m.prompt_cost * 1000,
-    output_cost_per_1k: m.completion_cost * 1000,
-    capabilities: {},
-    recommended_for: m.tags || [],
-    supports_functions: m.supports_tools,
-    supports_vision: m.supports_vision,
-    supports_streaming: m.supports_streaming,
-    status: m.status,
-    tier: m.tier,
-    category: m.category,
-    tags: m.tags || [],
-    is_featured: false,
-    is_default: false,
-    requires_plan: null,
-    install_count: 0,
-    is_installed: installedIds ? installedIds.has(m.model_id) : false,
-  }
+  provider_labels: Record<string, string>
+  vendors: Record<string, number>
+  last_synced: Record<string, string | null>
+  syncable: string[]
 }
 
 // ---------------------------------------------------------------------------
@@ -161,11 +101,13 @@ interface MarketplaceLlmsTabProps {
 export function MarketplaceLlmsTab({ searchQuery }: MarketplaceLlmsTabProps) {
   const queryClient = useQueryClient()
   const { isAdmin } = useSystemRole()
-  const syncMutation = useSyncOpenRouterCache()
   const [viewMode, setViewMode] = useViewMode('mp-llms')
+  const registry = useProviderRegistry()
 
-  // Filter state
+  // Filter state — the provider TAB is the serving provider (who you pay), the
+  // vendor chip is who made the model (PRD-236 W1)
   const [selectedProvider, setSelectedProvider] = useState('all')
+  const [selectedVendor, setSelectedVendor] = useState('all')
   const [selectedCategory, setSelectedCategory] = useState('all')
   const [selectedTier, setSelectedTier] = useState('all')
   const [sortBy, setSortBy] = useState<SortKey>('popularity')
@@ -190,22 +132,23 @@ export function MarketplaceLlmsTab({ searchQuery }: MarketplaceLlmsTabProps) {
   // Data fetching
   // -----------------------------------------------------------------------
 
-  // Fetch installed model IDs for this workspace (lightweight)
-  const { data: installedData } = useQuery<{ model_ids: string[] }>({
+  // Installed ROUTES for this workspace ("provider:model_id" keys)
+  const { data: installedData } = useQuery<{ model_ids: string[]; routes?: string[] }>({
     queryKey: ['installed-model-ids'],
     queryFn: () => apiClient.get('/api/marketplace/llm/installed-ids'),
     staleTime: 60 * 1000,
     refetchOnWindowFocus: false,
   })
-  const installedIds = useMemo(
-    () => new Set(installedData?.model_ids ?? []),
+  const installedRoutes = useMemo(
+    () => new Set(installedData?.routes ?? []),
     [installedData]
   )
 
-  const { data: response, isLoading } = useQuery<OpenRouterMarketplaceResponse>({
+  const { data: response, isLoading } = useQuery<CatalogResponse>({
     queryKey: [
-      'openrouterModels',
+      'marketplaceLlmCatalog',
       selectedProvider,
+      selectedVendor,
       selectedCategory,
       selectedTier,
       combinedSearch,
@@ -217,99 +160,94 @@ export function MarketplaceLlmsTab({ searchQuery }: MarketplaceLlmsTabProps) {
     queryFn: async () => {
       const params = new URLSearchParams()
       if (selectedProvider !== 'all') params.append('provider', selectedProvider)
+      if (selectedVendor !== 'all') params.append('vendor', selectedVendor)
       if (selectedCategory !== 'all') params.append('category', selectedCategory)
-      if (selectedTier !== 'all') params.append('tier', selectedTier)
+      if (selectedTier !== 'all') params.append('price_tier', selectedTier)
       if (combinedSearch) params.append('search', combinedSearch)
       if (sortBy) params.append('sort_by', sortBy)
       if (filterTools) params.append('supports_tools', 'true')
       if (filterVision) params.append('supports_vision', 'true')
-      if (filterReasoning) params.append('supports_reasoning', 'true')
+      if (filterReasoning) params.append('category', 'reasoning')
       params.append('limit', '500')
       const qs = params.toString()
-
-      // Try OpenRouter cache first, fall back to legacy LLM endpoint
-      try {
-        return await apiClient.get(`/api/openrouter/models${qs ? `?${qs}` : ''}`)
-      } catch {
-        // Fallback: legacy endpoint (returns LLMModel[] array, not wrapped)
-        const legacyParams = new URLSearchParams()
-        if (selectedProvider !== 'all') legacyParams.append('provider', selectedProvider)
-        if (selectedCategory !== 'all') legacyParams.append('category', selectedCategory)
-        if (selectedTier !== 'all') legacyParams.append('tier', selectedTier)
-        if (combinedSearch) legacyParams.append('search', combinedSearch)
-        const lqs = legacyParams.toString()
-        const legacyModels = await apiClient.get(`/api/marketplace/llm/models${lqs ? `?${lqs}` : ''}`)
-
-        // Wrap in the expected response shape
-        const providerMap: Record<string, number> = {}
-        for (const m of legacyModels) {
-          providerMap[m.provider] = (providerMap[m.provider] || 0) + 1
-        }
-        return {
-          models: legacyModels.map((m: any) => ({
-            id: m.id,
-            model_id: m.model_id,
-            slug: null,
-            display_name: m.display_name,
-            description: m.description,
-            provider: m.provider,
-            prompt_cost: (m.input_cost_per_1k || 0) / 1000,
-            completion_cost: (m.output_cost_per_1k || 0) / 1000,
-            image_cost: 0,
-            request_cost: 0,
-            cache_read_cost: 0,
-            cache_write_cost: 0,
-            context_length: m.context_window || 0,
-            max_completion_tokens: m.max_output_tokens || 0,
-            modality: null,
-            input_modalities: [],
-            output_modalities: [],
-            tokenizer: null,
-            supports_tools: m.supports_functions || false,
-            supports_vision: m.supports_vision || false,
-            supports_streaming: m.supports_streaming ?? true,
-            supports_json_mode: false,
-            supports_reasoning: false,
-            category: m.category,
-            tier: m.tier,
-            tags: m.tags || [],
-            status: m.status || 'active',
-            is_moderated: false,
-            last_synced_at: null,
-          })),
-          total: legacyModels.length,
-          providers: providerMap,
-          last_synced: null,
-        } as OpenRouterMarketplaceResponse
-      }
+      return apiClient.get(`/api/marketplace/llm/catalog${qs ? `?${qs}` : ''}`)
     },
     staleTime: 5 * 60 * 1000,
     refetchOnWindowFocus: false,
   })
 
+  // Sync one provider's catalogue (admin). OpenRouter and NVIDIA are syncable.
+  const syncMutation = useMutation({
+    mutationFn: (slug: string) => apiClient.post(`/api/marketplace/llm/sync/${encodeURIComponent(slug)}`),
+    onSuccess: (_data, slug) => {
+      toast.success(`${providerLabel(registry, slug)} catalogue synced`)
+      queryClient.invalidateQueries({ queryKey: ['marketplaceLlmCatalog'] })
+      queryClient.invalidateQueries({ queryKey: ['openrouterModels'] })
+    },
+    onError: (err: Error, slug) => {
+      toast.error(`${providerLabel(registry, slug)} sync failed`, { description: err.message })
+    },
+  })
+
   const rawModels = response?.models ?? []
   const providerCounts = response?.providers ?? {}
-  const lastSynced = response?.last_synced ?? null
+  const providerLabels = response?.provider_labels ?? {}
+  const vendorCounts = response?.vendors ?? {}
+  const syncable = response?.syncable ?? ['openrouter', 'nvidia']
+  const lastSyncedByProvider = response?.last_synced ?? {}
   const totalCount = response?.total ?? 0
-
-  // Build dynamic provider filter chips from actual data
-  const providerFilters = useMemo(() => {
-    const providers = Object.entries(providerCounts)
-      .sort((a, b) => b[1] - a[1])
-      .slice(0, 12)
-      .map(([id, count]) => ({ id, name: id.charAt(0).toUpperCase() + id.slice(1), count }))
-    return [{ id: 'all', name: 'All', count: totalCount }, ...providers]
-  }, [providerCounts, totalCount])
-
-  // Adapt to existing card format (with installed status)
-  const models = useMemo(
-    () => rawModels.map((m) => adaptToLLMModel(m, installedIds)),
-    [rawModels, installedIds]
+  const catalogTotal = useMemo(
+    () => Object.values(providerCounts).reduce((a, b) => a + b, 0),
+    [providerCounts]
   )
+
+  // Provider TABS: every registered chat provider, in registry order, with the
+  // number of routes it serves. Providers with no rows yet still get a tab so
+  // the "Sync" action has somewhere to live.
+  const providerTabs = useMemo(() => {
+    const ordered = registry.providers.filter((p) => p.chat).map((p) => p.slug)
+    const extra = Object.keys(providerCounts).filter((slug) => !ordered.includes(slug))
+    const tabs = [...ordered, ...extra]
+      .filter((slug) => (providerCounts[slug] ?? 0) > 0 || syncable.includes(slug))
+      .map((slug) => ({
+        id: slug,
+        name: providerLabels[slug] || providerLabel(registry, slug),
+        count: providerCounts[slug] ?? 0,
+      }))
+    return [{ id: 'all', name: 'All providers', count: catalogTotal }, ...tabs]
+  }, [registry, providerCounts, providerLabels, syncable, catalogTotal])
+
+  // Vendor chips within the selected provider tab
+  const vendorFilters = useMemo(() => {
+    const vendors = Object.entries(vendorCounts)
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 16)
+      .map(([id, count]) => ({ id, name: id.charAt(0).toUpperCase() + id.slice(1), count }))
+    return [{ id: 'all', name: 'All vendors', count: totalCount }, ...vendors]
+  }, [vendorCounts, totalCount])
+
+  // The catalog rows already match the card shape; installed is per ROUTE
+  const models = useMemo(
+    () =>
+      rawModels.map((m) => ({
+        ...m,
+        is_installed: installedRoutes.has(`${m.serving_provider || m.provider}:${m.model_id}`),
+      })),
+    [rawModels, installedRoutes]
+  )
+
+  // Which providers may be synced from the current tab
+  const syncTargets = useMemo(
+    () => (selectedProvider === 'all' ? syncable : syncable.filter((slug) => slug === selectedProvider)),
+    [selectedProvider, syncable]
+  )
+  const lastSynced = selectedProvider === 'all'
+    ? (lastSyncedByProvider['openrouter'] ?? null)
+    : (lastSyncedByProvider[selectedProvider] ?? null)
 
   // Active filter count (for indicator)
   const activeFilterCount = [
-    selectedProvider !== 'all',
+    selectedVendor !== 'all',
     selectedCategory !== 'all',
     selectedTier !== 'all',
     filterTools,
@@ -343,14 +281,14 @@ export function MarketplaceLlmsTab({ searchQuery }: MarketplaceLlmsTabProps) {
   }
 
   const handleInstall = () => {
-    queryClient.invalidateQueries({ queryKey: ['openrouterModels'] })
+    queryClient.invalidateQueries({ queryKey: ['marketplaceLlmCatalog'] })
     queryClient.invalidateQueries({ queryKey: ['marketplaceLlmModels'] })
     queryClient.invalidateQueries({ queryKey: ['installed-model-ids'] })
     queryClient.invalidateQueries({ queryKey: ['workspace-models'] })
   }
 
   const clearAllFilters = () => {
-    setSelectedProvider('all')
+    setSelectedVendor('all')
     setSelectedCategory('all')
     setSelectedTier('all')
     setFilterTools(false)
@@ -395,39 +333,70 @@ export function MarketplaceLlmsTab({ searchQuery }: MarketplaceLlmsTabProps) {
         </div>
         <div className="flex items-center gap-3">
           <ViewToggle value={viewMode} onChange={setViewMode} />
-          {isAdmin && (
+          {isAdmin && syncTargets.map((slug) => (
             <Button
+              key={slug}
               variant="outline"
               size="sm"
-              onClick={() => syncMutation.mutate()}
-              disabled={syncMutation.isPending}
+              onClick={() => syncMutation.mutate(slug)}
+              disabled={syncMutation.isLoading}
               className="gap-2 text-muted-foreground hover:text-foreground"
+              data-testid={`sync-${slug}`}
             >
-              <RefreshCw className={`w-3.5 h-3.5 ${syncMutation.isPending ? 'animate-spin' : ''}`} />
-              {syncMutation.isPending ? 'Syncing...' : 'Sync OpenRouter'}
+              <RefreshCw className={`w-3.5 h-3.5 ${syncMutation.isLoading && syncMutation.variables === slug ? 'animate-spin' : ''}`} />
+              {syncMutation.isLoading && syncMutation.variables === slug ? 'Syncing...' : `Sync ${providerLabels[slug] || providerLabel(registry, slug)}`}
             </Button>
-          )}
+          ))}
         </div>
       </div>
 
       {/* Filter bar */}
       <div className="space-y-4">
-        {/* Provider buttons (dynamic from cache) */}
+        {/* Provider TABS — who serves (and bills) the call. "Kimi K3 · NVIDIA" and
+            "Kimi K3 · OpenRouter" are different routes with different prices. */}
+        <div
+          role="tablist"
+          aria-label="Serving provider"
+          data-testid="provider-tabs"
+          className="flex gap-1 overflow-x-auto pb-1 border-b border-border/40 scrollbar-thin scrollbar-thumb-secondary scrollbar-track-transparent"
+        >
+          {providerTabs.map((tab) => (
+            <button
+              key={tab.id}
+              role="tab"
+              aria-selected={selectedProvider === tab.id}
+              onClick={() => {
+                setSelectedProvider(tab.id)
+                setSelectedVendor('all')
+              }}
+              className={`whitespace-nowrap flex-shrink-0 px-3 py-2 text-sm border-b-2 -mb-px transition-colors ${
+                selectedProvider === tab.id
+                  ? 'border-primary text-foreground font-semibold'
+                  : 'border-transparent text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              {tab.name}
+              <span className="ml-1.5 text-[10px] opacity-60">{tab.count}</span>
+            </button>
+          ))}
+        </div>
+
+        {/* Vendor chips within the tab — who made the model */}
         <div className="flex gap-2 overflow-x-auto pb-1 scrollbar-thin scrollbar-thumb-secondary scrollbar-track-transparent">
-          {providerFilters.map((provider) => (
+          {vendorFilters.map((vendor) => (
             <Button
-              key={provider.id}
-              variant={selectedProvider === provider.id ? 'default' : 'outline'}
+              key={vendor.id}
+              variant={selectedVendor === vendor.id ? 'default' : 'outline'}
               size="sm"
-              onClick={() => setSelectedProvider(provider.id)}
+              onClick={() => setSelectedVendor(vendor.id)}
               className={`whitespace-nowrap flex-shrink-0 ${
-                selectedProvider === provider.id
+                selectedVendor === vendor.id
                   ? 'bg-secondary border-primary/50 text-foreground font-semibold'
                   : 'border-secondary text-muted-foreground hover:bg-secondary'
               }`}
             >
-              {provider.name}
-              <span className="ml-1.5 text-[10px] opacity-60">{provider.count}</span>
+              {vendor.name}
+              <span className="ml-1.5 text-[10px] opacity-60">{vendor.count}</span>
             </Button>
           ))}
         </div>
@@ -605,7 +574,8 @@ export function MarketplaceLlmsTab({ searchQuery }: MarketplaceLlmsTabProps) {
                       </thead>
                       <tbody>
                         {[
-                          { label: 'Provider', render: (m: LLMModel) => m.provider },
+                          { label: 'Route', render: (m: LLMModel) => m.route_label || `${m.display_name} · ${m.serving_provider || m.provider}` },
+                          { label: 'Vendor', render: (m: LLMModel) => m.provider },
                           { label: 'Context Window', render: (m: LLMModel) => {
                             const n = m.context_window
                             return n >= 1_000_000 ? `${(n / 1_000_000).toFixed(1)}M` : n >= 1_000 ? `${(n / 1_000).toFixed(0)}K` : String(n)
@@ -684,20 +654,21 @@ export function MarketplaceLlmsTab({ searchQuery }: MarketplaceLlmsTabProps) {
           <p className="font-medium">No LLM models found</p>
           <p className="text-sm mt-1">
             {totalCount === 0
-              ? 'Cache is empty. Click "Sync OpenRouter" to load models.'
+              ? `No routes in this catalogue yet. ${isAdmin ? 'Sync a provider to load its models.' : 'Ask an admin to sync a provider.'}`
               : 'Try adjusting your filters or search query.'}
           </p>
-          {totalCount === 0 && isAdmin && (
+          {totalCount === 0 && isAdmin && syncTargets.map((slug) => (
             <Button
+              key={slug}
               variant="outline"
-              className="mt-4"
-              onClick={() => syncMutation.mutate()}
-              disabled={syncMutation.isPending}
+              className="mt-4 mr-2"
+              onClick={() => syncMutation.mutate(slug)}
+              disabled={syncMutation.isLoading}
             >
-              <RefreshCw className={`w-4 h-4 mr-2 ${syncMutation.isPending ? 'animate-spin' : ''}`} />
-              {syncMutation.isPending ? 'Syncing...' : 'Sync OpenRouter Models'}
+              <RefreshCw className={`w-4 h-4 mr-2 ${syncMutation.isLoading && syncMutation.variables === slug ? 'animate-spin' : ''}`} />
+              {syncMutation.isLoading && syncMutation.variables === slug ? 'Syncing...' : `Sync ${providerLabels[slug] || providerLabel(registry, slug)} models`}
             </Button>
-          )}
+          ))}
         </div>
       ) : (
         <>

--- a/frontend/components/settings/SystemLLMSettingsTab.tsx
+++ b/frontend/components/settings/SystemLLMSettingsTab.tsx
@@ -157,10 +157,14 @@ export default function SystemLLMSettingsTab({
   const availableModels = useMemo(() => {
     if (!Array.isArray(allModels)) return []
     if (!selectedProvider) return allModels
+    // PRD-236 W1: an installed row is a ROUTE — list the ones served by the
+    // selected provider. Rows from an older API (no serving_provider) keep the
+    // vendor/aggregator heuristic.
     const isAggregator = hostsVendorModels(registry, selectedProvider)
     return allModels.filter((model: any) =>
-      model.provider === selectedProvider ||
-      (isAggregator && model.tier === 'aggregator')
+      model.serving_provider
+        ? model.serving_provider === selectedProvider
+        : model.provider === selectedProvider || (isAggregator && (model.sourcing ?? model.tier) === 'aggregator')
     )
   }, [allModels, selectedProvider, registry])
 
@@ -459,14 +463,9 @@ export default function SystemLLMSettingsTab({
                   <Select
                     value={orchConfig?.llm?.model_id || ''}
                     onValueChange={(value) => {
+                      // PRD-236 W1: the list is already the selected provider's routes,
+                      // so the pick never changes the provider (the tag is the route).
                       handleLLMChange('model_id', value)
-                      // An aggregator-tier model needs a provider that hosts vendor-prefixed
-                      // ids. OpenRouter and NVIDIA both do (PRD-236) — only switch to
-                      // OpenRouter when the chosen provider cannot serve the model.
-                      const picked = allModels.find((m: any) => m.model_id === value)
-                      if (picked && (picked as any).tier === 'aggregator' && !hostsVendorModels(registry, orchConfig?.llm?.provider)) {
-                        handleLLMChange('provider', 'openrouter')
-                      }
                     }}
                     disabled={modelsLoading || !selectedProvider}
                   >
@@ -481,9 +480,9 @@ export default function SystemLLMSettingsTab({
                     </SelectTrigger>
                     <SelectContent>
                       {availableModels.length > 0 ? (
-                        availableModels.map((model: { model_id: string; display_name: string; context_window: number }) => (
-                          <SelectItem key={model.model_id} value={model.model_id}>
-                            {model.display_name}
+                        availableModels.map((model: { id?: number; model_id: string; display_name: string; context_window: number; is_free?: boolean }) => (
+                          <SelectItem key={model.id ?? model.model_id} value={model.model_id}>
+                            {model.display_name}{model.is_free ? ' · free' : ''}
                             {model.context_window >= 100000 && ` (${(model.context_window / 1000).toFixed(0)}K context)`}
                           </SelectItem>
                         ))

--- a/frontend/hooks/use-model-api.ts
+++ b/frontend/hooks/use-model-api.ts
@@ -14,6 +14,14 @@ import { useWorkspace } from '@/hooks/use-workspace'
 export interface ModelInfo {
   id: number
   provider: string
+  /** PRD-236 W1: the route that serves this row (openrouter, nvidia, openai…). */
+  serving_provider?: string
+  serving_provider_label?: string
+  route_label?: string
+  is_free?: boolean
+  price_tier?: string
+  key_available?: boolean
+  sourcing?: string
   model_id: string
   display_name: string
   model_family: string

--- a/orchestrator/alembic/versions/prd236_w1_serving_provider.py
+++ b/orchestrator/alembic/versions/prd236_w1_serving_provider.py
@@ -1,0 +1,81 @@
+"""PRD-236 Wave 1 — the catalogue knows who serves what.
+
+``llm_models`` gains ``serving_provider`` (the registry slug of the API that
+serves the row); the UNIQUE moves from ``model_id`` to
+``(serving_provider, model_id)`` so one vendor id can exist once per route —
+"moonshotai/kimi-k3" on OpenRouter AND on NVIDIA, each with its own price;
+``tier`` is renamed ``sourcing`` (PRD-223 §8 Q1, owner: yes) and set from the
+registry kind of the serving provider. ``external_id`` (already present) holds
+the provider-native id.
+
+Data rule: a row with ``tier='direct'`` and a registered direct provider keeps
+its ``provider`` as the serving provider. Everything else — aggregator rows
+(whose ``provider`` is the VENDOR), legacy 'aiml'/'together' seeds, byok_only —
+is served by OpenRouter, which is exactly where the factory's string-shape
+routing sent them at runtime. ``workspace_models`` is untouched: it already
+keys on the integer row, so an install IS the route tag.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "prd236_w1_serving_provider"
+down_revision = "prd234_s1a_cli_hosts_runtime_ref"
+branch_labels = None
+depends_on = None
+
+# Snapshot of the registry's direct chat providers at migration time
+# (core/llm/providers.py) — a migration must not import application code.
+_DIRECT_PROVIDERS = (
+    "openai", "anthropic", "google", "azure", "azure_openai",
+    "bedrock", "aws_bedrock", "grok", "huggingface", "deepseek",
+)
+
+
+def upgrade():
+    op.add_column(
+        "llm_models",
+        sa.Column("serving_provider", sa.String(length=50), nullable=False, server_default="openrouter"),
+    )
+    direct_list = ", ".join(f"'{p}'" for p in _DIRECT_PROVIDERS)
+    op.execute(
+        f"UPDATE llm_models SET serving_provider = provider "
+        f"WHERE tier = 'direct' AND provider IN ({direct_list})"
+    )
+    # alias normalisation — the registry slug is 'bedrock' / 'azure'
+    op.execute("UPDATE llm_models SET serving_provider = 'bedrock' WHERE serving_provider = 'aws_bedrock'")
+    op.execute("UPDATE llm_models SET serving_provider = 'azure' WHERE serving_provider = 'azure_openai'")
+    op.execute("UPDATE llm_models SET external_id = model_id WHERE external_id IS NULL")
+
+    # One row per route: UNIQUE (serving_provider, model_id) replaces UNIQUE (model_id).
+    # Tolerant of both writers: the alembic-created constraint and a create_all()
+    # unique index carry different names.
+    op.execute("ALTER TABLE llm_models DROP CONSTRAINT IF EXISTS llm_models_model_id_key")
+    op.execute("DROP INDEX IF EXISTS ix_llm_models_model_id")
+    op.create_unique_constraint(
+        "uq_llm_models_provider_model", "llm_models", ["serving_provider", "model_id"]
+    )
+    op.create_index("ix_llm_models_model_id", "llm_models", ["model_id"], unique=False)
+    op.create_index("idx_llm_models_serving_provider", "llm_models", ["serving_provider"], unique=False)
+
+    # PRD-223 Q1: the sourcing vocabulary gets its real name; values follow the
+    # registry kind of the serving provider.
+    op.alter_column("llm_models", "tier", new_column_name="sourcing")
+    op.execute(
+        "UPDATE llm_models SET sourcing = CASE "
+        "WHEN serving_provider = 'openrouter' THEN 'aggregator' "
+        "WHEN serving_provider = 'nvidia' THEN 'hosted_open' "
+        "ELSE 'direct' END"
+    )
+
+
+def downgrade():
+    op.alter_column("llm_models", "sourcing", new_column_name="tier")
+    op.drop_index("idx_llm_models_serving_provider", table_name="llm_models")
+    op.drop_index("ix_llm_models_model_id", table_name="llm_models")
+    op.drop_constraint("uq_llm_models_provider_model", "llm_models", type_="unique")
+    # Routes served by other providers cannot coexist under the old key.
+    op.execute("DELETE FROM llm_models WHERE serving_provider <> 'openrouter' AND tier <> 'direct'")
+    op.create_unique_constraint("llm_models_model_id_key", "llm_models", ["model_id"])
+    op.drop_column("llm_models", "serving_provider")

--- a/orchestrator/api/agent_endpoints.py
+++ b/orchestrator/api/agent_endpoints.py
@@ -573,15 +573,16 @@ async def update_agent_model_config(
         model_id = model_config.get("model_id")
         if model_id:
             from api.llm_marketplace import _get_or_create_from_cache
-            model = _get_or_create_from_cache(db, model_id)
+            model = _get_or_create_from_cache(db, model_id, model_config.get("provider"))
             if not model:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail=f"Invalid model_id: {model_id}"
                 )
-            # PRD-54: Always use the provider from the model registry
-            # The frontend may not know the correct provider for aggregated models
-            model_config["provider"] = model.provider
+            # PRD-236 W1: the stored provider is the ROUTE that serves the row
+            # (openrouter / nvidia / openai …), never the vendor — the factory
+            # routes to it as tagged.
+            model_config["provider"] = model.serving_provider
 
             # PRD-223 W1: policy gate. The Auto agent row is the orchestrator
             # seat — quarantined/unapproved models are rejected at write time
@@ -593,6 +594,7 @@ async def update_agent_model_config(
             )
             _allowed, _reason = check_model_for_agent(
                 db, ctx.workspace_id, model_id, orchestrator_seat=_is_auto_seat,
+                provider=model.serving_provider,
             )
             if not _allowed:
                 raise HTTPException(

--- a/orchestrator/api/llm_marketplace.py
+++ b/orchestrator/api/llm_marketplace.py
@@ -1,9 +1,17 @@
 """
-LLM Marketplace API (PRD-54)
-=============================
+LLM Marketplace API (PRD-54, PRD-236 W1)
+========================================
 
-Browse, compare, and install LLM models to workspaces.
-Extends the existing marketplace with LLM-specific endpoints.
+Browse, compare, and install LLM ROUTES to workspaces. A route is one row of
+``llm_models`` keyed by ``(serving_provider, model_id)``: the same vendor id
+("moonshotai/kimi-k3") is a different route on OpenRouter (paid) and on NVIDIA
+(free, trial terms), each with its own price. Installing a route creates the
+``workspace_models`` row for THAT row — the install is the tag the factory
+routes to.
+
+Catalogue rows are written by ``core.services.provider_catalog_sync``
+(OpenRouter via its cache, NVIDIA from its public list); direct providers keep
+their seeded rows.
 """
 
 import logging
@@ -21,16 +29,26 @@ from core.auth.hybrid import get_request_context_hybrid
 from core.database.database import get_db
 from core.models.core import LLMModel, WorkspaceModel
 from core.models.openrouter_cache import OpenRouterModelCache
+from core.llm import providers as registry
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/marketplace/llm", tags=["LLM Marketplace"])
+
+# Pricing tier thresholds, $ per 1K input tokens — the same bands the
+# OpenRouter cache uses per token (free / ≤$0.50 per M / ≤$3 per M / above).
+_PRICE_TIER_BUDGET_PER_1K = 0.0005
+_PRICE_TIER_MID_PER_1K = 0.003
 
 
 # ── Pydantic schemas ─────────────────────────────────────────────────
 
 class LLMModelOut(BaseModel):
     id: int
-    provider: str
+    provider: str                      # the VENDOR ('openai', 'moonshotai', …)
+    vendor: str                        # alias of provider, explicit for the UI
+    serving_provider: str              # the ROUTE ('openrouter', 'nvidia', 'openai', …)
+    serving_provider_label: str
+    route_label: str                   # "Kimi K3 · NVIDIA"
     model_id: str
     display_name: str
     model_family: Optional[str]
@@ -39,23 +57,38 @@ class LLMModelOut(BaseModel):
     max_output_tokens: int
     input_cost_per_1k: float
     output_cost_per_1k: float
+    is_free: bool = False
+    price_tier: str = "premium"        # free | budget | mid | premium (from price)
     capabilities: Dict[str, Any] = Field(default_factory=dict)
     recommended_for: List[str] = Field(default_factory=list)
     supports_functions: bool
     supports_vision: bool
     supports_streaming: bool
     status: str
-    tier: Optional[str]
+    sourcing: Optional[str]            # direct | aggregator | hosted_open (PRD-223 Q1)
     category: Optional[str]
     tags: List[str] = Field(default_factory=list)
     is_featured: bool = False
     is_default: bool = False
     requires_plan: Optional[str]
     install_count: int = 0
-    is_installed: bool = False  # populated per-request based on workspace
+    is_installed: bool = False         # THIS route, in this workspace
+    key_available: bool = True         # the workspace can call this route today
+    terms_note: Optional[str] = None
+    rate_limit_note: Optional[str] = None
 
     class Config:
         from_attributes = True
+
+
+class CatalogOut(BaseModel):
+    models: List[LLMModelOut]
+    total: int
+    providers: Dict[str, int]          # serving provider → count (unfiltered)
+    provider_labels: Dict[str, str]
+    vendors: Dict[str, int]            # vendor → count (within the provider filter)
+    last_synced: Dict[str, Optional[str]]
+    syncable: List[str]
 
 
 class CompareOut(BaseModel):
@@ -66,59 +99,106 @@ class InstallResult(BaseModel):
     success: bool
     message: str
     model_id: str
+    provider: str
 
 
 # ── Helpers ───────────────────────────────────────────────────────────
 
-def _model_to_out(m: LLMModel, installed_model_ids: set = None) -> LLMModelOut:
+def price_tier_for(input_cost_per_1k: float) -> str:
+    cost = float(input_cost_per_1k or 0)
+    if cost <= 0:
+        return "free"
+    if cost <= _PRICE_TIER_BUDGET_PER_1K:
+        return "budget"
+    if cost <= _PRICE_TIER_MID_PER_1K:
+        return "mid"
+    return "premium"
+
+
+def route_key(serving_provider: str, model_id: str) -> str:
+    return f"{serving_provider}:{model_id}"
+
+
+def _model_to_out(
+    m: LLMModel,
+    installed_row_ids: set = None,
+    available_providers: set = None,
+) -> LLMModelOut:
+    spec = registry.get_spec(m.serving_provider)
+    label = spec.label if spec else (m.serving_provider or "").title()
+    in_cost = float(m.input_cost_per_1k_tokens or 0)
+    out_cost = float(m.output_cost_per_1k_tokens or 0)
+    is_free = in_cost <= 0 and out_cost <= 0 and bool(spec and spec.free) or (in_cost <= 0 and out_cost <= 0)
     return LLMModelOut(
         id=m.id,
         provider=m.provider,
+        vendor=m.provider,
+        serving_provider=m.serving_provider,
+        serving_provider_label=label,
+        route_label=f"{m.display_name} · {label}",
         model_id=m.model_id,
         display_name=m.display_name,
         model_family=m.model_family,
         description=m.description,
-        context_window=m.context_window,
-        max_output_tokens=m.max_output_tokens,
-        input_cost_per_1k=float(m.input_cost_per_1k_tokens or 0),
-        output_cost_per_1k=float(m.output_cost_per_1k_tokens or 0),
+        context_window=m.context_window or 0,
+        max_output_tokens=m.max_output_tokens or 0,
+        input_cost_per_1k=in_cost,
+        output_cost_per_1k=out_cost,
+        is_free=is_free,
+        price_tier=price_tier_for(in_cost),
         capabilities=m.capabilities or {},
         recommended_for=m.recommended_for or [],
         supports_functions=m.supports_functions or False,
         supports_vision=m.supports_vision or False,
         supports_streaming=m.supports_streaming if m.supports_streaming is not None else True,
         status=m.status or "active",
-        tier=m.tier,
+        sourcing=m.sourcing,
         category=m.category,
         tags=m.tags or [],
         is_featured=m.is_featured or False,
         is_default=m.is_default or False,
         requires_plan=m.requires_plan,
         install_count=m.install_count or 0,
-        is_installed=m.id in (installed_model_ids or set()),
+        is_installed=m.id in (installed_row_ids or set()),
+        key_available=(available_providers is None) or (m.serving_provider in available_providers),
+        terms_note=spec.terms_note if spec else None,
+        rate_limit_note=spec.rate_limit_note if spec else None,
     )
 
 
-def _get_or_create_from_cache(db: Session, model_id: str) -> Optional[LLMModel]:
+def _find_route(db: Session, model_id: str, provider: Optional[str] = None) -> Optional[LLMModel]:
+    """The catalogue row for a model id — the caller's route, else OpenRouter's, else any."""
+    q = db.query(LLMModel).filter(LLMModel.model_id == model_id)
+    route = registry.normalize_slug(provider) if provider else None
+    if route:
+        return q.filter(LLMModel.serving_provider == route).first()
+    return q.filter(LLMModel.serving_provider == "openrouter").first() or q.first()
+
+
+def _get_or_create_from_cache(db: Session, model_id: str, provider: Optional[str] = None) -> Optional[LLMModel]:
+    """Find the route row; for OpenRouter, auto-create it from the cache.
+
+    Kept for the write paths that validate a model id (orchestrator settings,
+    agent config, the chat tools). The catalogue sync normally populates
+    OpenRouter rows ahead of time; this covers a cache row that was never
+    projected. Other providers are only served from synced rows.
     """
-    Find model in llm_models, or auto-create from openrouter_models_cache.
-    This bridges the two-table architecture: marketplace browses from OpenRouter
-    cache, but install/workspace tracking uses the llm_models table.
-    """
-    m = db.query(LLMModel).filter(LLMModel.model_id == model_id).first()
+    m = _find_route(db, model_id, provider)
     if m:
         return m
+    route = registry.normalize_slug(provider) if provider else None
+    if route not in (None, "openrouter"):
+        return None
 
-    # Try OpenRouter cache
     cached = db.query(OpenRouterModelCache).filter(
         OpenRouterModelCache.model_id == model_id
     ).first()
     if not cached:
         return None
 
-    # Auto-create LLMModel from cache data
     m = LLMModel(
         provider=cached.provider,
+        serving_provider="openrouter",
         model_id=cached.model_id,
         display_name=cached.display_name,
         description=cached.description,
@@ -131,7 +211,7 @@ def _get_or_create_from_cache(db: Session, model_id: str) -> Optional[LLMModel]:
         supports_vision=cached.supports_vision or False,
         supports_streaming=cached.supports_streaming if cached.supports_streaming is not None else True,
         status="active",
-        tier="aggregator",
+        sourcing="aggregator",
         category=cached.category,
         tags=cached.tags or [],
         capabilities={},
@@ -140,24 +220,19 @@ def _get_or_create_from_cache(db: Session, model_id: str) -> Optional[LLMModel]:
     )
     db.add(m)
     db.flush()
-    logger.info(f"Auto-created LLMModel from OpenRouter cache: {model_id}")
+    logger.info(f"Auto-created OpenRouter route from cache: {model_id}")
     return m
 
 
 def _get_available_providers(db: Session, workspace_id) -> set:
-    """
-    Return the set of provider names the workspace can actually use.
+    """Serving providers the workspace can call today (a key resolves for them).
 
-    Source of truth is the DB — NOT env vars (those are legacy).
-    Checks: 1) BYOK keys (UserApiKey), 2) Credential store entries.
+    Checks: 1) BYOK keys (UserApiKey), 2) the credential store (platform keys),
+    3) the operator's env keys where a platform key is allowed in this edition
+    (the local edition's .env). Never the key values — presence only.
     """
     available: set = set()
 
-    # PRD-236: the registry is the one list of providers (core/llm/providers.py).
-    from core.llm.providers import all_slugs
-    ALL_PROVIDERS = all_slugs()
-
-    # 1. BYOK keys stored in DB for this workspace
     if workspace_id:
         try:
             from core.models.core import UserApiKey
@@ -174,11 +249,10 @@ def _get_available_providers(db: Session, workspace_id) -> set:
         except Exception:
             pass  # table may not exist yet
 
-    # 2. Credential store entries (platform keys added via Settings)
     try:
         from core.credentials.resolver import get_credential_resolver
         resolver = get_credential_resolver()
-        for provider in ALL_PROVIDERS:
+        for provider in registry.platform_key_slugs():
             if provider in available:
                 continue
             for variation in [f"{provider}_api", provider]:
@@ -191,6 +265,10 @@ def _get_available_providers(db: Session, workspace_id) -> set:
                     continue
     except Exception:
         pass
+
+    for provider in registry.platform_key_slugs():
+        if provider not in available and registry.env_api_key(provider):
+            available.add(provider)
 
     return available
 
@@ -206,13 +284,124 @@ def _get_installed_ids(db: Session, workspace_id) -> set:
     return {r[0] for r in rows}
 
 
+def _apply_filters(query, *, provider, vendor, category, price_tier, min_context,
+                   max_cost, capability, supports_tools, supports_vision, search):
+    if provider:
+        query = query.filter(LLMModel.serving_provider == registry.normalize_slug(provider))
+    if vendor:
+        query = query.filter(LLMModel.provider == vendor)
+    if category:
+        query = query.filter(LLMModel.category == category)
+    if price_tier == "free":
+        query = query.filter(LLMModel.input_cost_per_1k_tokens <= 0)
+    elif price_tier == "budget":
+        query = query.filter(LLMModel.input_cost_per_1k_tokens > 0,
+                             LLMModel.input_cost_per_1k_tokens <= _PRICE_TIER_BUDGET_PER_1K)
+    elif price_tier == "mid":
+        query = query.filter(LLMModel.input_cost_per_1k_tokens > _PRICE_TIER_BUDGET_PER_1K,
+                             LLMModel.input_cost_per_1k_tokens <= _PRICE_TIER_MID_PER_1K)
+    elif price_tier == "premium":
+        query = query.filter(LLMModel.input_cost_per_1k_tokens > _PRICE_TIER_MID_PER_1K)
+    if min_context:
+        query = query.filter(LLMModel.context_window >= min_context)
+    if max_cost is not None:
+        query = query.filter(LLMModel.input_cost_per_1k_tokens <= max_cost)
+    if capability:
+        query = query.filter(LLMModel.capabilities[capability].isnot(None))
+    if supports_tools:
+        query = query.filter(LLMModel.supports_functions == True)
+    if supports_vision:
+        query = query.filter(LLMModel.supports_vision == True)
+    if search:
+        pattern = f"%{search}%"
+        query = query.filter(
+            or_(
+                LLMModel.display_name.ilike(pattern),
+                LLMModel.model_id.ilike(pattern),
+                LLMModel.description.ilike(pattern),
+            )
+        )
+    return query
+
+
+def _apply_sort(query, sort_by: Optional[str]):
+    if sort_by == "cost":
+        return query.order_by(LLMModel.input_cost_per_1k_tokens.asc(), LLMModel.display_name.asc())
+    if sort_by == "context":
+        return query.order_by(LLMModel.context_window.desc())
+    if sort_by == "name":
+        return query.order_by(LLMModel.display_name.asc())
+    if sort_by == "newest":
+        return query.order_by(LLMModel.created_at.desc().nullslast())
+    return query.order_by(LLMModel.install_count.desc(), LLMModel.is_featured.desc(), LLMModel.display_name.asc())
+
+
 # ── Endpoints ─────────────────────────────────────────────────────────
+
+@router.get("/catalog", response_model=CatalogOut)
+async def browse_catalog(
+    provider: Optional[str] = Query(None, description="Serving provider slug (openrouter, nvidia, openai…)"),
+    vendor: Optional[str] = Query(None, description="Vendor (moonshotai, deepseek, openai…)"),
+    category: Optional[str] = Query(None),
+    price_tier: Optional[str] = Query(None, description="free | budget | mid | premium"),
+    min_context: Optional[int] = Query(None),
+    max_cost: Optional[float] = Query(None, description="Max input cost per 1K tokens"),
+    capability: Optional[str] = Query(None),
+    supports_tools: Optional[bool] = Query(None),
+    supports_vision: Optional[bool] = Query(None),
+    search: Optional[str] = Query(None),
+    sort_by: Optional[str] = Query("popularity", description="cost|context|popularity|name|newest"),
+    limit: int = Query(200, ge=1, le=1000),
+    offset: int = Query(0, ge=0),
+    ctx: RequestContext = Depends(get_request_context_hybrid),
+    db: Session = Depends(get_db),
+):
+    """The per-route catalogue: one card per (serving provider, model)."""
+    from core.services.provider_catalog_sync import ProviderCatalogSync, SYNCABLE_PROVIDERS
+
+    base = db.query(LLMModel).filter(LLMModel.status == "active")
+    query = _apply_filters(
+        base, provider=provider, vendor=vendor, category=category, price_tier=price_tier,
+        min_context=min_context, max_cost=max_cost, capability=capability,
+        supports_tools=supports_tools, supports_vision=supports_vision, search=search,
+    )
+    total = query.count()
+    models = _apply_sort(query, sort_by).offset(offset).limit(limit).all()
+
+    provider_counts = dict(
+        db.query(LLMModel.serving_provider, func.count(LLMModel.id))
+        .filter(LLMModel.status == "active")
+        .group_by(LLMModel.serving_provider)
+        .all()
+    )
+    vendor_query = db.query(LLMModel.provider, func.count(LLMModel.id)).filter(LLMModel.status == "active")
+    if provider:
+        vendor_query = vendor_query.filter(LLMModel.serving_provider == registry.normalize_slug(provider))
+    vendor_counts = dict(vendor_query.group_by(LLMModel.provider).all())
+
+    installed = _get_installed_ids(db, ctx.workspace_id)
+    available = _get_available_providers(db, ctx.workspace_id)
+    labels = {
+        slug: (registry.get_spec(slug).label if registry.get_spec(slug) else slug.title())
+        for slug in provider_counts
+    }
+    return CatalogOut(
+        models=[_model_to_out(m, installed, available) for m in models],
+        total=total,
+        providers=provider_counts,
+        provider_labels=labels,
+        vendors=vendor_counts,
+        last_synced=ProviderCatalogSync(db).last_synced(),
+        syncable=list(SYNCABLE_PROVIDERS),
+    )
+
 
 @router.get("/models", response_model=List[LLMModelOut])
 async def browse_models(
-    provider: Optional[str] = Query(None),
+    provider: Optional[str] = Query(None, description="Serving provider slug"),
+    vendor: Optional[str] = Query(None),
     category: Optional[str] = Query(None),
-    tier: Optional[str] = Query(None),
+    price_tier: Optional[str] = Query(None),
     min_context: Optional[int] = Query(None),
     max_cost: Optional[float] = Query(None, description="Max input cost per 1K tokens"),
     capability: Optional[str] = Query(None, description="Required capability key"),
@@ -223,45 +412,17 @@ async def browse_models(
     ctx: RequestContext = Depends(get_request_context_hybrid),
     db: Session = Depends(get_db),
 ):
-    """Browse LLM models with rich filtering."""
-    query = db.query(LLMModel).filter(LLMModel.status == "active")
-
-    if provider:
-        query = query.filter(LLMModel.provider == provider)
-    if category:
-        query = query.filter(LLMModel.category == category)
-    if tier:
-        query = query.filter(LLMModel.tier == tier)
-    if min_context:
-        query = query.filter(LLMModel.context_window >= min_context)
-    if max_cost is not None:
-        query = query.filter(LLMModel.input_cost_per_1k_tokens <= max_cost)
-    if capability:
-        # Filter models whose JSON capabilities dict contains the requested key
-        query = query.filter(LLMModel.capabilities[capability].isnot(None))
-    if search:
-        pattern = f"%{search}%"
-        query = query.filter(
-            or_(
-                LLMModel.display_name.ilike(pattern),
-                LLMModel.model_id.ilike(pattern),
-                LLMModel.description.ilike(pattern),
-            )
-        )
-
-    # Sorting
-    if sort_by == "cost":
-        query = query.order_by(LLMModel.input_cost_per_1k_tokens.asc())
-    elif sort_by == "context":
-        query = query.order_by(LLMModel.context_window.desc())
-    elif sort_by == "name":
-        query = query.order_by(LLMModel.display_name.asc())
-    else:  # popularity
-        query = query.order_by(LLMModel.install_count.desc(), LLMModel.is_featured.desc())
-
-    models = query.offset(offset).limit(limit).all()
+    """Browse routes as a flat list (the catalog endpoint carries the facets)."""
+    query = _apply_filters(
+        db.query(LLMModel).filter(LLMModel.status == "active"),
+        provider=provider, vendor=vendor, category=category, price_tier=price_tier,
+        min_context=min_context, max_cost=max_cost, capability=capability,
+        supports_tools=None, supports_vision=None, search=search,
+    )
+    models = _apply_sort(query, sort_by).offset(offset).limit(limit).all()
     installed = _get_installed_ids(db, ctx.workspace_id)
-    return [_model_to_out(m, installed) for m in models]
+    available = _get_available_providers(db, ctx.workspace_id)
+    return [_model_to_out(m, installed, available) for m in models]
 
 
 @router.get("/installed", response_model=List[LLMModelOut])
@@ -269,80 +430,79 @@ async def get_installed_models(
     ctx: RequestContext = Depends(get_request_context_hybrid),
     db: Session = Depends(get_db),
 ):
-    """
-    Get installed models for the current workspace.
+    """Every route the workspace has installed — what the pickers list.
 
-    Returns ALL models the workspace has installed — the UI needs to show
-    them for selection and management. Provider availability (API key
-    checks) is enforced at execution time, not at display time.
+    Provider availability is reported (``key_available``), not enforced: the
+    factory's key resolution is the gate at execution time.
     """
     if not ctx.workspace_id:
         raise HTTPException(400, "Workspace context required")
 
     installed_ids = _get_installed_ids(db, ctx.workspace_id)
-
     if not installed_ids:
         return []
 
     models = (
         db.query(LLMModel)
-        .filter(
-            LLMModel.status == "active",
-            LLMModel.id.in_(installed_ids),
-        )
-        .order_by(LLMModel.provider, LLMModel.display_name)
+        .filter(LLMModel.status == "active", LLMModel.id.in_(installed_ids))
+        .order_by(LLMModel.serving_provider, LLMModel.display_name)
         .all()
     )
-
-    return [_model_to_out(m, installed_ids) for m in models]
+    available = _get_available_providers(db, ctx.workspace_id)
+    return [_model_to_out(m, installed_ids, available) for m in models]
 
 
 @router.get("/installed-ids")
-async def get_installed_model_ids(
+async def get_installed_ids(
     ctx: RequestContext = Depends(get_request_context_hybrid),
     db: Session = Depends(get_db),
 ):
-    """Return just the model_id strings installed in this workspace (lightweight)."""
+    """Installed routes, lightweight: ``routes`` are "provider:model_id" keys."""
     if not ctx.workspace_id:
-        return {"model_ids": []}
+        return {"model_ids": [], "routes": []}
     installed_llm_ids = _get_installed_ids(db, ctx.workspace_id)
     if not installed_llm_ids:
-        return {"model_ids": []}
+        return {"model_ids": [], "routes": []}
     rows = (
-        db.query(LLMModel.model_id)
+        db.query(LLMModel.serving_provider, LLMModel.model_id)
         .filter(LLMModel.id.in_(installed_llm_ids))
         .all()
     )
-    return {"model_ids": [r[0] for r in rows]}
+    return {
+        "model_ids": sorted({r[1] for r in rows}),
+        "routes": sorted(route_key(r[0], r[1]) for r in rows),
+    }
 
 
 @router.get("/models/{model_id:path}", response_model=LLMModelOut)
 async def get_model_detail(
     model_id: str,
+    provider: Optional[str] = Query(None, description="Serving provider slug"),
     ctx: RequestContext = Depends(get_request_context_hybrid),
     db: Session = Depends(get_db),
 ):
-    """Get full detail for a single model."""
-    m = _get_or_create_from_cache(db, model_id)
+    """Full detail for one route."""
+    m = _get_or_create_from_cache(db, model_id, provider)
     if not m:
         raise HTTPException(404, f"Model not found: {model_id}")
     installed = _get_installed_ids(db, ctx.workspace_id)
-    return _model_to_out(m, installed)
+    return _model_to_out(m, installed, _get_available_providers(db, ctx.workspace_id))
 
 
 @router.post("/models/{model_id:path}/install", response_model=InstallResult, dependencies=[Depends(require_workspace_permission("workspace:manage"))])
 async def install_model(
     model_id: str,
+    provider: Optional[str] = Query(None, description="Serving provider slug — the route to install"),
     ctx: RequestContext = Depends(get_request_context_hybrid),
     db: Session = Depends(get_db),
 ):
-    """Install a model to the current workspace."""
+    """Install a ROUTE to the current workspace (the install is the tag)."""
     if not ctx.workspace_id:
         raise HTTPException(400, "Workspace context required")
 
-    m = _get_or_create_from_cache(db, model_id)
+    m = _get_or_create_from_cache(db, model_id, provider)
     if not m:
-        raise HTTPException(404, f"Model not found: {model_id}")
+        raise HTTPException(404, f"Model not found: {model_id}" + (f" on {provider}" if provider else ""))
 
     existing = (
         db.query(WorkspaceModel)
@@ -353,8 +513,8 @@ async def install_model(
         if not existing.is_active:
             existing.is_active = True
             db.commit()
-            return InstallResult(success=True, message="Model re-activated", model_id=model_id)
-        return InstallResult(success=True, message="Model already installed", model_id=model_id)
+            return InstallResult(success=True, message="Model re-activated", model_id=model_id, provider=m.serving_provider)
+        return InstallResult(success=True, message="Model already installed", model_id=model_id, provider=m.serving_provider)
 
     wm = WorkspaceModel(
         workspace_id=ctx.workspace_id,
@@ -365,21 +525,22 @@ async def install_model(
     m.install_count = (m.install_count or 0) + 1
     db.commit()
 
-    logger.info(f"Model {model_id} installed to workspace {ctx.workspace_id}")
-    return InstallResult(success=True, message="Model installed", model_id=model_id)
+    logger.info(f"Route {m.serving_provider}:{model_id} installed to workspace {ctx.workspace_id}")
+    return InstallResult(success=True, message="Model installed", model_id=model_id, provider=m.serving_provider)
 
 
 @router.post("/models/{model_id:path}/uninstall", response_model=InstallResult, dependencies=[Depends(require_workspace_permission("workspace:manage"))])
 async def uninstall_model(
     model_id: str,
+    provider: Optional[str] = Query(None, description="Serving provider slug — the route to remove"),
     ctx: RequestContext = Depends(get_request_context_hybrid),
     db: Session = Depends(get_db),
 ):
-    """Remove a model from the current workspace."""
+    """Remove a route from the current workspace."""
     if not ctx.workspace_id:
         raise HTTPException(400, "Workspace context required")
 
-    m = _get_or_create_from_cache(db, model_id)
+    m = _find_route(db, model_id, provider)
     if not m:
         raise HTTPException(404, f"Model not found: {model_id}")
 
@@ -389,30 +550,39 @@ async def uninstall_model(
         .first()
     )
     if not wm:
-        return InstallResult(success=True, message="Model was not installed", model_id=model_id)
+        return InstallResult(success=True, message="Model was not installed", model_id=model_id, provider=m.serving_provider)
 
     wm.is_active = False
     db.commit()
-    return InstallResult(success=True, message="Model uninstalled", model_id=model_id)
+    return InstallResult(success=True, message="Model uninstalled", model_id=model_id, provider=m.serving_provider)
 
 
 @router.get("/compare", response_model=CompareOut)
 async def compare_models(
-    ids: str = Query(..., description="Comma-separated model_ids"),
+    ids: str = Query(..., description="Comma-separated model_ids or provider:model_id route keys"),
     ctx: RequestContext = Depends(get_request_context_hybrid),
     db: Session = Depends(get_db),
 ):
-    """Side-by-side comparison of 2-4 models."""
-    model_ids = [mid.strip() for mid in ids.split(",") if mid.strip()]
-    if len(model_ids) < 2 or len(model_ids) > 4:
+    """Side-by-side comparison of 2-4 routes. A bare model id compares every route for it."""
+    keys = [k.strip() for k in ids.split(",") if k.strip()]
+    if len(keys) < 2 or len(keys) > 4:
         raise HTTPException(400, "Provide 2-4 model IDs for comparison")
 
-    models = db.query(LLMModel).filter(LLMModel.model_id.in_(model_ids)).all()
+    models: List[LLMModel] = []
+    for key in keys:
+        if ":" in key and "/" not in key.split(":", 1)[0]:
+            prov, mid = key.split(":", 1)
+            m = _find_route(db, mid, prov)
+            if m:
+                models.append(m)
+        else:
+            models.extend(db.query(LLMModel).filter(LLMModel.model_id == key).all())
     if not models:
         raise HTTPException(404, "No models found")
 
     installed = _get_installed_ids(db, ctx.workspace_id)
-    return CompareOut(models=[_model_to_out(m, installed) for m in models])
+    available = _get_available_providers(db, ctx.workspace_id)
+    return CompareOut(models=[_model_to_out(m, installed, available) for m in models])
 
 
 @router.get("/categories", response_model=List[Dict[str, Any]])
@@ -429,11 +599,44 @@ async def list_categories(db: Session = Depends(get_db)):
 
 @router.get("/providers", response_model=List[Dict[str, Any]])
 async def list_providers(db: Session = Depends(get_db)):
-    """List available providers with counts."""
+    """Serving providers with route counts."""
     rows = (
-        db.query(LLMModel.provider, func.count(LLMModel.id))
+        db.query(LLMModel.serving_provider, func.count(LLMModel.id))
         .filter(LLMModel.status == "active")
-        .group_by(LLMModel.provider)
+        .group_by(LLMModel.serving_provider)
         .all()
     )
-    return [{"provider": prov, "count": count} for prov, count in rows]
+    out = []
+    for slug, count in rows:
+        spec = registry.get_spec(slug)
+        out.append({"provider": slug, "label": spec.label if spec else slug, "count": count})
+    return out
+
+
+@router.get("/sync/status")
+async def sync_status(db: Session = Depends(get_db)):
+    """When each syncable provider's catalogue was last refreshed."""
+    from core.services.provider_catalog_sync import ProviderCatalogSync, SYNCABLE_PROVIDERS
+    return {"last_synced": ProviderCatalogSync(db).last_synced(), "syncable": list(SYNCABLE_PROVIDERS)}
+
+
+@router.post("/sync/{provider}", dependencies=[Depends(require_workspace_permission("workspace:manage"))])
+async def sync_provider(
+    provider: str,
+    ctx: RequestContext = Depends(get_request_context_hybrid),
+    db: Session = Depends(get_db),
+):
+    """Refresh one provider's catalogue (admin). OpenRouter: cache sync + projection;
+    NVIDIA: the public model list, metadata borrowed from OpenRouter's rows."""
+    from core.services.provider_catalog_sync import ProviderCatalogSync, SYNCABLE_PROVIDERS
+
+    slug = registry.normalize_slug(provider)
+    if slug not in SYNCABLE_PROVIDERS:
+        raise HTTPException(400, f"'{provider}' has no catalogue sync. Syncable: {', '.join(SYNCABLE_PROVIDERS)}")
+    logger.info(f"Catalogue sync for {slug} requested by workspace {ctx.workspace_id}")
+    try:
+        result = ProviderCatalogSync(db).sync(slug)
+    except Exception as exc:
+        raise HTTPException(502, f"{slug} catalogue sync failed: {str(exc)[:300]}")
+    logger.info(f"Catalogue sync for {slug} completed: {result}")
+    return result

--- a/orchestrator/api/workspaces.py
+++ b/orchestrator/api/workspaces.py
@@ -752,7 +752,8 @@ async def save_orchestrator_settings(
         from api.llm_marketplace import _get_or_create_from_cache
         from core.llm.model_policy import check_model_for_agent
 
-        if not requested_model or _get_or_create_from_cache(db, requested_model) is None:
+        requested_provider = llm_payload.get("provider")
+        if not requested_model or _get_or_create_from_cache(db, requested_model, requested_provider) is None:
             raise HTTPException(
                 422,
                 f"Unknown model '{requested_model}' — not found in the model catalog. "
@@ -760,6 +761,7 @@ async def save_orchestrator_settings(
             )
         allowed, reason = check_model_for_agent(
             db, ctx.workspace_id, requested_model, orchestrator_seat=True,
+            provider=requested_provider,
         )
         if not allowed:
             raise HTTPException(

--- a/orchestrator/consumers/chatbot/service.py
+++ b/orchestrator/consumers/chatbot/service.py
@@ -1504,9 +1504,15 @@ class StreamingChatService:
             _in = usage.get("input_tokens", 0) or usage.get("prompt_tokens", 0) or 0
             _out = usage.get("output_tokens", 0) or usage.get("completion_tokens", 0) or 0
             if _in or _out:
-                from core.llm.manager import estimate_cost_usd
-                _model = getattr(getattr(agent_runtime.llm_manager, "config", None), "model", None)
-                turn_llm_cost_usd += estimate_cost_usd(_model, _in, _out)
+                _mgr = agent_runtime.llm_manager
+                if hasattr(_mgr, "_estimate_cost"):
+                    # PRD-236: per ROUTE — a free provider (NVIDIA trial) adds $0,
+                    # so the governor never forces synthesis over money not spent.
+                    turn_llm_cost_usd += _mgr._estimate_cost(_in, _out)
+                else:
+                    from core.llm.manager import estimate_cost_usd
+                    _model = getattr(getattr(_mgr, "config", None), "model", None)
+                    turn_llm_cost_usd += estimate_cost_usd(_model, _in, _out)
             return resp
 
         # State shared by callbacks within this turn.

--- a/orchestrator/core/llm/manager.py
+++ b/orchestrator/core/llm/manager.py
@@ -730,8 +730,16 @@ class LLMManager:
 
     def _estimate_cost(self, input_tokens: int, output_tokens: int) -> float:
         """Rough USD cost estimate for logging. Not for billing (see F059 note
-        on ``estimate_cost_usd``, which holds the shared price map)."""
-        return estimate_cost_usd(self.config.model, input_tokens, output_tokens)
+        on ``estimate_cost_usd``, which holds the shared price map).
+
+        PRD-236: the estimate is per ROUTE — a call served by a free provider
+        (NVIDIA's trial endpoint) is $0 whatever the vendor model's list price,
+        so the audit line and COST_ALERT never report a free call as spend.
+        """
+        from core.llm.providers import price_multiplier_for
+
+        provider = self.config.provider.value if self.config.provider else None
+        return estimate_cost_usd(self.config.model, input_tokens, output_tokens) * price_multiplier_for(provider)
 
     def _log_cost_audit(
         self,

--- a/orchestrator/core/llm/model_policy.py
+++ b/orchestrator/core/llm/model_policy.py
@@ -89,6 +89,7 @@ def check_model_for_agent(
     model_id: str,
     *,
     orchestrator_seat: bool,
+    provider: str = None,
 ) -> Tuple[bool, str]:
     """Full W1 predicate: workspace approval row + platform policy.
 
@@ -110,16 +111,22 @@ def check_model_for_agent(
 
     try:
         from core.models.core import LLMModel, WorkspaceModel
+        from core.llm.providers import normalize_slug
 
-        row = (
+        # PRD-236 W1: the same vendor id may be installed once per serving
+        # provider; when the caller knows the route, judge THAT row.
+        q = (
             db.query(WorkspaceModel)
             .join(LLMModel, WorkspaceModel.model_id == LLMModel.id)
             .filter(
                 WorkspaceModel.workspace_id == workspace_id,
                 LLMModel.model_id == candidate,
             )
-            .first()
         )
+        route = normalize_slug(provider) if provider else None
+        if route:
+            q = q.filter(LLMModel.serving_provider == route)
+        row = q.first()
         if row is not None:
             if getattr(row, "approval_status", None) == "quarantined":
                 return False, (

--- a/orchestrator/core/llm/model_registry.py
+++ b/orchestrator/core/llm/model_registry.py
@@ -159,7 +159,7 @@ class ModelRegistry:
         self.logger.info(f"Retrieved {len(result)} models (provider={provider}, status={status})")
         return result
     
-    def get_model(self, model_id: str) -> Optional[ModelInfo]:
+    def get_model(self, model_id: str, provider: Optional[str] = None) -> Optional[ModelInfo]:
         """
         Get specific model by ID.
         
@@ -169,9 +169,17 @@ class ModelRegistry:
         Returns:
             ModelInfo if found, None otherwise
         """
-        model = self.db.query(LLMModel).filter(
-            LLMModel.model_id == model_id
-        ).first()
+        # PRD-236 W1: a vendor id may exist once per serving provider; prefer
+        # the caller's route, then OpenRouter's row, then any row.
+        q = self.db.query(LLMModel).filter(LLMModel.model_id == model_id)
+        model = None
+        if provider:
+            from core.llm.providers import normalize_slug
+            route = normalize_slug(provider)
+            if route:
+                model = q.filter(LLMModel.serving_provider == route).first()
+        if model is None:
+            model = q.filter(LLMModel.serving_provider == "openrouter").first() or q.first()
         
         if model:
             self.logger.debug(f"Found model: {model_id}")

--- a/orchestrator/core/llm/providers.py
+++ b/orchestrator/core/llm/providers.py
@@ -81,8 +81,10 @@ _NVIDIA_TERMS = (
     "§1.2, §1.4, §4.3). Your key is your own agreement with NVIDIA."
 )
 _NVIDIA_RATE_LIMIT = (
-    "NVIDIA's free tier allows about 40 requests per minute per key. Above that "
-    "the call fails; it is never rerouted to a paid provider."
+    "NVIDIA's free tier allows about 40 requests per minute per key, and a popular "
+    "model can be at capacity (429 within a second even on your first call). The "
+    "call fails; it is never rerouted to a paid provider. Wait a minute or pick "
+    "another NVIDIA route — the smaller Nemotron models usually answer at once."
 )
 
 _SPECS: Tuple[ProviderSpec, ...] = (

--- a/orchestrator/core/llm/usage_tracker.py
+++ b/orchestrator/core/llm/usage_tracker.py
@@ -45,17 +45,30 @@ class UsageTracker:
 
             db = SessionLocal()
             try:
-                # Look up cost from model registry
-                model_row = db.query(LLMModel).filter(LLMModel.model_id == model_id).first()
-                if model_row:
-                    # PRD-236 S0.5 (W0 interim): the catalogue row carries ONE price
-                    # per model id; the serving provider's registry multiplier makes
-                    # a free route (NVIDIA) book zero. W1 prices per (provider, model).
-                    from core.llm.providers import price_multiplier_for
+                # PRD-236 W1: price the ROUTE that served the call — the row for
+                # (serving_provider, model_id). A vendor id may exist once per
+                # provider with different prices (Kimi K3: OpenRouter $3/M, NVIDIA 0).
+                from core.llm.providers import normalize_slug, price_multiplier_for
+                route = normalize_slug(provider)
+                model_row = None
+                if route:
+                    model_row = (
+                        db.query(LLMModel)
+                        .filter(LLMModel.model_id == model_id, LLMModel.serving_provider == route)
+                        .first()
+                    )
+                if model_row is None:
+                    # No route row yet (catalogue not synced for this provider):
+                    # fall back to any row for the id, corrected by the registry's
+                    # multiplier so a free route still books zero.
+                    model_row = db.query(LLMModel).filter(LLMModel.model_id == model_id).first()
                     multiplier = price_multiplier_for(provider)
+                else:
+                    multiplier = 1.0
+                if model_row:
                     input_cost = (input_tokens / 1000) * float(model_row.input_cost_per_1k_tokens or 0) * multiplier
                     output_cost = (output_tokens / 1000) * float(model_row.output_cost_per_1k_tokens or 0) * multiplier
-                    tier = model_row.tier or tier
+                    tier = model_row.sourcing or tier
                 else:
                     input_cost = 0.0
                     output_cost = 0.0

--- a/orchestrator/core/models/core.py
+++ b/orchestrator/core/models/core.py
@@ -50,10 +50,20 @@ class LLMModel(Base):
     Stores model metadata, capabilities, costs, and recommended use cases.
     """
     __tablename__ = 'llm_models'
-    
+    __table_args__ = (
+        # PRD-236 W1: one row per ROUTE — the same vendor id may be served by
+        # several providers ("moonshotai/kimi-k3" on OpenRouter and on NVIDIA).
+        UniqueConstraint('serving_provider', 'model_id', name='uq_llm_models_provider_model'),
+    )
+
     id = Column(Integer, primary_key=True)
-    provider = Column(String(50), nullable=False, index=True)  # 'openai', 'anthropic', 'huggingface'
-    model_id = Column(String(255), nullable=False, unique=True, index=True)  # 'gpt-4', 'claude-3-opus-20240229', etc.
+    # The VENDOR of the model ('openai', 'moonshotai', 'deepseek-ai'…) — for
+    # direct rows it coincides with the serving provider.
+    provider = Column(String(50), nullable=False, index=True)
+    # PRD-236 W1: the registry slug of the API that serves this row
+    # ('openrouter', 'nvidia', 'openai'…). Installs and routing key on it.
+    serving_provider = Column(String(50), nullable=False, index=True, server_default='openrouter', default='openrouter')
+    model_id = Column(String(255), nullable=False, index=True)  # vendor-prefixed for hosted routes
     display_name = Column(String(255), nullable=False)  # Human-readable name
     model_family = Column(String(100), index=True)  # 'gpt-4', 'claude-3', 'llama-2', etc.
     
@@ -81,8 +91,10 @@ class LLMModel(Base):
     min_temperature = Column(Float, default=0.0)
     max_temperature = Column(Float, default=2.0)
 
-    # PRD-54: Marketplace & multi-tier fields
-    tier = Column(String(50), default='direct')  # direct, aggregator, byok_only
+    # PRD-54: Marketplace fields. PRD-236 W1 / PRD-223 Q1: ``tier`` became
+    # ``sourcing`` — the registry kind of the serving provider
+    # (direct | aggregator | hosted_open); the PRICING tier is derived from price.
+    sourcing = Column(String(50), default='direct')
     tags = Column(JSON, default=list)
     category = Column(String(100))  # general, coding, creative, fast, premium
     popularity_score = Column(Integer, default=0)
@@ -91,7 +103,7 @@ class LLMModel(Base):
     is_featured = Column(Boolean, default=False)
     is_default = Column(Boolean, default=False)  # included in all workspaces
     requires_plan = Column(String(50))  # NULL (all plans), pro, enterprise
-    external_id = Column(String(255))  # OpenRouter model ID
+    external_id = Column(String(255))  # the serving provider's native id (PRD-236)
     pricing_updated_at = Column(DateTime)
 
     created_at = Column(DateTime, default=func.now())

--- a/orchestrator/core/services/provider_catalog_sync.py
+++ b/orchestrator/core/services/provider_catalog_sync.py
@@ -1,0 +1,275 @@
+"""
+Provider catalogue sync (PRD-236 W1 S1.2)
+=========================================
+
+Fills ``llm_models`` with one row per ROUTE — ``(serving_provider, model_id)``.
+
+- ``openrouter``: runs the existing cache sync (``OpenRouterSyncService``,
+  OpenRouter → ``openrouter_models_cache``) and then PROJECTS the cache into
+  ``llm_models`` rows served by OpenRouter, priced at OpenRouter's prices.
+- ``nvidia``: reads build.nvidia.com's public model list
+  (``GET {NVIDIA_BASE_URL}/models`` — ids only, no pricing or capability
+  fields) and writes rows served by NVIDIA at price 0, borrowing context
+  window, output cap, tool/vision flags, description and display name from
+  the OpenRouter cache row of the same vendor id when one exists.
+  Non-chat ids (embeddings, rerankers, reward models, OCR/parsers, safety
+  classifiers) are skipped — this is the chat catalogue.
+
+Direct providers (OpenAI, Anthropic, Google, DeepSeek…) keep their seeded
+rows; their ``/models`` endpoints need a key and publish no prices.
+
+Job history rides on ``openrouter_sync_jobs`` (``job_type`` distinguishes the
+provider) — no new table (CLAUDE.md §4).
+"""
+from __future__ import annotations
+
+import logging
+import re
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+import httpx
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.orm import Session
+
+from core.llm import providers as registry
+from core.models.core import LLMModel
+from core.models.openrouter_cache import OpenRouterModelCache, OpenRouterSyncJob
+from core.services.openrouter_sync_service import OpenRouterSyncService
+
+logger = logging.getLogger(__name__)
+
+SYNCABLE_PROVIDERS = ("openrouter", "nvidia")
+JOB_TYPES = {"openrouter": "full_sync", "nvidia": "nvidia_sync"}
+
+# NVIDIA lists embeddings, rerankers, reward models, OCR/parsers and safety
+# classifiers next to chat models. None of them answer chat completions.
+_NON_CHAT_ID = re.compile(
+    r"(embed|reward|rerank|parse|ocr|deplot|kosmos|fuyu|safety|guard|diffusion)", re.I
+)
+# NVIDIA vendor slug → OpenRouter vendor slug, for metadata borrowing.
+_VENDOR_ALIASES = {"deepseek-ai": "deepseek", "meta": "meta-llama"}
+
+NVIDIA_FETCH_TIMEOUT_S = 30
+
+
+class ProviderCatalogSync:
+    """One entry point per provider; every route lands in ``llm_models``."""
+
+    def __init__(self, db: Session):
+        self.db = db
+
+    # ------------------------------------------------------------------ #
+    # Dispatch
+    # ------------------------------------------------------------------ #
+
+    def sync(self, provider: str, api_key: Optional[str] = None) -> Dict[str, Any]:
+        slug = registry.normalize_slug(provider)
+        if slug == "openrouter":
+            return self.sync_openrouter()
+        if slug == "nvidia":
+            return self.sync_nvidia(api_key=api_key)
+        raise ValueError(f"Provider '{provider}' has no catalogue sync (syncable: {', '.join(SYNCABLE_PROVIDERS)})")
+
+    def last_synced(self) -> Dict[str, Optional[str]]:
+        """Latest completed sync per syncable provider, ISO timestamps."""
+        out: Dict[str, Optional[str]] = {}
+        for slug, job_type in JOB_TYPES.items():
+            job = (
+                self.db.query(OpenRouterSyncJob)
+                .filter(OpenRouterSyncJob.job_type == job_type, OpenRouterSyncJob.status == "completed")
+                .order_by(OpenRouterSyncJob.completed_at.desc().nullslast())
+                .first()
+            )
+            out[slug] = job.completed_at.isoformat() if job and job.completed_at else None
+        return out
+
+    # ------------------------------------------------------------------ #
+    # OpenRouter: cache sync + projection
+    # ------------------------------------------------------------------ #
+
+    def sync_openrouter(self) -> Dict[str, Any]:
+        result = OpenRouterSyncService(self.db).run_full_sync()
+        result["projection"] = self.project_openrouter_cache()
+        return result
+
+    def project_openrouter_cache(self) -> Dict[str, Any]:
+        """Every active cache row becomes an OpenRouter-served catalogue row."""
+        rows = (
+            self.db.query(OpenRouterModelCache)
+            .filter(OpenRouterModelCache.status == "active")
+            .all()
+        )
+        for cached in rows:
+            self._upsert_route("openrouter", cached.model_id, self._values_from_cache(cached))
+        self.db.commit()
+        logger.info("[CatalogSync] projected %d OpenRouter rows into llm_models", len(rows))
+        return {"provider": "openrouter", "rows": len(rows)}
+
+    @staticmethod
+    def _values_from_cache(cached: OpenRouterModelCache) -> Dict[str, Any]:
+        return dict(
+            provider=cached.provider,
+            display_name=cached.display_name,
+            description=cached.description,
+            model_family=cached.provider,
+            context_window=int(cached.context_length or 0),
+            max_output_tokens=int(cached.max_completion_tokens or 0),
+            input_cost_per_1k_tokens=float(cached.prompt_cost or 0) * 1000,
+            output_cost_per_1k_tokens=float(cached.completion_cost or 0) * 1000,
+            supports_functions=bool(cached.supports_tools),
+            supports_vision=bool(cached.supports_vision),
+            supports_streaming=True if cached.supports_streaming is None else bool(cached.supports_streaming),
+            status="active",
+            sourcing="aggregator",
+            category=cached.category,
+            tags=list(cached.tags or []),
+            capabilities={},
+            recommended_for=[],
+            external_id=cached.model_id,
+            pricing_updated_at=datetime.utcnow(),
+        )
+
+    # ------------------------------------------------------------------ #
+    # NVIDIA: public list + borrowed metadata
+    # ------------------------------------------------------------------ #
+
+    def sync_nvidia(self, api_key: Optional[str] = None) -> Dict[str, Any]:
+        started = datetime.utcnow()
+        job = OpenRouterSyncJob(job_type=JOB_TYPES["nvidia"], status="running", started_at=started)
+        self.db.add(job)
+        self.db.commit()
+
+        try:
+            ids = self._fetch_nvidia_ids(api_key)
+            synced = borrowed = skipped = 0
+            for model_id in ids:
+                if _NON_CHAT_ID.search(model_id):
+                    skipped += 1
+                    continue
+                cached = self._borrow(model_id)
+                if cached is not None:
+                    borrowed += 1
+                self._upsert_route("nvidia", model_id, self._values_for_nvidia(model_id, cached))
+                synced += 1
+
+            finished = datetime.utcnow()
+            job.status = "completed"
+            job.models_synced = synced
+            job.models_updated = synced
+            job.completed_at = finished
+            job.duration_ms = int((finished - started).total_seconds() * 1000)
+            job.job_metadata = {"skipped_non_chat": skipped, "borrowed_metadata": borrowed, "listed": len(ids)}
+            self.db.commit()
+            logger.info(
+                "[CatalogSync] NVIDIA: %d routes (%d with borrowed metadata, %d non-chat skipped)",
+                synced, borrowed, skipped,
+            )
+            return {
+                "provider": "nvidia", "status": "completed", "models_synced": synced,
+                "borrowed_metadata": borrowed, "skipped_non_chat": skipped, "listed": len(ids),
+            }
+        except Exception as exc:
+            self.db.rollback()
+            job.status = "failed"
+            job.errors_count = 1
+            job.error_details = {"error": str(exc)[:500]}
+            job.completed_at = datetime.utcnow()
+            self.db.add(job)
+            self.db.commit()
+            logger.error("[CatalogSync] NVIDIA sync failed: %s", exc)
+            raise
+
+    @staticmethod
+    def _fetch_nvidia_ids(api_key: Optional[str]) -> List[str]:
+        base = registry.base_url_for("nvidia")
+        if not base:
+            raise RuntimeError("NVIDIA base URL is not configured (NVIDIA_BASE_URL)")
+        headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+        with httpx.Client(timeout=NVIDIA_FETCH_TIMEOUT_S) as client:
+            resp = client.get(f"{base.rstrip('/')}/models", headers=headers)
+            resp.raise_for_status()
+            data = resp.json()
+        return sorted({m["id"] for m in data.get("data", []) if isinstance(m, dict) and m.get("id")})
+
+    def _borrow(self, model_id: str) -> Optional[OpenRouterModelCache]:
+        """The OpenRouter cache row for the same vendor id, if any."""
+        q = self.db.query(OpenRouterModelCache)
+        exact = q.filter(OpenRouterModelCache.model_id == model_id).first()
+        if exact is not None:
+            return exact
+        vendor, _, name = model_id.partition("/")
+        alias = _VENDOR_ALIASES.get(vendor)
+        if alias and name:
+            aliased = q.filter(OpenRouterModelCache.model_id == f"{alias}/{name}").first()
+            if aliased is not None:
+                return aliased
+        if name:
+            return q.filter(OpenRouterModelCache.model_id.endswith(f"/{name}")).first()
+        return None
+
+    def _values_for_nvidia(self, model_id: str, cached: Optional[OpenRouterModelCache]) -> Dict[str, Any]:
+        vendor, _, name = model_id.partition("/")
+        if cached is not None:
+            values = self._values_from_cache(cached)
+        else:
+            values = dict(
+                display_name=self._display_name(name or model_id),
+                description="Hosted by NVIDIA (build.nvidia.com). Context window not published by NVIDIA's catalogue.",
+                model_family=vendor,
+                context_window=0,
+                max_output_tokens=0,
+                supports_functions=False,
+                supports_vision=False,
+                supports_streaming=True,
+                status="active",
+                category="free",
+                tags=[],
+                capabilities={},
+                recommended_for=[],
+                pricing_updated_at=datetime.utcnow(),
+            )
+        values.update(
+            provider=vendor or "nvidia",
+            input_cost_per_1k_tokens=0.0,
+            output_cost_per_1k_tokens=0.0,
+            sourcing="hosted_open",
+            category=values.get("category") or "free",
+            tags=sorted(set(list(values.get("tags") or []) + ["free", "nvidia"])),
+            external_id=model_id,
+        )
+        return values
+
+    @staticmethod
+    def _display_name(name: str) -> str:
+        return " ".join(part.capitalize() if part.isalpha() else part for part in name.replace("_", "-").split("-"))
+
+    # ------------------------------------------------------------------ #
+    # Upsert
+    # ------------------------------------------------------------------ #
+
+    def _upsert_route(self, serving_provider: str, model_id: str, values: Dict[str, Any]) -> None:
+        """INSERT … ON CONFLICT (serving_provider, model_id) DO UPDATE.
+
+        Workspace-facing state (install_count, featured/default flags,
+        workspace_id, created_at) is never overwritten by a sync.
+        """
+        now = datetime.utcnow()
+        update = dict(values, serving_provider=serving_provider, model_id=model_id, updated_at=now)
+        insert = dict(
+            update,
+            created_at=now,
+            install_count=0,
+            popularity_score=0,
+            is_featured=False,
+            is_default=False,
+            default_temperature=0.7,
+            min_temperature=0.0,
+            max_temperature=2.0,
+        )
+        stmt = (
+            pg_insert(LLMModel.__table__)
+            .values(**insert)
+            .on_conflict_do_update(constraint="uq_llm_models_provider_model", set_=update)
+        )
+        self.db.execute(stmt)

--- a/orchestrator/core/services/provider_catalog_sync.py
+++ b/orchestrator/core/services/provider_catalog_sync.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 import logging
 import re
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 import httpx
@@ -45,7 +45,8 @@ JOB_TYPES = {"openrouter": "full_sync", "nvidia": "nvidia_sync"}
 # NVIDIA lists embeddings, rerankers, reward models, OCR/parsers and safety
 # classifiers next to chat models. None of them answer chat completions.
 _NON_CHAT_ID = re.compile(
-    r"(embed|reward|rerank|parse|ocr|deplot|kosmos|fuyu|safety|guard|diffusion)", re.I
+    r"(embed|reward|rerank|parse|ocr|deplot|kosmos|fuyu|safety|guard|diffusion|detector|nvclip|calibration)",
+    re.I,
 )
 # NVIDIA vendor slug → OpenRouter vendor slug, for metadata borrowing.
 _VENDOR_ALIASES = {"deepseek-ai": "deepseek", "meta": "meta-llama"}
@@ -81,7 +82,10 @@ class ProviderCatalogSync:
                 .order_by(OpenRouterSyncJob.completed_at.desc().nullslast())
                 .first()
             )
-            out[slug] = job.completed_at.isoformat() if job and job.completed_at else None
+            # Naive UTC in the DB → explicit UTC on the wire, or the browser reads it as local time.
+            out[slug] = (
+                job.completed_at.replace(tzinfo=timezone.utc).isoformat() if job and job.completed_at else None
+            )
         return out
 
     # ------------------------------------------------------------------ #
@@ -143,6 +147,7 @@ class ProviderCatalogSync:
         try:
             ids = self._fetch_nvidia_ids(api_key)
             synced = borrowed = skipped = 0
+            kept: List[str] = []
             for model_id in ids:
                 if _NON_CHAT_ID.search(model_id):
                     skipped += 1
@@ -151,7 +156,19 @@ class ProviderCatalogSync:
                 if cached is not None:
                     borrowed += 1
                 self._upsert_route("nvidia", model_id, self._values_for_nvidia(model_id, cached))
+                kept.append(model_id)
                 synced += 1
+            # Routes NVIDIA no longer lists (or that the chat filter now excludes)
+            # stop being offered; installs keep their row, marked deprecated.
+            deprecated = (
+                self.db.query(LLMModel)
+                .filter(
+                    LLMModel.serving_provider == "nvidia",
+                    LLMModel.status == "active",
+                    ~LLMModel.model_id.in_(kept),
+                )
+                .update({"status": "deprecated"}, synchronize_session=False)
+            )
 
             finished = datetime.utcnow()
             job.status = "completed"
@@ -159,15 +176,19 @@ class ProviderCatalogSync:
             job.models_updated = synced
             job.completed_at = finished
             job.duration_ms = int((finished - started).total_seconds() * 1000)
-            job.job_metadata = {"skipped_non_chat": skipped, "borrowed_metadata": borrowed, "listed": len(ids)}
+            job.job_metadata = {
+                "skipped_non_chat": skipped, "borrowed_metadata": borrowed,
+                "listed": len(ids), "deprecated": int(deprecated or 0),
+            }
             self.db.commit()
             logger.info(
-                "[CatalogSync] NVIDIA: %d routes (%d with borrowed metadata, %d non-chat skipped)",
-                synced, borrowed, skipped,
+                "[CatalogSync] NVIDIA: %d routes (%d with borrowed metadata, %d non-chat skipped, %d deprecated)",
+                synced, borrowed, skipped, int(deprecated or 0),
             )
             return {
                 "provider": "nvidia", "status": "completed", "models_synced": synced,
                 "borrowed_metadata": borrowed, "skipped_non_chat": skipped, "listed": len(ids),
+                "deprecated": int(deprecated or 0),
             }
         except Exception as exc:
             self.db.rollback()

--- a/orchestrator/core/services/provider_catalog_sync.py
+++ b/orchestrator/core/services/provider_catalog_sync.py
@@ -263,7 +263,7 @@ class ProviderCatalogSync:
 
     @staticmethod
     def _display_name(name: str) -> str:
-        return " ".join(part.capitalize() if part.isalpha() else part for part in name.replace("_", "-").split("-"))
+        return " ".join(part[:1].upper() + part[1:] for part in name.replace("_", "-").split("-") if part)
 
     # ------------------------------------------------------------------ #
     # Upsert

--- a/orchestrator/modules/agents/factory/agent_factory.py
+++ b/orchestrator/modules/agents/factory/agent_factory.py
@@ -874,6 +874,7 @@ class AgentFactory:
                     getattr(db_agent, "workspace_id", None),
                     llm_config_dict.get("model"),
                     orchestrator_seat=True,
+                    provider=llm_config_dict.get("provider"),
                 )
                 if not allowed:
                     blocked_model = llm_config_dict.get("model")

--- a/orchestrator/modules/policy/pricing.py
+++ b/orchestrator/modules/policy/pricing.py
@@ -22,7 +22,7 @@ from typing import Any, Optional
 logger = logging.getLogger(__name__)
 
 
-def price_per_1k(db: Any, model_id: str) -> Optional["ModelPrice"]:
+def price_per_1k(db: Any, model_id: str, provider: Optional[str] = None) -> Optional["ModelPrice"]:
     """Return the (input, output) $/1k-token price for ``model_id`` from the DB.
 
     ``None`` when the model is unknown to the registry or the registry can't be
@@ -33,7 +33,7 @@ def price_per_1k(db: Any, model_id: str) -> Optional["ModelPrice"]:
     try:
         from core.llm.model_registry import get_model_registry
 
-        info = get_model_registry(db).get_model(model_id)
+        info = get_model_registry(db).get_model(model_id, provider=provider)
         if info is None:
             return None
         return ModelPrice(

--- a/orchestrator/modules/tools/discovery/handlers_agents.py
+++ b/orchestrator/modules/tools/discovery/handlers_agents.py
@@ -218,7 +218,7 @@ async def create_agent(db: Session, workspace_id: UUID, params: Dict[str, Any]) 
         from api.llm_marketplace import _get_or_create_from_cache
         from core.llm.model_policy import check_model_for_agent
 
-        resolved = _get_or_create_from_cache(db, model_id)
+        resolved = _get_or_create_from_cache(db, model_id, params.get("provider"))
         if resolved is None:
             # Prod 2026-09-02 (post-#672): told "omit model_id to use the default",
             # the model retried the SAME unknown id twice and the build stalled.
@@ -236,11 +236,12 @@ async def create_agent(db: Session, workspace_id: UUID, params: Dict[str, Any]) 
         else:
             allowed, reason = check_model_for_agent(
                 db, workspace_id, model_id, orchestrator_seat=False,
+                provider=resolved.serving_provider,
             )
             if not allowed:
                 return {"success": False, "error": f"Model rejected: {reason}"}
             model_config["model_id"] = model_id
-            model_config["provider"] = resolved.provider
+            model_config["provider"] = resolved.serving_provider  # PRD-236 W1: the route, never the vendor
     if temperature is not None:
         model_config["temperature"] = max(0.0, min(2.0, float(temperature)))
 

--- a/orchestrator/modules/tools/discovery/handlers_marketplace.py
+++ b/orchestrator/modules/tools/discovery/handlers_marketplace.py
@@ -566,8 +566,16 @@ async def install_model(db: Session, workspace_id: UUID, params: Dict[str, Any])
 
     # Find or create LLMModel from OpenRouter cache
     # Try exact match first, then suffix match (seed data may omit provider prefix)
-    llm = db.query(LLMModel).filter(LLMModel.model_id == model_id).first()
-    if not llm:
+    # PRD-236 W1: one row per route — honour an explicit provider, else prefer
+    # the OpenRouter route (the platform key everyone has), else any row.
+    from core.llm.providers import normalize_slug
+    route = normalize_slug(params.get("provider"))
+    q = db.query(LLMModel).filter(LLMModel.model_id == model_id)
+    if route:
+        llm = q.filter(LLMModel.serving_provider == route).first()
+    else:
+        llm = q.filter(LLMModel.serving_provider == "openrouter").first() or q.first()
+    if not llm and not route:
         # Suffix match: "llama-3.3-70b-instruct" → "meta-llama/llama-3.3-70b-instruct"
         llm = db.query(LLMModel).filter(LLMModel.model_id.endswith(f"/{model_id}")).first()
 
@@ -597,7 +605,8 @@ async def install_model(db: Session, workspace_id: UUID, params: Dict[str, Any])
             supports_vision=cached.supports_vision or False,
             supports_streaming=cached.supports_streaming if cached.supports_streaming is not None else True,
             status="active",
-            tier="aggregator",
+            sourcing="aggregator",
+            serving_provider="openrouter",
             category=cached.category,
             tags=cached.tags or [],
             capabilities={},

--- a/orchestrator/reports/route-manifest.json
+++ b/orchestrator/reports/route-manifest.json
@@ -1,5 +1,5 @@
 {
-  "route_count": 785,
+  "route_count": 788,
   "routes": [
     {
       "method": "GET",
@@ -1519,6 +1519,10 @@
     },
     {
       "method": "GET",
+      "path": "/api/marketplace/llm/catalog"
+    },
+    {
+      "method": "GET",
       "path": "/api/marketplace/llm/categories"
     },
     {
@@ -1552,6 +1556,14 @@
     {
       "method": "GET",
       "path": "/api/marketplace/llm/providers"
+    },
+    {
+      "method": "GET",
+      "path": "/api/marketplace/llm/sync/status"
+    },
+    {
+      "method": "POST",
+      "path": "/api/marketplace/llm/sync/{provider}"
     },
     {
       "method": "GET",

--- a/orchestrator/services/workspace_model_seeding.py
+++ b/orchestrator/services/workspace_model_seeding.py
@@ -35,14 +35,12 @@ _SEED_CAP = 4
 
 
 def _openrouter_served(q):
-    """Filter llm_models to rows the platform OpenRouter key can serve."""
-    return q.filter(
-        or_(
-            LLMModel.provider == "openrouter",
-            LLMModel.tier == "openrouter",
-            LLMModel.model_id.contains("/"),
-        )
-    )
+    """Filter llm_models to rows the platform OpenRouter key can serve.
+
+    PRD-236 W1: the row says who serves it (``serving_provider``); the old
+    string-shape guess (any slash id) is gone with the per-route catalogue.
+    """
+    return q.filter(LLMModel.serving_provider == "openrouter")
 
 
 def pick_base_models(db: Session) -> list[LLMModel]:

--- a/orchestrator/tests/test_prd209_alembic_single_head.py
+++ b/orchestrator/tests/test_prd209_alembic_single_head.py
@@ -43,7 +43,9 @@ _COMPOSE = _REPO / "docker-compose.yml"
 # deliberate act that must update this pin — that is the point of the guard.
 # PRD-232 (2026-09-02): the one authorized 232 revision, prd232_cluster_provenance,
 # chains onto prd_workspace_models_backfill and is the new single head.
-EXPECTED_HEAD = "prd234_s1a_cli_hosts_runtime_ref"
+# PRD-236 W1 (2026-09-03): prd236_w1_serving_provider chains onto the PRD-234 S1a
+# head — the catalogue keyed by (serving_provider, model_id).
+EXPECTED_HEAD = "prd236_w1_serving_provider"
 
 
 def _literal(node: ast.AST):

--- a/orchestrator/tests/test_prd222_unknown_model_error_names_the_way_out.py
+++ b/orchestrator/tests/test_prd222_unknown_model_error_names_the_way_out.py
@@ -20,7 +20,7 @@ from modules.tools.discovery.handlers_agents import create_agent
 
 
 def test_unknown_model_creates_the_agent_on_the_default_and_says_so(monkeypatch, caplog):
-    monkeypatch.setattr(marketplace, "_get_or_create_from_cache", lambda db, model_id: None)
+    monkeypatch.setattr(marketplace, "_get_or_create_from_cache", lambda db, model_id, provider=None: None)
     with caplog.at_level(logging.WARNING, logger="modules.tools.discovery.handlers_agents"):
         res = asyncio.run(create_agent(MagicMock(), uuid4(), {"name": "Booking Assistant", "model_id": "anthropic/claude-sonnet-4-20250514"}))
     assert res["success"] is True
@@ -31,10 +31,13 @@ def test_unknown_model_creates_the_agent_on_the_default_and_says_so(monkeypatch,
 
 
 def test_known_model_still_passes_the_policy_gate(monkeypatch):
-    monkeypatch.setattr(marketplace, "_get_or_create_from_cache", lambda db, model_id: SimpleNamespace(provider="openrouter"))
+    monkeypatch.setattr(
+        marketplace, "_get_or_create_from_cache",
+        lambda db, model_id, provider=None: SimpleNamespace(provider="openrouter", serving_provider="openrouter"),
+    )
     seen = {}
 
-    def gate(db, workspace_id, model_id, orchestrator_seat=False):
+    def gate(db, workspace_id, model_id, orchestrator_seat=False, provider=None):
         seen["model_id"] = model_id
         return False, "not allowed on this plan"
 

--- a/orchestrator/tests/test_prd236_provider_registry.py
+++ b/orchestrator/tests/test_prd236_provider_registry.py
@@ -398,7 +398,10 @@ def _track(monkeypatch, provider: str):
     from core.llm.usage_tracker import UsageTracker
     from uuid import uuid4
 
-    row = SimpleNamespace(input_cost_per_1k_tokens=0.003, output_cost_per_1k_tokens=0.015, tier="aggregator")
+    row = SimpleNamespace(
+        input_cost_per_1k_tokens=0.003, output_cost_per_1k_tokens=0.015,
+        sourcing="aggregator", serving_provider="openrouter", model_id="moonshotai/kimi-k3",
+    )
     _FakeSession.added = []
     monkeypatch.setitem(
         sys.modules, "core.database.database", types.SimpleNamespace(SessionLocal=lambda: _FakeSession(row))

--- a/orchestrator/tests/test_prd236_provider_registry.py
+++ b/orchestrator/tests/test_prd236_provider_registry.py
@@ -365,24 +365,33 @@ def test_env_tier_reads_the_registry_for_every_provider(monkeypatch, platform_ti
 
 
 class _FakeQuery:
-    def __init__(self, row):
-        self._row = row
+    """Rows filtered in Python on ``Column == value`` predicates (route-aware, like the DB)."""
 
-    def filter(self, *_a, **_k):
-        return self
+    def __init__(self, rows):
+        self._rows = list(rows) if isinstance(rows, (list, tuple)) else [rows]
+
+    def filter(self, *clauses, **_k):
+        rows = self._rows
+        for c in clauses:
+            try:
+                col, val = c.left.name, c.right.value
+                rows = [r for r in rows if getattr(r, col, None) == val]
+            except Exception:
+                pass
+        return _FakeQuery(rows)
 
     def first(self):
-        return self._row
+        return self._rows[0] if self._rows else None
 
 
 class _FakeSession:
     added: list = []
 
-    def __init__(self, row):
-        self._row = row
+    def __init__(self, rows):
+        self._rows = rows
 
     def query(self, _model):
-        return _FakeQuery(self._row)
+        return _FakeQuery(self._rows)
 
     def add(self, obj):
         type(self).added.append(obj)
@@ -394,17 +403,20 @@ class _FakeSession:
         pass
 
 
-def _track(monkeypatch, provider: str):
+def _track(monkeypatch, provider: str, rows=None):
     from core.llm.usage_tracker import UsageTracker
     from uuid import uuid4
 
-    row = SimpleNamespace(
+    # Only the OpenRouter route row exists — the NVIDIA route has not been
+    # synced — so a call served by NVIDIA must fall back to the registry's
+    # multiplier (W0 S0.5) rather than book OpenRouter's price.
+    rows = rows or [SimpleNamespace(
         input_cost_per_1k_tokens=0.003, output_cost_per_1k_tokens=0.015,
         sourcing="aggregator", serving_provider="openrouter", model_id="moonshotai/kimi-k3",
-    )
+    )]
     _FakeSession.added = []
     monkeypatch.setitem(
-        sys.modules, "core.database.database", types.SimpleNamespace(SessionLocal=lambda: _FakeSession(row))
+        sys.modules, "core.database.database", types.SimpleNamespace(SessionLocal=lambda: _FakeSession(rows))
     )
     UsageTracker.track(
         workspace_id=uuid4(), model_id="moonshotai/kimi-k3", provider=provider,

--- a/orchestrator/tests/test_prd236_w1_routes.py
+++ b/orchestrator/tests/test_prd236_w1_routes.py
@@ -51,27 +51,47 @@ def _row(**kw):
 class _Q:
     """A query whose filters are evaluated in Python over a row list.
 
-    Only the predicate shapes used by the code under test are understood:
-    ``Column == value`` comparisons on ``model_id`` / ``serving_provider`` /
-    ``workspace_id`` / ``status``. Everything else is a no-op filter.
+    Like SQLAlchemy, ``filter()`` returns a NEW query and never mutates the
+    receiver (the code under test reuses a base query for several probes).
+    Understood predicate shapes: ``Column == value`` on any attribute,
+    ``Column.endswith(x)``, ``~Column.in_(xs)``; anything else is a no-op.
     """
 
     def __init__(self, rows):
         self._rows = list(rows)
 
-    def _apply(self, clause):
+    @staticmethod
+    def _apply(rows, clause):
         try:
-            col = clause.left.name
-            val = clause.right.value
+            op = clause.operator.__name__
         except Exception:
-            return self._rows
-        return [r for r in self._rows if getattr(r, col, None) == val]
+            op = ""
+        try:
+            if op == "eq":
+                col, val = clause.left.name, clause.right.value
+                return [r for r in rows if getattr(r, col, None) == val]
+            if op in ("endswith_op", "endswith"):
+                col, val = clause.left.name, clause.right.value
+                return [r for r in rows if str(getattr(r, col, "")).endswith(val)]
+            if op in ("not_in_op", "notin_op"):
+                col = clause.left.name
+                vals = [b.value for b in clause.right.element.clauses] if hasattr(clause.right, "element") else []
+                return [r for r in rows if getattr(r, col, None) not in vals]
+        except Exception:
+            return rows
+        return rows
 
     def filter(self, *clauses):
         rows = self._rows
         for c in clauses:
-            self._rows = rows = _Q(rows)._apply(c)
-        return self
+            rows = self._apply(rows, c)
+        return _Q(rows)
+
+    def update(self, values, synchronize_session=False):
+        for r in self._rows:
+            for k, v in values.items():
+                setattr(r, k, v)
+        return len(self._rows)
 
     def join(self, *_a, **_k):
         return self
@@ -268,10 +288,11 @@ def test_non_chat_ids_are_skipped():
     from core.services.provider_catalog_sync import _NON_CHAT_ID
 
     for skipped in ("nvidia/nemotron-3-embed-1b", "nvidia/nemotron-4-340b-reward", "nvidia/nemotron-parse",
-                    "nvidia/llama-3.1-nemotron-safety-guard-8b-v3", "google/deplot", "adept/fuyu-8b"):
+                    "nvidia/llama-3.1-nemotron-safety-guard-8b-v3", "google/deplot", "adept/fuyu-8b",
+                    "nvidia/ai-synthetic-video-detector", "nvidia/nvclip", "nvidia/ising-calibration-1.5-31b"):
         assert _NON_CHAT_ID.search(skipped), skipped
     for kept in ("moonshotai/kimi-k3", "deepseek-ai/deepseek-v4-pro-0813", "openai/gpt-oss-20b",
-                 "nvidia/nemotron-3-ultra-550b-a55b"):
+                 "nvidia/nemotron-3-ultra-550b-a55b", "meta/llama-3.2-11b-vision-instruct", "nvidia/vila"):
         assert not _NON_CHAT_ID.search(kept), kept
 
 
@@ -316,9 +337,13 @@ def test_sync_nvidia_upserts_routes_and_records_a_job(monkeypatch):
     upserts = []
     monkeypatch.setattr(sync, "_upsert_route", lambda sp, mid, values: upserts.append((sp, mid, values)))
 
+    stale = _row(id=9, serving_provider="nvidia", model_id="nvidia/gone-model", status="active")
+    kept_row = _row(id=8, serving_provider="nvidia", model_id="moonshotai/kimi-k3", status="active")
+    db.rows = [stale, kept_row]
     result = sync.sync_nvidia()
     assert result["status"] == "completed"
     assert result["models_synced"] == 2 and result["skipped_non_chat"] == 1 and result["borrowed_metadata"] == 1
+    assert result["deprecated"] == 1 and stale.status == "deprecated" and kept_row.status == "active"
     assert [(sp, mid) for sp, mid, _ in upserts] == [("nvidia", "moonshotai/kimi-k3"), ("nvidia", "openai/gpt-oss-20b")]
     job = db.added[0]
     assert job.job_type == "nvidia_sync" and job.status == "completed" and job.models_synced == 2

--- a/orchestrator/tests/test_prd236_w1_routes.py
+++ b/orchestrator/tests/test_prd236_w1_routes.py
@@ -75,7 +75,13 @@ class _Q:
                 return [r for r in rows if str(getattr(r, col, "")).endswith(val)]
             if op in ("not_in_op", "notin_op"):
                 col = clause.left.name
-                vals = [b.value for b in clause.right.element.clauses] if hasattr(clause.right, "element") else []
+                right = clause.right
+                if hasattr(right, "value") and isinstance(right.value, (list, tuple, set)):
+                    vals = list(right.value)
+                elif hasattr(right, "element") and hasattr(right.element, "clauses"):
+                    vals = [b.value for b in right.element.clauses]
+                else:
+                    vals = []
                 return [r for r in rows if getattr(r, col, None) not in vals]
         except Exception:
             return rows
@@ -425,3 +431,17 @@ def test_route_manifest_lists_the_catalog_and_sync_endpoints():
     ):
         assert entry in routes, entry
     assert manifest["route_count"] == len(routes)
+
+
+def test_audit_cost_estimate_is_zero_on_a_free_route():
+    from core.llm.clients.base import LLMConfig, LLMProvider
+    from core.llm.manager import LLMManager
+
+    free = LLMManager.__new__(LLMManager)
+    free.config = LLMConfig(provider=LLMProvider.NVIDIA, model="moonshotai/kimi-k3", api_key="k")
+    assert free._estimate_cost(30000, 100) == 0.0
+
+    paid = LLMManager.__new__(LLMManager)
+    paid.config = LLMConfig(provider=LLMProvider.OPENROUTER, model="moonshotai/kimi-k3", api_key="k")
+    assert paid._estimate_cost(30000, 100) > 0.0
+

--- a/orchestrator/tests/test_prd236_w1_routes.py
+++ b/orchestrator/tests/test_prd236_w1_routes.py
@@ -1,0 +1,402 @@
+"""PRD-236 W1 — the catalogue knows who serves what.
+
+Pure tests (no Postgres, no network): fake sessions stand in for the ORM, the
+NVIDIA list is stubbed at the httpx boundary. What is pinned:
+
+- the migration chains onto the PRD-234 S1a head and the head guard follows;
+- pricing tiers derive from the row price; a route key is "provider:model_id";
+- `_find_route` honours the caller's route, then OpenRouter's row, then any;
+- `_model_to_out` labels the route, marks free routes and missing keys;
+- the NVIDIA sync borrows metadata from OpenRouter's row for the same vendor id
+  (alias-aware), prices the route at zero, skips non-chat ids, records a job;
+- `check_model_for_agent` judges the tagged route only;
+- `UsageTracker` prices the route that served the call;
+- `installed-ids` returns per-route keys; the manifest lists the new endpoints.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+import types
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from core.llm import providers as reg
+
+
+# --------------------------------------------------------------------------- #
+# Fakes
+# --------------------------------------------------------------------------- #
+
+
+def _row(**kw):
+    base = dict(
+        id=1, provider="moonshotai", serving_provider="openrouter", model_id="moonshotai/kimi-k3",
+        display_name="Kimi K3", model_family="moonshotai", description="d", context_window=1048576,
+        max_output_tokens=32768, input_cost_per_1k_tokens=0.003, output_cost_per_1k_tokens=0.015,
+        capabilities={}, recommended_for=[], supports_functions=True, supports_vision=False,
+        supports_streaming=True, status="active", sourcing="aggregator", category="premium",
+        tags=["function-calling"], is_featured=False, is_default=False, requires_plan=None,
+        install_count=0,
+    )
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+class _Q:
+    """A query whose filters are evaluated in Python over a row list.
+
+    Only the predicate shapes used by the code under test are understood:
+    ``Column == value`` comparisons on ``model_id`` / ``serving_provider`` /
+    ``workspace_id`` / ``status``. Everything else is a no-op filter.
+    """
+
+    def __init__(self, rows):
+        self._rows = list(rows)
+
+    def _apply(self, clause):
+        try:
+            col = clause.left.name
+            val = clause.right.value
+        except Exception:
+            return self._rows
+        return [r for r in self._rows if getattr(r, col, None) == val]
+
+    def filter(self, *clauses):
+        rows = self._rows
+        for c in clauses:
+            self._rows = rows = _Q(rows)._apply(c)
+        return self
+
+    def join(self, *_a, **_k):
+        return self
+
+    def first(self):
+        return self._rows[0] if self._rows else None
+
+    def all(self):
+        return list(self._rows)
+
+    def order_by(self, *_a):
+        return self
+
+    def distinct(self):
+        return self
+
+
+class _Session:
+    def __init__(self, rows_by_model=None, cache_rows=None, jobs=None):
+        self.rows = rows_by_model or []
+        self.cache = cache_rows or []
+        self.added = []
+        self.executed = []
+        self.commits = 0
+
+    def query(self, model, *rest):
+        name = getattr(model, "__name__", "") or getattr(getattr(model, "class_", None), "__name__", "")
+        if "Cache" in name:
+            return _Q(self.cache)
+        if "Job" in name:
+            return _Q([])
+        return _Q(self.rows)
+
+    def add(self, obj):
+        self.added.append(obj)
+
+    def execute(self, stmt, *a, **k):
+        self.executed.append(stmt)
+
+    def commit(self):
+        self.commits += 1
+
+    def rollback(self):
+        pass
+
+    def flush(self):
+        pass
+
+    def close(self):
+        pass
+
+
+# --------------------------------------------------------------------------- #
+# S1.1 — migration + head guard
+# --------------------------------------------------------------------------- #
+
+
+def test_migration_chains_onto_prd234_head_and_guard_follows():
+    versions = Path(__file__).resolve().parents[1] / "alembic" / "versions"
+    src = (versions / "prd236_w1_serving_provider.py").read_text()
+    assert 'revision = "prd236_w1_serving_provider"' in src
+    assert 'down_revision = "prd234_s1a_cli_hosts_runtime_ref"' in src
+    assert "uq_llm_models_provider_model" in src and "serving_provider" in src
+    assert "new_column_name=\"sourcing\"" in src  # PRD-223 Q1 executed
+    guard = (Path(__file__).resolve().parent / "test_prd209_alembic_single_head.py").read_text()
+    assert 'EXPECTED_HEAD = "prd236_w1_serving_provider"' in guard
+
+
+def test_orm_row_is_keyed_by_route():
+    from core.models.core import LLMModel
+
+    cols = {c.name for c in LLMModel.__table__.columns}
+    assert {"serving_provider", "sourcing", "external_id"} <= cols
+    assert "tier" not in cols
+    uniques = [tuple(c.name for c in u.columns) for u in LLMModel.__table__.constraints if u.__class__.__name__ == "UniqueConstraint"]
+    assert ("serving_provider", "model_id") in uniques
+    assert not LLMModel.__table__.c.model_id.unique
+
+
+# --------------------------------------------------------------------------- #
+# S1.3 — marketplace helpers
+# --------------------------------------------------------------------------- #
+
+
+def test_price_tier_and_route_key():
+    from api.llm_marketplace import price_tier_for, route_key
+
+    assert price_tier_for(0) == "free"
+    assert price_tier_for(0.0004) == "budget"
+    assert price_tier_for(0.003) == "mid"
+    assert price_tier_for(0.0031) == "premium"
+    assert route_key("nvidia", "moonshotai/kimi-k3") == "nvidia:moonshotai/kimi-k3"
+
+
+def test_find_route_prefers_the_callers_route_then_openrouter_then_any():
+    from api.llm_marketplace import _find_route
+
+    nv = _row(id=2, serving_provider="nvidia", input_cost_per_1k_tokens=0, output_cost_per_1k_tokens=0)
+    orr = _row(id=1)
+    db = _Session(rows_by_model=[nv, orr])
+    assert _find_route(db, "moonshotai/kimi-k3", "nvidia") is nv
+    assert _find_route(db, "moonshotai/kimi-k3", "NVIDIA") is nv  # alias-normalised
+    assert _find_route(db, "moonshotai/kimi-k3") is orr           # OpenRouter first
+    assert _find_route(_Session(rows_by_model=[nv]), "moonshotai/kimi-k3") is nv  # any
+    assert _find_route(db, "moonshotai/kimi-k3", "deepseek") is None
+
+
+def test_model_to_out_labels_the_route_free_and_missing_key():
+    from api.llm_marketplace import _model_to_out
+
+    nv = _row(id=2, serving_provider="nvidia", sourcing="hosted_open",
+              input_cost_per_1k_tokens=0, output_cost_per_1k_tokens=0)
+    out = _model_to_out(nv, installed_row_ids={2}, available_providers={"openrouter"})
+    assert out.serving_provider == "nvidia" and out.serving_provider_label == "NVIDIA"
+    assert out.route_label == "Kimi K3 · NVIDIA"
+    assert out.vendor == "moonshotai" and out.provider == "moonshotai"
+    assert out.is_free and out.price_tier == "free"
+    assert out.is_installed is True
+    assert out.key_available is False
+    assert "trial" in (out.terms_note or "").lower()
+
+    orr = _model_to_out(_row(), installed_row_ids=set(), available_providers={"openrouter"})
+    assert orr.route_label == "Kimi K3 · OpenRouter" and not orr.is_free
+    assert orr.price_tier == "mid" and orr.key_available is True and orr.is_installed is False
+
+
+def test_installed_ids_returns_route_keys():
+    import api.llm_marketplace as mp
+
+    class _WSQ:
+        def __init__(self, rows):
+            self.rows = rows
+        def filter(self, *a):
+            return self
+        def all(self):
+            return self.rows
+
+    class _DB:
+        def query(self, *cols):
+            # first call: WorkspaceModel.model_id ; second: (serving_provider, model_id)
+            if len(cols) == 1:
+                return _WSQ([(1,), (2,)])
+            return _WSQ([("openrouter", "moonshotai/kimi-k3"), ("nvidia", "moonshotai/kimi-k3")])
+
+    ctx = SimpleNamespace(workspace_id=uuid4())
+    payload = asyncio.run(mp.get_installed_ids(ctx=ctx, db=_DB()))
+    assert payload["model_ids"] == ["moonshotai/kimi-k3"]
+    assert payload["routes"] == ["nvidia:moonshotai/kimi-k3", "openrouter:moonshotai/kimi-k3"]
+
+
+# --------------------------------------------------------------------------- #
+# S1.2 — NVIDIA catalogue sync
+# --------------------------------------------------------------------------- #
+
+
+def _cache_row(model_id="moonshotai/kimi-k3", **kw):
+    base = dict(
+        model_id=model_id, provider=model_id.split("/")[0], display_name="Kimi K3", description="Moonshot's K3",
+        context_length=1048576, max_completion_tokens=32768, prompt_cost=0.000003, completion_cost=0.000015,
+        supports_tools=True, supports_vision=False, supports_streaming=True, category="premium",
+        tags=["function-calling"], status="active",
+    )
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+def test_nvidia_values_borrow_metadata_and_price_zero():
+    from core.services.provider_catalog_sync import ProviderCatalogSync
+
+    sync = ProviderCatalogSync(_Session(cache_rows=[_cache_row()]))
+    values = sync._values_for_nvidia("moonshotai/kimi-k3", sync._borrow("moonshotai/kimi-k3"))
+    assert values["display_name"] == "Kimi K3" and values["context_window"] == 1048576
+    assert values["supports_functions"] is True
+    assert values["input_cost_per_1k_tokens"] == 0.0 and values["output_cost_per_1k_tokens"] == 0.0
+    assert values["sourcing"] == "hosted_open" and values["provider"] == "moonshotai"
+    assert {"free", "nvidia", "function-calling"} <= set(values["tags"])
+    assert values["external_id"] == "moonshotai/kimi-k3"
+
+
+def test_nvidia_borrow_is_alias_aware_and_falls_back_to_defaults():
+    from core.services.provider_catalog_sync import ProviderCatalogSync
+
+    sync = ProviderCatalogSync(_Session(cache_rows=[_cache_row("deepseek/deepseek-v4-pro-0813", display_name="DeepSeek V4 Pro")]))
+    borrowed = sync._borrow("deepseek-ai/deepseek-v4-pro-0813")  # NVIDIA vendor slug differs
+    assert borrowed is not None and borrowed.display_name == "DeepSeek V4 Pro"
+
+    values = sync._values_for_nvidia("nvidia/nemotron-3-super-120b-a12b", None)
+    assert values["display_name"] == "Nemotron 3 Super 120b A12b"
+    assert values["context_window"] == 0 and values["category"] == "free"
+    assert values["input_cost_per_1k_tokens"] == 0.0 and values["sourcing"] == "hosted_open"
+
+
+def test_non_chat_ids_are_skipped():
+    from core.services.provider_catalog_sync import _NON_CHAT_ID
+
+    for skipped in ("nvidia/nemotron-3-embed-1b", "nvidia/nemotron-4-340b-reward", "nvidia/nemotron-parse",
+                    "nvidia/llama-3.1-nemotron-safety-guard-8b-v3", "google/deplot", "adept/fuyu-8b"):
+        assert _NON_CHAT_ID.search(skipped), skipped
+    for kept in ("moonshotai/kimi-k3", "deepseek-ai/deepseek-v4-pro-0813", "openai/gpt-oss-20b",
+                 "nvidia/nemotron-3-ultra-550b-a55b"):
+        assert not _NON_CHAT_ID.search(kept), kept
+
+
+def test_fetch_nvidia_ids_uses_the_registry_base_url(monkeypatch):
+    from core.services import provider_catalog_sync as pcs
+
+    seen = {}
+
+    class _Resp:
+        def raise_for_status(self):
+            pass
+        def json(self):
+            return {"data": [{"id": "moonshotai/kimi-k3"}, {"id": "nvidia/nemotron-3-embed-1b"}, {"id": "moonshotai/kimi-k3"}]}
+
+    class _Client:
+        def __init__(self, timeout=None):
+            seen["timeout"] = timeout
+        def __enter__(self):
+            return self
+        def __exit__(self, *a):
+            return False
+        def get(self, url, headers=None):
+            seen["url"] = url
+            seen["headers"] = headers
+            return _Resp()
+
+    monkeypatch.setattr(pcs.httpx, "Client", _Client)
+    ids = pcs.ProviderCatalogSync._fetch_nvidia_ids(None)
+    assert seen["url"] == "https://integrate.api.nvidia.com/v1/models" and seen["headers"] == {}
+    assert ids == ["moonshotai/kimi-k3", "nvidia/nemotron-3-embed-1b"]  # de-duplicated, sorted
+    pcs.ProviderCatalogSync._fetch_nvidia_ids("nvapi-x")
+    assert seen["headers"] == {"Authorization": "Bearer nvapi-x"}
+
+
+def test_sync_nvidia_upserts_routes_and_records_a_job(monkeypatch):
+    from core.services import provider_catalog_sync as pcs
+
+    db = _Session(cache_rows=[_cache_row()])
+    sync = pcs.ProviderCatalogSync(db)
+    monkeypatch.setattr(pcs.ProviderCatalogSync, "_fetch_nvidia_ids", staticmethod(
+        lambda api_key=None: ["moonshotai/kimi-k3", "nvidia/nemotron-3-embed-1b", "openai/gpt-oss-20b"]))
+    upserts = []
+    monkeypatch.setattr(sync, "_upsert_route", lambda sp, mid, values: upserts.append((sp, mid, values)))
+
+    result = sync.sync_nvidia()
+    assert result["status"] == "completed"
+    assert result["models_synced"] == 2 and result["skipped_non_chat"] == 1 and result["borrowed_metadata"] == 1
+    assert [(sp, mid) for sp, mid, _ in upserts] == [("nvidia", "moonshotai/kimi-k3"), ("nvidia", "openai/gpt-oss-20b")]
+    job = db.added[0]
+    assert job.job_type == "nvidia_sync" and job.status == "completed" and job.models_synced == 2
+    assert job.job_metadata["skipped_non_chat"] == 1
+
+
+def test_sync_dispatch_refuses_unsyncable_providers():
+    from core.services.provider_catalog_sync import ProviderCatalogSync, SYNCABLE_PROVIDERS
+
+    assert SYNCABLE_PROVIDERS == ("openrouter", "nvidia")
+    with pytest.raises(ValueError):
+        ProviderCatalogSync(_Session()).sync("cohere")
+
+
+def test_upsert_route_targets_the_route_constraint():
+    from core.services.provider_catalog_sync import ProviderCatalogSync
+
+    db = _Session()
+    ProviderCatalogSync(db)._upsert_route("nvidia", "moonshotai/kimi-k3", {
+        "provider": "moonshotai", "display_name": "Kimi K3", "context_window": 1, "max_output_tokens": 1,
+        "input_cost_per_1k_tokens": 0.0, "output_cost_per_1k_tokens": 0.0, "status": "active",
+        "sourcing": "hosted_open", "tags": [], "capabilities": {}, "recommended_for": [],
+    })
+    stmt = db.executed[0]
+    compiled = str(stmt.compile(compile_kwargs={"literal_binds": False}))
+    assert "ON CONFLICT ON CONSTRAINT uq_llm_models_provider_model DO UPDATE" in compiled
+    assert "install_count" in compiled and "serving_provider" in compiled
+
+
+# --------------------------------------------------------------------------- #
+# S1.5/S2.1 — governance and pricing judge the tagged route
+# --------------------------------------------------------------------------- #
+
+
+def test_check_model_for_agent_judges_only_the_tagged_route(monkeypatch):
+    from core.llm import model_policy
+
+    quarantined_nv = SimpleNamespace(approval_status="quarantined", approved_roles=None,
+                                     serving_provider="nvidia", model_id="moonshotai/kimi-k3", workspace_id="ws")
+    approved_or = SimpleNamespace(approval_status="approved", approved_roles=None,
+                                  serving_provider="openrouter", model_id="moonshotai/kimi-k3", workspace_id="ws")
+    db = _Session(rows_by_model=[quarantined_nv, approved_or])
+    monkeypatch.setattr(model_policy, "check_orchestrator_model", lambda m: (True, "ok"))
+
+    allowed, reason = model_policy.check_model_for_agent(db, "ws", "moonshotai/kimi-k3", orchestrator_seat=False, provider="nvidia")
+    assert not allowed and "quarantined" in reason
+    allowed, _ = model_policy.check_model_for_agent(db, "ws", "moonshotai/kimi-k3", orchestrator_seat=False, provider="openrouter")
+    assert allowed
+
+
+def test_usage_tracker_prices_the_route_that_served_the_call(monkeypatch):
+    from core.llm.usage_tracker import UsageTracker
+
+    nv = _row(id=2, serving_provider="nvidia", input_cost_per_1k_tokens=0, output_cost_per_1k_tokens=0, sourcing="hosted_open")
+    orr = _row(id=1)
+    captured = []
+
+    class _S(_Session):
+        def add(self, obj):
+            captured.append(obj)
+
+    monkeypatch.setitem(sys.modules, "core.database.database",
+                        types.SimpleNamespace(SessionLocal=lambda: _S(rows_by_model=[nv, orr])))
+    UsageTracker.track(workspace_id=uuid4(), model_id="moonshotai/kimi-k3", provider="nvidia",
+                       input_tokens=1000, output_tokens=1000)
+    UsageTracker.track(workspace_id=uuid4(), model_id="moonshotai/kimi-k3", provider="openrouter",
+                       input_tokens=1000, output_tokens=1000)
+    assert captured[0].provider == "nvidia" and captured[0].total_cost == 0.0 and captured[0].tier == "hosted_open"
+    assert captured[1].provider == "openrouter" and captured[1].total_cost == pytest.approx(0.018)
+
+
+def test_route_manifest_lists_the_catalog_and_sync_endpoints():
+    manifest = json.loads((Path(__file__).resolve().parents[1] / "reports" / "route-manifest.json").read_text())
+    routes = manifest["routes"]
+    for entry in (
+        {"method": "GET", "path": "/api/marketplace/llm/catalog"},
+        {"method": "GET", "path": "/api/marketplace/llm/sync/status"},
+        {"method": "POST", "path": "/api/marketplace/llm/sync/{provider}"},
+    ):
+        assert entry in routes, entry
+    assert manifest["route_count"] == len(routes)


### PR DESCRIPTION
## PRD-236 W1 — the catalogue knows who serves what: provider tabs, one card per route, NVIDIA sync

Stacked on #699 (W0). Owner's go-ahead (2026-09-03): *"separate tabs in marketplace for OpenRouter and NVIDIA… so Kimi K3 on OpenRouter is different from NVIDIA Kimi K3."*

**What the user gets.** Marketplace → LLMs has provider tabs (All · OpenRouter · NVIDIA · OpenAI · DeepSeek …) with vendor chips beneath. Each card is a ROUTE — "Kimi K3 · OpenRouter · $3 / $15 per M" and "Kimi K3 · NVIDIA · Free" are two cards, installed separately, each with its own price. Admins get a Sync button per provider (OpenRouter, NVIDIA). Installing a route tags the workspace with it; Settings → Orchestrator lists the selected provider's installed routes and never flips the provider again.

### Schema (one migration, `prd236_w1_serving_provider`, head guard re-pinned)
- `llm_models.serving_provider` (registry slug of the API that serves the row); UNIQUE moves from `model_id` to `(serving_provider, model_id)`; `tier` → `sourcing` (PRD-223 §8 Q1, owner: yes), values from the registry kind (`direct | aggregator | hosted_open`); `external_id` = provider-native id.
- Data rule: `tier='direct'` + registered direct provider keeps `provider` as the route; everything else is served by OpenRouter — exactly where the factory's string-shape routing sent it. `workspace_models` untouched (it keys on the row id, so an install IS the tag).

### Catalogue sync — `core/services/provider_catalog_sync.py`
- **OpenRouter:** existing cache sync, then a projection of the cache into `llm_models` rows served by OpenRouter at OpenRouter's prices.
- **NVIDIA:** `GET {NVIDIA_BASE_URL}/models` (public, ids only) → rows at price 0, `sourcing='hosted_open'`, tags `free`/`nvidia`; context window, output cap, tool/vision flags, description and display name borrowed from the OpenRouter cache row of the same vendor id (alias-aware: `deepseek-ai`→`deepseek`, `meta`→`meta-llama`, suffix fallback). Embeddings, rerankers, reward models, OCR/parsers and safety classifiers are skipped (chat catalogue). Job history on `openrouter_sync_jobs.job_type`, no new table.
- Direct providers keep their seeded rows (their `/models` need a key and publish no prices).

### API — `api/llm_marketplace.py`
- `GET /catalog` — one row per route with facets: `providers` (serving), `provider_labels`, `vendors`, `last_synced`, `syncable`; filters `provider`, `vendor`, `category`, `price_tier` (from the row price), `supports_tools/vision`, search, sort.
- `LLMModelOut` gains `serving_provider`, `serving_provider_label`, `route_label`, `vendor`, `sourcing`, `price_tier`, `is_free`, `key_available` (the workspace can call the route today — BYOK, credential store, or env in the local edition), `terms_note`, `rate_limit_note`. `tier` is gone.
- `install` / `uninstall` / detail take `?provider=`; `installed-ids` returns `routes` ("provider:model_id"); `compare` accepts route keys; `POST /sync/{provider}`, `GET /sync/status`. Manifest 785 → 788.

### Routing, governance, pricing judge the tagged route
- `check_model_for_agent(..., provider=)` filters the approval row by `serving_provider`; every write path (orchestrator settings, agent config, the chat tools) resolves the route and stores its **serving provider, never the vendor** — before this, an agent set to Kimi got `provider='moonshotai'` and relied on runtime string-shape inference.
- `UsageTracker` prices the `(serving_provider, model_id)` row; the W0 multiplier remains only as the fallback when a route row is absent (never books a free route at a paid price).
- `price_per_1k` / `ModelRegistry.get_model` take an optional provider (route first, then OpenRouter's row, then any). Seeding keys on `serving_provider='openrouter'`.

### Frontend
- `marketplace-llms-tab.tsx`: single source (`/catalog`), provider tabs (registry order, counts), vendor chips, price-tier filter, per-provider Sync (admin), per-route installed state; the OpenRouter-cache/legacy dual read is deleted.
- `llm-model-card.tsx` / detail modal: route badge (+ "by vendor" when they differ), `Free` and "Add a NVIDIA key" badges, sourcing label, install/uninstall pinned to the route (`?provider=`).
- `SystemLLMSettingsTab.tsx`: models = the selected provider's installed routes; the auto-switch-to-OpenRouter is deleted.

### Tests
- `tests/test_prd236_w1_routes.py`: migration/head-guard pin, ORM keyed by route, price tiers + route keys, `_find_route` preference, `_model_to_out` labels, `installed-ids` route keys, NVIDIA sync (borrowing, alias, defaults, non-chat skip, fetch headers, job record, ON CONFLICT target), `check_model_for_agent` per route, `UsageTracker` per route, manifest entries.
- CI's `alembic-from-zero` exercises the migration on a fresh database.

### Test plan (owner, local edition — after the W0 steps)
1. Marketplace → LLMs → **NVIDIA** tab → *Sync NVIDIA* → cards appear (Kimi K3, DeepSeek V4, Nemotron 3, gpt-oss…) all marked Free; the OpenRouter tab still shows the paid Kimi K3.
2. Install "Kimi K3 · NVIDIA". The OpenRouter Kimi card stays uninstalled.
3. Settings → Orchestrator → provider NVIDIA → the model list shows Kimi K3 (and only NVIDIA routes) → save → chat → `llm_usage` row `provider='nvidia'`, `total_cost=0`.
4. Switch provider to OpenRouter: the model list shows the OpenRouter routes only.
5. Delete the NVIDIA key: the NVIDIA cards show "Add a NVIDIA key".

### Open (owner)
Q3 the OpenRouter cache table stays as the sync's staging table (not deleted in W1). Direct-provider catalogues (OpenAI/Anthropic rows are stale seeds) are unchanged.
