### PR TITLE
fix(marketplace): a fresh install can import the baseline skills

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -57,6 +57,10 @@ the models you want — "Kimi K3 · NVIDIA" is a different route from
 route in **Settings → Orchestrator** (or on any agent): provider *NVIDIA*, model
 *Kimi K3*. (PRD-236)
 
+**Skills.** A fresh install has none. **Marketplace → Capabilities → Import from
+GitHub**, then *Use baseline repo* to import the free library at
+`https://github.com/AutomatosAI/automatos-skills.git`.
+
 ## 2. Start the platform
 
 ```bash

--- a/docs/getting-started/self-hosting.md
+++ b/docs/getting-started/self-hosting.md
@@ -67,6 +67,13 @@ there is also what embeddings use (`PLATFORM_KEY_WORKSPACE_ID` in
 document uploads index with it; without any embedding provider an upload is
 accepted but its processing ends `failed`.
 
+**Skills.** A fresh install ships with no skills in the marketplace. Start with
+the free baseline library: in **Marketplace → Capabilities** press *Import from
+GitHub* (the local operator is the instance's super admin, so the button is
+there) and import `https://github.com/AutomatosAI/automatos-skills.git` — the
+modal offers it as *Use baseline repo*. Every `SKILL.md` in the repo becomes a
+marketplace skill you can enable per agent; re-import later to pick up updates.
+
 ## 3. What runs where
 
 `docker compose up` starts the default profile. Nothing in it needs the

--- a/frontend/components/marketplace/__tests__/github-import-modal.test.tsx
+++ b/frontend/components/marketplace/__tests__/github-import-modal.test.tsx
@@ -1,0 +1,36 @@
+/**
+ * A fresh install has no skills. The import modal must point at the free
+ * baseline library and fill the URL in one click, and honour a prefill from a
+ * caller (the Skills tab opens it on the baseline repo).
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+vi.mock('@/lib/api-client', () => ({ apiClient: { post: vi.fn() } }))
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
+
+import { GitHubImportModal } from '../github-import-modal'
+import { BASELINE_SKILLS_REPO_URL } from '@/lib/baseline-skills'
+
+const PLACEHOLDER = 'https://github.com/user/repo'
+
+describe('GitHubImportModal — baseline skills', () => {
+  it('offers the baseline repo and fills the URL on click', () => {
+    render(<GitHubImportModal open onClose={() => {}} onImportComplete={() => {}} />)
+    expect(screen.getByText(/Start with the free baseline skills/)).toBeInTheDocument()
+    expect(screen.getByPlaceholderText(PLACEHOLDER)).toHaveValue('')
+    fireEvent.click(screen.getByRole('button', { name: /use baseline repo/i }))
+    expect(screen.getByPlaceholderText(PLACEHOLDER)).toHaveValue(BASELINE_SKILLS_REPO_URL)
+  })
+
+  it('prefills from initialUrl', () => {
+    render(
+      <GitHubImportModal open onClose={() => {}} onImportComplete={() => {}} initialUrl={BASELINE_SKILLS_REPO_URL} />,
+    )
+    expect(screen.getByPlaceholderText(PLACEHOLDER)).toHaveValue(BASELINE_SKILLS_REPO_URL)
+  })
+
+  it('the baseline URL is the public skills repo', () => {
+    expect(BASELINE_SKILLS_REPO_URL).toBe('https://github.com/AutomatosAI/automatos-skills.git')
+  })
+})

--- a/frontend/components/marketplace/__tests__/marketplace-admin-gate.test.ts
+++ b/frontend/components/marketplace/__tests__/marketplace-admin-gate.test.ts
@@ -1,0 +1,39 @@
+/**
+ * The marketplace's admin controls (Import from GitHub, approve / reject) used
+ * to show only for a Clerk user whose email contained "automatos.app". A local
+ * install has no Clerk user, so the local operator never saw Import from GitHub
+ * although the backend already accepts them (the operator is super_admin).
+ * The gate is the role context now — the same system_role hierarchy the admin
+ * routes enforce. This guard keeps the email check from creeping back.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import path from 'path'
+
+const TABS = [
+  'marketplace-plugins-tab.tsx',
+  'marketplace-agents-tab.tsx',
+  'marketplace-playbooks-tab.tsx',
+]
+
+describe('marketplace admin gate', () => {
+  for (const tab of TABS) {
+    it(`${tab} gates on the system role, not an email domain`, () => {
+      const src = readFileSync(path.resolve(__dirname, '..', tab), 'utf8')
+      expect(src).not.toContain('automatos.app')
+      expect(src).not.toContain('emailAddresses')
+      expect(src).toContain("useSystemRole } from '@/contexts/role-context'")
+      expect(src).toContain('const { isAdmin } = useSystemRole()')
+    })
+  }
+})
+
+describe('skills tab empty state', () => {
+  it('points a fresh install at the baseline library and opens the import on it', () => {
+    const src = readFileSync(path.resolve(__dirname, '..', 'marketplace-skills-tab.tsx'), 'utf8')
+    expect(src).not.toContain('Plugins > Import from GitHub')
+    expect(src).toContain('BASELINE_SKILLS_REPO_LABEL')
+    expect(src).toContain('initialUrl={BASELINE_SKILLS_REPO_URL}')
+    expect(src).toContain('const { isAdmin } = useSystemRole()')
+  })
+})

--- a/frontend/components/marketplace/github-import-modal.tsx
+++ b/frontend/components/marketplace/github-import-modal.tsx
@@ -7,6 +7,7 @@ import { Input } from '@/components/ui/input'
 import { Badge } from '@/components/ui/badge'
 import { apiClient } from '@/lib/api-client'
 import { toast } from 'sonner'
+import { BASELINE_SKILLS_REPO_URL } from '@/lib/baseline-skills'
 
 interface ImportResult {
   slug: string
@@ -21,10 +22,12 @@ interface GitHubImportModalProps {
   open: boolean
   onClose: () => void
   onImportComplete: () => void
+  /** Prefill the repository URL (the Skills tab opens the modal on the baseline repo). */
+  initialUrl?: string
 }
 
