### PR TITLE
feat(local): one deliverables root on your machine — the workspace root, beside your projects

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -105,11 +105,23 @@ ADMINER_PORT=8080
 # - See docs/QUICKSTART.md for detailed setup guide
 # =============================================================================
 
-# PRD-234 S2 (local edition, session mode): your own projects folder. Shown
-# read-only in Deliverables → Explorer under projects/ and registered by the
-# CLI host, so a Claude Code session can work in a real repository inside it.
-# Unset = ./workspaces/projects (empty). Restart with `make up` after changing.
+# Where your agents' work lives on this machine (local edition). Two folders,
+# one layout — Deliverables → Explorer, the chat's Code mode and your Claude
+# Code sessions all read and write these:
+#
+#   LOCAL_PROJECTS_DIR       your own projects folder — the repositories your
+#                            agents may work in; shown under projects/
+#   AUTOMATOS_WORKSPACE_DIR  the deliverables root — what API agents write
+#                            (artifacts/, reports/, content/…) and where a
+#                            Claude Code session with no folder runs
+#                            (sessions/<ticket>). Mounted AS the workspace
+#                            root: no workspace-id folder on your disk.
+#                            Default ./workspaces next to docker-compose.yml.
+#
+# Recommended: the deliverables root next to (or inside) your projects folder,
+# so one place holds everything. Absolute paths; restart with `make up`.
 # LOCAL_PROJECTS_DIR=/Users/you/Development
+# AUTOMATOS_WORKSPACE_DIR=/Users/you/Development/deliverables
 # Mount mode for that folder inside the workspace-worker: ro (default) or rw.
 # rw lets the Code Canvas editor save into your repositories; sessions never
 # need it (they write through the CLI host on your machine).

--- a/Makefile
+++ b/Makefile
@@ -105,14 +105,14 @@ status:
 # Python 3.9+; nothing to install. Stop with Ctrl-C.
 cli-host:
 	@mkdir -p "$(AUTOMATOS_WORKSPACE_DIR)"
-	@cd services/cli-host && python3 -m automatos_cli_host --allow "$(AUTOMATOS_WORKSPACE_DIR)" $(if $(LOCAL_PROJECTS_DIR),--allow "$(LOCAL_PROJECTS_DIR)",) $(if $(PAIR),--pair $(PAIR),) $(CLI_HOST_ARGS)
+	@cd services/cli-host && python3 -m automatos_cli_host --allow "$(AUTOMATOS_WORKSPACE_DIR)" --default-root "$(AUTOMATOS_WORKSPACE_DIR)" $(if $(LOCAL_PROJECTS_DIR),--allow "$(LOCAL_PROJECTS_DIR)",) $(if $(PAIR),--pair $(PAIR),) $(CLI_HOST_ARGS)
 
 # PRD-235 W3: the host as a login service — starts at login, restarts on exit,
 # restarts itself when its code or the backend's contract changed. Pair once
 # with `make cli-host PAIR=<code>` (Ctrl-C after "paired"), then install.
 cli-host-install:
 	@mkdir -p "$(AUTOMATOS_WORKSPACE_DIR)"
-	@cd services/cli-host && python3 -m automatos_cli_host --install --allow "$(AUTOMATOS_WORKSPACE_DIR)" $(if $(LOCAL_PROJECTS_DIR),--allow "$(LOCAL_PROJECTS_DIR)",) $(CLI_HOST_ARGS)
+	@cd services/cli-host && python3 -m automatos_cli_host --install --allow "$(AUTOMATOS_WORKSPACE_DIR)" --default-root "$(AUTOMATOS_WORKSPACE_DIR)" $(if $(LOCAL_PROJECTS_DIR),--allow "$(LOCAL_PROJECTS_DIR)",) $(CLI_HOST_ARGS)
 
 cli-host-uninstall:
 	@cd services/cli-host && python3 -m automatos_cli_host --uninstall

--- a/Makefile
+++ b/Makefile
@@ -23,15 +23,47 @@ DEV_COMPOSE  ?= docker compose -f docker-compose.yml -f docker-compose.dev.yml
 # PRD-234 S2: LOCAL_PROJECTS_DIR (root .env) is the owner's projects folder; the
 # default bind source ./workspaces/projects must exist before compose mounts it.
 LOCAL_PROJECTS_DIR ?= $(shell sed -n 's/^LOCAL_PROJECTS_DIR=//p' .env 2>/dev/null | tail -1 | tr -d '"')
