### PR TITLE
feat(calendar): board deadlines on the grid, actions on events, one feed

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -2214,7 +2214,9 @@
     display: inline-flex; align-items: center; gap: 6px;
     padding: 3px 9px; border-radius: 4px;
     background: hsl(var(--secondary));
-    border-left: 2px solid hsl(var(--muted-foreground));
+    /* a <button> now (it opens the routine's action menu): drop the UA border */
+    border: 0; border-left: 2px solid hsl(var(--muted-foreground));
+    cursor: pointer;
     font-family: var(--font-geist-mono, monospace);
     font-size: 10.5px; color: hsl(var(--foreground));
   }

--- a/frontend/components/activity/board/board-view.tsx
+++ b/frontend/components/activity/board/board-view.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useEffect, useRef } from 'react'
+import { useSearchParams } from 'next/navigation'
 import { DragDropContext, type DropResult } from '@hello-pangea/dnd'
 import { Plus } from 'lucide-react'
 import { Button } from '@/components/ui/button'
@@ -8,7 +9,7 @@ import { BoardColumn } from './board-column'
 import { BoardFiltersBar } from './board-filters'
 import { BoardTaskViewer } from './board-task-viewer'
 import { CreateTaskDialog } from './create-task-dialog'
-import { useBoardTasks, useUpdateTaskStatus, type BoardFilters } from '@/hooks/use-board-tasks'
+import { useBoardTasks, useBoardTask, useUpdateTaskStatus, type BoardFilters } from '@/hooks/use-board-tasks'
 import { useDeleteTask } from '@/hooks/use-board-tasks-api'
 import type { BoardTask, BoardStatus } from '@/types/board'
 import { cn } from '@/lib/utils'
@@ -59,6 +60,19 @@ export function BoardView({ period, className }: BoardViewProps) {
     setTaskViewerOpen(open)
     if (!open) setOpenTask(null)
   }, [])
