### PR TITLE
fix(command-center): calendar renders unstyled outside the studio theme

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -273,6 +273,13 @@
     --card-accent-alpha-hover: 0;
     --card-highlight-alpha: 0;
 
+    /* Command Centre calendar — CD's cream hover + olive live-dot. The same
+       calendar renders under the classic themes (see .cc-cal-root), where
+       these are undefined and the rules fall back to --muted / --success. */
+    --cc-hover: 38 45% 96%;
+    --cc-hover-border: 40 30% 70%;
+    --cc-live-dot: 82 50% 22%;
+
     /* Semantic — olive = good, navy = info, warn = sand */
     --success: 82 30% 33%;           /* #5b6f3a olive */
     --success-foreground: 38 50% 96%;
@@ -1574,7 +1581,7 @@
     font-weight: 600; color: hsl(var(--foreground));
   }
   .studio .cc-actions { display: inline-flex; gap: 6px; flex-shrink: 0; }
-  .studio .cc-btn {
+  :is(.studio, .cc-cal-root) .cc-btn {
     display: inline-flex; align-items: center; gap: 6px;
     height: 30px; padding: 0 12px;
     background: hsl(var(--card)); border: 1px solid hsl(var(--border));
@@ -1582,14 +1589,15 @@
     font-size: 12px; font-weight: 500; cursor: pointer;
     transition: border-color 140ms ease, background 140ms ease;
   }
-  .studio .cc-btn:hover {
-    border-color: hsl(40 30% 70%); background: hsl(38 45% 96%);
+  :is(.studio, .cc-cal-root) .cc-btn:hover {
+    border-color: hsl(var(--cc-hover-border, var(--border)));
+    background: hsl(var(--cc-hover, var(--muted)));
   }
-  .studio .cc-btn.primary {
+  :is(.studio, .cc-cal-root) .cc-btn.primary {
     background: hsl(var(--primary)); color: hsl(var(--primary-foreground));
     border-color: hsl(var(--primary));
   }
-  .studio .cc-btn.primary:hover { opacity: 0.9; background: hsl(var(--primary)); }
+  :is(.studio, .cc-cal-root) .cc-btn.primary:hover { opacity: 0.9; background: hsl(var(--primary)); }
 
   /* Tabs strip (bespoke to /command-center, distinct from .sh-tabs) */
   .studio .cc-tabs {
@@ -1735,7 +1743,7 @@
     letter-spacing: 0.04em;
   }
   .studio .cc-panel-head .right { margin-left: auto; display: inline-flex; gap: 6px; }
-  .studio .cc-panel-empty {
+  :is(.studio, .cc-cal-root) .cc-panel-empty {
     padding: 24px 18px; text-align: center;
     color: hsl(var(--muted-foreground)); font-size: 12.5px;
     font-family: var(--font-newsreader, serif); line-height: 1.5;
@@ -1939,17 +1947,17 @@
   .studio .cc-toolbar {
     display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
   }
-  .studio .cc-seg {
+  :is(.studio, .cc-cal-root) .cc-seg {
     display: inline-flex; background: hsl(var(--muted));
     padding: 3px; border-radius: 6px; gap: 2px;
   }
-  .studio .cc-seg button {
+  :is(.studio, .cc-cal-root) .cc-seg button {
     background: transparent; border: 0; padding: 5px 10px;
     border-radius: 4px; font-size: 11.5px; color: hsl(var(--muted-foreground));
     display: inline-flex; align-items: center; gap: 5px; font-weight: 500;
     cursor: pointer;
   }
-  .studio .cc-seg button.on {
+  :is(.studio, .cc-cal-root) .cc-seg button.on {
     background: hsl(var(--card)); color: hsl(var(--foreground));
     box-shadow: 0 1px 0 hsla(30 50% 18% / 0.05);
   }
@@ -2085,41 +2093,55 @@
     height: 3px; background: hsl(var(--muted)); border-radius: 2px; opacity: 0.5;
   }
 
+  /* Calendar root — the scope every calendar rule below hangs off, via
+     `:is(.studio, .cc-cal-root)`. The studio shell mounts CalendarTab inside
+     .cc-body (a flex column, gap 14px); the classic ActivityPage mounts the
+     SAME component under the dark/light/matte themes, where no `.studio`
+     ancestor exists — so the root carries the layout itself and the classic
+     themes get the grid, not a stack of unstyled divs. */
+  .cc-cal-root {
+    display: flex; flex-direction: column; gap: 14px;
+    flex: 1; min-height: 0;
+  }
+  /* Classic themes: the page scrolls, so bound the frame and let the hour
+     grid scroll inside it, as it does inside the studio shell's .cc-body. */
+  html:not(.studio) .cc-cal-root .cc-cal-frame { max-height: 72vh; }
+
   /* Calendar */
-  .studio .cc-cal-toolbar {
+  :is(.studio, .cc-cal-root) .cc-cal-toolbar {
     display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
   }
-  .studio .cc-cal-frame {
+  :is(.studio, .cc-cal-root) .cc-cal-frame {
     flex: 1; min-height: 0; overflow: hidden;
     background: hsl(var(--card)); border: 1px solid hsl(var(--border));
     border-radius: 10px;
     display: flex; flex-direction: column;
   }
-  .studio .cc-cal-head {
+  :is(.studio, .cc-cal-root) .cc-cal-head {
     display: grid; grid-template-columns: 60px repeat(7, 1fr);
     border-bottom: 1px solid hsl(var(--border));
     background: hsl(var(--secondary));
   }
-  .studio .cc-cal-head .h {
+  :is(.studio, .cc-cal-root) .cc-cal-head .h {
     padding: 10px 12px;
     border-right: 1px solid hsl(var(--border));
   }
-  .studio .cc-cal-head .h:last-child { border-right: 0; }
-  .studio .cc-cal-head .h .d {
+  :is(.studio, .cc-cal-root) .cc-cal-head .h:last-child { border-right: 0; }
+  :is(.studio, .cc-cal-root) .cc-cal-head .h .d {
     font-family: var(--font-geist-mono, monospace);
     font-size: 10px; letter-spacing: 0.10em; text-transform: uppercase;
     color: hsl(var(--muted-foreground)); font-weight: 600;
   }
-  .studio .cc-cal-head .h .n {
+  :is(.studio, .cc-cal-root) .cc-cal-head .h .n {
     font-family: var(--font-newsreader, serif);
     font-size: 18px; font-weight: 500;
     letter-spacing: -0.01em; color: hsl(var(--foreground)); margin-top: 2px;
   }
-  .studio .cc-cal-head .h.today .n {
+  :is(.studio, .cc-cal-root) .cc-cal-head .h.today .n {
     background: hsl(var(--foreground)); color: hsl(var(--background));
     display: inline-block; padding: 2px 10px; border-radius: 14px;
   }
-  .studio .cc-cal-grid {
+  :is(.studio, .cc-cal-root) .cc-cal-grid {
     flex: 1; min-height: 0; overflow: auto;
     display: grid;
     grid-template-columns: 60px repeat(7, 1fr);
@@ -2129,30 +2151,30 @@
       hsl(var(--border)) calc(40px - 1px), hsl(var(--border)) 40px);
     background-size: 100% 40px;
   }
-  .studio .cc-cal-hourlabel {
+  :is(.studio, .cc-cal-root) .cc-cal-hourlabel {
     padding: 4px 8px;
     font-family: var(--font-geist-mono, monospace);
     font-size: 9.5px; color: hsl(var(--muted-foreground));
     letter-spacing: 0.04em;
     height: 40px; box-sizing: border-box;
   }
-  .studio .cc-cal-daycol {
+  :is(.studio, .cc-cal-root) .cc-cal-daycol {
     border-right: 1px solid hsl(var(--border));
     position: relative;
   }
-  .studio .cc-cal-daycol:last-child { border-right: 0; }
-  .studio .cc-cal-daycol.today { background: hsl(var(--accent) / 0.03); }
-  .studio .cc-cal-nowline {
+  :is(.studio, .cc-cal-root) .cc-cal-daycol:last-child { border-right: 0; }
+  :is(.studio, .cc-cal-root) .cc-cal-daycol.today { background: hsl(var(--accent) / 0.03); }
+  :is(.studio, .cc-cal-root) .cc-cal-nowline {
     position: absolute; left: 0; right: 0; height: 0;
     border-top: 1.5px solid hsl(var(--accent));
     pointer-events: none; z-index: 2;
   }
-  .studio .cc-cal-nowline::before {
+  :is(.studio, .cc-cal-root) .cc-cal-nowline::before {
     content: ''; position: absolute; left: -3px; top: -4px;
     width: 7px; height: 7px; border-radius: 50%;
     background: hsl(var(--accent));
   }
-  .studio .cc-cal-event {
+  :is(.studio, .cc-cal-root) .cc-cal-event {
     position: absolute; left: 4px; right: 4px;
     border-radius: 4px; padding: 4px 6px;
     font-size: 10.5px; line-height: 1.25;
@@ -2161,22 +2183,22 @@
     border-left: 2px solid hsl(var(--muted-foreground));
     background: hsl(var(--secondary));
   }
-  .studio .cc-cal-event .nm {
+  :is(.studio, .cc-cal-root) .cc-cal-event .nm {
     font-family: var(--font-geist-mono, monospace);
     font-size: 9px; letter-spacing: 0.06em; font-weight: 600;
     color: hsl(var(--muted-foreground)); text-transform: uppercase;
   }
-  .studio .cc-cal-event .ttl {
+  :is(.studio, .cc-cal-root) .cc-cal-event .ttl {
     font-family: var(--font-geist-sans, sans-serif);
     font-weight: 500; margin-top: 1px;
   }
-  .studio .cc-cal-alwayson {
+  :is(.studio, .cc-cal-root) .cc-cal-alwayson {
     display: grid; grid-template-columns: 60px 1fr;
     background: hsl(var(--card));
     border: 1px solid hsl(var(--border));
     border-radius: 10px; overflow: hidden;
   }
-  .studio .cc-cal-alwayson .lbl {
+  :is(.studio, .cc-cal-root) .cc-cal-alwayson .lbl {
     padding: 10px 8px;
     font-family: var(--font-geist-mono, monospace);
     font-size: 10px; color: hsl(var(--muted-foreground));
@@ -2184,11 +2206,11 @@
     border-right: 1px solid hsl(var(--border));
     display: flex; align-items: center; gap: 6px;
   }
-  .studio .cc-cal-alwayson .pills {
+  :is(.studio, .cc-cal-root) .cc-cal-alwayson .pills {
     padding: 8px 10px; display: flex; align-items: center; gap: 8px;
     flex-wrap: wrap;
   }
-  .studio .cc-cal-alwayson .pill {
+  :is(.studio, .cc-cal-root) .cc-cal-alwayson .pill {
     display: inline-flex; align-items: center; gap: 6px;
     padding: 3px 9px; border-radius: 4px;
     background: hsl(var(--secondary));
@@ -2196,83 +2218,84 @@
     font-family: var(--font-geist-mono, monospace);
     font-size: 10.5px; color: hsl(var(--foreground));
   }
-  .studio .cc-cal-alwayson .pill .dot {
-    width: 5px; height: 5px; border-radius: 50%; background: hsl(82 50% 22%);
+  :is(.studio, .cc-cal-root) .cc-cal-alwayson .pill .dot {
+    width: 5px; height: 5px; border-radius: 50%;
+    background: hsl(var(--cc-live-dot, var(--success)));
   }
 
   /* Calendar — bump readability over CD's slim defaults */
-  .studio .cc-cal-event {
+  :is(.studio, .cc-cal-root) .cc-cal-event {
     font-size: 11.5px; cursor: pointer;
     border-left-width: 3px;
     transition: background 140ms ease, transform 140ms ease;
   }
-  .studio .cc-cal-event:hover {
-    background: hsl(38 45% 96%) !important;
+  :is(.studio, .cc-cal-root) .cc-cal-event:hover {
+    background: hsl(var(--cc-hover, var(--muted))) !important;
     transform: translateX(1px);
   }
-  .studio .cc-cal-event .nm {
+  :is(.studio, .cc-cal-root) .cc-cal-event .nm {
     font-family: var(--font-geist-mono, monospace);
     font-size: 10px; letter-spacing: 0.06em; font-weight: 600;
     color: hsl(var(--muted-foreground)); text-transform: uppercase;
   }
-  .studio .cc-cal-event .ttl {
+  :is(.studio, .cc-cal-root) .cc-cal-event .ttl {
     font-family: var(--font-geist-sans, sans-serif);
     font-weight: 500; font-size: 12.5px; margin-top: 2px;
     color: hsl(var(--foreground));
     white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
   }
-  .studio .cc-cal-hourlabel {
+  :is(.studio, .cc-cal-root) .cc-cal-hourlabel {
     font-size: 10.5px;
   }
-  .studio .cc-cal-head .h .d { font-size: 10.5px; }
-  .studio .cc-cal-head .h .n { font-size: 19px; }
+  :is(.studio, .cc-cal-root) .cc-cal-head .h .d { font-size: 10.5px; }
+  :is(.studio, .cc-cal-root) .cc-cal-head .h .n { font-size: 19px; }
 
   /* Month grid */
-  .studio .cc-cal-month {
+  :is(.studio, .cc-cal-root) .cc-cal-month {
     flex: 1; min-height: 0; display: flex; flex-direction: column;
     background: hsl(var(--card)); border: 1px solid hsl(var(--border));
     border-radius: 10px; overflow: hidden;
   }
-  .studio .cc-cal-month-head {
+  :is(.studio, .cc-cal-root) .cc-cal-month-head {
     display: grid; grid-template-columns: repeat(7, 1fr);
     background: hsl(var(--secondary));
     border-bottom: 1px solid hsl(var(--border));
   }
-  .studio .cc-cal-month-head .h {
+  :is(.studio, .cc-cal-root) .cc-cal-month-head .h {
     padding: 10px 12px;
     font-family: var(--font-geist-mono, monospace);
     font-size: 10.5px; letter-spacing: 0.10em; text-transform: uppercase;
     color: hsl(var(--muted-foreground)); font-weight: 600;
     border-right: 1px solid hsl(var(--border));
   }
-  .studio .cc-cal-month-head .h:last-child { border-right: 0; }
-  .studio .cc-cal-month-grid {
+  :is(.studio, .cc-cal-root) .cc-cal-month-head .h:last-child { border-right: 0; }
+  :is(.studio, .cc-cal-root) .cc-cal-month-grid {
     display: grid; grid-template-columns: repeat(7, 1fr);
     grid-auto-rows: minmax(110px, 1fr);
     flex: 1; min-height: 0;
   }
-  .studio .cc-cal-month-cell {
+  :is(.studio, .cc-cal-root) .cc-cal-month-cell {
     border-right: 1px solid hsl(var(--border));
     border-bottom: 1px solid hsl(var(--border));
     padding: 8px; display: flex; flex-direction: column; gap: 6px;
     min-width: 0; overflow: hidden;
   }
-  .studio .cc-cal-month-cell:nth-child(7n) { border-right: 0; }
-  .studio .cc-cal-month-cell.outside .n,
-  .studio .cc-cal-month-cell.outside .evts { opacity: 0.4; }
-  .studio .cc-cal-month-cell .n {
+  :is(.studio, .cc-cal-root) .cc-cal-month-cell:nth-child(7n) { border-right: 0; }
+  :is(.studio, .cc-cal-root) .cc-cal-month-cell.outside .n,
+  :is(.studio, .cc-cal-root) .cc-cal-month-cell.outside .evts { opacity: 0.4; }
+  :is(.studio, .cc-cal-root) .cc-cal-month-cell .n {
     font-family: var(--font-newsreader, serif);
     font-size: 14px; font-weight: 500; color: hsl(var(--foreground));
   }
-  .studio .cc-cal-month-cell.today .n > span {
+  :is(.studio, .cc-cal-root) .cc-cal-month-cell.today .n > span {
     background: hsl(var(--foreground)); color: hsl(var(--background));
     display: inline-block; padding: 0 8px; border-radius: 12px;
   }
-  .studio .cc-cal-month-cell .evts {
+  :is(.studio, .cc-cal-root) .cc-cal-month-cell .evts {
     display: flex; flex-direction: column; gap: 2px;
     overflow: hidden;
   }
-  .studio .cc-cal-month-evt {
+  :is(.studio, .cc-cal-root) .cc-cal-month-evt {
     text-align: left; background: hsl(var(--secondary));
     border: 0; border-left: 3px solid hsl(var(--muted-foreground));
     border-radius: 3px; padding: 2px 6px;
@@ -2280,12 +2303,12 @@
     white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
     transition: background 140ms ease;
   }
-  .studio .cc-cal-month-evt:hover { background: hsl(38 45% 96%); }
-  .studio .cc-cal-month-evt .t {
+  :is(.studio, .cc-cal-root) .cc-cal-month-evt:hover { background: hsl(var(--cc-hover, var(--muted))); }
+  :is(.studio, .cc-cal-root) .cc-cal-month-evt .t {
     font-family: var(--font-geist-mono, monospace);
     font-size: 9.5px; color: hsl(var(--muted-foreground));
   }
-  .studio .cc-cal-month-more {
+  :is(.studio, .cc-cal-root) .cc-cal-month-more {
     font-family: var(--font-geist-mono, monospace);
     font-size: 10px; color: hsl(var(--muted-foreground));
     padding: 1px 6px;

--- a/frontend/components/command-center/__tests__/calendar-tab-scope.test.tsx
+++ b/frontend/components/command-center/__tests__/calendar-tab-scope.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * The Command Centre calendar renders in two places: the studio shell
+ * (`.studio` on <html>) and the classic ActivityPage (dark / light / matte —
+ * no `.studio` anywhere). Every `cc-cal-*` rule in globals.css used to be
+ * `.studio`-scoped, so the classic Command Centre showed the week grid as a
+ * stack of unstyled divs (2026-09-08). These guards keep both mounts styled:
+ * the component owns a `.cc-cal-root` scope, and the stylesheet reaches every
+ * calendar rule from it.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import { readFileSync } from 'fs'
+import path from 'path'
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}))
+vi.mock('@/hooks/use-activity-api', () => ({
+  useActivitySchedule: () => ({
+    data: { scheduled: [] },
+    isLoading: false,
+    isError: false,
+    refetch: vi.fn(),
+  }),
+  useSchedulerHealth: () => ({ data: { healthy: null, last_fired_at: null } }),
+}))
+vi.mock('@/hooks/use-heartbeats-api', () => ({
+  useHeartbeats: () => ({ data: { heartbeats: [] } }),
+}))
+
+import { CalendarTab } from '../calendar-tab'
+
+const css = readFileSync(
+  path.resolve(__dirname, '..', '..', '..', 'app', 'globals.css'),
+  'utf8',
+)
+
+describe('CalendarTab — styled outside the studio theme', () => {
+  it('wraps the calendar in its own .cc-cal-root scope', () => {
+    const { container } = render(<CalendarTab />)
+    const root = container.querySelector('.cc-cal-root')
+    expect(root).not.toBeNull()
+    expect(root!.querySelector('.cc-cal-toolbar')).not.toBeNull()
+    expect(root!.querySelector('.cc-cal-grid')).not.toBeNull()
+  })
+
+  it('no calendar rule is reachable only from .studio', () => {
+    expect(css).not.toMatch(/^\s*\.studio\s+\.cc-cal-/m)
+    expect(css).toMatch(/^\s*:is\(\.studio, \.cc-cal-root\) \.cc-cal-grid \{/m)
+    expect(css).toMatch(/^\s*\.cc-cal-root \{/m)
+  })
+
+  it('the primitives the calendar uses are reachable from .cc-cal-root', () => {
+    for (const cls of ['cc-btn', 'cc-seg', 'cc-panel-empty']) {
+      expect(css).toMatch(
+        new RegExp(`^\\s*:is\\(\\.studio, \\.cc-cal-root\\) \\.${cls}\\b`, 'm'),
+      )
+    }
+  })
+
+  it('hover and live-dot colours fall back to theme tokens outside studio', () => {
+    // CD's cream hover is a studio-only token; a dark-theme event must not
+    // flash near-white on hover.
+    expect(css).not.toMatch(/\.cc-cal-event:hover \{[^}]*hsl\(38 45% 96%\)/)
+    expect(css).toMatch(/^\s*--cc-hover:\s*38 45% 96%;/m)
+    expect(css).toMatch(/hsl\(var\(--cc-hover, var\(--muted\)\)\) !important/)
+    expect(css).toMatch(/hsl\(var\(--cc-live-dot, var\(--success\)\)\)/)
+  })
+})

--- a/frontend/components/command-center/calendar-tab.tsx
+++ b/frontend/components/command-center/calendar-tab.tsx
@@ -16,6 +16,12 @@
  * Prev / Today / Next actually move the visible window. No speculative
  * "Schedule task" / "Filter" / "Export" CTAs — those don't belong on a
  * monitoring surface.
+ *
+ * Mounted by BOTH the studio CommandCenterShell and the classic ActivityPage
+ * (dark / light / matte themes). Every `cc-cal-*` rule in globals.css is
+ * scoped `:is(.studio, .cc-cal-root)`, so the `.cc-cal-root` wrapper below is
+ * what styles the calendar when no `.studio` ancestor exists — drop it and
+ * the classic Command Centre renders the grid as a stack of unstyled divs.
  */
 
 import { useMemo, useState } from 'react'
@@ -456,7 +462,7 @@ export function CalendarTab() {
   })()
 
   return (
-    <>
+    <div className="cc-cal-root">
       <div className="cc-cal-toolbar">
         <div className="cc-seg" role="group" aria-label="Calendar mode">
           <button
@@ -751,7 +757,7 @@ export function CalendarTab() {
           )}
         </div>
       )}
-    </>
+    </div>
   )
 }
 


### PR DESCRIPTION
## Summary

The Command Centre **Calendar** tab rendered as a vertical stack of unstyled text under the dark / light / matte themes (and studio on mobile): "DayWeekMonth" run together, SUN…SAT stacked, one hour label per line.

**Root cause.** `app/command-center/page.tsx` renders the studio `CommandCenterShell` only for studio-desktop; every other theme renders the classic `ActivityPage`, which (since PRD-162 S4) mounts the same `CalendarTab`. Every `cc-cal-*` rule in `globals.css`, plus the `cc-btn` / `cc-seg` / `cc-panel-empty` primitives the tab uses, was scoped under `.studio` — a class next-themes stamps on `<html>` only for the studio theme. Under dark/light/matte no rule matched.

**Fix.**
- `CalendarTab` owns a `.cc-cal-root` wrapper (flex column, gap 14px — the layout `.cc-body` already gives it in the studio shell, so the studio render is unchanged).
- Every calendar rule is scoped `:is(.studio, .cc-cal-root)` — same specificity, so the studio cascade is untouched; classic themes now reach the grid.
- CD's hard-coded studio colours on the calendar path (cream hover, tan hover border, olive live-dot) become studio-only tokens (`--cc-hover`, `--cc-hover-border`, `--cc-live-dot`) with `--muted` / `--border` / `--success` fallbacks. Studio keeps the exact CD values; a dark-theme event no longer flashes near-white on hover.
- Classic themes bound the frame to `72vh` so the hour grid scrolls inside it, as it does inside `.cc-body` in the studio shell.

No data / API changes. `.sh-chat-act:hover` (the other rule sharing the cream hover value) is deliberately untouched.

Replaces #709 (same diff; that commit lacked the DCO sign-off).

## Test plan
- [ ] CI `frontend` job: new `components/command-center/__tests__/calendar-tab-scope.test.tsx` — renders `CalendarTab` and asserts the `.cc-cal-root` scope wraps the toolbar + grid; asserts no `.studio .cc-cal-*` selector remains, the primitives are reachable from `.cc-cal-root`, and the hover/live-dot colours fall back to tokens. (Passed on #709's identical diff.)
- [ ] Railway: `/command-center?tab=calendar` in **dark** theme shows the week grid (7 columns, hour rows, 24/7 band, Next Up).
- [ ] Railway: studio theme calendar is pixel-unchanged (cream hover, olive dot, same spacing).