+# The deliverables root (root .env AUTOMATOS_WORKSPACE_DIR, default ./workspaces):
+# compose mounts it as the local workspace's root, so your machine sees
+# artifacts/, reports/, sessions/… directly. Exported ABSOLUTE so the backend can
+# map session file paths and Settings → Session mode can show it.
+AUTOMATOS_WORKSPACE_DIR ?= $(shell sed -n 's/^AUTOMATOS_WORKSPACE_DIR=//p' .env 2>/dev/null | tail -1 | tr -d '"')
+ifeq ($(strip $(AUTOMATOS_WORKSPACE_DIR)),)
+AUTOMATOS_WORKSPACE_DIR := $(CURDIR)/workspaces
+endif
+AUTOMATOS_WORKSPACE_DIR := $(patsubst ~%,$(HOME)%,$(AUTOMATOS_WORKSPACE_DIR))
+export AUTOMATOS_WORKSPACE_DIR
+DEFAULT_WORKSPACE_ID ?= $(shell sed -n 's/^DEFAULT_WORKSPACE_ID=//p' .env 2>/dev/null | tail -1 | tr -d '"')
+ifeq ($(strip $(DEFAULT_WORKSPACE_ID)),)
+DEFAULT_WORKSPACE_ID := 00000000-0000-0000-0000-0000000000c1
+endif
+
+# One-time layout migration: before 2026-09-09 the host folder held
+# <workspace_id>/artifacts/…; it now IS the workspace root. Move the old
+# subtree up one level, once, and only when the root has no layout of its own.
+define migrate_workspace_layout
+@if [ -d "$(AUTOMATOS_WORKSPACE_DIR)/$(DEFAULT_WORKSPACE_ID)" ] && [ ! -d "$(AUTOMATOS_WORKSPACE_DIR)/artifacts" ]; then \
+  echo "deliverables: moving $(AUTOMATOS_WORKSPACE_DIR)/$(DEFAULT_WORKSPACE_ID)/* up to $(AUTOMATOS_WORKSPACE_DIR)/ (the workspace root is the folder itself now)"; \
+  for entry in "$(AUTOMATOS_WORKSPACE_DIR)/$(DEFAULT_WORKSPACE_ID)"/* "$(AUTOMATOS_WORKSPACE_DIR)/$(DEFAULT_WORKSPACE_ID)"/.[!.]*; do \
+    [ -e "$$entry" ] || continue; \
+    case "$$(basename "$$entry")" in projects) rmdir "$$entry" 2>/dev/null || true; continue;; esac; \
+    mv -n "$$entry" "$(AUTOMATOS_WORKSPACE_DIR)/"; \
+  done; \
+  rmdir "$(AUTOMATOS_WORKSPACE_DIR)/$(DEFAULT_WORKSPACE_ID)" 2>/dev/null || echo "deliverables: $(AUTOMATOS_WORKSPACE_DIR)/$(DEFAULT_WORKSPACE_ID) kept (not empty) — check it and remove it by hand"; \
+fi
+endef
 
 up:
-	@mkdir -p "$(CURDIR)/workspaces/projects"
+	@mkdir -p "$(AUTOMATOS_WORKSPACE_DIR)/projects"
+	$(migrate_workspace_layout)
 	$(COMPOSE) up -d --build --remove-orphans
 	@$(MAKE) --no-print-directory clean
 	@$(MAKE) --no-print-directory status
 	@$(MAKE) --no-print-directory cli-host-nudge
 
 dev:
+	@mkdir -p "$(AUTOMATOS_WORKSPACE_DIR)/projects"
+	$(migrate_workspace_layout)
 	$(DEV_COMPOSE) up -d --build --remove-orphans
 	@$(MAKE) --no-print-directory clean
 
@@ -66,21 +98,21 @@ status:
 # machine (local edition only; CLI_RUNTIME_ENABLED=true in .env).
 #   make cli-host PAIR=XXXX-XXXX   first time — the code comes from Settings → Session mode
 #   make cli-host                  afterwards
-# Registers ./workspaces (the compose default) as a working directory; a ticket
-# without one runs in ./workspaces/<workspace id>/sessions/<ticket>, which
-# Deliverables → Explorer shows live. Your own repositories: LOCAL_PROJECTS_DIR
+# Registers the deliverables root (AUTOMATOS_WORKSPACE_DIR, default ./workspaces)
+# as a working directory; a ticket without one runs in <that root>/sessions/<ticket>,
+# which Deliverables → Explorer shows live. Your own repositories: LOCAL_PROJECTS_DIR
 # in .env (browsable under projects/) or CLI_HOST_ARGS="--allow /path/to/repo". Standard library
 # Python 3.9+; nothing to install. Stop with Ctrl-C.
 cli-host:
-	@mkdir -p "$(CURDIR)/workspaces"
-	@cd services/cli-host && python3 -m automatos_cli_host --allow "$(CURDIR)/workspaces" $(if $(LOCAL_PROJECTS_DIR),--allow "$(LOCAL_PROJECTS_DIR)",) $(if $(PAIR),--pair $(PAIR),) $(CLI_HOST_ARGS)
+	@mkdir -p "$(AUTOMATOS_WORKSPACE_DIR)"
+	@cd services/cli-host && python3 -m automatos_cli_host --allow "$(AUTOMATOS_WORKSPACE_DIR)" $(if $(LOCAL_PROJECTS_DIR),--allow "$(LOCAL_PROJECTS_DIR)",) $(if $(PAIR),--pair $(PAIR),) $(CLI_HOST_ARGS)
 
 # PRD-235 W3: the host as a login service — starts at login, restarts on exit,
 # restarts itself when its code or the backend's contract changed. Pair once
 # with `make cli-host PAIR=<code>` (Ctrl-C after "paired"), then install.
 cli-host-install:
-	@mkdir -p "$(CURDIR)/workspaces"
-	@cd services/cli-host && python3 -m automatos_cli_host --install --allow "$(CURDIR)/workspaces" $(if $(LOCAL_PROJECTS_DIR),--allow "$(LOCAL_PROJECTS_DIR)",) $(CLI_HOST_ARGS)
+	@mkdir -p "$(AUTOMATOS_WORKSPACE_DIR)"
+	@cd services/cli-host && python3 -m automatos_cli_host --install --allow "$(AUTOMATOS_WORKSPACE_DIR)" $(if $(LOCAL_PROJECTS_DIR),--allow "$(LOCAL_PROJECTS_DIR)",) $(CLI_HOST_ARGS)
 
 cli-host-uninstall:
 	@cd services/cli-host && python3 -m automatos_cli_host --uninstall

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -61,6 +61,21 @@ route in **Settings → Orchestrator** (or on any agent): provider *NVIDIA*, mod
 GitHub**, then *Use baseline repo* to import the free library at
 `https://github.com/AutomatosAI/automatos-skills`.
 
+**Your files.** Everything your agents write lives in one folder on your
+machine: `AUTOMATOS_WORKSPACE_DIR` in `.env` (default `./workspaces` next to
+`docker-compose.yml`), mounted as the workspace root — you see `artifacts/`,
+`reports/`, `sessions/`… directly, no workspace-id folder. Put it next to your
+projects folder and the Deliverables Explorer, the chat's Code mode and your
+Claude Code sessions all share the one place:
+
+```
+LOCAL_PROJECTS_DIR=/Users/you/Development
+AUTOMATOS_WORKSPACE_DIR=/Users/you/Development/deliverables
+```
+
+`make up` moves an older `./workspaces/<workspace id>/` layout up one level
+for you, once.
+
 ## 2. Start the platform
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ No login. Add one model key and run the seeded *Two-minute brief* Playbook:
 - `NVIDIA_API_KEY` from build.nvidia.com runs the hosted open models for free — in Marketplace → LLMs open the NVIDIA tab, sync once, add a model;
 - keys can also be added later under Settings → API Keys.
 
-To run your own Claude Code as an agent: set `CLI_RUNTIME_ENABLED=true` and `LOCAL_PROJECTS_DIR=/path/to/your/projects` in `.env`, `make up`, then Settings → Session mode → *Get a pairing code* and run the command it shows. [QUICKSTART.md](QUICKSTART.md) is the short walkthrough; [docs/getting-started/self-hosting.md](docs/getting-started/self-hosting.md) covers every service, dial, session mode in depth, and what the local edition does not include.
+To run your own Claude Code as an agent: set `CLI_RUNTIME_ENABLED=true` and `LOCAL_PROJECTS_DIR=/path/to/your/projects` in `.env`, `make up`, then Settings → Session mode → *Get a pairing code* and run the command it shows. Everything your agents write lands in one folder on your machine — `AUTOMATOS_WORKSPACE_DIR`, e.g. `/path/to/your/projects/deliverables` — which Deliverables → Explorer, the chat's Code mode and your sessions share. [QUICKSTART.md](QUICKSTART.md) is the short walkthrough; [docs/getting-started/self-hosting.md](docs/getting-started/self-hosting.md) covers every service, dial, session mode in depth, and what the local edition does not include.
 
 ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,8 +18,14 @@
 # Profiles:
 #   - Default: postgres, redis, minio (+ minio-init), backend, frontend and the
 #     workspace-worker (Code Canvas runtime). The worker's files live in a host
-#     directory bind-mounted at /workspaces — AUTOMATOS_WORKSPACE_DIR in .env,
-#     default ./workspaces next to this file, created on first boot (PRD-233 S1).
+#     directory — AUTOMATOS_WORKSPACE_DIR in .env, default ./workspaces next to
+#     this file, created on first boot (PRD-233 S1). It is mounted as THE local
+#     workspace's root (/workspaces/<DEFAULT_WORKSPACE_ID>), so on your machine
+#     it holds artifacts/, reports/, sessions/… directly — no workspace-id
+#     folder in between. Point it next to your projects folder
+#     (e.g. LOCAL_PROJECTS_DIR=~/Development, AUTOMATOS_WORKSPACE_DIR=~/Development/deliverables)
+#     and Deliverables → Explorer, the chat's Code mode and your Claude Code
+#     sessions all read and write the one place.
 #   - All: Add --profile all (adminer database GUI, gotenberg document conversion)
 # =============================================================================
 
@@ -194,6 +200,11 @@ services:
       # path mapping only — the folder itself is mounted into the workspace-worker).
       LOCAL_PROJECTS_DIR: ${LOCAL_PROJECTS_DIR:-}
       LOCAL_PROJECTS_MOUNT: ${LOCAL_PROJECTS_MOUNT:-ro}
+      # The deliverables root on the HOST (the folder mounted as the local
+      # workspace's root, below) — a string for path mapping and for Settings →
+      # Session mode. `make up` exports it absolute; a relative value (plain
+      # `docker compose up`) is shown but not used for mapping.
+      AUTOMATOS_WORKSPACE_DIR: ${AUTOMATOS_WORKSPACE_DIR:-./workspaces}
 
       # Object storage — local MinIO via the S3 seam (PRD-176 F089).
       # S3_ENDPOINT_URL points boto at MinIO. The store's credentials are mapped
@@ -245,8 +256,9 @@ services:
       # The workspace-worker's host directory, read-only (PRD-233 S1): the
       # backend's WORKSPACE_VOLUME_PATH view of agent deliverables. The file
       # browser and Code Canvas go through the worker's HTTP API instead
-      # (WORKER_INTERNAL_URL in envs/api.defaults).
-      - ${AUTOMATOS_WORKSPACE_DIR:-./workspaces}:/workspaces:ro
+      # (WORKER_INTERNAL_URL in envs/api.defaults). Mounted as the local
+      # workspace's root (same shape as the worker's mount below).
+      - ${AUTOMATOS_WORKSPACE_DIR:-./workspaces}:/workspaces/${DEFAULT_WORKSPACE_ID:-00000000-0000-0000-0000-0000000000c1}:ro
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
       interval: 30s
@@ -306,12 +318,14 @@ services:
   # ===========================================================================
   # Runs in the DEFAULT profile: agents act on files that live on YOUR machine.
   # The host directory ${AUTOMATOS_WORKSPACE_DIR:-./workspaces} is bind-mounted
-  # at /workspaces (created on first boot). Each workspace gets
-  # /workspaces/<workspace_id>/; every Code Canvas tool call is confined to it
-  # (canvas_confinement.py) and mutations still need approval
-  # (canvas_approvals.py) — local is not unguarded. AUTOMATOS_WORKSPACE_DIR in
-  # .env is the ONE dial that widens host access. The backend reaches this
-  # service over the compose network at WORKER_INTERNAL_URL (envs/api.defaults).
+  # as the local workspace's root, /workspaces/<DEFAULT_WORKSPACE_ID> (created
+  # on first boot): the worker still sees /workspaces/<workspace_id>/…, your
+  # machine sees artifacts/, reports/, sessions/… directly. Every Code Canvas
+  # tool call is confined to that root (canvas_confinement.py) and mutations
+  # still need approval (canvas_approvals.py) — local is not unguarded.
+  # AUTOMATOS_WORKSPACE_DIR in .env is the ONE dial that widens host access.
+  # The backend reaches this service over the compose network at
+  # WORKER_INTERNAL_URL (envs/api.defaults).
   # ===========================================================================
   workspace-worker:
     build:
@@ -355,8 +369,10 @@ services:
       LOG_RELAY_ENABLED: "false"
       SERVICE_NAME: workspace-worker
     volumes:
-      # Host directory (bind mount, read-write) — the ONE host-access dial.
-      - ${AUTOMATOS_WORKSPACE_DIR:-./workspaces}:/workspaces
+      # Host directory (bind mount, read-write) — the ONE host-access dial,
+      # mounted as THE local workspace's root (no <workspace_id> folder on the
+      # host). `make up` migrates an older ./workspaces/<workspace_id>/ layout.
+      - ${AUTOMATOS_WORKSPACE_DIR:-./workspaces}:/workspaces/${DEFAULT_WORKSPACE_ID:-00000000-0000-0000-0000-0000000000c1}
       # PRD-234 S2 (local edition): your own projects folder, read-only, shown by
       # Deliverables → Explorer under projects/. Sessions write to it through the
       # CLI host on your machine, never through this container. Nested inside the

--- a/docs/getting-started/self-hosting.md
+++ b/docs/getting-started/self-hosting.md
@@ -180,11 +180,20 @@ edits files and runs commands. In the local edition it runs in the default
 profile and its files live **on your machine**:
 
 - `AUTOMATOS_WORKSPACE_DIR` in `.env` (default `./workspaces`, next to
-  `docker-compose.yml`, created on first boot, gitignored) is bind-mounted at
-  `/workspaces` — read-write in the worker, read-only in the backend. It is
-  the one dial that decides what the agents can touch: point it at a
-  different folder to hand them that folder.
-- Each workspace gets its own subdirectory, `/workspaces/<workspace_id>/`
+  `docker-compose.yml`, created on first boot, gitignored) is bind-mounted as
+  the local workspace's root, `/workspaces/<workspace_id>/` — read-write in
+  the worker, read-only in the backend. On your machine the folder holds
+  `artifacts/`, `reports/`, `content/`, `sessions/`… directly: there is no
+  workspace-id folder on disk (before 2026-09-09 there was; `make up` moves
+  that layout up one level, once). It is the one dial that decides what the
+  agents can touch: point it at a different folder to hand them that folder.
+  Recommended layout — the deliverables root beside your projects folder, so
+  the Deliverables Explorer, the chat's Code mode and your Claude Code sessions
+  share one place: `LOCAL_PROJECTS_DIR=/Users/you/Development`,
+  `AUTOMATOS_WORKSPACE_DIR=/Users/you/Development/deliverables`. (With the
+  deliverables root inside the projects folder, the Explorer also lists it
+  under `projects/` — the same files twice, harmless.)
+- Inside the containers each workspace is `/workspaces/<workspace_id>/`
   (the local workspace id is the `DEFAULT_WORKSPACE_ID` value in
   `envs/api.defaults`). Every Canvas tool call is re-bound to that root
   before it runs: `..` traversal, symlink escapes, null bytes and shell
@@ -527,7 +536,7 @@ session agent in the workspace.
 
 `make cli-host` registers `./workspaces` (the compose default). A ticket whose
 agent names no working directory runs in
-`./workspaces/<workspace id>/sessions/<ticket>` — the folder **Deliverables →
+`<AUTOMATOS_WORKSPACE_DIR>/sessions/<ticket>` — the folder **Deliverables →
 Explorer** shows live. When the ticket finishes, every file the session wrote
 there is registered as one of the ticket's deliverables (the ticket's
 Deliverables block, the Deliverables gallery) and the task report carries the

--- a/frontend/components/settings/SessionModeTab.tsx
+++ b/frontend/components/settings/SessionModeTab.tsx
@@ -43,10 +43,33 @@ export interface SessionModeSettings {
   default_folder_explicit: boolean
   local_projects_dir: string | null
   projects_mount: string | null
+  /** The deliverables root on the host (AUTOMATOS_WORKSPACE_DIR as `make up` exported it), null when unknown. */
+  workspace_dir: string | null
   host_allowed_roots: string[]
 }
 