+
+  // Deep link: /command-center?tab=board&task_id=123 (the calendar's "Open on
+  // board", notifications). Fetched by id so a period/agent filter that hides
+  // the card from the columns can't hide it from the link. Opens once per id.
+  const deepLinkTaskId = useSearchParams().get('task_id')
+  const { data: deepLinkedTask } = useBoardTask(deepLinkTaskId)
+  const openedDeepLink = useRef<string | null>(null)
+  useEffect(() => {
+    if (!deepLinkTaskId || !deepLinkedTask || openedDeepLink.current === deepLinkTaskId) return
+    openedDeepLink.current = deepLinkTaskId
+    setOpenTask(deepLinkedTask)
+    setTaskViewerOpen(true)
+  }, [deepLinkTaskId, deepLinkedTask])
 
   const handleSelectAgent = useCallback((agentId: number | null) => {
     setSelectedAgentId(agentId)

--- a/frontend/components/command-center/__tests__/calendar-actions.test.ts
+++ b/frontend/components/command-center/__tests__/calendar-actions.test.ts
@@ -1,0 +1,85 @@
+/**
+ * The calendar's event menu is a pure function of the feed item: every item
+ * kind gets the actions its backing endpoint supports, nothing more. Routes and
+ * statuses are asserted here so a rename in the pages or the scheduled-task
+ * API can't silently strand a menu entry.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import type { ScheduleItem } from '@/hooks/use-activity-api'
+import { buildEventActions, isDeadlineItem, type EventActionDeps } from '../calendar-actions'
+
+function deps(): EventActionDeps & { navigate: ReturnType<typeof vi.fn> } {
+  return { navigate: vi.fn(), pauseRoutine: vi.fn(), setScheduledTaskStatus: vi.fn() }
+}
+
+function item(over: Partial<ScheduleItem>): ScheduleItem {
+  return {
+    id: 'x',
+    name: 'X',
+    type: 'routine',
+    next_run_at: null,
+    frequency: '',
+    agent_name: null,
+    agent_id: null,
+    ...over,
+  }
+}
+
+const labels = (actions: { label: string }[]) => actions.map((a) => a.label)
+
+describe('buildEventActions', () => {
+  it('routine: open the agent, pause the heartbeat', () => {
+    const d = deps()
+    const actions = buildEventActions(item({ type: 'routine', agent_id: 7, agent_name: 'Ops' }), d)
+    expect(labels(actions)).toEqual(['Open agent', 'Pause routine'])
+    actions[0].run()
+    expect(d.navigate).toHaveBeenCalledWith('/agents?agent=7')
+    actions[1].run()
+    expect(d.pauseRoutine).toHaveBeenCalledWith(7)
+  })
+
+  it('scheduled task: pause, cancel (danger), then the agent', () => {
+    const d = deps()
+    const actions = buildEventActions(
+      item({ type: 'task', scheduled_task_id: 12, agent_id: 3 }),
+      d,
+    )
+    expect(labels(actions)).toEqual(['Pause', 'Cancel', 'Open agent'])
+    expect(actions[1].tone).toBe('danger')
+    actions[0].run()
+    expect(d.setScheduledTaskStatus).toHaveBeenCalledWith(12, 'paused')
+    actions[1].run()
+    expect(d.setScheduledTaskStatus).toHaveBeenCalledWith(12, 'cancelled')
+  })
+
+  it('playbook and mission open their own pages', () => {
+    const d = deps()
+    buildEventActions(item({ type: 'recipe', playbook_id: 5 }), d)[0].run()
+    expect(d.navigate).toHaveBeenCalledWith('/assignments?tab=playbooks&id=5')
+    buildEventActions(item({ type: 'mission', mission_id: 9 }), d)[0].run()
+    expect(d.navigate).toHaveBeenCalledWith('/missions/9')
+  })
+
+  it('board-task deadline opens the card on the board via ?task_id=', () => {
+    const d = deps()
+    const actions = buildEventActions(item({ type: 'task_due', board_task_id: 42, agent_id: 3 }), d)
+    expect(labels(actions)).toEqual(['Open on board', 'Open agent'])
+    actions[0].run()
+    expect(d.navigate).toHaveBeenCalledWith('/command-center?tab=board&task_id=42')
+  })
+
+  it('an item with nothing to act on still opens the activity view', () => {
+    const d = deps()
+    const actions = buildEventActions(item({ type: 'recipe' }), d)
+    expect(labels(actions)).toEqual(['Open activity'])
+    actions[0].run()
+    expect(d.navigate).toHaveBeenCalledWith('/command-center?tab=activity')
+  })
+
+  it('deadline items are missions and board tasks only', () => {
+    expect(isDeadlineItem({ type: 'mission' })).toBe(true)
+    expect(isDeadlineItem({ type: 'task_due' })).toBe(true)
+    expect(isDeadlineItem({ type: 'routine' })).toBe(false)
+    expect(isDeadlineItem({ type: 'task' })).toBe(false)
+  })
+})

--- a/frontend/components/command-center/__tests__/calendar-tab-feed.test.tsx
+++ b/frontend/components/command-center/__tests__/calendar-tab-feed.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * The calendar draws everything from the schedule feed (GET /api/activity/schedule).
+ * It used to take its routine rows and 24/7 band from /api/heartbeat/workspace,
+ * a router behind the PRD-143 super-admin lock (403 for everyone else, polled
+ * every 30s) whose next_run_at came from the one worker hosting APScheduler.
+ * These tests pin the feed-only contract and the new deadline items.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { readFileSync } from 'fs'
+import path from 'path'
+import type { ScheduleItem } from '@/hooks/use-activity-api'
+
+const feed = vi.hoisted(() => ({ items: [] as unknown[] }))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}))
+vi.mock('@/hooks/use-activity-api', () => ({
+  activityQueryKeys: { all: ['activity'] },
+  useActivitySchedule: () => ({
+    data: { scheduled: feed.items },
+    isLoading: false,
+    isError: false,
+    refetch: vi.fn(),
+  }),
+  useSchedulerHealth: () => ({ data: { healthy: null, last_fired_at: null } }),
+}))
+vi.mock('@/hooks/use-heartbeats-api', () => ({
+  useToggleHeartbeat: () => ({ mutate: vi.fn() }),
+}))
+vi.mock('@/hooks/use-scheduled-tasks-api', () => ({
+  useUpdateScheduledTaskStatus: () => ({ mutate: vi.fn() }),
+}))
+
+import { CalendarTab } from '../calendar-tab'
+
+const src = readFileSync(path.resolve(__dirname, '..', 'calendar-tab.tsx'), 'utf8')
+
+function routine(id: number, name: string, intervalMinutes: number, nextRunAt: Date): ScheduleItem {
+  return {
+    id: `routine-${id}`,
+    name: `${name} Routine`,
+    type: 'routine',
+    next_run_at: nextRunAt.toISOString(),
+    frequency: `Every ${intervalMinutes}m`,
+    agent_name: name,
+    agent_id: id,
+    recurrence: {
+      cron_expression: null,
+      interval_minutes: intervalMinutes,
+      timezone: 'UTC',
+      active_hours: null,
+    },
+  }
+}
+
+/** A moment inside today's visible week that is never near a day boundary. */
+function midToday(): Date {
+  const d = new Date()
+  d.setHours(12, 30, 0, 0)
+  return d
+}
+
+describe('CalendarTab — feed-only data contract', () => {
+  it('never calls the super-admin-locked heartbeat list', () => {
+    expect(src).not.toContain('useHeartbeats(')
+    expect(src).not.toContain('/api/heartbeat/workspace')
+    // The schedule feed is the one read; the toggle hook is only a mutation.
+    expect(src).toContain('useActivitySchedule(')
+    expect(src).toContain('useToggleHeartbeat')
+  })
+
+  it('a frequent routine is summarised in the 24/7 band, not plotted', () => {
+    feed.items = [routine(1, 'Ops', 15, midToday())]
+    const { container } = render(<CalendarTab />)
+    expect(screen.getByText(/Ops · every 15m/)).toBeInTheDocument()
+    expect(container.querySelector('.cc-cal-event')).toBeNull()
+  })
+
+  it('an hourly routine is plotted from its structured recurrence and next run', () => {
+    feed.items = [routine(2, 'Research', 60, midToday())]
+    const { container } = render(<CalendarTab />)
+    const plotted = container.querySelectorAll('.cc-cal-event')
+    expect(plotted.length).toBeGreaterThan(1) // expanded across the day, not one anchor
+    expect(plotted[0].textContent).toContain('Research')
+  })
+
+  it('a board-task SLA deadline is a DUE event and sits in Next Up', () => {
+    const due = new Date(midToday().getTime() + 30 * 60_000)
+    feed.items = [
+      {
+        id: 'board-42',
+        board_task_id: 42,
+        name: 'Fix the calendar',
+        type: 'task_due',
+        next_run_at: due.toISOString(),
+        frequency: 'SLA deadline',
+        agent_name: 'Ops',
+        agent_id: 1,
+        status: 'assigned',
+        priority: 'high',
+      } satisfies ScheduleItem,
+    ]
+    const { container } = render(<CalendarTab />)
+    const evt = container.querySelector('.cc-cal-event')
+    expect(evt).not.toBeNull()
+    expect(evt!.textContent).toContain('Fix the calendar')
+    expect(evt!.textContent).toMatch(/DUE|OVERDUE/)
+    expect(screen.getByText('Next up')).toBeInTheDocument()
+  })
+})

--- a/frontend/components/command-center/__tests__/calendar-tab-feed.test.tsx
+++ b/frontend/components/command-center/__tests__/calendar-tab-feed.test.tsx
@@ -35,7 +35,10 @@ vi.mock('@/hooks/use-scheduled-tasks-api', () => ({
 
 import { CalendarTab } from '../calendar-tab'
 
+// Code only: the header comment is allowed to NAME the endpoint it no longer calls.
 const src = readFileSync(path.resolve(__dirname, '..', 'calendar-tab.tsx'), 'utf8')
+  .replace(/\/\*[\s\S]*?\*\//g, '')
+  .replace(/^\s*\/\/.*$/gm, '')
 
 function routine(id: number, name: string, intervalMinutes: number, nextRunAt: Date): ScheduleItem {
   return {

--- a/frontend/components/command-center/__tests__/calendar-tab-scope.test.tsx
+++ b/frontend/components/command-center/__tests__/calendar-tab-scope.test.tsx
@@ -16,6 +16,7 @@ vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: vi.fn() }),
 }))
 vi.mock('@/hooks/use-activity-api', () => ({
+  activityQueryKeys: { all: ['activity'] },
   useActivitySchedule: () => ({
     data: { scheduled: [] },
     isLoading: false,
@@ -25,7 +26,10 @@ vi.mock('@/hooks/use-activity-api', () => ({
   useSchedulerHealth: () => ({ data: { healthy: null, last_fired_at: null } }),
 }))
 vi.mock('@/hooks/use-heartbeats-api', () => ({
-  useHeartbeats: () => ({ data: { heartbeats: [] } }),
+  useToggleHeartbeat: () => ({ mutate: vi.fn() }),
+}))
+vi.mock('@/hooks/use-scheduled-tasks-api', () => ({
+  useUpdateScheduledTaskStatus: () => ({ mutate: vi.fn() }),
 }))
 
 import { CalendarTab } from '../calendar-tab'

--- a/frontend/components/command-center/board-tab.tsx
+++ b/frontend/components/command-center/board-tab.tsx
@@ -19,7 +19,8 @@
  * lives in /chat?mode=plan and routine creation in /agents.
  */
 
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { useSearchParams } from 'next/navigation'
 import {
   DragDropContext,
   Droppable,
@@ -35,7 +36,7 @@ import {
   BookMarked,
   CheckSquare,
 } from 'lucide-react'
-import { useBoardTasks, useUpdateTaskStatus } from '@/hooks/use-board-tasks'
+import { useBoardTasks, useBoardTask, useUpdateTaskStatus } from '@/hooks/use-board-tasks'
 import { useAssignableAgents } from '@/hooks/use-agent-api'
 import { BoardTaskViewer } from '@/components/activity/board/board-task-viewer'
 import type { BoardTask, BoardStatus } from '@/types/board'
@@ -77,6 +78,19 @@ export function BoardTab() {
   const updateStatus = useUpdateTaskStatus()
 
   const allTasks = useMemo(() => columns.flatMap((c) => c.tasks), [columns])
+
+  // Deep link: ?task_id=123 (the calendar's "Open on board", notifications).
+  // Fetched by id so the search/agent/priority filters can't hide the card
+  // from the link. Opens once per id.
+  const deepLinkTaskId = useSearchParams().get('task_id')
+  const { data: deepLinkedTask } = useBoardTask(deepLinkTaskId)
+  const openedDeepLink = useRef<string | null>(null)
+  useEffect(() => {
+    if (!deepLinkTaskId || !deepLinkedTask || openedDeepLink.current === deepLinkTaskId) return
+    openedDeepLink.current = deepLinkTaskId
+    setOpenTask(deepLinkedTask)
+    setViewerOpen(true)
+  }, [deepLinkTaskId, deepLinkedTask])
 
   const handleDragEnd = (result: DropResult) => {
     if (!result.destination) return

--- a/frontend/components/command-center/calendar-actions.ts
+++ b/frontend/components/command-center/calendar-actions.ts
@@ -1,0 +1,102 @@
+/**
+ * What a click on a calendar event can do — one pure function so the menu
+ * wiring in CalendarTab stays thin and the rules are unit-testable.
+ *
+ * Every action rides an endpoint or route that already exists:
+ *   routine   → the agent page, or pause the heartbeat (PATCH /api/heartbeat/{agent}/toggle)
+ *   task      → pause / cancel the scheduled task (PATCH /api/v1/scheduled-tasks/{id}/status)
+ *   recipe    → the playbook in the Assignments hub
+ *   mission   → the mission page
+ *   task_due  → the board, with the card opened (?task_id=)
+ */
+
+import type { ScheduleItem } from '@/hooks/use-activity-api'
+import type { ScheduledTaskStatus } from '@/hooks/use-scheduled-tasks-api'
+
+export interface EventAction {
+  label: string
+  run: () => void
+  tone?: 'default' | 'danger'
+}
+
+export interface EventActionDeps {
+  navigate: (href: string) => void
+  pauseRoutine: (agentId: number) => void
+  setScheduledTaskStatus: (taskId: number, status: ScheduledTaskStatus) => void
+}
+
+/** Deadline items (mission / board-task SLA) are due times, not runs. */
+export function isDeadlineItem(item: Pick<ScheduleItem, 'type'>): boolean {
+  return item.type === 'mission' || item.type === 'task_due'
+}
+
+export function agentHref(agentId: number): string {
+  return `/agents?agent=${agentId}`
+}
+
+export function boardTaskHref(boardTaskId: number): string {
+  return `/command-center?tab=board&task_id=${boardTaskId}`
+}
+
+export function playbookHref(playbookId: number): string {
+  return `/assignments?tab=playbooks&id=${playbookId}`
+}
+
+export function missionHref(missionId: number): string {
+  return `/missions/${missionId}`
+}
+
+const ACTIVITY_FALLBACK_HREF = '/command-center?tab=activity'
+
+export function buildEventActions(item: ScheduleItem, deps: EventActionDeps): EventAction[] {
+  const actions: EventAction[] = []
+  const agentId = item.agent_id
+  const openAgent: EventAction | null =
+    agentId != null ? { label: 'Open agent', run: () => deps.navigate(agentHref(agentId)) } : null
+
+  switch (item.type) {
+    case 'routine':
+      if (openAgent) actions.push(openAgent)
+      if (agentId != null) {
+        actions.push({ label: 'Pause routine', run: () => deps.pauseRoutine(agentId) })
+      }
+      break
+    case 'task': {
+      const taskId = item.scheduled_task_id
+      if (taskId != null) {
+        actions.push({ label: 'Pause', run: () => deps.setScheduledTaskStatus(taskId, 'paused') })
+        actions.push({
+          label: 'Cancel',
+          tone: 'danger',
+          run: () => deps.setScheduledTaskStatus(taskId, 'cancelled'),
+        })
+      }
+      if (openAgent) actions.push(openAgent)
+      break
+    }
+    case 'recipe':
+      if (item.playbook_id != null) {
+        const playbookId = item.playbook_id
+        actions.push({ label: 'Open playbook', run: () => deps.navigate(playbookHref(playbookId)) })
+      }
+      break
+    case 'mission':
+      if (item.mission_id != null) {
+        const missionId = item.mission_id
+        actions.push({ label: 'Open mission', run: () => deps.navigate(missionHref(missionId)) })
+      }
+      break
+    case 'task_due':
+      if (item.board_task_id != null) {
+        const boardTaskId = item.board_task_id
+        actions.push({ label: 'Open on board', run: () => deps.navigate(boardTaskHref(boardTaskId)) })
+      }
+      if (openAgent) actions.push(openAgent)
+      break
+  }
+
+  if (actions.length === 0) {
+    actions.push({ label: 'Open activity', run: () => deps.navigate(ACTIVITY_FALLBACK_HREF) })
+  }
+  return actions
+}

--- a/frontend/components/command-center/calendar-tab.tsx
+++ b/frontend/components/command-center/calendar-tab.tsx
@@ -1,17 +1,28 @@
 'use client'
 
 /**
- * CalendarTab — Studio calendar for scheduled routines.
+ * CalendarTab — Studio calendar for scheduled work.
  *
  * Three real view modes (all wired):
  *  - Day: single column for the selected day, hour-by-hour
  *  - Week: 7 columns (Sun–Sat), hour-by-hour (default)
  *  - Month: classic 6×7 grid with event chips per day
  *
- * Events come from `useActivitySchedule`. Always-on heartbeats from
- * `useHeartbeats()` render in a band above week/day views. Events are
- * clickable — clicking routes to the assigned agent's detail page so the
- * user can inspect / pause / tune the routine.
+ * ONE data source: `useActivitySchedule` (GET /api/activity/schedule), the
+ * DB-first feed PRD-162 made identical on every worker. It carries five kinds
+ * of item (see ScheduleItemType): heartbeat routines with a structured
+ * recurrence, cron playbooks, agent-scheduled tasks, mission SLA deadlines and
+ * board-task SLA deadlines. The always-on band and the grid's routine rows are
+ * built from the routine items' `recurrence.interval_minutes` — NOT from
+ * /api/heartbeat/workspace, which sits behind the PRD-143 router-wide
+ * super-admin lock (a 403 for every other user, polled every 30s) and read
+ * `next_run_at` from the one worker that hosts APScheduler (null on the others,
+ * so routines anchored at "now" and shifted on every refresh).
+ *
+ * Events are actionable: clicking one opens a small menu — open the agent /
+ * playbook / mission / board card, pause a routine, pause or cancel a
+ * scheduled task. Every action rides an endpoint that already exists (see
+ * calendar-actions.ts). Deadline items carry a DUE tag; overdue ones go amber.
  *
  * Prev / Today / Next actually move the visible window. No speculative
  * "Schedule task" / "Filter" / "Export" CTAs — those don't belong on a
@@ -24,12 +35,29 @@
  * the classic Command Centre renders the grid as a stack of unstyled divs.
  */
 
-import { useMemo, useState } from 'react'
+import { useMemo, useState, type ReactNode } from 'react'
 import { useRouter } from 'next/navigation'
 import { ChevronLeft, ChevronRight, Zap } from 'lucide-react'
-import { useActivitySchedule, useSchedulerHealth } from '@/hooks/use-activity-api'
-import { useHeartbeats } from '@/hooks/use-heartbeats-api'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import {
+  useActivitySchedule,
+  useSchedulerHealth,
+  type ScheduleItem,
+} from '@/hooks/use-activity-api'
+import { useToggleHeartbeat } from '@/hooks/use-heartbeats-api'
+import { useUpdateScheduledTaskStatus } from '@/hooks/use-scheduled-tasks-api'
 import { toneFor } from './agent-tones'
+import {
+  buildEventActions,
+  isDeadlineItem,
+  type EventAction,
+  type EventActionDeps,
+} from './calendar-actions'
 
 type ViewMode = 'day' | 'week' | 'month'
 
@@ -37,6 +65,18 @@ const HOUR_PX = 44
 const START_HR = 0
 const END_HR = 22
 const HOURS = Array.from({ length: END_HR - START_HR + 1 }, (_, i) => i + START_HR)
+/** Routines more frequent than this stay in the always-on band: on the grid
+ *  they would clutter every column. */
+const GRID_MIN_INTERVAL_MIN = 30
+/** Routines at least this frequent are summarised in the always-on band. */
+const BAND_MAX_INTERVAL_MIN = 60
+/** Safety cap per item so a frequent routine can't run away across a month. */
+const MAX_OCCURRENCES = 200
+const ROUTINE_MIN_DUR_MIN = 15
+const ROUTINE_MAX_DUR_MIN = 45
+const RECURRING_DUR_MIN = 20
+const SINGLE_DUR_MIN = 15
+const OVERDUE_TONE = 'hsl(45 80% 55%)'
 
 interface DayCell {
   short: string
@@ -54,11 +94,19 @@ interface CalEvent {
   durMin: number
   name: string
   agent: string | null
-  agentId: number | null
   dayKey: string
   date: Date
+  /** the feed item behind this occurrence — the event menu acts on it */
+  item: ScheduleItem
   /** true when this event is a synthesised recurrence (not the literal next_run_at) */
   recurring?: boolean
+  /** an SLA deadline (mission or board task), not a run */
+  due?: boolean
+}
+
+interface WindowSpan {
+  start: Date
+  end: Date
 }
 
 /**
@@ -130,34 +178,25 @@ function addDays(d: Date, n: number): Date {
   return out
 }
 
+function toDayCell(d: Date): DayCell {
+  return {
+    short: d.toLocaleDateString('en-GB', { weekday: 'short' }).toUpperCase(),
+    iso: d.toISOString().slice(0, 10),
+    n: d.getDate(),
+    month: d.getMonth(),
+    today: d.toDateString() === new Date().toDateString(),
+    date: d,
+  }
+}
+
 function buildWeek(anchor: Date): DayCell[] {
   const sun = startOfWeek(anchor)
-  return Array.from({ length: 7 }, (_, i) => {
-    const d = addDays(sun, i)
-    return {
-      short: d.toLocaleDateString('en-GB', { weekday: 'short' }).toUpperCase(),
-      iso: d.toISOString().slice(0, 10),
-      n: d.getDate(),
-      month: d.getMonth(),
-      today: d.toDateString() === new Date().toDateString(),
-      date: d,
-    }
-  })
+  return Array.from({ length: 7 }, (_, i) => toDayCell(addDays(sun, i)))
 }
 
 function buildMonthGrid(anchor: Date): DayCell[] {
   const start = startOfMonthGrid(anchor)
-  return Array.from({ length: 42 }, (_, i) => {
-    const d = addDays(start, i)
-    return {
-      short: d.toLocaleDateString('en-GB', { weekday: 'short' }).toUpperCase(),
-      iso: d.toISOString().slice(0, 10),
-      n: d.getDate(),
-      month: d.getMonth(),
-      today: d.toDateString() === new Date().toDateString(),
-      date: d,
-    }
-  })
+  return Array.from({ length: 42 }, (_, i) => toDayCell(addDays(start, i)))
 }
 
 /** Relative "in 12m / in 3h / in 2d" label for the Next Up list. */
@@ -173,6 +212,133 @@ function formatNextRun(iso: string | null): string {
   return `in ${Math.round(hrs / 24)}d`
 }
 
+function occurrence(item: ScheduleItem, d: Date, durMin: number, recurring: boolean): CalEvent {
+  return {
+    id: `${item.id}-${d.getTime()}`,
+    hour: d.getHours(),
+    min: d.getMinutes(),
+    durMin,
+    name: item.name,
+    agent: item.agent_name,
+    dayKey: d.toDateString(),
+    date: d,
+    item,
+    recurring,
+    due: isDeadlineItem(item),
+  }
+}
+
+/** Walk an interval backwards and forwards from its anchor across the window. */
+function expandInterval(
+  item: ScheduleItem,
+  anchor: Date,
+  intervalMin: number,
+  span: WindowSpan,
+  durMin: number,
+): CalEvent[] {
+  const out: CalEvent[] = []
+  const step = intervalMin * 60_000
+  let count = 0
+  let t = anchor.getTime()
+  while (t >= span.start.getTime() && count < MAX_OCCURRENCES) {
+    if (t <= span.end.getTime()) {
+      out.push(occurrence(item, new Date(t), durMin, true))
+      count++
+    }
+    t -= step
+  }
+  t = anchor.getTime() + step
+  while (t <= span.end.getTime() && count < MAX_OCCURRENCES) {
+    if (t >= span.start.getTime()) {
+      out.push(occurrence(item, new Date(t), durMin, true))
+      count++
+    }
+    t += step
+  }
+  return out
+}
+
+/** Every occurrence of one feed item inside the window. */
+function expandItem(item: ScheduleItem, span: WindowSpan): CalEvent[] {
+  if (item.type === 'routine') {
+    // Structured recurrence from the feed — no string parsing. Sub-30-minute
+    // routines live in the always-on band only; a routine with no next run
+    // (outside its active hours for the whole horizon) has nothing to place.
+    const interval = item.recurrence?.interval_minutes ?? null
+    if (interval === null || interval < GRID_MIN_INTERVAL_MIN || !item.next_run_at) return []
+    const dur = Math.min(Math.max(interval, ROUTINE_MIN_DUR_MIN), ROUTINE_MAX_DUR_MIN)
+    return expandInterval(item, new Date(item.next_run_at), interval, span, dur)
+  }
+
+  const interval = parseIntervalMinutes(item.frequency)
+  if (interval !== null && interval > 60) {
+    const anchorDate = item.next_run_at ? new Date(item.next_run_at) : new Date()
+    return expandInterval(item, anchorDate, interval, span, RECURRING_DUR_MIN)
+  }
+
+  // Cron with day-of-week + hour fields (e.g. "0 9 * * 1-5") — an event on
+  // every matching day in the window.
+  const dow = cronDaysOfWeek(item.frequency)
+  const cronHm = cronHourMin(item.frequency)
+  if (dow && cronHm) {
+    const out: CalEvent[] = []
+    for (let i = 0; i < 42; i++) {
+      const d = addDays(span.start, i)
+      if (d > span.end) break
+      if (!dow.includes(d.getDay())) continue
+      d.setHours(cronHm.h, cronHm.m, 0, 0)
+      out.push(occurrence(item, new Date(d), RECURRING_DUR_MIN, true))
+    }
+    return out
+  }
+
+  // Single occurrence at next_run_at (one-shot tasks, SLA deadlines).
+  if (item.next_run_at) {
+    const d = new Date(item.next_run_at)
+    if (d >= span.start && d <= span.end) return [occurrence(item, d, SINGLE_DUR_MIN, false)]
+  }
+  return []
+}
+
+function EventMenu({ actions, children }: { actions: EventAction[]; children: ReactNode }) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>{children}</DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="min-w-[180px]">
+        {actions.map((a) => (
+          <DropdownMenuItem
+            key={a.label}
+            onSelect={() => a.run()}
+            className={a.tone === 'danger' ? 'text-destructive focus:text-destructive' : undefined}
+          >
+            {a.label}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+function DueTag({ overdue }: { overdue: boolean }) {
+  const tone = overdue ? 'hsl(var(--destructive))' : OVERDUE_TONE
+  return (
+    <span
+      className="due"
+      style={{
+        marginLeft: 6,
+        padding: '0 4px',
+        borderRadius: 3,
+        fontWeight: 700,
+        letterSpacing: 0.4,
+        background: overdue ? 'hsl(var(--destructive) / 0.15)' : 'hsl(45 80% 55% / 0.18)',
+        color: tone,
+      }}
+    >
+      {overdue ? 'OVERDUE' : 'DUE'}
+    </span>
+  )
+}
+
 export function CalendarTab() {
   const router = useRouter()
   const [mode, setMode] = useState<ViewMode>('week')
@@ -180,8 +346,18 @@ export function CalendarTab() {
 
   const range = mode === 'month' ? '30d' : '7d'
   const { data: schedule, isLoading, isError, refetch } = useActivitySchedule(range)
-  const { data: heartbeats } = useHeartbeats()
   const { data: health } = useSchedulerHealth()
+  const { mutate: toggleHeartbeat } = useToggleHeartbeat()
+  const { mutate: updateScheduledTask } = useUpdateScheduledTaskStatus()
+
+  const actionDeps = useMemo<EventActionDeps>(
+    () => ({
+      navigate: (href) => router.push(href as any),
+      pauseRoutine: (agentId) => toggleHeartbeat(agentId),
+      setScheduledTaskStatus: (taskId, status) => updateScheduledTask({ taskId, status }),
+    }),
+    [router, toggleHeartbeat, updateScheduledTask],
+  )
 
   const week = useMemo(() => buildWeek(anchor), [anchor])
   const monthCells = useMemo(() => buildMonthGrid(anchor), [anchor])
@@ -200,26 +376,13 @@ export function CalendarTab() {
       .slice(0, 6)
   }, [schedule])
 
-  const visibleDays = useMemo<DayCell[]>(() => {
-    if (mode === 'day') {
-      return [
-        {
-          short: anchor
-            .toLocaleDateString('en-GB', { weekday: 'short' })
-            .toUpperCase(),
-          iso: anchor.toISOString().slice(0, 10),
-          n: anchor.getDate(),
-          month: anchor.getMonth(),
-          today: anchor.toDateString() === new Date().toDateString(),
-          date: new Date(anchor),
-        },
-      ]
-    }
-    return week
-  }, [mode, anchor, week])
+  const visibleDays = useMemo<DayCell[]>(
+    () => (mode === 'day' ? [toDayCell(new Date(anchor))] : week),
+    [mode, anchor, week],
+  )
 
   // Window covered by the current view (used to expand recurring events).
-  const windowSpan = useMemo(() => {
+  const windowSpan = useMemo<WindowSpan>(() => {
     if (mode === 'day') {
       const start = new Date(anchor)
       start.setHours(0, 0, 0, 0)
@@ -240,196 +403,25 @@ export function CalendarTab() {
     return { start, end }
   }, [mode, anchor])
 
-  const events = useMemo<CalEvent[]>(() => {
-    const out: CalEvent[] = []
-    const MAX_OCCURRENCES = 200 // safety cap so a 5-min heartbeat doesn't run away
+  const events = useMemo<CalEvent[]>(
+    () => (schedule?.scheduled ?? []).flatMap((item) => expandItem(item, windowSpan)),
+    [schedule, windowSpan],
+  )
 
-    // Pass 1: heartbeats (routines). Use structured interval_minutes — no
-    // string parsing — and expand across the visible window.
-    if (heartbeats?.heartbeats) {
-      heartbeats.heartbeats
-        .filter((h) => h.enabled)
-        .forEach((h) => {
-          const interval = h.interval_minutes
-          // Sub-30min heartbeats are summarised in the always-on band only.
-          // Putting them on the grid would clutter every column.
-          if (interval < 30) return
-          const anchorDate = h.next_run_at
-            ? new Date(h.next_run_at)
-            : new Date()
-          const name = `${h.agent_name} routine`
-          let count = 0
-          // Walk back
-          let t = anchorDate.getTime()
-          while (t >= windowSpan.start.getTime() && count < MAX_OCCURRENCES) {
-            if (t <= windowSpan.end.getTime()) {
-              const d = new Date(t)
-              out.push({
-                id: `hb-${h.id}-${t}`,
-                hour: d.getHours(),
-                min: d.getMinutes(),
-                durMin: Math.min(Math.max(interval, 15), 45),
-                name,
-                agent: h.agent_name,
-                agentId: h.agent_id,
-                dayKey: d.toDateString(),
-                date: d,
-                recurring: true,
-              })
-              count++
-            }
-            t -= interval * 60_000
-          }
-          // Walk forward
-          t = anchorDate.getTime() + interval * 60_000
-          while (t <= windowSpan.end.getTime() && count < MAX_OCCURRENCES) {
-            if (t >= windowSpan.start.getTime()) {
-              const d = new Date(t)
-              out.push({
-                id: `hb-${h.id}-${t}`,
-                hour: d.getHours(),
-                min: d.getMinutes(),
-                durMin: Math.min(Math.max(interval, 15), 45),
-                name,
-                agent: h.agent_name,
-                agentId: h.agent_id,
-                dayKey: d.toDateString(),
-                date: d,
-                recurring: true,
-              })
-              count++
-            }
-            t += interval * 60_000
-          }
-        })
-    }
-
-    // Pass 2: items from the schedule endpoint that aren't heartbeats
-    // (recipes / one-offs). Fall through if next_run_at is in window.
-    if (!schedule?.scheduled) return out
-    schedule.scheduled.forEach((s, idx) => {
-      // Skip routine items — heartbeats already cover those above and
-      // contain structured interval data we don't need to re-parse.
-      if (s.type === 'routine') return
-
-      const interval = parseIntervalMinutes(s.frequency)
-      const dow = cronDaysOfWeek(s.frequency)
-      const cronHm = cronHourMin(s.frequency)
-
-      if (interval !== null && interval > 60) {
-        // Anchor at next_run_at and walk backwards + forwards across window.
-        const anchorDate = s.next_run_at ? new Date(s.next_run_at) : new Date()
-        // Walk back
-        let t = anchorDate.getTime()
-        while (t > windowSpan.start.getTime() - 1) {
-          if (t <= windowSpan.end.getTime()) {
-            const d = new Date(t)
-            out.push({
-              id: `${s.id}-${t}`,
-              hour: d.getHours(),
-              min: d.getMinutes(),
-              durMin: 20,
-              name: s.name,
-              agent: s.agent_name,
-              agentId: s.agent_id,
-              dayKey: d.toDateString(),
-              date: d,
-              recurring: true,
-            })
-          }
-          t -= interval * 60_000
-        }
-        // Walk forward
-        t = anchorDate.getTime() + interval * 60_000
-        while (t < windowSpan.end.getTime() + 1) {
-          if (t >= windowSpan.start.getTime()) {
-            const d = new Date(t)
-            out.push({
-              id: `${s.id}-${t}`,
-              hour: d.getHours(),
-              min: d.getMinutes(),
-              durMin: 20,
-              name: s.name,
-              agent: s.agent_name,
-              agentId: s.agent_id,
-              dayKey: d.toDateString(),
-              date: d,
-              recurring: true,
-            })
-          }
-          t += interval * 60_000
-        }
-        return
-      }
-
-      // Cron with day-of-week + hour fields (e.g. "0 9 * * 1-5") — render
-      // an event on every matching day in the window.
-      if (dow && cronHm) {
-        for (let i = 0; i < 42; i++) {
-          const d = addDays(windowSpan.start, i)
-          if (d > windowSpan.end) break
-          if (!dow.includes(d.getDay())) continue
-          d.setHours(cronHm.h, cronHm.m, 0, 0)
-          out.push({
-            id: `${s.id}-${d.toISOString()}`,
-            hour: cronHm.h,
-            min: cronHm.m,
-            durMin: 20,
-            name: s.name,
-            agent: s.agent_name,
-            agentId: s.agent_id,
-            dayKey: d.toDateString(),
-            date: new Date(d),
-            recurring: true,
-          })
-        }
-        return
-      }
-
-      // Fallback: single occurrence at next_run_at when we can't parse
-      // anything else. Better than nothing — the user still sees something.
-      if (s.next_run_at) {
-        const d = new Date(s.next_run_at)
-        if (d >= windowSpan.start && d <= windowSpan.end) {
-          out.push({
-            id: `${s.id}-${idx}`,
-            hour: d.getHours(),
-            min: d.getMinutes(),
-            durMin: 15,
-            name: s.name,
-            agent: s.agent_name,
-            agentId: s.agent_id,
-            dayKey: d.toDateString(),
-            date: d,
-          })
-        }
-      }
-    })
-    return out
-  }, [schedule, windowSpan, heartbeats])
-
-  const alwaysOn = useMemo(() => {
-    if (!heartbeats?.heartbeats) return []
-    return heartbeats.heartbeats
-      .filter((h) => h.enabled && h.interval_minutes <= 60)
-      .map((h) => ({
-        id: h.id,
-        name: `${h.agent_name} · every ${h.interval_minutes}m`,
-        agent: h.agent_name,
-      }))
-  }, [heartbeats])
+  // Routines frequent enough to summarise rather than plot, from the same feed.
+  const alwaysOn = useMemo(
+    () =>
+      (schedule?.scheduled ?? []).filter(
+        (s) =>
+          s.type === 'routine' &&
+          (s.recurrence?.interval_minutes ?? Number.POSITIVE_INFINITY) <= BAND_MAX_INTERVAL_MIN,
+      ),
+    [schedule],
+  )
 
   const now = new Date()
   const nowHourPos =
     (now.getHours() - START_HR) * HOUR_PX + (now.getMinutes() / 60) * HOUR_PX
-
-  const handleEventClick = (evt: CalEvent) => {
-    if (evt.agentId) {
-      router.push(`/agents?agent=${evt.agentId}` as any)
-    } else {
-      router.push('/command-center?tab=activity' as any)
-    }
-  }
 
   const shiftAnchor = (direction: -1 | 0 | 1) => {
     if (direction === 0) {
@@ -541,7 +533,7 @@ export function CalendarTab() {
             border: '1px solid hsl(45 80% 55% / 0.4)',
             borderRadius: 8,
             background: 'hsl(45 80% 55% / 0.08)',
-            color: 'hsl(45 80% 55%)',
+            color: OVERDUE_TONE,
           }}
         >
           <Zap style={{ width: 12, height: 12 }} />
@@ -565,21 +557,24 @@ export function CalendarTab() {
       {mode !== 'month' && alwaysOn.length > 0 && (
         <div className="cc-cal-alwayson">
           <div className="lbl">
-            <Zap style={{ width: 12, height: 12, color: 'hsl(45 80% 55%)' }} />
+            <Zap style={{ width: 12, height: 12, color: OVERDUE_TONE }} />
             24/7
           </div>
           <div className="pills">
-            {alwaysOn.map((p) => {
-              const tone = toneFor(p.agent)
+            {alwaysOn.map((s) => {
+              const tone = toneFor(s.agent_name)
               return (
-                <span
-                  key={p.id}
-                  className="pill"
-                  style={{ borderLeftColor: tone.bg }}
-                >
-                  <span className="dot" />
-                  {p.name}
-                </span>
+                <EventMenu key={s.id} actions={buildEventActions(s, actionDeps)}>
+                  <button
+                    type="button"
+                    className="pill"
+                    style={{ borderLeftColor: tone.bg, cursor: 'pointer' }}
+                    title={`${s.agent_name} routine — click for actions`}
+                  >
+                    <span className="dot" />
+                    {s.agent_name} · every {s.recurrence?.interval_minutes}m
+                  </button>
+                </EventMenu>
               )
             })}
           </div>
@@ -616,7 +611,8 @@ export function CalendarTab() {
             const overdue = item.next_run_at
               ? new Date(item.next_run_at).getTime() < Date.now()
               : false
-            const accent = overdue ? 'hsl(45 80% 55%)' : 'hsl(var(--muted-foreground))'
+            const accent = overdue ? OVERDUE_TONE : 'hsl(var(--muted-foreground))'
+            const due = isDeadlineItem(item)
             return (
               <span
                 key={item.id}
@@ -627,7 +623,7 @@ export function CalendarTab() {
                 />
                 <span style={{ fontWeight: 500 }}>{item.name}</span>
                 <span style={{ color: accent }}>
-                  {overdue ? 'overdue' : formatNextRun(item.next_run_at)}
+                  {overdue ? (due ? 'overdue' : 'missed') : `${due ? 'due ' : ''}${formatNextRun(item.next_run_at)}`}
                 </span>
               </span>
             )
@@ -640,7 +636,7 @@ export function CalendarTab() {
           cells={monthCells}
           events={events}
           anchorMonth={anchor.getMonth()}
-          onEventClick={handleEventClick}
+          actionDeps={actionDeps}
         />
       ) : (
         <div className="cc-cal-frame">
@@ -708,31 +704,33 @@ export function CalendarTab() {
                       (evt.min / 60) * HOUR_PX
                     const height = Math.max((evt.durMin / 60) * HOUR_PX, 28)
                     const tone = toneFor(evt.agent)
+                    const overdue = Boolean(evt.due) && evt.date.getTime() < Date.now()
                     return (
-                      <button
-                        key={evt.id}
-                        type="button"
-                        className="cc-cal-event"
-                        style={{
-                          top,
-                          height,
-                          borderLeftColor: tone.bg,
-                          background: 'hsl(var(--secondary))',
-                        }}
-                        title={`${evt.name} — click for agent details`}
-                        onClick={() => handleEventClick(evt)}
-                      >
-                        <div className="nm">
-                          {String(evt.hour).padStart(2, '0')}:
-                          {String(evt.min).padStart(2, '0')}
-                          {evt.agent && (
-                            <span style={{ marginLeft: 6, opacity: 0.85 }}>
-                              · {evt.agent}
-                            </span>
-                          )}
-                        </div>
-                        <div className="ttl">{evt.name}</div>
-                      </button>
+                      <EventMenu key={evt.id} actions={buildEventActions(evt.item, actionDeps)}>
+                        <button
+                          type="button"
+                          className="cc-cal-event"
+                          style={{
+                            top,
+                            height,
+                            borderLeftColor: overdue ? OVERDUE_TONE : tone.bg,
+                            background: 'hsl(var(--secondary))',
+                          }}
+                          title={`${evt.name} — click for actions`}
+                        >
+                          <div className="nm">
+                            {String(evt.hour).padStart(2, '0')}:
+                            {String(evt.min).padStart(2, '0')}
+                            {evt.agent && (
+                              <span style={{ marginLeft: 6, opacity: 0.85 }}>
+                                · {evt.agent}
+                              </span>
+                            )}
+                            {evt.due && <DueTag overdue={overdue} />}
+                          </div>
+                          <div className="ttl">{evt.name}</div>
+                        </button>
+                      </EventMenu>
                     )
                   })}
                   {d.today && (
@@ -749,7 +747,7 @@ export function CalendarTab() {
           {isLoading && events.length === 0 && (
             <div className="cc-panel-empty">Loading schedule…</div>
           )}
-          {!isLoading && events.length === 0 && alwaysOn.length === 0 && (
+          {!isLoading && !isError && events.length === 0 && alwaysOn.length === 0 && (
             <div className="cc-panel-empty">
               No scheduled work in this window. Enable a heartbeat in /agents
               to populate the calendar.
@@ -765,12 +763,12 @@ function MonthGrid({
   cells,
   events,
   anchorMonth,
-  onEventClick,
+  actionDeps,
 }: {
   cells: DayCell[]
   events: CalEvent[]
   anchorMonth: number
-  onEventClick: (e: CalEvent) => void
+  actionDeps: EventActionDeps
 }) {
   const todayStart = new Date()
   todayStart.setHours(0, 0, 0, 0)
@@ -799,21 +797,26 @@ function MonthGrid({
               <div className="evts">
                 {dayEvents.slice(0, 3).map((evt) => {
                   const tone = toneFor(evt.agent)
+                  const overdue = Boolean(evt.due) && evt.date.getTime() < Date.now()
                   return (
-                    <button
-                      key={evt.id}
-                      type="button"
-                      className="cc-cal-month-evt"
-                      style={{ borderLeftColor: tone.bg, opacity: past ? 0.5 : 1 }}
-                      onClick={() => onEventClick(evt)}
-                      title={evt.name}
-                    >
-                      <span className="t">
-                        {String(evt.hour).padStart(2, '0')}:
-                        {String(evt.min).padStart(2, '0')}
-                      </span>{' '}
-                      <span className="n2">{evt.name}</span>
-                    </button>
+                    <EventMenu key={evt.id} actions={buildEventActions(evt.item, actionDeps)}>
+                      <button
+                        type="button"
+                        className="cc-cal-month-evt"
+                        style={{
+                          borderLeftColor: overdue ? OVERDUE_TONE : tone.bg,
+                          opacity: past && !evt.due ? 0.5 : 1,
+                        }}
+                        title={evt.name}
+                      >
+                        <span className="t">
+                          {String(evt.hour).padStart(2, '0')}:
+                          {String(evt.min).padStart(2, '0')}
+                        </span>{' '}
+                        {evt.due && <DueTag overdue={overdue} />}{' '}
+                        <span className="n2">{evt.name}</span>
+                      </button>
+                    </EventMenu>
                   )
                 })}
                 {dayEvents.length > 3 && (

--- a/frontend/hooks/use-activity-api.ts
+++ b/frontend/hooks/use-activity-api.ts
@@ -89,15 +89,32 @@ export interface ScheduleRecurrence {
   active_hours: Record<string, unknown> | null
 }
 
+/**
+ * The five sources of the schedule feed (PRD-162 + the board-task SLA source):
+ * routine = agent heartbeat, recipe = cron playbook, task = agent-scheduled task,
+ * mission = a mission's SLA deadline, task_due = a board task's SLA deadline.
+ */
+export type ScheduleItemType = 'routine' | 'recipe' | 'task' | 'mission' | 'task_due'
+
 export interface ScheduleItem {
   id: string
   name: string
-  type: 'routine' | 'recipe' | 'task' | 'mission'
+  type: ScheduleItemType
   next_run_at: string | null
   frequency: string
   agent_name: string | null
   agent_id: number | null
   recurrence?: ScheduleRecurrence
+  /** The row behind the item, so the calendar can act on it (pause, cancel,
+   *  open) without parsing the composite `id`. Each source sets its own. */
+  scheduled_task_id?: number
+  task_type?: 'one_shot' | 'recurring'
+  mission_id?: number
+  playbook_id?: number
+  board_task_id?: number
+  /** task_due only: the board card's status and priority */
+  status?: string
+  priority?: string
 }
 
 export interface ScheduleResponse {

--- a/frontend/hooks/use-board-tasks.ts
+++ b/frontend/hooks/use-board-tasks.ts
@@ -30,9 +30,24 @@ interface BoardResponse {
 export const boardQueryKeys = {
   all: ['board'] as const,
   tasks: (filters?: any) => ['board', 'tasks', filters] as const,
+  task: (taskId: string) => ['board', 'task', taskId] as const,
 }
 
 // ============= HOOKS =============
+
+/**
+ * One board task by id (GET /api/v1/tasks/{id}) — for deep links such as the
+ * calendar's "Open on board" (?task_id=), which must open the card even when
+ * the loaded columns are filtered and don't contain it. Disabled without an id.
+ */
+export function useBoardTask(taskId: string | null) {
+  return useQuery<BoardTask>({
+    queryKey: boardQueryKeys.task(taskId ?? ''),
+    queryFn: async () => mapTaskToBoardTask(await apiClient.request<any>(`/api/v1/tasks/${taskId}`)),
+    enabled: Boolean(taskId),
+    staleTime: 30000,
+  })
+}
 
 /**
  * Fetch all board tasks from /api/v1/tasks and group into columns.

--- a/frontend/hooks/use-heartbeats-api.ts
+++ b/frontend/hooks/use-heartbeats-api.ts
@@ -124,6 +124,9 @@ export function useToggleHeartbeat() {
     onSuccess: (data) => {
       queryClient.invalidateQueries({ queryKey: heartbeatQueryKeys.all })
       queryClient.invalidateQueries({ queryKey: heartbeatQueryKeys.detail(data.agent_id) })
+      // The Command Centre calendar derives its routine rows from the schedule
+      // feed (not from this hook), so a pause/resume must refresh that too.
+      queryClient.invalidateQueries({ queryKey: ['activity', 'schedule'] })
       toast.success(data.message)
     },
     onError: (error) => {

--- a/frontend/hooks/use-scheduled-tasks-api.ts
+++ b/frontend/hooks/use-scheduled-tasks-api.ts
@@ -1,0 +1,54 @@
+/**
+ * Scheduled-task API hooks — the PRD-77 `agent_scheduled_tasks` rows the
+ * Command Centre calendar surfaces.
+ *
+ * PATCH /api/v1/scheduled-tasks/{id}/status pauses, resumes or cancels a task
+ * (all three are reversible: a cancelled task can be set active again). The
+ * calendar reads these rows through the schedule feed, so a successful change
+ * invalidates that feed rather than a scheduled-task list of its own.
+ */
+
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+import { apiClient } from '@/lib/api-client'
+import { activityQueryKeys } from './use-activity-api'
+
+export type ScheduledTaskStatus = 'active' | 'paused' | 'cancelled'
+
+export interface ScheduledTaskStatusResponse {
+  success: boolean
+  task_id: number
+  status: ScheduledTaskStatus
+}
+
+const STATUS_VERB: Record<ScheduledTaskStatus, string> = {
+  active: 'resumed',
+  paused: 'paused',
+  cancelled: 'cancelled',
+}
+
+/** The query-key prefix every schedule range shares (`['activity', 'schedule', range]`). */
+export const SCHEDULE_FEED_KEY = [...activityQueryKeys.all, 'schedule'] as const
+
+export function useUpdateScheduledTaskStatus() {
+  const queryClient = useQueryClient()
+
+  return useMutation<
+    ScheduledTaskStatusResponse,
+    Error,
+    { taskId: number; status: ScheduledTaskStatus }
+  >({
+    mutationFn: ({ taskId, status }) =>
+      apiClient.request<ScheduledTaskStatusResponse>(
+        `/api/v1/scheduled-tasks/${taskId}/status`,
+        { method: 'PATCH', body: JSON.stringify({ status }) },
+      ),
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: SCHEDULE_FEED_KEY })
+      toast.success(`Scheduled task #${data.task_id} ${STATUS_VERB[data.status]}`)
+    },
+    onError: (error) => {
+      toast.error(error.message || 'Could not update the scheduled task')
+    },
+  })
+}

--- a/orchestrator/modules/tools/discovery/actions_scheduling.py
+++ b/orchestrator/modules/tools/discovery/actions_scheduling.py
@@ -113,10 +113,12 @@ def register_scheduling_actions(registry: ActionRegistry) -> None:
         name="platform_get_schedule",
         description=(
             "Show everything scheduled in the workspace right now — agent heartbeat "
-            "routines, cron-scheduled playbooks, and scheduled tasks — each with its "
-            "next run time. This is the same source of truth the calendar shows. Use "
-            "when asked 'what's scheduled?', 'what runs next?', or to review what "
-            "automations are set up."
+            "routines, cron-scheduled playbooks, scheduled tasks, and the SLA "
+            "deadlines on open missions and board tasks — each with its next run "
+            "or due time (a past due time on an open item means it is overdue). "
+            "This is the same source of truth the calendar shows. Use when asked "
+            "'what's scheduled?', 'what runs next?', 'what is due?', or to review "
+            "what automations are set up."
         ),
         category="scheduling",
         parameters={

--- a/orchestrator/services/activity_service.py
+++ b/orchestrator/services/activity_service.py
@@ -26,6 +26,11 @@ from core.models.core import (
 )
 from services.schedule_util import interval_to_cron, is_valid_cron, next_run
 
+# Board tasks in these states are closed: their SLA deadline is history, not a
+# due time the calendar should show. Mirrors api.board_tasks.VALID_STATUSES.
+_BOARD_CLOSED_STATUSES = ("done", "failed", "cancelled")
+_BOARD_CLOSED_SQL = ", ".join(f"'{status}'" for status in _BOARD_CLOSED_STATUSES)
+
 logger = logging.getLogger(__name__)
 
 
@@ -782,6 +787,7 @@ class ActivityService:
             self._playbook_cron_items,
             self._scheduled_task_items,
             self._mission_sla_items,
+            self._board_task_sla_items,
         ):
             try:
                 items.extend(source(now, horizon))
@@ -856,6 +862,7 @@ class ActivityService:
             goal = ((row.goal or "").strip() or "Mission").splitlines()[0]
             items.append({
                 "id": f"mission-{row.id}",
+                "mission_id": row.id,
                 "name": goal[:80],
                 "type": "mission",
                 "next_run_at": deadline.isoformat(),
@@ -938,6 +945,7 @@ class ActivityService:
                 continue
             items.append({
                 "id": f"recipe-{tpl.id}",
+                "playbook_id": tpl.id,
                 "name": tpl.name,
                 "type": "recipe",
                 "next_run_at": nxt.isoformat(),
@@ -978,6 +986,8 @@ class ActivityService:
             label = (row.description or row.task_type or "Scheduled task").strip()
             items.append({
                 "id": f"task-{row.id}",
+                "scheduled_task_id": row.id,
+                "task_type": row.task_type,
                 "name": label[:80],
                 "type": "task",
                 "next_run_at": nxt.isoformat(),
@@ -986,6 +996,57 @@ class ActivityService:
                 "agent_id": None,
                 "recurrence": {
                     "cron_expression": cron,
+                    "interval_minutes": None,
+                    "timezone": "UTC",
+                    "active_hours": None,
+                },
+            })
+        return items
+
+    def _board_task_sla_items(
+        self, now: datetime, horizon: datetime
+    ) -> List[Dict[str, Any]]:
+        """Board-task SLA deadlines — ONE query over open tasks with a deadline.
+
+        Every board task carries an ``sla_deadline`` (stamped from its priority at
+        creation, or set explicitly by ``platform_create_task``) and the board
+        card shows it, but until now the calendar never did. Same rule as the
+        mission SLA source: a past deadline on a still-open task is included as
+        overdue (the frontend styles past-due items distinctly); a deadline past
+        the horizon is not."""
+        rows = self.db.execute(
+            text(
+                f"""
+                SELECT t.id, t.title, t.status, t.priority, t.sla_deadline,
+                       t.assigned_agent_id, a.name AS agent_name
+                FROM board_tasks t
+                LEFT JOIN agents a ON a.id = t.assigned_agent_id
+                WHERE t.workspace_id = :ws
+                  AND t.sla_deadline IS NOT NULL
+                  AND t.status NOT IN ({_BOARD_CLOSED_SQL})
+                """
+            ),
+            {"ws": self._ws_str},
+        ).fetchall()
+        items: List[Dict[str, Any]] = []
+        for row in rows:
+            deadline = _as_utc(row.sla_deadline)
+            if deadline is None or deadline > horizon:
+                continue
+            title = (row.title or "").strip() or "Task"
+            items.append({
+                "id": f"board-{row.id}",
+                "board_task_id": row.id,
+                "name": title[:80],
+                "type": "task_due",
+                "next_run_at": deadline.isoformat(),
+                "frequency": "SLA deadline",
+                "agent_name": row.agent_name,
+                "agent_id": row.assigned_agent_id,
+                "status": row.status,
+                "priority": row.priority,
+                "recurrence": {
+                    "cron_expression": None,
                     "interval_minutes": None,
                     "timezone": "UTC",
                     "active_hours": None,

--- a/orchestrator/tests/test_schedule_endpoint.py
+++ b/orchestrator/tests/test_schedule_endpoint.py
@@ -133,11 +133,13 @@ class _FakeScheduleDB:
     calls so a test can prove there is no per-row N+1.
     """
 
-    def __init__(self, agents=None, templates=None, tasks=None, missions=None, raise_on_query=None):
+    def __init__(self, agents=None, templates=None, tasks=None, missions=None, board_tasks=None,
+                 raise_on_query=None):
         self._agents = agents or []
         self._templates = templates or []
         self._tasks = tasks or []
         self._missions = missions or []
+        self._board_tasks = board_tasks or []
         self._raise_on_query = raise_on_query
         self.query_calls = 0
         self.execute_calls = 0
@@ -151,9 +153,10 @@ class _FakeScheduleDB:
 
     def execute(self, stmt, params=None):
         self.execute_calls += 1
-        # get_schedule calls execute() in a fixed order: scheduled_tasks first,
-        # then mission SLAs.
-        rows = self._tasks if self.execute_calls == 1 else self._missions
+        # get_schedule calls execute() in a fixed order: scheduled_tasks, then
+        # mission SLAs, then board-task SLAs.
+        by_call = {1: self._tasks, 2: self._missions, 3: self._board_tasks}
+        rows = by_call.get(self.execute_calls, [])
         return _FakeResult(rows)
 
     def rollback(self):
@@ -200,7 +203,7 @@ def test_get_schedule_no_n_plus_one_at_scale():
     out = _svc(db).get_schedule(range_days=7)
     assert len(out["scheduled"]) == 200
     assert db.query_calls == 2      # agents + templates, regardless of row count
-    assert db.execute_calls == 2    # scheduled tasks + mission SLAs (one each)
+    assert db.execute_calls == 3    # scheduled tasks + mission SLAs + board SLAs (one each)
 
 
 @_needs_croniter
@@ -265,9 +268,63 @@ def test_get_schedule_includes_mission_sla_deadlines():
     out = _svc(db).get_schedule(range_days=30)
     mission = next(i for i in out["scheduled"] if i["type"] == "mission")
     assert mission["id"] == "mission-7"
+    assert mission["mission_id"] == 7  # explicit id: the calendar's 'Open mission' action
     assert mission["name"] == "Ship PRD-162"  # first line of the goal only
     assert mission["frequency"] == "SLA deadline"
     assert mission["next_run_at"] == soon.isoformat()
+
+
+# ── Board-task SLA deadlines (the 6th feed source) ─────────────────────────
+
+@_needs_croniter
+def test_get_schedule_includes_board_task_sla_deadlines():
+    """Open board tasks with an SLA deadline appear as 'task_due' items — the
+    same rule as missions: within the horizon, overdue included, closed never."""
+    from datetime import datetime, timezone, timedelta
+    now = datetime.now(timezone.utc).replace(microsecond=0)
+    soon = now + timedelta(hours=6)
+    overdue = now - timedelta(hours=3)
+    far = now + timedelta(days=90)
+    db = _FakeScheduleDB(
+        board_tasks=[
+            _Row(id=42, title="  Fix the calendar  ", status="assigned", priority="high",
+                 sla_deadline=soon, assigned_agent_id=3, agent_name="Ops"),
+            _Row(id=43, title="Stale inbox item", status="inbox", priority="medium",
+                 sla_deadline=overdue, assigned_agent_id=None, agent_name=None),
+            _Row(id=44, title="Next quarter", status="assigned", priority="low",
+                 sla_deadline=far, assigned_agent_id=None, agent_name=None),
+        ],
+    )
+    out = _svc(db).get_schedule(range_days=30)
+    due = {i["board_task_id"]: i for i in out["scheduled"] if i["type"] == "task_due"}
+    assert set(due) == {42, 43}  # 44 is past the horizon
+    assert due[42]["id"] == "board-42"
+    assert due[42]["name"] == "Fix the calendar"
+    assert due[42]["frequency"] == "SLA deadline"
+    assert due[42]["next_run_at"] == soon.isoformat()
+    assert due[42]["agent_name"] == "Ops" and due[42]["agent_id"] == 3
+    assert due[42]["status"] == "assigned" and due[42]["priority"] == "high"
+    assert due[43]["next_run_at"] == overdue.isoformat()  # overdue stays visible
+    assert db.execute_calls == 3
+
+
+def test_board_task_sla_source_only_reads_open_tasks():
+    """Closed tasks are excluded in SQL, not in Python — the query carries the
+    closed-status list, so a done task's deadline never reaches the calendar."""
+    from datetime import datetime, timezone
+    from services import activity_service as mod
+
+    class _CaptureDB(_FakeScheduleDB):
+        def execute(self, stmt, params=None):
+            self.last_sql = str(stmt)
+            return super().execute(stmt, params)
+
+    db = _CaptureDB()
+    now = datetime.now(timezone.utc)
+    _svc(db)._board_task_sla_items(now, now)
+    for status in mod._BOARD_CLOSED_STATUSES:
+        assert f"'{status}'" in db.last_sql
+    assert "sla_deadline IS NOT NULL" in db.last_sql
 
 
 def test_scheduler_health_returns_none_when_unknown():


### PR DESCRIPTION
Stacked on #710 (merge that first; GitHub retargets this to `main` when its branch is deleted).

## What changes for the user
- **The calendar works for every user, not just super admins.** The 24/7 band and routine rows came from `/api/heartbeat/workspace`, a router behind the PRD-143 router-wide super-admin lock. Railway logs (09-08) show it answering **403** in the same second the schedule answers 200, polled every 30 s. The feed's routine items already carry `recurrence.interval_minutes` and a worker-invariant `next_run_at`, so the calendar reads only the schedule feed now.
- **Routines stop shifting on refresh.** That endpoint's `next_run_at` came from the in-process APScheduler on one of four workers; the other three returned null and the grid anchored every routine at "now".
- **Board-task SLA deadlines are on the calendar** (5th source, one query over open tasks). They appear as `DUE` events (`OVERDUE` once past) and in Next Up, same rule as mission SLAs.
- **Events are actionable.** Click one for a menu: open agent / pause routine, pause / cancel a scheduled task, open playbook, open mission, open the board card. Every action rides an existing endpoint.
- **`?task_id=` deep links open the card** on both board views, fetched by id so filters can't hide it.
- `platform_get_schedule` now describes deadlines, so Auto answers "what is due?" from the same feed.

## Latency evidence (thin, stated as such)
Today's Railway window holds one full user page-load: preflight-to-response gap `/api/activity/schedule` ≈ 1.0 s, `/scheduler-health` ≈ 0.19 s; the heartbeat poll was a 403 every 30 s. Removing that poll is the measurable change here; the schedule read itself is unchanged.

## Known limit (unchanged)
The heartbeat pause rides the super-admin-locked heartbeat router, so a non-super-admin sees the 403 as a toast. Relaxing PRD-143's lock is a product decision, not taken here.

## Test plan
- [ ] `orchestrator` tests: `test_schedule_endpoint.py` (5th source, ids, SQL excludes closed statuses, execute-call count).
- [ ] `frontend` vitest: `calendar-actions.test.ts` (menu per item kind + routes), `calendar-tab-feed.test.tsx` (band vs grid from recurrence, DUE event, no heartbeat endpoint), `calendar-tab-scope.test.tsx`.
- [ ] Railway, dark + studio: calendar shows routines without a 403 in the network tab; a board task's deadline shows as DUE; clicking it opens the card on the board.
