### PR TITLE
fix(composio): forward COMPOSIO_KEY through compose so a local .env key works

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,21 @@ OPENAI_API_KEY=
 # Required for: Claude models
 ANTHROPIC_API_KEY=
 
+# Every other model provider (OpenRouter, NVIDIA, DeepSeek, Google, Grok,
+# Cohere, Azure, Bedrock, HuggingFace) is added in the app under
+# Settings -> API Keys, which validates the key on save. Nothing to put here.
+
+# =============================================================================
+# Composio — third-party app integrations (Gmail, Slack, GitHub, Shopify, ...)
+# =============================================================================
+# OPTIONAL. Free tier at https://app.composio.dev. Env-only — there is no field
+# for it in Settings, so set it here and restart the backend to pick it up:
+#   docker compose up -d backend
+# Then open Marketplace -> Tools and press Sync to pull the toolkit catalogue.
+# Without it the Tools page says integrations are disabled and the catalogue
+# stays empty.
+COMPOSIO_KEY=
+
 # =============================================================================
 # Authentication (PRD-37: SaaS Foundation)
 # =============================================================================

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -36,14 +36,14 @@ want AI features:
 
 ```bash
 OPENAI_API_KEY=sk-...          # or
-ANTHROPIC_API_KEY=sk-ant-...   # or
-OPENROUTER_API_KEY=sk-or-...   # one key, 400+ models (paid per call)
-NVIDIA_API_KEY=nvapi-...       # build.nvidia.com — open models (Kimi, DeepSeek, Nemotron…) at no charge
-DEEPSEEK_API_KEY=sk-...        # DeepSeek's own API
+ANTHROPIC_API_KEY=sk-ant-...   # or any provider below, via the UI
 ```
 
-You can also add keys later through **Settings → API Keys** in the UI (until
-you do, the chat page shows *"Add an LLM key to bring Auto to life"*).
+**Every provider is added in the app** — **Settings → API Keys** lists OpenAI,
+Anthropic, OpenRouter, NVIDIA, DeepSeek, Google, Grok / xAI, Cohere, Azure
+OpenAI, AWS Bedrock and HuggingFace, and validates the key on save. Nothing but
+the two lines above ever needs to go in `.env`. (Until a key is stored the chat
+page shows *"Add an LLM key to bring Auto to life"*.)
 
 **About the NVIDIA key.** NVIDIA's hosted endpoint is a trial: its terms allow
 internal testing and evaluation, not production, and no personal, financial or
@@ -185,11 +185,13 @@ figure to invent. The full reference is the
   needs an embedding provider too (an OpenAI or OpenRouter key, or the local
   HuggingFace provider under Settings → System Settings → Embeddings).
 - **Composio-powered integrations** (Gmail, Slack, GitHub, Shopify and the rest
-  of the third-party app catalogue) need your own Composio key in `.env`
-  (`COMPOSIO_API_KEY=…`, free tier at app.composio.dev; env-only, there is no
-  UI field), then `docker compose up -d backend` to apply it. On that boot the
-  backend syncs the catalogue itself and re-binds the seeded agents to their
-  apps. Without a key the Tools page says *"Integrations are disabled — no
+  of the third-party app catalogue) need your own Composio key. Put
+  `COMPOSIO_KEY=…` in `.env` (free tier at app.composio.dev; env-only, there is
+  no UI field for it — the line is in `.env.example`), then
+  `docker compose up -d backend` to apply it. On that boot the backend syncs
+  the catalogue itself; you can also pull it on demand from **Marketplace →
+  Tools → Sync**, which fetches every toolkit and its actions. Without a key
+  the Tools page and Marketplace → Tools say *"Integrations are disabled — no
   Composio API key is configured."*, Composio tools are not offered to agents,
   and the native platform tools keep working (PRD-233 S2).
 - **Durable memory (mem0) and field memory (Qdrant)** are not in the default

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -191,6 +191,11 @@ services:
       CREDENTIAL_ENCRYPTION_KEY: ${CREDENTIAL_ENCRYPTION_KEY:-}
       # Composio (hosted tool integrations) — bring your own key; without it the
       # integrations surface stays empty (PRD-233 makes that honest in the UI).