-export function GitHubImportModal({ open, onClose, onImportComplete }: GitHubImportModalProps) {
-  const [url, setUrl] = useState('')
+export function GitHubImportModal({ open, onClose, onImportComplete, initialUrl }: GitHubImportModalProps) {
+  const [url, setUrl] = useState(initialUrl ?? '')
   const [isImporting, setIsImporting] = useState(false)
   const [results, setResults] = useState<ImportResult[] | null>(null)
 
@@ -47,7 +50,7 @@ export function GitHubImportModal({ open, onClose, onImportComplete }: GitHubImp
       // Auto-close after 2s on success
       if (successCount > 0) {
         setTimeout(() => {
-          setUrl('')
+          setUrl(initialUrl ?? '')
           setResults(null)
           onClose()
         }, 2000)
@@ -62,7 +65,7 @@ export function GitHubImportModal({ open, onClose, onImportComplete }: GitHubImp
   }
 
   const handleClose = () => {
-    setUrl('')
+    setUrl(initialUrl ?? '')
     setResults(null)
     onClose()
   }
@@ -85,6 +88,27 @@ export function GitHubImportModal({ open, onClose, onImportComplete }: GitHubImp
 
         {/* Body */}
         <div className="p-4 space-y-4">
+          {/* A fresh install has no skills: point at the free baseline library first. */}
+          <div className="rounded-lg border border-border bg-muted/30 p-3 space-y-2">
+            <p className="text-sm">
+              <span className="font-medium">New install?</span> Start with the free baseline skills:
+              the Automatos skills library imports as marketplace skills you can enable per agent.
+            </p>
+            <div className="flex items-center justify-between gap-2">
+              <code className="text-xs text-muted-foreground truncate">{BASELINE_SKILLS_REPO_URL}</code>
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                className="whitespace-nowrap"
+                disabled={isImporting}
+                onClick={() => setUrl(BASELINE_SKILLS_REPO_URL)}
+              >
+                Use baseline repo
+              </Button>
+            </div>
+          </div>
+
           <div className="space-y-2">
             <label className="text-sm text-muted-foreground">
               GitHub Repository URL

--- a/frontend/components/marketplace/marketplace-agents-tab.tsx
+++ b/frontend/components/marketplace/marketplace-agents-tab.tsx
@@ -22,7 +22,7 @@ import { useMarketplaceItems, useInstallMarketplaceItem } from '@/hooks/use-mark
 import { useSystemIcons } from '@/hooks/use-system-config-api'
 import { AGENT_CATEGORIES as UNIFIED_CATEGORIES, LEGACY_CATEGORY_MAP } from '@/lib/agent-constants'
 import { MarketplaceItemModal } from './marketplace-item-modal'
-import { useUser } from '@/lib/auth-hooks'
+import { useSystemRole } from '@/contexts/role-context'
 import { toast } from 'sonner'
 import { apiClient } from '@/lib/api-client'
 
@@ -69,7 +69,6 @@ interface MarketplaceAgentsTabProps {
 }
 
 export function MarketplaceAgentsTab({ searchQuery }: MarketplaceAgentsTabProps) {
-  const { user } = useUser()
   const [viewMode, setViewMode] = useViewMode('mp-agents')
   const [selectedCategory, setSelectedCategory] = useState('all')
   const [selectedAgentId, setSelectedAgentId] = useState<number | null>(null)
@@ -78,8 +77,10 @@ export function MarketplaceAgentsTab({ searchQuery }: MarketplaceAgentsTabProps)
   const [installingId, setInstallingId] = useState<number | null>(null)
   const [installedIds, setInstalledIds] = useState<Set<number>>(new Set())
 
-  // Check if user is admin (you can adjust this check based on your admin logic)
-  const isAdmin = user?.emailAddresses?.[0]?.emailAddress?.includes('automatos.app') || false
+  // Admin controls follow the backend's system_role (super_admin ⊇ admin), the
+  // same gate the admin routes enforce. The local operator is super_admin, so a
+  // fresh local install sees Import from GitHub; a Clerk email domain never did.
+  const { isAdmin } = useSystemRole()
 
   // Fetch all marketplace agents (filter client-side by unified category)
   const { data: rawAgents = [], isLoading, refetch } = useMarketplaceItems({

--- a/frontend/components/marketplace/marketplace-playbooks-tab.tsx
+++ b/frontend/components/marketplace/marketplace-playbooks-tab.tsx
@@ -19,7 +19,7 @@ import { Separator } from '@/components/ui/separator'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { apiClient } from '@/lib/api-client'
 import { toast } from 'sonner'
-import { useUser } from '@/lib/auth-hooks'
+import { useSystemRole } from '@/contexts/role-context'
 import { useInstallPlaybookFromMarketplace } from '@/hooks/use-playbook-api'
 import { ViewPlaybookModal } from '@/components/workflows/view-playbook-modal'
 
@@ -35,13 +35,15 @@ export function MarketplacePlaybooksTab({ searchQuery }: MarketplacePlaybooksTab
   const [showViewModal, setShowViewModal] = useState(false)
   const [approvingId, setApprovingId] = useState<number | null>(null)
   const [deletingId, setDeletingId] = useState<number | null>(null)
-  const { user } = useUser()
   const queryClient = useQueryClient()
   const installMutation = useInstallPlaybookFromMarketplace()
   const { data: iconMappings = {} } = useSystemIcons()
 
   // Admin check (same pattern as agents tab)
-  const isAdmin = user?.emailAddresses?.[0]?.emailAddress?.includes('automatos.app') || false
+  // Admin controls follow the backend's system_role (super_admin ⊇ admin), the
+  // same gate the admin routes enforce. The local operator is super_admin, so a
+  // fresh local install sees Import from GitHub; a Clerk email domain never did.
+  const { isAdmin } = useSystemRole()
 
   const handleApprove = async (e: React.MouseEvent, recipeId: number) => {
     e.stopPropagation()

--- a/frontend/components/marketplace/marketplace-plugins-tab.tsx
+++ b/frontend/components/marketplace/marketplace-plugins-tab.tsx
@@ -41,7 +41,7 @@ import { useSystemIcons } from '@/hooks/use-system-config-api'
 import { ViewToggle } from '@/components/shared/view-toggle'
 import { useViewMode } from '@/hooks/use-view-mode'
 import { apiClient } from '@/lib/api-client'
-import { useUser } from '@/lib/auth-hooks'
+import { useSystemRole } from '@/contexts/role-context'
 import { MarketplacePluginDetailModal } from './marketplace-plugin-detail-modal'
 import { GitHubImportModal } from './github-import-modal'
 
@@ -92,13 +92,14 @@ interface MarketplacePluginsTabProps {
 // ===================================================================
 
 export function MarketplacePluginsTab({ searchQuery, workspaceId }: MarketplacePluginsTabProps) {
-  const { user } = useUser()
   const [viewMode, setViewMode] = useViewMode('mp-plugins')
   const { data: iconMappings = {} } = useSystemIcons()
   const globalPluginIcon = iconMappings['global_plugin'] || null
 
-  // Admin check (same pattern as agents tab)
-  const isAdmin = user?.emailAddresses?.[0]?.emailAddress?.includes('automatos.app') || false
+  // Admin controls follow the backend's system_role (super_admin ⊇ admin), the
+  // same gate the admin routes enforce. The local operator is super_admin, so a
+  // fresh local install sees Import from GitHub; a Clerk email domain never did.
+  const { isAdmin } = useSystemRole()
 
   // State
   const [plugins, setPlugins] = useState<PluginSummary[]>([])

--- a/frontend/components/marketplace/marketplace-skills-tab.tsx
+++ b/frontend/components/marketplace/marketplace-skills-tab.tsx
@@ -20,6 +20,9 @@ import { useViewMode } from '@/hooks/use-view-mode'
 import { useSystemIcons } from '@/hooks/use-system-config-api'
 import { apiClient } from '@/lib/api-client'
 import { toast } from 'sonner'
+import { useSystemRole } from '@/contexts/role-context'
+import { GitHubImportModal } from './github-import-modal'
+import { BASELINE_SKILLS_REPO_LABEL, BASELINE_SKILLS_REPO_URL } from '@/lib/baseline-skills'
 
 // ===================================================================
 // Types
@@ -66,6 +69,10 @@ export function MarketplaceSkillsTab({ searchQuery, workspaceId }: MarketplaceSk
   const [enabling, setEnabling] = useState<number | null>(null)
   const [disabling, setDisabling] = useState<number | null>(null)
   const [localSearch, setLocalSearch] = useState('')
+  // A fresh install has no skills. Admins (the local operator is super_admin)
+  // get a one-click import of the free baseline library from the empty state.
+  const [showImport, setShowImport] = useState(false)
+  const { isAdmin } = useSystemRole()
 
   const { data: iconMappings = {} } = useSystemIcons()
 
@@ -243,8 +250,13 @@ export function MarketplaceSkillsTab({ searchQuery, workspaceId }: MarketplaceSk
           <p className="text-muted-foreground mb-4">
             {(searchQuery || localSearch)
               ? `No skills match "${searchQuery || localSearch}"`
-              : 'No marketplace skills available yet. Import skills via Plugins > Import from GitHub.'}
+              : `No marketplace skills yet. Start with the free baseline skills at ${BASELINE_SKILLS_REPO_LABEL} — Capabilities › Plugins › Import from GitHub.`}
           </p>
+          {isAdmin && !(searchQuery || localSearch) && (
+            <Button size="sm" onClick={() => setShowImport(true)}>
+              Import the baseline skills
+            </Button>
+          )}
         </div>
       ) : viewMode === 'list' ? (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
@@ -320,6 +332,15 @@ export function MarketplaceSkillsTab({ searchQuery, workspaceId }: MarketplaceSk
             </div>
           )}
         </div>
+      )}
+
+      {isAdmin && (
+        <GitHubImportModal
+          open={showImport}
+          onClose={() => setShowImport(false)}
+          onImportComplete={fetchAvailable}
+          initialUrl={BASELINE_SKILLS_REPO_URL}
+        />
       )}
     </div>
   )

--- a/frontend/lib/baseline-skills.ts
+++ b/frontend/lib/baseline-skills.ts
@@ -1,0 +1,14 @@
+/**
+ * The free baseline skill library — the repo a fresh install imports first.
+ *
+ * A new install (local edition especially) ships with no skills in the
+ * marketplace. Every `SKILL.md` in this repo imports as a marketplace skill
+ * through Marketplace → Capabilities → Import from GitHub, which the local
+ * operator can use because the operator is the instance's super admin. The
+ * skills repo is the source of truth for the library; re-import to pick up
+ * updates.
+ */
+export const BASELINE_SKILLS_REPO_URL = 'https://github.com/AutomatosAI/automatos-skills.git'
+
+/** The same repo without the `.git` suffix, for display. */
+export const BASELINE_SKILLS_REPO_LABEL = 'github.com/AutomatosAI/automatos-skills'


### PR DESCRIPTION
## What the customer sees
- **Marketplace → Capabilities → Import from GitHub is there on a fresh local install.** It used to appear only when the Clerk user's email contained `automatos.app`; a local install has no Clerk user, so the local operator never saw it, even though the backend already accepts them (the operator is `super_admin`, and the admin routes gate on `caller_is_admin`).
- **The modal points at the free baseline library first**: a callout with `https://github.com/AutomatosAI/automatos-skills.git` and a *Use baseline repo* button that fills the URL.
- **The Skills tab's empty state** names the baseline repo and the real path, and (for admins) opens the import on that repo in one click.
- QUICKSTART and the self-hosting guide carry the same instruction.

## Gate change, stated plainly
The plugins, agents and playbooks tabs now gate their admin controls on `useSystemRole().isAdmin` (the role context that mirrors the backend's `system_role` hierarchy) instead of an email-domain check. Hosted edition: platform admins see the controls by role, which is what the routes already permit. No backend change.

## Test plan
- [ ] `frontend` vitest: `github-import-modal.test.tsx` (callout, fill, prefill), `marketplace-admin-gate.test.ts` (no email gate; Skills tab points at the baseline repo).
- [ ] Local stack: Marketplace → Capabilities shows *Import from GitHub*; *Use baseline repo* → Import → skills appear under Skills; Skills empty state shows *Import the baseline skills*.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added guidance for importing the free baseline skills library during setup.
  * Added a “Use baseline repo” option to prefill the GitHub import dialog.
  * Added baseline skills guidance and import controls to the Skills marketplace tab for administrators.
  * Marketplace admin controls now follow system roles rather than email domains.

* **Documentation**
  * Updated quick-start and self-hosting guides with baseline skills import instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->