### PR TITLE
fix(cli-host): the backend expects host 0.6.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,7 +96,12 @@ jobs:
       # shared libs the dependency set needs at import time.
       - name: Install system libraries
         run: |
-          sudo apt-get update
+          # The runner image carries third-party apt sources (Google Chrome,
+          # Microsoft); a stale index there ("Hash Sum mismatch", 2026-09-09) makes
+          # apt-get update exit 100 and bash -e kills the step before a single
+          # test runs. The packages below come from Ubuntu's own archive, so a
+          # partial update is fine — install fails loudly if THAT index is stale.
+          sudo apt-get update || echo "::warning::apt-get update reported errors (a third-party index?) — continuing with the indexes that did refresh"
           sudo apt-get install -y --no-install-recommends \
             libpango-1.0-0 libpangocairo-1.0-0 libgdk-pixbuf-2.0-0 \
             libcairo2 libffi-dev libmagic1 ghostscript
@@ -189,7 +194,12 @@ jobs:
 
       - name: Install system libraries
         run: |
-          sudo apt-get update
+          # The runner image carries third-party apt sources (Google Chrome,
+          # Microsoft); a stale index there ("Hash Sum mismatch", 2026-09-09) makes
+          # apt-get update exit 100 and bash -e kills the step before a single
+          # test runs. The packages below come from Ubuntu's own archive, so a
+          # partial update is fine — install fails loudly if THAT index is stale.
+          sudo apt-get update || echo "::warning::apt-get update reported errors (a third-party index?) — continuing with the indexes that did refresh"
           sudo apt-get install -y --no-install-recommends \
             libpango-1.0-0 libpangocairo-1.0-0 libgdk-pixbuf-2.0-0 \
             libcairo2 libffi-dev libmagic1 ghostscript
@@ -458,7 +468,12 @@ jobs:
 
       - name: Install system libraries
         run: |
-          sudo apt-get update
+          # The runner image carries third-party apt sources (Google Chrome,
+          # Microsoft); a stale index there ("Hash Sum mismatch", 2026-09-09) makes
+          # apt-get update exit 100 and bash -e kills the step before a single
+          # test runs. The packages below come from Ubuntu's own archive, so a
+          # partial update is fine — install fails loudly if THAT index is stale.
+          sudo apt-get update || echo "::warning::apt-get update reported errors (a third-party index?) — continuing with the indexes that did refresh"
           sudo apt-get install -y --no-install-recommends \
             libpango-1.0-0 libpangocairo-1.0-0 libgdk-pixbuf-2.0-0 \
             libcairo2 libffi-dev libmagic1 ghostscript
@@ -733,7 +748,12 @@ jobs:
 
       - name: Install system libraries
         run: |
-          sudo apt-get update
+          # The runner image carries third-party apt sources (Google Chrome,
+          # Microsoft); a stale index there ("Hash Sum mismatch", 2026-09-09) makes
+          # apt-get update exit 100 and bash -e kills the step before a single
+          # test runs. The packages below come from Ubuntu's own archive, so a
+          # partial update is fine — install fails loudly if THAT index is stale.
+          sudo apt-get update || echo "::warning::apt-get update reported errors (a third-party index?) — continuing with the indexes that did refresh"
           sudo apt-get install -y --no-install-recommends \
             libpango-1.0-0 libpangocairo-1.0-0 libgdk-pixbuf-2.0-0 \
             libcairo2 libffi-dev libmagic1 ghostscript

--- a/orchestrator/services/cli_host_service.py
+++ b/orchestrator/services/cli_host_service.py
@@ -168,7 +168,7 @@ def revoke_host(db: Session, host: CliHost) -> None:
 # was built for. A host that sees the fingerprint change drains and exits; its
 # service manager brings it back on the new code. Bump EXPECTED_CLI_HOST_VERSION
 # whenever the wire contract changes so a stale checkout is told, not surprised.
-EXPECTED_CLI_HOST_VERSION = "0.5.0"  # 2026-09-09: session results and TerminalClosed carry the turn's token usage (analytics)
+EXPECTED_CLI_HOST_VERSION = "0.6.0"  # 2026-09-09: a no-folder ticket runs in <deliverables root>/sessions/<ticket>; --default-root (#722). 0.5.0: results and TerminalClosed carry the turn's token usage
 
 _CONTRACT_MODULES = ("api/cli_hosts.py", "services/cli_host_service.py", "core/cli_runtime.py")
 

--- a/orchestrator/tests/test_prd235_host_always_on.py
+++ b/orchestrator/tests/test_prd235_host_always_on.py
@@ -20,7 +20,7 @@ def test_contract_fields_are_stable_and_versioned():
     assert re.fullmatch(r"[0-9a-f]{16}", f["host_contract"])
     # 0.4.0: PRD-239 S7 v2 — terminal grants carry a launch; TerminalOpened/Closed events.
     # 0.5.0: session results and TerminalClosed carry the turn's token usage (analytics).
-    assert f["expected_host_version"] == svc.EXPECTED_CLI_HOST_VERSION == "0.5.0"
+    assert f["expected_host_version"] == svc.EXPECTED_CLI_HOST_VERSION == "0.6.0"
     assert svc.contract_fields() == f
 
 

--- a/orchestrator/tests/test_prd239_session_prompt.py
+++ b/orchestrator/tests/test_prd239_session_prompt.py
@@ -188,4 +188,4 @@ def test_the_sessions_real_directory_always_wins(monkeypatch):
 
 def test_host_contract_version_moved_with_the_claim_shape():
     # 0.5.0 (2026-09-09): results and TerminalClosed carry the turn's token usage
-    assert svc.EXPECTED_CLI_HOST_VERSION == "0.5.0"
+    assert svc.EXPECTED_CLI_HOST_VERSION == "0.6.0"


### PR DESCRIPTION
#722 shipped host 0.6.0 (flat `sessions/<ticket>`, `--default-root`) but left `EXPECTED_CLI_HOST_VERSION` at 0.5.0, so an updated host warns on every heartbeat. One-line pin bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the CLI host contract to version 0.6.0.
  - No-folder tickets now run in a dedicated session directory under the deliverables root.

- **Bug Fixes**
  - System-library setup in CI now continues when third-party package indexes fail to refresh, while still reporting installation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->