+      # COMPOSIO_KEY is the canonical name (it matches the Railway variable);
+      # config.py accepts COMPOSIO_API_KEY as an alias. BOTH are forwarded — only
+      # COMPOSIO_API_KEY used to be, so a .env carrying COMPOSIO_KEY never reached
+      # the process and integrations stayed off with no way to tell why.
+      COMPOSIO_KEY: ${COMPOSIO_KEY:-}
       COMPOSIO_API_KEY: ${COMPOSIO_API_KEY:-}
       # PRD-234 Session mode — tickets of `runtime: cli` agents run as YOUR OWN
       # Claude Code sessions on this machine via `make cli-host`. Off by default;

--- a/docs/getting-started/self-hosting.md
+++ b/docs/getting-started/self-hosting.md
@@ -260,20 +260,27 @@ Third-party app integrations (Gmail, Slack, GitHub, Shopify and the rest of
 the Composio catalogue) run through Composio. In the local edition that is a
 **bring-your-own key, env-only** setting:
 
-1. Put `COMPOSIO_API_KEY=…` in `.env` (free tier at app.composio.dev).
+1. Put `COMPOSIO_KEY=…` in `.env` (free tier at app.composio.dev). That is the
+   canonical name — it matches the Railway variable; `COMPOSIO_API_KEY` is
+   accepted as an alias. `docker-compose.yml` forwards both.
 2. Apply it: `docker compose up -d backend` (the container must be recreated;
-   the key is read from the environment, not from the UI).
+   the key is read from the environment at process start, not from the UI).
 3. On that boot, if the local catalogue (`composio_apps_cache`) is empty, the
    backend syncs the full Composio catalogue in a background thread and then
    re-binds the seeded marketplace agents to the apps they were designed for.
    A later boot with a populated catalogue only re-binds anything still
    unbound. The Tools page shows *"Integration catalogue is syncing"* while
    this runs.
+4. To pull the catalogue on demand instead of waiting for a boot, press
+   **Sync** on **Marketplace → Tools** (or `POST /api/tools/sync?sync_type=full`).
+   It fetches every toolkit and its actions into the cache; a full catalogue is
+   several hundred apps, so it takes a few minutes. Without a valid key the
+   request returns 400 with the reason rather than reporting a sync of 0 apps.
 
 Without a key the platform is honest rather than empty:
 
-- the Tools page shows *"Integrations are disabled — no Composio API key is
-  configured."* with the fix;
+- the Tools page **and Marketplace → Tools** show *"Integrations are disabled —
+  no Composio API key is configured."* with the fix;
 - Composio tools are not offered to agents at all (excluded from discovery),
   and a direct call returns an explicit `integrations_unavailable` error —
   never a silent success;
@@ -404,8 +411,10 @@ purpose).
 **Chat answers nothing; banner "Add an LLM key to bring Auto to life".** No
 model key is stored. Settings → API Keys, or one of the keys in §2.
 
-**Tools page: "Integrations are disabled".** No `COMPOSIO_API_KEY` (§7). Native
-tools keep working.
+**Tools page: "Integrations are disabled".** No `COMPOSIO_KEY` (§7) — check the
+variable actually reached the container (`docker compose exec backend env | grep
+COMPOSIO`); it is read at process start, so a `.env` edit needs
+`docker compose up -d backend`. Native tools keep working.
 
 **Code Canvas session fails as soon as it starts.** The worker has no model
 credential: set `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN` in `.env`

