### PR TITLE
fix(marketplace): the baseline skills URL is the plain repo page, not the .git clone URL

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -59,7 +59,7 @@ route in **Settings → Orchestrator** (or on any agent): provider *NVIDIA*, mod
 
 **Skills.** A fresh install has none. **Marketplace → Capabilities → Import from
 GitHub**, then *Use baseline repo* to import the free library at
-`https://github.com/AutomatosAI/automatos-skills.git`.
+`https://github.com/AutomatosAI/automatos-skills`.
 
 ## 2. Start the platform
 

--- a/docs/getting-started/self-hosting.md
+++ b/docs/getting-started/self-hosting.md
@@ -70,7 +70,7 @@ accepted but its processing ends `failed`.
 **Skills.** A fresh install ships with no skills in the marketplace. Start with
 the free baseline library: in **Marketplace → Capabilities** press *Import from
 GitHub* (the local operator is the instance's super admin, so the button is
-there) and import `https://github.com/AutomatosAI/automatos-skills.git` — the
+there) and import `https://github.com/AutomatosAI/automatos-skills` — the
 modal offers it as *Use baseline repo*. Every `SKILL.md` in the repo becomes a
 marketplace skill you can enable per agent; re-import later to pick up updates.
 

--- a/frontend/components/marketplace/__tests__/github-import-modal.test.tsx
+++ b/frontend/components/marketplace/__tests__/github-import-modal.test.tsx
@@ -31,6 +31,6 @@ describe('GitHubImportModal — baseline skills', () => {
   })
 
   it('the baseline URL is the public skills repo', () => {
-    expect(BASELINE_SKILLS_REPO_URL).toBe('https://github.com/AutomatosAI/automatos-skills.git')
+    expect(BASELINE_SKILLS_REPO_URL).toBe('https://github.com/AutomatosAI/automatos-skills')
   })
 })

--- a/frontend/lib/baseline-skills.ts
+++ b/frontend/lib/baseline-skills.ts
@@ -7,8 +7,12 @@
  * operator can use because the operator is the instance's super admin. The
  * skills repo is the source of truth for the library; re-import to pick up
  * updates.
+ *
+ * The URL is the plain repository page, not the `.git` clone URL: people copy
+ * and paste what they see, and the browser address bar has no `.git`. The
+ * import route appends `.git` itself when it is missing.
  */
-export const BASELINE_SKILLS_REPO_URL = 'https://github.com/AutomatosAI/automatos-skills.git'
+export const BASELINE_SKILLS_REPO_URL = 'https://github.com/AutomatosAI/automatos-skills'
 
 /** The same repo without the `.git` suffix, for display. */
 export const BASELINE_SKILLS_REPO_LABEL = 'github.com/AutomatosAI/automatos-skills'


### PR DESCRIPTION
People copy and paste what they see, and the address bar has no `.git`. The import route (`admin_plugins.import_github`) already appends `.git` when it is missing, so the plain URL imports the same repo. Modal callout, *Use baseline repo*, the Skills tab, QUICKSTART and the self-hosting guide now show `https://github.com/AutomatosAI/automatos-skills`. Follow-up to #720.

Test plan: `github-import-modal.test.tsx` asserts the plain URL; local stack shows it after the rebuild.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Quick Start and self-hosting instructions to use the baseline skills repository URL without the `.git` suffix.

* **Bug Fixes**
  * Standardized baseline skills imports to accept the repository page URL while preserving successful import behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->