-export const PROJECTS_ENV_LINES = (folder: string) => `LOCAL_PROJECTS_DIR=${folder}\nLOCAL_PROJECTS_MOUNT=rw`
+export const PROJECTS_ENV_LINES = (folder: string, deliverables?: string) =>
+  `LOCAL_PROJECTS_DIR=${folder}\nLOCAL_PROJECTS_MOUNT=rw` + (deliverables ? `\nAUTOMATOS_WORKSPACE_DIR=${deliverables}` : '')
+
+/** The deliverables root we suggest for a projects folder: one place, beside the repos. */
+export const suggestedDeliverablesRoot = (projectsFolder: string) => `${projectsFolder.replace(/\/$/, '')}/deliverables`
+
+const inside = (path: string, roots: string[]) => roots.some((r) => path === r || path.startsWith(r.replace(/\/$/, '') + '/'))
+
+/** The one-line state of the deliverables root — what API agents write and where a session with no folder runs. */
+export function describeDeliverablesRoot(s: SessionModeSettings | undefined): { tone: 'ok' | 'warn' | 'muted'; text: string } {
+  if (!s) return { tone: 'muted', text: '…' }
+  if (!s.workspace_dir) {
+    return {
+      tone: 'muted',
+      text: 'The compose default (./workspaces next to docker-compose.yml). Set AUTOMATOS_WORKSPACE_DIR in .env and start with make up to put it beside your projects.',
+    }
+  }
+  if (!inside(s.workspace_dir, s.host_allowed_roots)) {
+    return { tone: 'warn', text: `${s.workspace_dir} — mounted as the workspace root, but your CLI host does not allow it yet: run make cli-host-install again.` }
+  }
+  return { tone: 'ok', text: `${s.workspace_dir} — mounted as the workspace root; sessions without a folder run in sessions/<ticket> inside it.` }
+}
 
 /** The one-line state of the projects folder for the tab. */
 export function describeProjectsFolder(s: SessionModeSettings | undefined): { tone: 'ok' | 'warn' | 'muted'; text: string } {
@@ -117,6 +140,10 @@ export function SessionModeTab() {
   const [hostName, setHostName] = useState('')
   const [saving, setSaving] = useState(false)
   const folderState = describeProjectsFolder(settings.data)
+  const deliverablesState = describeDeliverablesRoot(settings.data)
+  const projectsFolderForEnv = settings.data?.local_projects_dir || '/Users/you/Development'
+  const deliverablesForEnv = settings.data?.workspace_dir || suggestedDeliverablesRoot(projectsFolderForEnv)
+  const envLines = PROJECTS_ENV_LINES(projectsFolderForEnv, deliverablesForEnv)
   const saveDefaultFolder = async (choice: 'projects' | 'sessions') => {
     setSaving(true)
     try {
@@ -244,8 +271,8 @@ export function SessionModeTab() {
                       <CopyButton value={pairing.pair_command} label="Copy the pair command" />
                     </div>
                     <p className="text-xs text-muted-foreground">
-                      From the repository root. The host may run sessions in <span className="font-mono">./workspaces</span> and in
-                      your projects folder (below).
+                      From the repository root. The host may run sessions in your deliverables root and in
+                      your projects folder (both below).
                     </p>
                   </div>
                 )}
@@ -266,12 +293,25 @@ export function SessionModeTab() {
                   containers start, so it cannot be changed from a running page. Set it once:
                 </p>
                 <div className="flex items-start gap-2">
-                  <code className="flex-1 whitespace-pre rounded bg-muted px-3 py-2 font-mono text-xs overflow-x-auto">{PROJECTS_ENV_LINES(settings.data?.local_projects_dir || '/Users/you/Development')}</code>
-                  <CopyButton value={PROJECTS_ENV_LINES(settings.data?.local_projects_dir || '/Users/you/Development')} label="Copy the .env lines" />
+                  <code className="flex-1 whitespace-pre rounded bg-muted px-3 py-2 font-mono text-xs overflow-x-auto">{envLines}</code>
+                  <CopyButton value={envLines} label="Copy the .env lines" />
                 </div>
                 <p>
                   then <span className="font-mono">make up</span> (remounts it) and <span className="font-mono">make cli-host-install</span> (lets
                   the host run sessions there). Come back here: the line above turns green.
+                </p>
+              </div>
+              <div className="rounded-lg border border-border/40 p-4 space-y-3 text-xs text-muted-foreground" data-testid="deliverables-root">
+                <p className="text-sm font-medium text-foreground">Your deliverables root</p>
+                <p className={deliverablesState.tone === 'ok' ? 'text-[hsl(var(--success))]' : deliverablesState.tone === 'warn' ? 'text-[hsl(var(--warning))]' : ''} data-testid="deliverables-root-state">
+                  {deliverablesState.text}
+                </p>
+                <p>
+                  Everything your agents write lands here — <span className="font-mono">artifacts/</span>, <span className="font-mono">reports/</span>,
+                  <span className="font-mono">content/</span>, and <span className="font-mono">sessions/&lt;ticket&gt;</span> for a Claude Code session
+                  with no folder of its own. It is mounted as the workspace root, so there is no workspace-id folder on your disk:
+                  Deliverables → Explorer, the chat&apos;s Code mode and your sessions all show this one place. Put it beside your
+                  projects folder (<span className="font-mono">AUTOMATOS_WORKSPACE_DIR</span> in the <span className="font-mono">.env</span> lines above).
                 </p>
               </div>
               <div className="rounded-lg border border-border/40 p-4 space-y-3 text-xs text-muted-foreground" data-testid="default-folder">
@@ -302,7 +342,7 @@ export function SessionModeTab() {
                       onChange={() => saveDefaultFolder('sessions')}
                     />
                     <span>
-                      <span className="text-foreground">A fresh folder per ticket</span> — <span className="font-mono">./workspaces/&lt;workspace&gt;/sessions/&lt;ticket&gt;</span>.
+                      <span className="text-foreground">A fresh folder per ticket</span> — <span className="font-mono">sessions/&lt;ticket&gt;</span> inside your deliverables root.
                       Keeps experiments apart; whatever the session writes there is registered as the ticket&apos;s deliverables.
                     </span>
                   </label>

--- a/frontend/components/settings/__tests__/session-mode-tab.test.ts
+++ b/frontend/components/settings/__tests__/session-mode-tab.test.ts
@@ -1,11 +1,18 @@
 import { describe, expect, it } from 'vitest'
-import { PROJECTS_ENV_LINES, describeProjectsFolder, type SessionModeSettings } from '@/components/settings/SessionModeTab'
+import {
+  PROJECTS_ENV_LINES,
+  describeDeliverablesRoot,
+  describeProjectsFolder,
+  suggestedDeliverablesRoot,
+  type SessionModeSettings,
+} from '@/components/settings/SessionModeTab'
 
 const base: SessionModeSettings = {
   default_folder: 'projects',
   default_folder_explicit: false,
   local_projects_dir: '/Users/me/Development',
   projects_mount: 'rw',
+  workspace_dir: '/Users/me/Development/deliverables',
   host_allowed_roots: ['/Users/me/ws/workspaces', '/Users/me/Development'],
 }
 
@@ -30,7 +37,33 @@ describe('Settings → Session mode (PRD-239 S6c)', () => {
     expect(describeProjectsFolder(undefined).tone).toBe('muted')
   })
 
-  it('hands the operator the two .env lines for their folder', () => {
+  it('hands the operator the .env lines for their folders', () => {
     expect(PROJECTS_ENV_LINES('/Users/me/Development')).toBe('LOCAL_PROJECTS_DIR=/Users/me/Development\nLOCAL_PROJECTS_MOUNT=rw')
+    expect(PROJECTS_ENV_LINES('/Users/me/Development', '/Users/me/Development/deliverables')).toBe(
+      'LOCAL_PROJECTS_DIR=/Users/me/Development\nLOCAL_PROJECTS_MOUNT=rw\nAUTOMATOS_WORKSPACE_DIR=/Users/me/Development/deliverables',
+    )
+    expect(suggestedDeliverablesRoot('/Users/me/Development/')).toBe('/Users/me/Development/deliverables')
+  })
+})
+
+describe('Settings → Session mode — the deliverables root', () => {
+  it('is green when mounted and allowed by the host (a sub-folder of an allowed root counts)', () => {
+    const s = describeDeliverablesRoot(base)
+    expect(s.tone).toBe('ok')
+    expect(s.text).toContain('/Users/me/Development/deliverables')
+    expect(s.text).toContain('sessions/<ticket>')
+  })
+
+  it('warns when the host does not allow it yet', () => {
+    const s = describeDeliverablesRoot({ ...base, workspace_dir: '/Users/me/Automatos/deliverables' })
+    expect(s.tone).toBe('warn')
+    expect(s.text).toContain('make cli-host-install')
+  })
+
+  it('explains the compose default when the stack did not export the root', () => {
+    const s = describeDeliverablesRoot({ ...base, workspace_dir: null })
+    expect(s.tone).toBe('muted')
+    expect(s.text).toContain('AUTOMATOS_WORKSPACE_DIR')
+    expect(describeDeliverablesRoot(undefined).tone).toBe('muted')
   })
 })

--- a/orchestrator/config.py
+++ b/orchestrator/config.py
@@ -642,6 +642,11 @@ class Config:
     LOCAL_PROJECTS_DIR: str = os.getenv("LOCAL_PROJECTS_DIR", "").strip()
     # PRD-239: how the projects folder is mounted into the worker (ro|rw) — shown in Settings → Session mode.
     LOCAL_PROJECTS_MOUNT: str = os.getenv("LOCAL_PROJECTS_MOUNT", "").strip().lower()
+    # Local edition: the deliverables root on the HOST — the folder compose mounts as
+    # the local workspace's root (/workspaces/<DEFAULT_WORKSPACE_ID>), so the host's
+    # `<root>/sessions/68/x.py` is the worker's `sessions/68/x.py`. `make up` exports
+    # it absolute; a relative value (plain `docker compose up`) is display-only.
+    AUTOMATOS_WORKSPACE_DIR: str = os.getenv("AUTOMATOS_WORKSPACE_DIR", "").strip()
     # PRD-239 S3b: how long a playbook step waits for a session agent's Claude Code session
     # (a real session runs for minutes; API steps keep the recipe's own step timeout).
     CLI_LANE_STEP_TIMEOUT_SECONDS: int = int(os.getenv("CLI_LANE_STEP_TIMEOUT_SECONDS", "1800"))

--- a/orchestrator/services/cli_host_service.py
+++ b/orchestrator/services/cli_host_service.py
@@ -457,6 +457,9 @@ def session_mode_settings(db: Session, workspace_id: Any) -> Dict[str, Any]:
         "default_folder_explicit": stored.get("default_folder") in DEFAULT_FOLDER_CHOICES,
         "local_projects_dir": projects_dir,
         "projects_mount": (getattr(config, "LOCAL_PROJECTS_MOUNT", "") or None),
+        # The deliverables root on the host (AUTOMATOS_WORKSPACE_DIR as `make up`
+        # exported it) — beside the projects folder in Settings → Session mode.
+        "workspace_dir": configured_workspace_dir(),
         "host_allowed_roots": host_allow_dirs(db, workspace_id),
     }
 
@@ -947,6 +950,19 @@ _DELIVERABLE_TYPE_OVERRIDES = {"report": "document"}
 
 
 PROJECTS_PREFIX = "projects"
+# The explorer root for the deliverables folder itself — the Canvas's own root
+# token (frontend `WORKSPACE_ROOT`), so a session rooted there browses everything.
+WORKSPACE_ROOT_FOLDER = "."
+
+
+def configured_workspace_dir() -> Optional[str]:
+    """The deliverables root on the host, when the stack was started with an
+    ABSOLUTE ``AUTOMATOS_WORKSPACE_DIR`` (what ``make up`` exports). Compose mounts
+    that folder as the local workspace's root, so it is the second anchor for
+    mapping a session's host paths onto the worker's view. A relative value (a
+    plain ``docker compose up`` with the default) means nothing to this process."""
+    raw = (getattr(config, "AUTOMATOS_WORKSPACE_DIR", "") or "").strip().rstrip("/")
+    return raw if raw.startswith("/") else None
 
 
 def _clean_relative(rel: str) -> Optional[str]:
@@ -956,14 +972,27 @@ def _clean_relative(rel: str) -> Optional[str]:
     return rel
 
 
-def workspace_relative_path(host_path: str, workspace_id: str, projects_dir: Optional[str] = None) -> Optional[str]:
+def workspace_relative_path(
+    host_path: str,
+    workspace_id: str,
+    projects_dir: Optional[str] = None,
+    workspace_dir: Optional[str] = None,
+) -> Optional[str]:
     """A session's file path on the host → the worker's view of it, or ``None``.
 
-    * ``…/<AUTOMATOS_WORKSPACE_DIR>/<workspace_id>/sessions/68/hello.py`` →
-      ``sessions/68/hello.py`` — the workspace-id segment is the anchor both
-      sides share (the worker's layout is ``<root>/<workspace_id>/<relative>``).
+    * ``…/<workspace_id>/sessions/68/hello.py`` → ``sessions/68/hello.py`` — the
+      workspace-id segment is an anchor both sides share (the nested layout:
+      ``<volume>/<workspace_id>/<relative>``).
+    * ``<AUTOMATOS_WORKSPACE_DIR>/sessions/68/hello.py`` → ``sessions/68/hello.py``
+      — the local edition mounts that folder AS the workspace root (no
+      workspace-id folder on the host), so the folder itself is the anchor.
     * ``<LOCAL_PROJECTS_DIR>/repo/app.py`` → ``projects/repo/app.py`` — the owner's
       projects folder is mounted read-only into the worker under ``projects/``.
+
+    When the deliverables root sits inside the projects folder (or the other way
+    round) the LONGER matching root wins, so ``~/Development/deliverables/reports/x.md``
+    is ``reports/x.md``, not ``projects/deliverables/reports/x.md``. ``workspace_dir``
+    defaults to the configured ``AUTOMATOS_WORKSPACE_DIR`` when absolute.
 
     The host's absolute path means nothing inside this container. ``None`` when
     the file is elsewhere — it then stays a reference in ``runtime_ref.files_touched``.
@@ -973,10 +1002,19 @@ def workspace_relative_path(host_path: str, workspace_id: str, projects_dir: Opt
     idx = path.find(marker)
     if idx >= 0:
         return _clean_relative(path[idx + len(marker):])
-    root = (projects_dir or "").rstrip("/")
-    if root and (path == root or path.startswith(root + "/")):
-        rel = _clean_relative(path[len(root):])
-        return f"{PROJECTS_PREFIX}/{rel}" if rel else None
+    if workspace_dir is None:
+        workspace_dir = configured_workspace_dir()
+    anchors = [
+        (root.rstrip("/"), prefix)
+        for root, prefix in ((workspace_dir, ""), (projects_dir, PROJECTS_PREFIX))
+        if root and root.rstrip("/")
+    ]
+    for root, prefix in sorted(anchors, key=lambda a: len(a[0]), reverse=True):
+        if path == root or path.startswith(root + "/"):
+            rel = _clean_relative(path[len(root):])
+            if not rel:
+                return None
+            return f"{prefix}/{rel}" if prefix else rel
     return None
 
 
@@ -1113,6 +1151,9 @@ def browsable_root(folder: str, workspace_id: str, projects_dir: Optional[str]) 
     root = (projects_dir or "").rstrip("/")
     if root and folder.rstrip("/") == root:
         return PROJECTS_PREFIX
+    workspace_dir = configured_workspace_dir()
+    if workspace_dir and folder.rstrip("/") == workspace_dir:
+        return WORKSPACE_ROOT_FOLDER
     return workspace_relative_path(folder, workspace_id, projects_dir)
 
 

--- a/orchestrator/tests/test_prd233_s1_worker_local_profile.py
+++ b/orchestrator/tests/test_prd233_s1_worker_local_profile.py
@@ -265,11 +265,22 @@ def test_named_workspace_volume_is_gone():
 
 
 def test_mount_target_matches_worker_config_default():
+    """The host folder is mounted AS the local workspace's root: the compose
+    target is the worker's root (``worker_config.DEFAULT_WORKSPACE_ROOT``,
+    ``/workspaces``) plus the local workspace id — the layout the worker builds
+    (``<root>/<workspace_id>/…``) is unchanged inside the container, and the id
+    expression is the one the entrypoint seeds (``DEFAULT_WORKSPACE_ID``, with
+    the same default)."""
+    root = wc.DEFAULT_WORKSPACE_ROOT
     compose = _compose()
-    worker_env = _env(compose["services"][WORKER_SERVICE])
-    assert worker_env[wc.WORKSPACE_ROOT_ENV] == MOUNT_TARGET == wc.DEFAULT_WORKSPACE_ROOT
-    # The backend's view of the same directory (config.WORKSPACE_VOLUME_PATH).
-    assert _api_defaults()[wc.WORKSPACE_ROOT_ENV] == MOUNT_TARGET
+    # Both containers still address the volume at the worker root…
+    assert _env(compose["services"][WORKER_SERVICE])[wc.WORKSPACE_ROOT_ENV] == root
+    assert _api_defaults()[wc.WORKSPACE_ROOT_ENV] == root
+    # …and the host folder is mounted one level below it, as the local workspace.
+    assert MOUNT_TARGET.startswith(root + "/"), MOUNT_TARGET
+    workspace_segment = MOUNT_TARGET[len(root) + 1:]
+    assert workspace_segment == "${DEFAULT_WORKSPACE_ID:-00000000-0000-0000-0000-0000000000c1}"
+    assert "/" not in workspace_segment  # exactly one level below the worker root
 
 
 def test_worker_keeps_credential_passthrough_and_limits():

--- a/orchestrator/tests/test_prd233_s1_worker_local_profile.py
+++ b/orchestrator/tests/test_prd233_s1_worker_local_profile.py
@@ -2,7 +2,8 @@
 
 The Code Canvas runtime (``services/workspace-worker``) ships to the laptop:
 compose runs it by default against a designated HOST directory
-(``${AUTOMATOS_WORKSPACE_DIR:-./workspaces}`` bind-mounted at ``/workspaces``),
+(``${AUTOMATOS_WORKSPACE_DIR:-./workspaces}`` bind-mounted AS the local workspace's
+root, ``/workspaces/<DEFAULT_WORKSPACE_ID>`` — 2026-09-09: no workspace-id folder on the host),
 and the worker resolves its confinement root through ONE seam,
 ``worker_config.workspace_root()`` — env reads live only in ``worker_config``
 (the worker's mirror of the orchestrator's ``config.py`` discipline).
@@ -58,7 +59,10 @@ finally:
 
 WORKER_SERVICE = "workspace-worker"
 BACKEND_SERVICE = "backend"
-MOUNT_TARGET = "/workspaces"
+# The local workspace's root — the host folder is mounted AS that root (2026-09-09),
+# so on the host there is no workspace-id folder; inside the containers the layout
+# is unchanged (/workspaces/<workspace_id>/…).
+MOUNT_TARGET = "/workspaces/${DEFAULT_WORKSPACE_ID:-00000000-0000-0000-0000-0000000000c1}"
 # The designated host directory — Q1 owner decision: one dial, safe default.
 HOST_DIR_SOURCE = "${AUTOMATOS_WORKSPACE_DIR:-./workspaces}"
 RETIRED_VOLUME = "workspace_data"
@@ -173,9 +177,10 @@ def test_confinement_follows_the_dial_not_a_baked_in_path(monkeypatch, tmp_path)
 # Compose source guard — the local profile carries the worker
 # ---------------------------------------------------------------------------
 
-# Short-syntax volume entry: SOURCE:TARGET[:MODE]. The source may itself hold
-# ':' (``${VAR:-default}``), so the target is anchored on the first ':/'.
-_SHORT_VOLUME_RE = re.compile(r"^(?P<source>.+?):(?P<target>/[^:]*)(?::(?P<mode>[a-zA-Z,]+))?$")
+# Short-syntax volume entry: SOURCE:TARGET[:MODE]. Source AND target may hold
+# ':' inside ``${VAR:-default}``, so the target is anchored on the first ':/' and
+# a ``${…}`` group inside it is consumed atomically.
+_SHORT_VOLUME_RE = re.compile(r"^(?P<source>.+?):(?P<target>/(?:\$\{[^}]*\}|[^:])*)(?::(?P<mode>[a-zA-Z,]+|\$\{[^}]*\}))?$")
 
 
 def _compose() -> dict:

--- a/orchestrator/tests/test_prd234_s2_session_deliverables.py
+++ b/orchestrator/tests/test_prd234_s2_session_deliverables.py
@@ -45,3 +45,33 @@ def test_project_files_map_onto_the_workers_projects_view():
     assert workspace_relative_path(f"{root}-other/app.py", WS, root) is None  # prefix, not the folder
     assert workspace_relative_path(f"{root}/../secret", WS, root) is None
     assert workspace_relative_path("/Users/me/elsewhere/app.py", WS, None) is None
+
+
+# ── the deliverables root as an anchor (2026-09-09: AUTOMATOS_WORKSPACE_DIR is the workspace root) ──
+
+def test_session_files_under_the_deliverables_root_map_without_a_workspace_id_segment():
+    root = "/Users/me/Development/deliverables"
+    assert workspace_relative_path(f"{root}/sessions/68/hello.py", WS, None, root) == "sessions/68/hello.py"
+    assert workspace_relative_path(f"{root}/reports/weekly.md", WS, None, root + "/") == "reports/weekly.md"
+    assert workspace_relative_path(root, WS, None, root) is None  # the folder itself is not a file
+    assert workspace_relative_path(f"{root}-old/x.md", WS, None, root) is None  # prefix, not the folder
+    assert workspace_relative_path(f"{root}/../secret", WS, None, root) is None
+
+
+def test_the_longer_root_wins_when_the_deliverables_root_sits_inside_the_projects_folder():
+    projects = "/Users/me/Development"
+    root = f"{projects}/deliverables"
+    assert workspace_relative_path(f"{root}/reports/weekly.md", WS, projects, root) == "reports/weekly.md"
+    assert workspace_relative_path(f"{projects}/repo/app.py", WS, projects, root) == "projects/repo/app.py"
+    # …and the other way round (projects folder inside the deliverables root)
+    assert workspace_relative_path(f"{root}/projects/repo/app.py", WS, f"{root}/projects", root) == "projects/repo/app.py"
+
+
+def test_the_configured_root_is_the_default_anchor_and_must_be_absolute(monkeypatch):
+    from services import cli_host_service as svc
+    monkeypatch.setattr(svc.config, "AUTOMATOS_WORKSPACE_DIR", "/srv/deliverables", raising=False)
+    assert workspace_relative_path("/srv/deliverables/artifacts/a.png", WS) == "artifacts/a.png"
+    assert svc.browsable_root("/srv/deliverables", WS, None) == "."
+    monkeypatch.setattr(svc.config, "AUTOMATOS_WORKSPACE_DIR", "./workspaces", raising=False)
+    assert workspace_relative_path("./workspaces/artifacts/a.png", WS) is None
+    assert svc.configured_workspace_dir() is None

--- a/orchestrator/tests/test_prd239_session_mode_settings.py
+++ b/orchestrator/tests/test_prd239_session_mode_settings.py
@@ -90,6 +90,7 @@ def test_the_default_is_the_projects_folder_when_one_is_configured(monkeypatch):
     assert out == {
         "default_folder": "projects", "default_folder_explicit": False,
         "local_projects_dir": "/Users/me/Development", "projects_mount": "rw",
+        "workspace_dir": None,
         "host_allowed_roots": ["/Users/me/Development"],
     }
     assert svc.default_session_folder(_DB(workspace=_ws(None)), WS) == "/Users/me/Development"
@@ -144,3 +145,13 @@ def test_the_settings_routes_are_declared_in_the_mount_manifest():
     manifest = json.loads((_ORCH / "reports" / "route-manifest.json").read_text())
     for method in ("GET", "PUT"):
         assert {"path": "/api/v1/cli-hosts/settings", "method": method} in manifest["routes"]
+
+
+def test_the_settings_carry_the_deliverables_root_only_when_absolute(monkeypatch):
+    monkeypatch.setattr(svc.config, "LOCAL_PROJECTS_DIR", "/Users/me/Development", raising=False)
+    monkeypatch.setattr(svc, "host_allow_dirs", lambda db, ws: [])
+    monkeypatch.setattr(svc.config, "AUTOMATOS_WORKSPACE_DIR", "/Users/me/Development/deliverables/", raising=False)
+    assert svc.session_mode_settings(_DB(workspace=_ws(None)), WS)["workspace_dir"] == "/Users/me/Development/deliverables"
+    # a plain `docker compose up` passes the relative compose default: display-only, never an anchor
+    monkeypatch.setattr(svc.config, "AUTOMATOS_WORKSPACE_DIR", "./workspaces", raising=False)
+    assert svc.session_mode_settings(_DB(workspace=_ws(None)), WS)["workspace_dir"] is None

--- a/services/cli-host/automatos_cli_host/__init__.py
+++ b/services/cli-host/automatos_cli_host/__init__.py
@@ -21,4 +21,4 @@ Invariants (PRD-234 §Terms — every one has a source guard in the tests):
 Standard library only, Python 3.9+, so ``make cli-host`` needs no virtualenv.
 """
 
-__version__ = "0.5.0"  # 0.5.0: results and TerminalClosed carry the turn's token usage; 0.3.0: persona + skills in the session prompt (PRD-239)
+__version__ = "0.6.0"  # 0.6.0: a ticket with no folder runs in <root>/sessions/<ticket> (the deliverables root IS the workspace root); 0.5.0: results and TerminalClosed carry the turn's token usage; 0.3.0: persona + skills in the session prompt (PRD-239)

--- a/services/cli-host/automatos_cli_host/allowlist.py
+++ b/services/cli-host/automatos_cli_host/allowlist.py
@@ -73,13 +73,15 @@ def resolve_allowed(cwd: Optional[str], roots: Iterable[str], *, default_root: O
 
 def default_session_cwd(default_root: str, workspace_id: str, task_id: str) -> Path:
     """Where a ticket with no working directory runs:
-    ``<root>/<workspace_id>/sessions/<task_id>`` — the workspace-worker's layout
-    for this workspace, so Deliverables → Explorer shows the session's files live
-    and the backend can register them as the ticket's deliverables (PRD-234 S2).
-    Created on demand; a hostile id cannot escape the root."""
+    ``<root>/sessions/<task_id>`` — the root is the deliverables folder compose
+    mounts AS the workspace's root (AUTOMATOS_WORKSPACE_DIR, 2026-09-09: no
+    workspace-id folder on the host any more), so Deliverables → Explorer shows
+    the session's files live and the backend can register them as the ticket's
+    deliverables (PRD-234 S2). ``workspace_id`` stays in the signature for the
+    callers; the layout no longer uses it. Created on demand; a hostile id
+    cannot escape the root."""
     root = Path(default_root).expanduser().resolve()
-    ws = (workspace_id or "").strip() or "local"
-    target = (root / ws / "sessions" / str(task_id)).resolve()
+    target = (root / "sessions" / str(task_id)).resolve()
     if not is_inside(target, root):
         raise NotAllowed(f"default session directory escapes the root: {target}")
     target.mkdir(parents=True, exist_ok=True)

--- a/services/cli-host/automatos_cli_host/allowlist.py
+++ b/services/cli-host/automatos_cli_host/allowlist.py
@@ -11,7 +11,7 @@ resolved allowed root.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Iterable, List, Optional
+from typing import Iterable, List, Optional, Tuple
 
 
 class NotAllowed(PermissionError):
@@ -69,6 +69,25 @@ def resolve_allowed(cwd: Optional[str], roots: Iterable[str], *, default_root: O
         f"{resolved} is outside every registered directory "
         f"({', '.join(str(r) for r in allowed)}); register it with --allow"
     )
+
+
+def choose_default_root(saved: List[str], requested: Optional[str]) -> Tuple[List[str], str]:
+    """The allowed roots and the one a ticket with no folder runs under.
+
+    ``--default-root`` (the Makefile passes AUTOMATOS_WORKSPACE_DIR, the folder
+    compose mounts as the workspace root) wins and is added to the allowed roots
+    when missing; without it the first registered root is the default — which,
+    on a host whose allowlist grew over time, is whatever was registered first.
+    Raises ``NotAllowed`` when nothing is registered at all."""
+    roots = list(saved)
+    if requested:
+        resolved = str(Path(requested).expanduser().resolve())
+        if resolved not in roots:
+            roots.append(resolved)
+        return roots, resolved
+    if not roots:
+        raise NotAllowed("no directories registered — start with `--allow <dir>` (make cli-host registers the deliverables root)")
+    return roots, roots[0]
 
 
 def default_session_cwd(default_root: str, workspace_id: str, task_id: str) -> Path:

--- a/services/cli-host/automatos_cli_host/config.py
+++ b/services/cli-host/automatos_cli_host/config.py
@@ -39,6 +39,9 @@ class HostConfig:
     url: str = DEFAULT_URL
     state_dir: Path = DEFAULT_STATE_DIR
     allow_dirs: List[Path] = field(default_factory=list)
+    # Where a ticket with no folder runs (<root>/sessions/<ticket>): the deliverables
+    # root compose mounts as the workspace root. None = the first registered root.
+    default_root: Optional[Path] = None
     pair_code: Optional[str] = None
     name: str = field(default_factory=lambda: socket.gethostname() or "cli-host")
     once: bool = False
@@ -97,6 +100,9 @@ def build_parser() -> argparse.ArgumentParser:
                    help="host state directory (token, allowlist, process table)")
     p.add_argument("--allow", action="append", default=[], metavar="DIR",
                    help="a directory sessions may work in (repeatable); registered directories only")
+    p.add_argument("--default-root", default=None, metavar="DIR",
+                   help="where a ticket with no folder runs (<DIR>/sessions/<ticket>); registered too. "
+                        "make cli-host passes the deliverables root. Default: the first registered directory")
     p.add_argument("--pair", default=None, metavar="CODE",
                    help="pair this host with the one-time code from Settings → Session mode")
     p.add_argument("--name", default=None, help="how this host appears in the fleet")
@@ -139,6 +145,7 @@ def parse_args(argv: Optional[List[str]] = None) -> HostConfig:
         url=ns.url.rstrip("/"),
         state_dir=Path(ns.dir).expanduser(),
         allow_dirs=[Path(d).expanduser() for d in ns.allow],
+        default_root=Path(ns.default_root).expanduser() if ns.default_root else None,
         pair_code=ns.pair,
         once=ns.once,
         max_sessions=max(0, ns.max_sessions),

--- a/services/cli-host/automatos_cli_host/host.py
+++ b/services/cli-host/automatos_cli_host/host.py
@@ -24,6 +24,7 @@ from typing import Any, Dict, List, Optional
 
 from . import state
 from . import __version__
+from .allowlist import NotAllowed, choose_default_root
 from .api import BackendClient, BackendError
 from .config import HostConfig, parse_args
 from .hook_server import HookServer
@@ -87,6 +88,7 @@ class Host:
         self.threads: Dict[str, threading.Thread] = {}
         self.pending_results: Dict[str, Dict[str, Any]] = {}
         self.allow_roots: List[str] = []
+        self.default_root: Optional[str] = None
         self.stop = threading.Event()
         self._last_heartbeat = 0.0
         self._last_flush = 0.0
@@ -113,10 +115,16 @@ class Host:
             resolved = str(Path(d).expanduser().resolve())
             if resolved not in saved:
                 saved.append(resolved)
+        # The default root (--default-root, the deliverables root) is allowed too
+        # and is where a ticket with no folder runs; else the first registered one.
+        try:
+            saved, self.default_root = choose_default_root(
+                saved, str(self.cfg.default_root) if self.cfg.default_root else None,
+            )
+        except NotAllowed as exc:
+            raise HostRefused(str(exc)) from None
         state.save_allowlist(self.cfg.allowlist_path, saved)
         self.allow_roots = saved
-        if not self.allow_roots:
-            raise HostRefused("no directories registered — start with `--allow <dir>` (make cli-host registers ./workspaces)")
 
         # PRD-239 S7: start the terminal before the first capabilities announce so
         # the backend learns the port at pairing / on the first heartbeat.
@@ -284,7 +292,7 @@ class Host:
 
     def _start(self, ticket: Dict[str, Any]) -> None:
         task_id = str(ticket.get("task_id"))
-        session = Session(ticket, self.cfg, self.allow_roots, self.cfg.socket_path, default_root=self.allow_roots[0],
+        session = Session(ticket, self.cfg, self.allow_roots, self.cfg.socket_path, default_root=self.default_root,
                           workspace_id=str((self.identity or {}).get("workspace_id") or ""))
         self.sessions[task_id] = session
         self.hooks.register(task_id, session.handle_hook)

--- a/services/cli-host/automatos_cli_host/service.py
+++ b/services/cli-host/automatos_cli_host/service.py
@@ -42,6 +42,8 @@ def service_argv(cfg: HostConfig, passthrough: Optional[List[str]] = None) -> Li
     argv = [sys.executable, "-m", "automatos_cli_host", "--url", cfg.url, "--dir", str(cfg.state_dir), "--name", cfg.name]
     for d in cfg.allow_dirs:
         argv += ["--allow", str(Path(d).expanduser().resolve())]
+    if cfg.default_root:
+        argv += ["--default-root", str(Path(cfg.default_root).expanduser().resolve())]
     if cfg.max_sessions > 0:
         argv += ["--max-sessions", str(cfg.max_sessions)]
     if cfg.claude_binary:

--- a/services/cli-host/tests/test_service_and_drift.py
+++ b/services/cli-host/tests/test_service_and_drift.py
@@ -28,6 +28,10 @@ def test_service_argv_reproduces_the_host_invocation(tmp_path):
     assert argv[1:3] == ["-m", "automatos_cli_host"]
     assert argv[argv.index("--url") + 1] == "http://127.0.0.1:8000"
     assert argv[argv.index("--allow") + 1] == str((tmp_path / "repo").resolve())
+    assert "--default-root" not in argv  # none requested → the host's first root
+    cfg.default_root = tmp_path / "deliverables"
+    argv = service_argv(cfg)
+    assert argv[argv.index("--default-root") + 1] == str((tmp_path / "deliverables").resolve())
     assert "--max-sessions" in argv and argv[argv.index("--max-sessions") + 1] == "2"
     assert "--no-worktrees" in argv and argv[-1] == "--verbose"
     assert "--pair" not in argv and "--install" not in argv  # a service never re-pairs or re-installs

--- a/services/cli-host/tests/test_service_and_drift.py
+++ b/services/cli-host/tests/test_service_and_drift.py
@@ -29,9 +29,8 @@ def test_service_argv_reproduces_the_host_invocation(tmp_path):
     assert argv[argv.index("--url") + 1] == "http://127.0.0.1:8000"
     assert argv[argv.index("--allow") + 1] == str((tmp_path / "repo").resolve())
     assert "--default-root" not in argv  # none requested → the host's first root
-    cfg.default_root = tmp_path / "deliverables"
-    argv = service_argv(cfg)
-    assert argv[argv.index("--default-root") + 1] == str((tmp_path / "deliverables").resolve())
+    with_root = service.service_argv(_cfg(tmp_path, default_root=tmp_path / "deliverables"))
+    assert with_root[with_root.index("--default-root") + 1] == str((tmp_path / "deliverables").resolve())
     assert "--max-sessions" in argv and argv[argv.index("--max-sessions") + 1] == "2"
     assert "--no-worktrees" in argv and argv[-1] == "--verbose"
     assert "--pair" not in argv and "--install" not in argv  # a service never re-pairs or re-installs

--- a/services/cli-host/tests/test_terminal_server.py
+++ b/services/cli-host/tests/test_terminal_server.py
@@ -81,12 +81,12 @@ def test_grants_are_single_use_and_expire():
 
 def test_directory_resolution_follows_the_allow_list(tmp_path):
     root = tmp_path / "ws"
-    (root / "wsid" / "sessions").mkdir(parents=True)
+    (root / "sessions").mkdir(parents=True)  # the root IS the workspace root (2026-09-09)
     repo = tmp_path / "repo"
     repo.mkdir()
     server = ts.TerminalServer([str(root), str(repo)], str(root), workspace_id=lambda: "wsid")
     assert server.resolve_directory(ts.Grant("t", str(repo), None, 0)) == repo.resolve()
-    assert server.resolve_directory(ts.Grant("t", None, "95", 0)) == (root / "wsid" / "sessions" / "95").resolve()
+    assert server.resolve_directory(ts.Grant("t", None, "95", 0)) == (root / "sessions" / "95").resolve()
     assert server.resolve_directory(ts.Grant("t", None, None, 0)) == Path(str(root))
     with pytest.raises(ts.NotAllowed):
         server.resolve_directory(ts.Grant("t", str(tmp_path / "elsewhere"), None, 0))

--- a/services/cli-host/tests/test_units.py
+++ b/services/cli-host/tests/test_units.py
@@ -445,3 +445,20 @@ def test_terminal_log_keeps_the_newest_bytes_and_a_readable_tail(tmp_path):
     log.close()
     log.write(b"after close")  # ignored, never raises
     assert oct((tmp_path / "s" / "terminal.log").stat().st_mode & 0o777) == "0o600"
+
+
+def test_default_root_flag_is_parsed_and_wins_over_the_allowlist_order(tmp_path):
+    """The Makefile passes AUTOMATOS_WORKSPACE_DIR as --default-root so a ticket with
+    no folder runs there even on a host whose allowlist grew in another order."""
+    from automatos_cli_host.config import parse_args
+    cfg = parse_args(["--allow", str(tmp_path / "Development"), "--default-root", str(tmp_path / "Development" / "deliverables")])
+    assert cfg.default_root == tmp_path / "Development" / "deliverables"
+    saved = [str((tmp_path / "Development").resolve()), str((tmp_path / "old-workspaces").resolve())]
+    roots, default = allowlist.choose_default_root(saved, str(cfg.default_root))
+    assert default == str((tmp_path / "Development" / "deliverables").resolve())
+    assert roots == saved + [default]  # registered too, once
+    assert allowlist.choose_default_root(roots, str(cfg.default_root))[0] == roots
+    # without the flag: the first registered root, and nothing registered is refused
+    assert allowlist.choose_default_root(saved, None) == (saved, saved[0])
+    with pytest.raises(allowlist.NotAllowed):
+        allowlist.choose_default_root([], None)

--- a/services/cli-host/tests/test_units.py
+++ b/services/cli-host/tests/test_units.py
@@ -355,12 +355,16 @@ def test_policy_lets_a_session_run_its_own_code(tmp_path):
 
 def test_default_session_cwd_is_the_workspace_sessions_folder(tmp_path):
     """PRD-234 S2: a ticket without a working directory runs where the
-    Deliverables explorer looks — <root>/<workspace id>/sessions/<ticket>."""
+    Deliverables explorer looks — <root>/sessions/<ticket>. The root IS the
+    workspace root since 2026-09-09 (compose mounts AUTOMATOS_WORKSPACE_DIR as
+    /workspaces/<workspace id>), so no workspace-id folder on the host."""
     target = allowlist.default_session_cwd(str(tmp_path), "00000000-0000-0000-0000-0000000000c1", "68")
-    assert target == (tmp_path / "00000000-0000-0000-0000-0000000000c1" / "sessions" / "68").resolve()
+    assert target == (tmp_path / "sessions" / "68").resolve()
     assert target.is_dir()
+    # the workspace id no longer shapes the path — a hostile one cannot escape either
+    assert allowlist.default_session_cwd(str(tmp_path), "../escape", "69") == (tmp_path / "sessions" / "69").resolve()
     with pytest.raises(allowlist.NotAllowed):
-        allowlist.default_session_cwd(str(tmp_path), "../escape", "68")
+        allowlist.default_session_cwd(str(tmp_path), "00000000-0000-0000-0000-0000000000c1", "../../escape")
 
 
 def test_emit_subject_is_the_command_or_path_only():


### PR DESCRIPTION
## What changes for a local install
- **`AUTOMATOS_WORKSPACE_DIR` is mounted as the workspace root** (`/workspaces/<DEFAULT_WORKSPACE_ID>`, worker rw, backend ro). Your machine sees `artifacts/`, `reports/`, `content/`, `sessions/…` directly — no workspace-id folder. Containers still see `/workspaces/<id>/…`, so confinement, the Explorer and the Canvas code are untouched.
- **One place for everything**: put the root beside your projects (`LOCAL_PROJECTS_DIR=~/Development`, `AUTOMATOS_WORKSPACE_DIR=~/Development/deliverables`) and Deliverables → Explorer, the chat's Code mode and your Claude Code sessions all read and write it.
- **`make up`** exports the root absolute to compose, allows it for the CLI host (was a hard-coded `./workspaces`), and migrates an older `<root>/<workspace id>/` layout up one level, once, guarded.
- **Backend** maps a session's host paths through the deliverables root as a second anchor (longest matching root wins), and Settings → Session mode shows the root beside the projects folder with the `.env` lines to copy.
- **CLI host 0.6.0**: a ticket with no folder runs in `<root>/sessions/<ticket>`.
- `.env.example`, README, QUICKSTART and the self-hosting guide describe the layout.

## Known, documented
With the deliverables root inside the projects folder the Explorer also lists it under `projects/` — the same files twice, harmless.

## Test plan
- [ ] `orchestrator`: `test_prd234_s2_session_deliverables.py` (root anchor, longest-root rule, absolute-only), `test_prd239_session_mode_settings.py` (`workspace_dir`).
- [ ] `services/cli-host` tests: flat `sessions/<ticket>`, hostile ids still cannot escape.
- [ ] `frontend`: `session-mode-tab.test.ts` (deliverables-root states, env lines).
- [ ] Owner's stack: rebuild with `AUTOMATOS_WORKSPACE_DIR=/Users/gkavanagh/Development/deliverables`; Explorer shows the folders at that path; a ticket with no folder lands in `deliverables/sessions/<ticket>`; Settings → Session mode shows both roots green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Configure separate local projects and deliverables/workspace directories.
  - View deliverables-root status and guidance in Session Mode settings.
  - Browse deliverables directly from the configured workspace root.
  - Session folders now use `sessions/<ticket>` within the deliverables directory.

- **Bug Fixes**
  - Existing workspace layouts are migrated automatically when starting the application.

- **Documentation**
  - Updated setup, self-hosting, and quick-start guidance for the new workspace layout and shared deliverables location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->