--- a/frontend/components/marketplace/marketplace-tools-tab.tsx
+++ b/frontend/components/marketplace/marketplace-tools-tab.tsx
@@ -41,7 +41,8 @@ import {
 import { MarketplaceAppDetailsModal } from './marketplace-app-details-modal'
 import { apiClient } from '@/lib/api-client'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
-import { useSyncToolsCache } from '@/hooks/use-tools-api'
+import { useSyncToolsCache, useIntegrationsStatus } from '@/hooks/use-tools-api'
+import { IntegrationsDisabledCard } from '@/components/tools/integrations-disabled-card'
 import { useSystemRole } from '@/contexts/role-context'
 import { EnhancedPagination } from '@/components/ui/pagination'
 
@@ -65,6 +66,10 @@ interface MarketplaceToolsTabProps {
 
 export function MarketplaceToolsTab({ searchQuery }: MarketplaceToolsTabProps) {
     const { isAdmin } = useSystemRole()
+    // The Tools page has always explained the no-key case; the marketplace grid
+    // rendered empty with no reason, which is what read as "the marketplace is
+    // broken" rather than "no Composio key yet — add one and press Sync".
+    const { data: integrationsStatus } = useIntegrationsStatus()
     const syncCacheMutation = useSyncToolsCache()
     const [viewMode, setViewMode] = useViewMode('mp-tools')
     const [selectedCategory, setSelectedCategory] = useState('all')
@@ -352,6 +357,8 @@ export function MarketplaceToolsTab({ searchQuery }: MarketplaceToolsTabProps) {
 
     return (
         <div className="space-y-6">
+            <IntegrationsDisabledCard status={integrationsStatus} />
+
             {/* Header Stats */}
             <div className="flex items-center justify-between">
                 <div>

--- a/frontend/components/tools/__tests__/integrations-disabled-card.test.tsx
+++ b/frontend/components/tools/__tests__/integrations-disabled-card.test.tsx
@@ -19,7 +19,7 @@ afterEach(() => cleanup())
 
 const noKey: IntegrationsStatus = {
   available: false,
-  reason: 'COMPOSIO_API_KEY is not configured',
+  reason: 'COMPOSIO_KEY is not configured',
   key_configured: false,
   apps_cached: 0,
   last_sync: null,
@@ -35,10 +35,10 @@ describe('PRD-233 S2 — IntegrationsDisabledCard', () => {
     expect(card).toHaveAttribute('role', 'alert')
     expect(screen.getByText(INTEGRATIONS_DISABLED_NO_KEY_TITLE)).toBeInTheDocument()
     const text = card.textContent || ''
-    expect(text).toContain(
-      'Add COMPOSIO_API_KEY to .env, then docker compose up -d backend; the catalogue syncs automatically on boot.',
-    )
-    expect(text).toContain('Reason: COMPOSIO_API_KEY is not configured')
+    expect(text).toContain('Add COMPOSIO_KEY to .env, then docker compose up -d backend')
+    // The user's route back: the Sync button on the marketplace tab.
+    expect(text).toContain('press Sync on Marketplace → Tools')
+    expect(text).toContain('Reason: COMPOSIO_KEY is not configured')
     expect(text).toContain('Native platform tools keep working')
   })
 

--- a/frontend/components/tools/integrations-disabled-card.tsx
+++ b/frontend/components/tools/integrations-disabled-card.tsx
@@ -39,8 +39,9 @@ export function IntegrationsDisabledCard({ status }: IntegrationsDisabledCardPro
         <AlertTitle>{title}</AlertTitle>
         <AlertDescription className="space-y-1">
           <p>
-            Add <code>COMPOSIO_API_KEY</code> to <code>.env</code>, then{' '}
-            <code>docker compose up -d backend</code>; the catalogue syncs automatically on boot.
+            Add <code>COMPOSIO_KEY</code> to <code>.env</code>, then{' '}
+            <code>docker compose up -d backend</code>; the catalogue syncs automatically on boot,
+            or press <strong>Sync</strong> on Marketplace &rarr; Tools.
           </p>
           {status.reason ? <p className="text-muted-foreground">Reason: {status.reason}</p> : null}
           <p className="text-muted-foreground">
@@ -61,7 +62,7 @@ export function IntegrationsDisabledCard({ status }: IntegrationsDisabledCardPro
       <AlertDescription>
         {failed ? (
           <p>
-            The last catalogue sync did not complete — check that <code>COMPOSIO_API_KEY</code> is valid
+            The last catalogue sync did not complete — check that <code>COMPOSIO_KEY</code> is valid
             (backend logs carry the error), then run Sync or restart the backend.
           </p>
         ) : (

--- a/orchestrator/api/tools.py
+++ b/orchestrator/api/tools.py
@@ -777,6 +777,11 @@ async def sync(
     db: Session = Depends(get_db),
 ):
     logger.info(f"Sync requested: type={sync_type}, workspace_id={ctx.workspace_id}")
+    # Without a key the SDK wrapper returns an empty app list, so the sync used
+    # to report success with 0 apps synced — the Sync button looked like it had
+    # worked and the catalogue stayed empty. Say what is actually wrong instead.
+    if not composio_available():
+        raise HTTPException(status_code=400, detail=composio_unavailable_reason())
     service = MetadataSyncService(db)
     if sync_type == "incremental":
         result = service.run_incremental_sync()

--- a/orchestrator/core/composio/client.py
+++ b/orchestrator/core/composio/client.py
@@ -1436,7 +1436,7 @@ def get_composio_client() -> ComposioClient:
 # is env-only and the SDK install is static) — ``reset_composio_availability``
 # exists for tests that flip the config.
 
-COMPOSIO_UNAVAILABLE_NO_KEY = "COMPOSIO_API_KEY is not configured"
+COMPOSIO_UNAVAILABLE_NO_KEY = "COMPOSIO_KEY is not configured"
 # NOTE: keep "composio-openai" out of this string — tool_router's
 # _is_fatal_dependency_error() keys on it and would replace the honest
 # message with a generic "restart the backend" line.

--- a/orchestrator/tests/test_prd209_quickstart_honest.py
+++ b/orchestrator/tests/test_prd209_quickstart_honest.py
@@ -25,6 +25,7 @@ _COMPOSE = _REPO_ROOT / "docker-compose.yml"
 _QUICKSTART = _REPO_ROOT / "QUICKSTART.md"
 _README = _REPO_ROOT / "README.md"
 _SELF_HOSTING = _REPO_ROOT / "docs" / "getting-started" / "self-hosting.md"
+_ENV_EXAMPLE = _REPO_ROOT / ".env.example"
 
 # ${VAR:?message} — a variable compose treats as REQUIRED (errors if unset/empty).
 _REQUIRED_VAR = re.compile(r"\$\{([A-Z_][A-Z0-9_]*):\?")
@@ -131,3 +132,41 @@ def test_readme_quickstart_references_required_secrets_or_quickstart():
     assert ("POSTGRES_PASSWORD" in text) or ("QUICKSTART.md" in text), (
         "README quickstart must name the required secrets or link QUICKSTART.md"
     )
+
+
+# ---------------------------------------------------------------------------
+# The env var has to actually reach the container (2026-09-10)
+# ---------------------------------------------------------------------------
+
+
+def test_env_example_names_the_composio_key():
+    """`cp .env.example .env` must produce a file with a line for the key.
+
+    QUICKSTART told readers to put the Composio key in `.env` while
+    `.env.example` had no such line, so a fresh install had nowhere to put it.
+    """
+    assert re.search(r"^COMPOSIO_KEY=", _ENV_EXAMPLE.read_text(encoding="utf-8"), re.MULTILINE), (
+        "COMPOSIO_KEY is named in the install docs but has no line in .env.example"
+    )
+
+
+def test_env_example_documents_every_compose_required_secret():
+    text = _ENV_EXAMPLE.read_text(encoding="utf-8")
+    missing = sorted(v for v in _required_secrets() if v not in text)
+    assert not missing, f".env.example omits compose-required secrets: {missing}"
+
+
+def test_compose_forwards_both_composio_key_names():
+    """The bug this guards.
+
+    `config.py` reads ``COMPOSIO_API_KEY or COMPOSIO_KEY``, and COMPOSIO_KEY is
+    the canonical name (it matches the Railway variable). But docker-compose.yml
+    forwarded ONLY COMPOSIO_API_KEY, so a `.env` carrying COMPOSIO_KEY never
+    reached the process: the fallback could not fire, integrations stayed off,
+    and the Tools marketplace looked broken rather than unconfigured.
+    """
+    compose = _COMPOSE.read_text(encoding="utf-8")
+    for var in ("COMPOSIO_KEY", "COMPOSIO_API_KEY"):
+        assert re.search(rf"^\s*{var}:\s*\$\{{{var}", compose, re.MULTILINE), (
+            f"docker-compose.yml does not forward {var} — a .env line for it would be inert"
+        )

--- a/orchestrator/tests/test_prd233_s2_composio_degrade.py
+++ b/orchestrator/tests/test_prd233_s2_composio_degrade.py
@@ -419,6 +419,41 @@ async def test_status_endpoint_reports_available_state(composio_on):
 
 
 # ---------------------------------------------------------------------------
+# 4c. POST /api/tools/sync — the Marketplace -> Tools "Sync" button
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sync_refuses_without_a_key_instead_of_reporting_zero_apps(composio_off):
+    """Keyless, the SDK wrapper returns an empty app list, so the sync used to
+    finish "successfully" having synced 0 apps — the button looked like it had
+    worked and the catalogue stayed empty."""
+    from fastapi import HTTPException
+
+    from api.tools import sync
+
+    with patch("api.tools.MetadataSyncService") as service:
+        with pytest.raises(HTTPException) as excinfo:
+            await sync(sync_type="full", ctx=MagicMock(), db=MagicMock())
+
+    assert excinfo.value.status_code == 400
+    assert excinfo.value.detail == cc.COMPOSIO_UNAVAILABLE_NO_KEY
+    service.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_sync_runs_the_full_catalogue_sync_when_a_key_is_configured(composio_on):
+    from api.tools import sync
+
+    with patch("api.tools.MetadataSyncService") as service:
+        service.return_value.run_full_sync.return_value = {"apps_synced": 880}
+        out = await sync(sync_type="full", ctx=MagicMock(), db=MagicMock())
+
+    assert out == {"apps_synced": 880}
+    service.return_value.run_full_sync.assert_called_once_with()
+
+
+# ---------------------------------------------------------------------------
 # 5. Boot bootstrap (pure — session + service mocked)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## The bug

An open-source user reported: *"we cant load COMPOSIO, marketplace is empty, so we cant add them to the workspace… they have no tools."*

`config.py:539` reads:

```python
COMPOSIO_API_KEY: str = os.getenv("COMPOSIO_API_KEY") or os.getenv("COMPOSIO_KEY")
```

…but `docker-compose.yml` forwarded **only** `COMPOSIO_API_KEY: ${COMPOSIO_API_KEY:-}`.

So a `.env` carrying `COMPOSIO_KEY=…` — the canonical name, and **the one set on Railway** — never reached the backend process. The fallback could not fire, `composio_available()` stayed false, no Composio tools were offered, and the Tools marketplace rendered empty with no explanation. On Railway it works because variables are set on the service directly, with no compose in the path; this only ever broke the Docker/open-source path.

Compounding it, `.env.example` had **no Composio line at all**, while QUICKSTART told readers to put the key in `.env`. `cp .env.example .env` produced a file with nowhere to put it.

## Changes

- **`docker-compose.yml` forwards both names.** An empty `COMPOSIO_API_KEY` is falsy, so the config fallback still resolves `COMPOSIO_KEY`. Nothing changes for anyone already using `COMPOSIO_API_KEY`.
- **`.env.example` carries a `COMPOSIO_KEY=` line** with the apply step and what happens without it.
- **Docs name `COMPOSIO_KEY` as canonical** (`COMPOSIO_API_KEY` noted as the alias) and spell out the on-demand path: **Marketplace → Tools → Sync**.
- **`POST /api/tools/sync` fails fast with 400** when no key is configured. Keyless, the SDK wrapper returns an empty app list, so the sync reported success having synced 0 apps — the Sync button looked like it had worked and the catalogue stayed empty.
- **`IntegrationsDisabledCard` renders on Marketplace → Tools**, not just the Tools page, and names the Sync button. That empty grid with no reason is what read as "the marketplace is broken".
- The user-facing reason string now reads `COMPOSIO_KEY is not configured`.

Model-provider keys are deliberately **not** added to `.env.example`. QUICKSTART now says plainly that every provider (OpenRouter, NVIDIA, DeepSeek, Google, Grok, Cohere, Azure, Bedrock, HuggingFace) is entered under **Settings → API Keys**, which validates the key on save. Only `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` belong in `.env` (the Canvas worker reads env).

## The flow this restores

```
COMPOSIO_KEY=…  in .env
docker compose up -d backend
Marketplace → Tools → Sync      # pulls every toolkit + its actions
```

The Sync button was already reachable locally — `useSystemRole().isAdmin` is true and the local operator is `super_admin`, which bypasses `workspace:manage`.

## Test plan

New guards, all pure (no services):

- `test_prd209_quickstart_honest.py`
  - `test_compose_forwards_both_composio_key_names` — **the regression guard**: a `.env` line for either name must not be inert.
  - `test_env_example_names_the_composio_key`
  - `test_env_example_documents_every_compose_required_secret`
- `test_prd233_s2_composio_degrade.py`
  - `test_sync_refuses_without_a_key_instead_of_reporting_zero_apps`
  - `test_sync_runs_the_full_catalogue_sync_when_a_key_is_configured`
- `integrations-disabled-card.test.tsx` updated for the `COMPOSIO_KEY` copy and the Sync pointer.

Not run locally — CI is the gate here.

**Manual check on a fresh clone:** put `COMPOSIO_KEY=` in `.env`, `docker compose up -d backend`, then `docker compose exec backend env | grep COMPOSIO` (the value must be present) and `curl -s localhost:8000/api/tools/integrations/status` (`key_configured: true`, `available: true`). Marketplace → Tools → Sync should then fill the catalogue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring Composio with the `COMPOSIO_KEY` environment variable.
  * Added manual toolkit catalogue synchronization from Marketplace → Tools.
  * Marketplace now explains when tools are unavailable because Composio is not configured.

* **Bug Fixes**
  * Improved synchronization errors when no valid Composio key is available.
  * Docker deployments now forward the canonical key and supported alias correctly.

* **Documentation**
  * Updated setup, quickstart, and troubleshooting guidance for Composio configuration and synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->