### PR TITLE
Retier a workspace from the admin console, and see when each one was last active

### DIFF
--- a/frontend/app/admin/workspaces/page.tsx
+++ b/frontend/app/admin/workspaces/page.tsx
@@ -28,6 +28,10 @@ import { usePageAPI } from '@/hooks/use-page-api'
 import { apiClient } from '@/lib/api-client'
 import { SaasOnlyNotice } from '@/components/local/saas-only-notice'
 import { isRouteAvailableInEdition } from '@/lib/auth-edition'
+import {
+  WorkspacePlanSelect,
+  type PlanTier,
+} from '@/components/admin/workspace-plan-select'
 
 // ===================================================================
 // Types
@@ -46,6 +50,8 @@ interface WorkspaceRow {
   documents_count: number
   storage_bytes: number
   chats_count: number
+  members_count: number
+  last_active_at: string | null
   created_at: string | null
   paused_at: string | null
   paused_reason: string | null
@@ -82,6 +88,28 @@ function formatDate(iso: string | null): string {
     month: 'short',
     day: 'numeric',
   })
+}
+
+/**
+ * "Last active" reads as elapsed time, not a date — the console is scanned to
+ * spot who is live during a pilot, and "3d ago" answers that at a glance where
+ * a timestamp has to be subtracted first. Anything older than a month falls
+ * back to the absolute date, where the elapsed form stops being informative.
+ */
+function formatRelative(iso: string | null): string {
+  if (!iso) return 'never'
+  const then = new Date(iso).getTime()
+  if (Number.isNaN(then)) return 'never'
+  const seconds = Math.floor((Date.now() - then) / 1000)
+  if (seconds < 0) return 'just now'
+  if (seconds < 60) return 'just now'
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  if (days < 31) return `${days}d ago`
+  return formatDate(iso)
 }
 
 function stateBadge(w: WorkspaceRow) {
@@ -125,6 +153,10 @@ function AdminWorkspacesConsole() {
   const [sort, setSort] = useState<'created_at' | 'name' | 'storage_bytes' | 'agents_count'>('created_at')
   const [order, setOrder] = useState<'asc' | 'desc'>('desc')
 
+  // Fetched once for the whole table — the dropdown is rendered per row, but the
+  // catalogue behind it is identical for every row.
+  const [tiers, setTiers] = useState<PlanTier[]>([])
+
   const [actionId, setActionId] = useState<string | null>(null)
   const [copiedId, setCopiedId] = useState<string | null>(null)
 
@@ -164,6 +196,23 @@ function AdminWorkspacesConsole() {
   useEffect(() => {
     fetchWorkspaces()
   }, [fetchWorkspaces])
+
+  useEffect(() => {
+    let cancelled = false
+    apiClient
+      .request<{ tiers: PlanTier[] }>('/api/admin/workspaces/plans')
+      .then((data) => {
+        if (!cancelled) setTiers(data?.tiers ?? [])
+      })
+      .catch(() => {
+        // The table is still fully usable without the catalogue — the plan
+        // dropdown simply stays disabled rather than blocking the console.
+        if (!cancelled) setTiers([])
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
 
   async function copyWorkspaceId(id: string) {
     try {
@@ -363,7 +412,7 @@ function AdminWorkspacesConsole() {
                   <tr>
                     <th className="text-left px-3 py-2.5 w-[260px]">Workspace</th>
                     <th className="text-left px-3 py-2.5 w-[200px]">Owner</th>
-                    <th className="text-left px-3 py-2.5 w-[110px]">Plan</th>
+                    <th className="text-left px-3 py-2.5 w-[150px]">Plan</th>
                     <th className="text-left px-3 py-2.5 w-[90px]">State</th>
                     <th className="text-right px-2 py-2.5 w-[52px]">
                       <Users className="h-3.5 w-3.5 inline" />
@@ -377,6 +426,7 @@ function AdminWorkspacesConsole() {
                     <th className="text-right px-2 py-2.5 w-[52px]">
                       <MessageSquare className="h-3.5 w-3.5 inline" />
                     </th>
+                    <th className="text-left px-3 py-2.5 w-[100px]">Last active</th>
                     <th className="text-left px-3 py-2.5 w-[90px]">Created</th>
                     <th className="text-right px-3 py-2.5 w-[100px]">Actions</th>
                   </tr>
@@ -384,14 +434,14 @@ function AdminWorkspacesConsole() {
                 <tbody>
                   {loading && workspaces.length === 0 && (
                     <tr>
-                      <td colSpan={10} className="px-4 py-12 text-center">
+                      <td colSpan={11} className="px-4 py-12 text-center">
                         <Loader2 className="h-6 w-6 animate-spin mx-auto text-muted-foreground" />
                       </td>
                     </tr>
                   )}
                   {!loading && workspaces.length === 0 && (
                     <tr>
-                      <td colSpan={10} className="px-4 py-12 text-center text-muted-foreground">
+                      <td colSpan={11} className="px-4 py-12 text-center text-muted-foreground">
                         No workspaces found.
                       </td>
                     </tr>
@@ -432,14 +482,23 @@ function AdminWorkspacesConsole() {
                         </div>
                       </td>
                       <td className="px-3 py-2.5">
-                        <Badge variant="outline" className="capitalize">
-                          {w.plan || '—'}
-                        </Badge>
-                        {w.is_personal && (
-                          <Badge variant="outline" className="ml-1 text-[10px]">
-                            personal
-                          </Badge>
-                        )}
+                        <div className="flex items-center gap-1">
+                          <WorkspacePlanSelect
+                            workspaceId={w.id}
+                            workspaceName={w.name}
+                            plan={w.plan}
+                            membersCount={w.members_count}
+                            tiers={tiers}
+                            disabled={!!w.deleted_at || actionId === w.id}
+                            onChanged={fetchWorkspaces}
+                            onError={setError}
+                          />
+                          {w.is_personal && (
+                            <Badge variant="outline" className="text-[10px]">
+                              personal
+                            </Badge>
+                          )}
+                        </div>
                       </td>
                       <td className="px-3 py-2.5">{stateBadge(w)}</td>
                       <td className="px-2 py-2.5 text-right tabular-nums">
@@ -453,6 +512,16 @@ function AdminWorkspacesConsole() {
                       </td>
                       <td className="px-2 py-2.5 text-right tabular-nums">
                         {w.chats_count}
+                      </td>
+                      <td
+                        className="px-3 py-2.5 text-xs text-muted-foreground whitespace-nowrap"
+                        title={
+                          w.last_active_at
+                            ? new Date(w.last_active_at).toLocaleString()
+                            : 'Not seen since last-active tracking shipped'
+                        }
+                      >
+                        {formatRelative(w.last_active_at)}
                       </td>
                       <td className="px-3 py-2.5 text-xs text-muted-foreground whitespace-nowrap">
                         {formatDate(w.created_at)}

--- a/frontend/components/admin/workspace-plan-select.tsx
+++ b/frontend/components/admin/workspace-plan-select.tsx
@@ -1,0 +1,307 @@
+'use client'
+
+/**
+ * The operator console's plan dropdown (admin/workspaces).
+ *
+ * Changing a tier changes what a LIVE tenant can see and do, so the control is
+ * deliberately asymmetric:
+ *
+ *   * an UPGRADE (nothing is taken away) applies on selection — that is the
+ *     common case, and the reason this control exists;
+ *   * a change that REMOVES something — a nav surface the tier no longer
+ *     exposes, or a seat cap below the members already in the workspace —
+ *     stops for confirmation and names exactly what it removes first.
+ *
+ * The backend never writes a spend ceiling from this path
+ * (``assign_plan(..., with_budget=False)``), so no tier change here can hand a
+ * tenant a ``check_budget`` throttle it did not already have.
+ */
+
+import { useMemo, useState } from 'react'
+import { AlertTriangle, Loader2 } from 'lucide-react'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import { apiClient } from '@/lib/api-client'
+
+export interface PlanTier {
+  name: string
+  display_name: string | null
+  assignable: boolean
+  coming_soon: boolean
+  seats: number | null
+  max_agents: number | null
+  marketplace_depth: number
+  families: Record<string, boolean>
+  nav: Record<string, boolean>
+}
+
+interface PlanChangeResponse {
+  plan: string
+  previous_plan: string | null
+  warnings: string[]
+}
+
+interface WorkspacePlanSelectProps {
+  workspaceId: string
+  workspaceName: string
+  plan: string | null
+  membersCount: number
+  tiers: PlanTier[]
+  disabled?: boolean
+  onChanged: () => void | Promise<void>
+  onError: (message: string) => void
+}
+
+/** Nav keys the exposure profile actually gates, in the rail's own words. */
+const NAV_LABELS: Record<string, string> = {
+  team: 'Team Management',
+  analytics: 'Analytics',
+}
+
+/** Capability families, as Auto's tool surface trims them. */
+const FAMILY_LABELS: Record<string, string> = {
+  codegraph: 'CodeGraph tools',
+  nl2sql: 'Data queries & analytics tools',
+  team: 'Team tools',
+  voice: 'Voice',
+}
+
+function tierLabel(tier: PlanTier): string {
+  const name = tier.display_name || tier.name
+  return tier.coming_soon ? `${name} (coming soon)` : name
+}
+
+/**
+ * What moving `from` → `to` adds and removes.
+ *
+ * Visibility mirrors `lib/nav-exposure.isNavItemVisible`: a key is visible
+ * unless it is explicitly `false`. A tier that declares no policy at all
+ * (enterprise) is therefore unrestricted, matching the backend.
+ */
+function surfaceDelta(from: PlanTier | undefined, to: PlanTier | undefined) {
+  const gained: string[] = []
+  const lost: string[] = []
+  if (!from || !to) return { gained, lost }
+
+  const compare = (
+    beforeMap: Record<string, boolean>,
+    afterMap: Record<string, boolean>,
+    labels: Record<string, string>,
+  ) => {
+    const keys = new Set([...Object.keys(beforeMap), ...Object.keys(afterMap)])
+    keys.forEach((key) => {
+      const before = beforeMap[key] !== false
+      const after = afterMap[key] !== false
+      const label = labels[key] || key
+      if (!before && after) gained.push(label)
+      if (before && !after) lost.push(label)
+    })
+  }
+
+  compare(from.nav || {}, to.nav || {}, NAV_LABELS)
+  compare(from.families || {}, to.families || {}, FAMILY_LABELS)
+  return { gained, lost }
+}
+
+/**
+ * Would this tier's seat cap sit below the members already in the workspace?
+ *
+ * Mirrors the enforcement in ``core/workspaces/invitations.py`` exactly: -1 is
+ * the only unlimited sentinel there, so seats=0 is a hard block, not
+ * "unlimited". (plan_tiers documents 0-means-unlimited for max_agents and
+ * watcher_limit — a different key with a different rule. Do not borrow it.)
+ */
+function isSeatSqueeze(tier: PlanTier | undefined, membersCount: number): boolean {
+  if (typeof tier?.seats !== 'number') return false
+  return tier.seats !== -1 && tier.seats < membersCount
+}
+
+export function WorkspacePlanSelect({
+  workspaceId,
+  workspaceName,
+  plan,
+  membersCount,
+  tiers,
+  disabled = false,
+  onChanged,
+  onError,
+}: WorkspacePlanSelectProps) {
+  const [pending, setPending] = useState<string | null>(null)
+  const [saving, setSaving] = useState(false)
+
+  const current = useMemo(
+    () => tiers.find((t) => t.name === plan),
+    [tiers, plan],
+  )
+  const target = useMemo(
+    () => tiers.find((t) => t.name === pending),
+    [tiers, pending],
+  )
+
+  const delta = useMemo(() => surfaceDelta(current, target), [current, target])
+
+  // Mirrors core/workspaces/invitations.py, where -1 is the ONLY "unlimited"
+  // sentinel — a tier tuned to seats=0 blocks every invite and must still warn.
+  const seatSqueeze = isSeatSqueeze(target, membersCount)
+
+  async function apply(nextPlan: string) {
+    setSaving(true)
+    try {
+      // apiClient.patch types its body as `any`; passing an object literal
+      // straight into request()'s RequestInit would be a type error.
+      // The response is typed for the contract, not consumed: the confirm modal
+      // has already shown the operator any warning this call can return.
+      await apiClient.patch<PlanChangeResponse>(
+        `/api/admin/workspaces/${workspaceId}/plan`,
+        { plan: nextPlan },
+      )
+      setPending(null)
+      await onChanged()
+    } catch (err: any) {
+      onError(err?.message || `Failed to move ${workspaceName} to ${nextPlan}`)
+      setPending(null)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  function handleSelect(nextPlan: string) {
+    if (!nextPlan || nextPlan === plan) return
+    const next = tiers.find((t) => t.name === nextPlan)
+    const removes = surfaceDelta(current, next)
+    const squeezes = isSeatSqueeze(next, membersCount)
+    // Pure upgrade — nothing is taken away, so don't make the operator confirm.
+    if (removes.lost.length === 0 && !squeezes) {
+      void apply(nextPlan)
+      return
+    }
+    setPending(nextPlan)
+  }
+
+  // A plan string with no matching tier (a stray or renamed value) still has to
+  // render as the current selection rather than showing an empty control.
+  const unknownPlan = plan && !current
+
+  return (
+    <>
+      <Select
+        value={plan || undefined}
+        onValueChange={handleSelect}
+        disabled={disabled || saving || tiers.length === 0}
+      >
+        <SelectTrigger className="h-7 w-[124px] text-xs capitalize">
+          {saving ? (
+            <Loader2 className="h-3 w-3 animate-spin" />
+          ) : (
+            <SelectValue placeholder="—" />
+          )}
+        </SelectTrigger>
+        <SelectContent>
+          {unknownPlan && (
+            <SelectItem value={plan} disabled className="text-xs">
+              {plan} (unknown tier)
+            </SelectItem>
+          )}
+          {tiers.map((tier) => (
+            <SelectItem
+              key={tier.name}
+              value={tier.name}
+              // Non-assignable tiers stay visible so a workspace already on one
+              // reads correctly, but they cannot be selected.
+              disabled={!tier.assignable && tier.name !== plan}
+              className="text-xs"
+            >
+              {tierLabel(tier)}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      {pending && (
+        <div
+          className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
+          onClick={() => !saving && setPending(null)}
+        >
+          <Card className="max-w-md w-full" onClick={(e) => e.stopPropagation()}>
+            <CardContent className="p-6 space-y-4">
+              <div className="flex items-center gap-2 text-warning">
+                <AlertTriangle className="h-5 w-5" />
+                <h2 className="text-lg font-semibold">
+                  Move to {target ? tierLabel(target) : pending}?
+                </h2>
+              </div>
+
+              <p className="text-sm text-muted-foreground">
+                <span className="font-semibold text-foreground">{workspaceName}</span>{' '}
+                moves from {current ? tierLabel(current) : plan || 'no plan'} to{' '}
+                {target ? tierLabel(target) : pending}. This takes effect immediately.
+              </p>
+
+              {delta.lost.length > 0 && (
+                <div className="text-sm">
+                  <p className="font-medium text-destructive mb-1">Removes</p>
+                  <ul className="list-disc pl-5 text-muted-foreground space-y-0.5">
+                    {delta.lost.map((item) => (
+                      <li key={item}>{item}</li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              {delta.gained.length > 0 && (
+                <div className="text-sm">
+                  <p className="font-medium text-success mb-1">Adds</p>
+                  <ul className="list-disc pl-5 text-muted-foreground space-y-0.5">
+                    {delta.gained.map((item) => (
+                      <li key={item}>{item}</li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              {seatSqueeze && (
+                <p className="text-sm text-warning">
+                  This workspace has {membersCount} active members but{' '}
+                  {target?.display_name || pending} allows {target?.seats}. Nobody is
+                  removed — the cap applies to the next invitation.
+                </p>
+              )}
+
+              <p className="text-xs text-muted-foreground">
+                No spend ceiling is written by this action.
+              </p>
+
+              <div className="flex justify-end gap-2">
+                <Button
+                  variant="outline"
+                  onClick={() => setPending(null)}
+                  disabled={saving}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  onClick={() => apply(pending)}
+                  disabled={saving}
+                  className="bg-warning hover:bg-warning/80 text-white"
+                >
+                  {saving ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    'Change plan'
+                  )}
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+    </>
+  )
+}

--- a/orchestrator/alembic/versions/users_last_sign_in_column.py
+++ b/orchestrator/alembic/versions/users_last_sign_in_column.py
@@ -1,0 +1,48 @@
+"""users.last_sign_in — make the column the console reads a guaranteed column.
+
+``users.last_sign_in`` has been on the model (``core/models/core.py``) since the
+Clerk cutover but NO migration ever declared it, so its existence rests entirely
+on ``Base.metadata.create_all`` having built that table after the attribute
+appeared. ``create_all`` CREATES missing tables; it never ALTERs an existing one
+— so any database whose ``users`` table predates the attribute simply does not
+have the column, silently, and nothing has ever noticed because nothing read it
+(1 of 25 production rows were populated as of 2026-09-10).
+
+The operator console now DOES read it — ``func.max(User.last_sign_in)`` in the
+admin workspace list and detail routes — and a missing column there is a 500 on
+every console load, not a blank cell. This migration closes that gap.
+
+Production already carries the column (verified 2026-09-11 against
+``information_schema.columns``: ``timestamp without time zone``), so upgrade is
+a no-op there; ``IF NOT EXISTS`` keeps it a no-op on every create_all-first boot
+too, matching the idempotent house style of ``prd240_llm_usage_cache_tokens``.
+
+Nullable with no default on purpose: NULL is the honest "never seen", and the
+console renders it as such rather than inventing an activity timestamp.
+
+Revision ID: users_last_sign_in_column
+Revises: prd240_llm_usage_cache_tokens
+Create Date: 2026-09-11
+"""
+
+from alembic import op
+
+
+revision = "users_last_sign_in_column"
+down_revision = "prd240_llm_usage_cache_tokens"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE users ADD COLUMN IF NOT EXISTS last_sign_in TIMESTAMP WITHOUT TIME ZONE;"
+    )
+
+
+def downgrade() -> None:
+    # Deliberately a no-op. This migration only ever ADDS a column that most
+    # databases (production included) already had, so dropping it on downgrade
+    # would destroy sign-in history this migration never created. Reverting the
+    # console feature does not require reverting the column.
+    pass

--- a/orchestrator/api/admin_workspaces.py
+++ b/orchestrator/api/admin_workspaces.py
@@ -17,7 +17,7 @@ the normal list view (use `?include_deleted=true` to see them).
 from __future__ import annotations
 
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 from uuid import UUID
 
@@ -26,11 +26,15 @@ from pydantic import BaseModel, Field
 from sqlalchemy import desc, func
 from sqlalchemy.orm import Session
 
+from core.auth.actor import resolve_internal_user_id
 from core.auth.dependencies import RequestContext
 from core.auth.hybrid import get_request_context_hybrid
 from core.database.database import get_db
 from core.models.core import Agent, Chat, Document, Message, User
 from core.models.workspaces import Workspace
+from core.workspaces.audit import AuditService
+from core.workspaces.models import WorkspaceMember
+from services.plan_tiers import assign_plan, assignable_tiers, exposure_for_plan, get_tier
 from services.workspace_purge import purge_workspace_sync
 
 logger = logging.getLogger(__name__)
@@ -41,6 +45,24 @@ router = APIRouter(prefix="/api/admin/workspaces", tags=["Admin Workspaces"])
 # ===================================================================
 # Helpers
 # ===================================================================
+
+def _utc_iso(value: Optional[datetime]) -> Optional[str]:
+    """A naive-UTC timestamp as an ISO-8601 string that SAYS it is UTC.
+
+    ``users.last_sign_in`` is ``timestamp without time zone`` stamped from
+    Postgres ``now()`` on a UTC server, so the value is UTC but carries no
+    offset. Plain ``.isoformat()`` would emit ``2026-09-11T09:20:20`` — and
+    ECMAScript parses a date-time string with NO offset as LOCAL time, so
+    ``new Date(...)`` in a UK browser would read it an hour early and the
+    console's elapsed-time column would be wrong by the viewer's UTC offset.
+    Stamping the offset here fixes it at the boundary, for every reader.
+    """
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.isoformat()
+
 
 def _is_admin(ctx: RequestContext) -> bool:
     if not ctx.user:
@@ -72,6 +94,12 @@ class WorkspaceListItem(BaseModel):
     documents_count: int = 0
     storage_bytes: int = 0
     chats_count: int = 0
+    members_count: int = 0
+    # Max ``users.last_sign_in`` across the workspace's active members and its
+    # owner — "last authenticated request", stamped by core.auth.hybrid. None
+    # means nobody on this workspace has been seen since the stamp shipped.
+    last_active_at: Optional[str] = None
+    plan_limits: Dict[str, Any] = Field(default_factory=dict)
     created_at: Optional[str] = None
     paused_at: Optional[str] = None
     paused_reason: Optional[str] = None
@@ -164,6 +192,25 @@ async def list_workspaces(
             .all()
         ) if workspace_ids else {}
 
+        # Active members + last-seen, batched the same way (never N+1). The seat
+        # cap in core/workspaces/invitations.py counts exactly these rows
+        # (is_active members), so members_count is directly comparable to a
+        # tier's seats — that is what the console's downgrade warning reads.
+        member_agg = (
+            db.query(
+                WorkspaceMember.workspace_id,
+                func.count(WorkspaceMember.id),
+                func.max(User.last_sign_in),
+            )
+            .join(User, User.id == WorkspaceMember.user_id)
+            .filter(WorkspaceMember.workspace_id.in_(workspace_ids))
+            .filter(WorkspaceMember.is_active.is_(True))
+            .group_by(WorkspaceMember.workspace_id)
+            .all()
+        ) if workspace_ids else []
+        members_by_ws = {ws_id: cnt for ws_id, cnt, _ in member_agg}
+        member_seen_by_ws = {ws_id: seen for ws_id, _, seen in member_agg}
+
         # Owner lookup (bulk)
         owner_ids = {w.owner_id for w in workspaces if w.owner_id is not None}
         owners = (
@@ -174,6 +221,13 @@ async def list_workspaces(
         items: List[WorkspaceListItem] = []
         for w in workspaces:
             owner = owner_by_id.get(w.owner_id) if w.owner_id else None
+            # The owner is counted even when no membership row exists for them —
+            # a solo workspace is otherwise reported as never active.
+            seen_candidates = [
+                t for t in (member_seen_by_ws.get(w.id), getattr(owner, "last_sign_in", None))
+                if t is not None
+            ]
+            last_active = max(seen_candidates) if seen_candidates else None
             items.append(WorkspaceListItem(
                 id=str(w.id),
                 name=w.name,
@@ -187,6 +241,9 @@ async def list_workspaces(
                 documents_count=docs_count_by_ws.get(w.id, 0),
                 storage_bytes=storage_by_ws.get(w.id, 0),
                 chats_count=chats_by_ws.get(w.id, 0),
+                members_count=members_by_ws.get(w.id, 0),
+                last_active_at=_utc_iso(last_active),
+                plan_limits=dict(w.plan_limits or {}),
                 created_at=w.created_at.isoformat() if w.created_at else None,
                 paused_at=w.paused_at.isoformat() if w.paused_at else None,
                 paused_reason=w.paused_reason,
@@ -212,6 +269,181 @@ async def list_workspaces(
     except Exception as e:
         logger.exception("Error listing workspaces: %s", e)
         raise HTTPException(status_code=500, detail="Failed to list workspaces")
+
+
+# ── Plan tiers (operator console) ────────────────────────────────────────────
+#
+# Declared BEFORE the ``/{workspace_id}`` detail route on purpose: a literal
+# segment registered after a path-parameter route is shadowed by it (the
+# PRD-220 route-order trap). ``workspace_id`` is typed ``UUID`` so "plans" would
+# 422 rather than fall through, but order is the thing that makes it correct.
+
+
+class PlanTierInfo(BaseModel):
+    name: str
+    display_name: Optional[str] = None
+    assignable: bool = False
+    coming_soon: bool = False
+    seats: Optional[int] = None
+    max_agents: Optional[int] = None
+    marketplace_depth: int = 1
+    families: Dict[str, bool] = Field(default_factory=dict)
+    nav: Dict[str, bool] = Field(default_factory=dict)
+
+
+class PlanChangeBody(BaseModel):
+    plan: str = Field(..., min_length=1, max_length=50)
+
+
+@router.get("/plans")
+async def list_plan_tiers(
+    ctx: RequestContext = Depends(get_request_context_hybrid),
+) -> Dict[str, Any]:
+    """The tier catalogue behind the console's plan dropdown. Admin-only.
+
+    Every tier is returned, not just the assignable ones, so a workspace sitting
+    on a non-assignable tier (``enterprise`` today) still renders its own plan
+    as the current value instead of showing blank. ``assignable`` says which the
+    dropdown may actually select.
+
+    ``nav`` is the same exposure the client gets from
+    ``GET /api/workspaces/current`` — it is what makes the consequence of a tier
+    legible in the console ("Basic hides Team and Analytics") rather than
+    something the operator has to infer from the families map.
+    """
+    _assert_admin(ctx)
+    from config import PLAN_TIERS
+
+    selectable = assignable_tiers()
+    tiers = [
+        PlanTierInfo(
+            name=name,
+            display_name=tier.get("display_name"),
+            assignable=name in selectable,
+            coming_soon=bool(tier.get("coming_soon")),
+            seats=tier.get("seats"),
+            max_agents=tier.get("max_agents"),
+            marketplace_depth=int(tier.get("marketplace_depth", 1) or 1),
+            families=dict(tier.get("families") or {}),
+            nav=dict(exposure_for_plan(name).get("nav") or {}),
+        ).model_dump()
+        for name, tier in PLAN_TIERS.items()
+        if isinstance(tier, dict)
+    ]
+    # No budget figure is advertised: the console never writes one (see below).
+    return {"tiers": tiers}
+
+
+@router.patch("/{workspace_id}/plan")
+async def change_workspace_plan(
+    workspace_id: UUID,
+    body: PlanChangeBody,
+    ctx: RequestContext = Depends(get_request_context_hybrid),
+    db: Session = Depends(get_db),
+) -> Dict[str, Any]:
+    """Move a workspace onto another tier. Admin-only.
+
+    Routed through ``services.plan_tiers.assign_plan`` — the ONE writer of
+    ``workspaces.plan`` / ``plan_limits`` (FR-4 auditability) — so the tier's
+    seats and agent cap apply exactly as they do on the onboarding path.
+
+    ``with_budget=False`` (owner decision, 2026-09-11): an operator retiering a
+    LIVE tenant must never hand it a spend ceiling it did not have a moment ago.
+    ``modules/policy/budget.py`` enforces ``plan_limits.budget`` through
+    ``check_budget``, and a workspace with no budget key is ceiling-less today —
+    so minting one here would silently throttle a pilot. The same switch clears a
+    stale TIER-owned ceiling a previous assignment left behind, while an admin
+    custom budget (``source != "tier"``) is the customer's own and survives
+    untouched.
+
+    Downgrades are permitted but reported: a tier whose ``seats`` sit below the
+    workspace's active member count comes back in ``warnings``. Nothing is
+    removed — the cap binds the NEXT invitation
+    (``core/workspaces/invitations.py``), never the members already in place.
+    """
+    _assert_admin(ctx)
+
+    workspace = db.query(Workspace).filter(Workspace.id == workspace_id).first()
+    if not workspace:
+        raise HTTPException(status_code=404, detail="Workspace not found")
+    # Every sibling mutator in this router refuses on a soft-deleted workspace;
+    # the console disables the control too, but that is client-side only and a
+    # purge is already queued against these rows (services/workspace_purge.py).
+    if workspace.deleted_at:
+        raise HTTPException(
+            status_code=400, detail="Cannot change the plan of a deleted workspace"
+        )
+
+    previous_plan = workspace.plan
+    previous_limits = dict(workspace.plan_limits or {})
+
+    try:
+        new_limits = assign_plan(db, workspace, body.plan, with_budget=False)
+    except ValueError as exc:
+        # Unknown / non-assignable tier — the caller's input, not a server fault.
+        raise HTTPException(status_code=400, detail=str(exc))
+    except Exception as exc:
+        logger.exception("Plan change failed for workspace %s: %s", workspace_id, exc)
+        db.rollback()
+        raise HTTPException(status_code=500, detail="Failed to change plan")
+
+    limits_changed = {
+        key: {"from": previous_limits.get(key), "to": new_limits.get(key)}
+        for key in sorted(set(previous_limits) | set(new_limits))
+        if previous_limits.get(key) != new_limits.get(key)
+    }
+
+    members_count = (
+        db.query(func.count(WorkspaceMember.id))
+        .filter(WorkspaceMember.workspace_id == workspace.id)
+        .filter(WorkspaceMember.is_active.is_(True))
+        .scalar()
+    ) or 0
+
+    warnings: List[str] = []
+    seats = (get_tier(workspace.plan) or {}).get("seats")
+    # Mirror the enforcement exactly (core/workspaces/invitations.py): -1 is the
+    # only "unlimited" sentinel there, so a tier tuned to seats=0 via
+    # AUTOMATOS_PLAN_TIERS_JSON blocks EVERY invite and must still warn. Do not
+    # borrow the 0-means-unlimited convention that plan_tiers documents for
+    # max_agents / watcher_limit — that is a different key with a different rule.
+    if isinstance(seats, int) and seats != -1 and seats < members_count:
+        warnings.append(
+            f"{workspace.name} has {members_count} active members but "
+            f"{workspace.plan} allows {seats}. No one was removed — the cap "
+            f"applies to the next invitation."
+        )
+
+    AuditService(db).log(
+        workspace_id=str(workspace.id),
+        user_id=resolve_internal_user_id(db, ctx),
+        action="workspace.plan_changed",
+        resource_type="workspace",
+        resource_id=str(workspace.id),
+        resource_name=workspace.name,
+        details={
+            "from_plan": previous_plan,
+            "to_plan": workspace.plan,
+            "limits_changed": limits_changed,
+            "budget_applied": False,
+            "actor_email": getattr(ctx.user, "email", None),
+            "warnings": warnings,
+        },
+    )
+    logger.info(
+        "[admin] workspace %s plan %s -> %s by %s",
+        workspace.id, previous_plan, workspace.plan, getattr(ctx.user, "email", "?"),
+    )
+
+    return {
+        "id": str(workspace.id),
+        "plan": workspace.plan,
+        "previous_plan": previous_plan,
+        "plan_limits": new_limits,
+        "limits_changed": limits_changed,
+        "members_count": members_count,
+        "warnings": warnings,
+    }
 
 
 @router.get("/{workspace_id}", response_model=WorkspaceDetail)
@@ -253,6 +485,21 @@ async def get_workspace(
             Message.workspace_id == workspace_id
         ).scalar() or 0
 
+        # Same shape as the list route — the detail view inherits these fields,
+        # so leaving them at their defaults would report 0 members and no limits
+        # for a workspace that has both.
+        members_count, member_seen = (
+            db.query(func.count(WorkspaceMember.id), func.max(User.last_sign_in))
+            .join(User, User.id == WorkspaceMember.user_id)
+            .filter(WorkspaceMember.workspace_id == workspace_id)
+            .filter(WorkspaceMember.is_active.is_(True))
+            .one()
+        )
+        seen_candidates = [
+            t for t in (member_seen, getattr(owner, "last_sign_in", None)) if t is not None
+        ]
+        last_active = max(seen_candidates) if seen_candidates else None
+
         return WorkspaceDetail(
             id=str(w.id),
             name=w.name,
@@ -268,6 +515,9 @@ async def get_workspace(
             storage_bytes=int(storage_bytes),
             chats_count=chats_count,
             messages_count=messages_count,
+            members_count=members_count or 0,
+            last_active_at=_utc_iso(last_active),
+            plan_limits=dict(w.plan_limits or {}),
             created_at=w.created_at.isoformat() if w.created_at else None,
             updated_at=w.updated_at.isoformat() if w.updated_at else None,
             paused_at=w.paused_at.isoformat() if w.paused_at else None,

--- a/orchestrator/api/harness.py
+++ b/orchestrator/api/harness.py
@@ -22,40 +22,27 @@ service account self-management authority over itself.
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
 from api.harness_commands import handle_harness_command
+from core.auth.actor import resolve_internal_user_id
 from core.auth.dependencies import RequestContext
 from core.auth.hybrid import get_request_context_hybrid
 from core.auth.workspace_permission import require_workspace_permission
 from core.database.database import get_db
-from core.models.core import User
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/harness", tags=["HARNESS"])
 
 
-def _resolve_internal_user_id(db: Session, ctx: RequestContext) -> Optional[int]:
-    """Resolve the integer ``users.id`` for the authenticated principal.
-
-    ``ctx.user.id`` is a Clerk string id or email, but the HARNESS authz keys on
-    the integer ``workspace_members.user_id`` — so the row is looked up first.
-    Fail-closed: returns None when nothing matches, and the handler's admin gate
-    then refuses (an unresolved principal can never mutate state). Mirrors
-    ``api.team._resolve_internal_user_id`` — there is no shared util yet.
-    """
-    if not ctx.user:
-        return None
-    user = None
-    if ctx.user.clerk_user_id:
-        user = db.query(User).filter(User.clerk_user_id == ctx.user.clerk_user_id).first()
-    if not user and ctx.user.email:
-        user = db.query(User).filter(User.email == ctx.user.email).first()
-    return user.id if user else None
+# The canonical resolver lives in core.auth.actor (extracted from the copy that
+# used to sit here). Fail-closed semantics are unchanged: an unresolved
+# principal yields None, and the handler's admin gate then refuses.
+_resolve_internal_user_id = resolve_internal_user_id
 
 
 async def _run_command(

--- a/orchestrator/api/team.py
+++ b/orchestrator/api/team.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel, EmailStr
 from typing import List, Optional
 from core.auth.hybrid import get_request_context_hybrid as get_request_context
 from core.auth.dependencies import RequestContext
+from core.auth.actor import resolve_internal_user_id
 from core.auth.clerk import get_clerk_auth
 from core.database.database import get_db
 from core.auth.workspace_permission import require_workspace_permission
@@ -26,21 +27,9 @@ router = APIRouter(prefix="/api/workspaces/{workspace_id}/team", tags=["team"])
 public_router = APIRouter(prefix="/api/team", tags=["team"])
 
 
-def _resolve_internal_user_id(db: Session, ctx: RequestContext) -> Optional[int]:
-    """Resolve internal users.id (integer) from RequestContext.
-
-    ctx.user.id is a Clerk string ID or email — both audit_logs.user_id and
-    workspace_invitations.invited_by are Integer FKs to users.id, so we must
-    look up the matching row before writing.
-    """
-    if not ctx.user:
-        return None
-    user = None
-    if ctx.user.clerk_user_id:
-        user = db.query(User).filter(User.clerk_user_id == ctx.user.clerk_user_id).first()
-    if not user and ctx.user.email:
-        user = db.query(User).filter(User.email == ctx.user.email).first()
-    return user.id if user else None
+# The canonical resolver lives in core.auth.actor; the module-level name is kept
+# so every call site in this file (and its tests) reads unchanged.
+_resolve_internal_user_id = resolve_internal_user_id
 
 class InviteMemberRequest(BaseModel):
     email: EmailStr

--- a/orchestrator/core/auth/actor.py
+++ b/orchestrator/core/auth/actor.py
@@ -1,0 +1,39 @@
+"""The authenticated principal as an integer ``users.id``.
+
+``RequestContext.user.id`` is a Clerk string id or an email address — never the
+integer primary key. Every FK that records "who did this" (``audit_logs.user_id``,
+``workspace_invitations.invited_by``, ``workspace_members.user_id``) is an
+Integer FK to ``users.id``, so the row must be looked up before it can be
+written. Treating ``ctx.user.id`` as ``users.id`` is a known 500 (#513).
+
+Resolution order — Clerk id first (the stable identity), email second (covers a
+principal whose Clerk id has not been backfilled onto its ``users`` row).
+
+FAIL-CLOSED: an unresolvable principal returns ``None`` rather than a guess.
+Callers that gate on identity must treat ``None`` as "not authorised"; callers
+that only record it may store ``None`` (``AuditService.log`` accepts it and
+carries ``actor_type`` instead).
+
+Extracted 2026-09-11 from the byte-identical copies in ``api.team`` and
+``api.harness`` — both now import from here.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from core.auth.dependencies import RequestContext
+from core.models.core import User
+
+
+def resolve_internal_user_id(db: Session, ctx: RequestContext) -> Optional[int]:
+    """The integer ``users.id`` for ``ctx``'s principal, or None if unresolvable."""
+    if not ctx.user:
+        return None
+    user = None
+    if ctx.user.clerk_user_id:
+        user = db.query(User).filter(User.clerk_user_id == ctx.user.clerk_user_id).first()
+    if not user and ctx.user.email:
+        user = db.query(User).filter(User.email == ctx.user.email).first()
+    return user.id if user else None

--- a/orchestrator/core/auth/hybrid.py
+++ b/orchestrator/core/auth/hybrid.py
@@ -496,6 +496,74 @@ def _resolve_workspace_for_clerk_user(
 
 
 # ---------------------------------------------------------------------------
+# Last-seen stamp — the operator console's "Last active" column
+# ---------------------------------------------------------------------------
+
+# ``users.last_sign_in`` has existed on the model since the Clerk cutover but
+# nothing ever wrote it (1 of 25 rows populated in production, 2026-09-10), so
+# the admin console had no way to tell an active pilot tenant from a dormant one.
+# It is stamped HERE because the Clerk lane is the one place every authenticated
+# request passes through — which also makes it the hottest path in the app, so
+# the write is throttled twice over:
+#
+#   1. an in-process map skips the statement entirely for the whole interval —
+#      most requests do no DB work at all, and
+#   2. the UPDATE repeats the age predicate itself, so a cold process, a second
+#      Railway replica or a racing request can still only write once per
+#      interval. No read-then-write, so there is nothing to race.
+#
+# The semantics are therefore "last authenticated request", i.e. last SEEN —
+# browsing counts, not just a fresh login. The console labels it that way.
+_LAST_SEEN_THROTTLE_SECONDS = 900.0  # 15 minutes
+_LAST_SEEN_CACHE_MAX = 2048
+_last_seen_touched: dict = {}
+
+
+def _touch_last_seen(db, clerk_user_id: Optional[str]) -> None:
+    """Stamp ``users.last_sign_in`` for this caller, at most once per interval.
+
+    Best-effort and never fatal: nobody loses a request because a bookkeeping
+    write failed, so a failure rolls back (the caller reuses this session for
+    workspace resolution immediately afterwards) and returns quietly.
+    """
+    if not clerk_user_id:
+        return
+    now = time.monotonic()
+    seen_at = _last_seen_touched.get(clerk_user_id)
+    if seen_at is not None and (now - seen_at) < _LAST_SEEN_THROTTLE_SECONDS:
+        return
+    try:
+        db.execute(
+            text(
+                "UPDATE users SET last_sign_in = now() "
+                "WHERE clerk_user_id = :cid "
+                "  AND (last_sign_in IS NULL "
+                "       OR last_sign_in < now() - make_interval(secs => :age))"
+            ),
+            {"cid": clerk_user_id, "age": _LAST_SEEN_THROTTLE_SECONDS},
+        )
+        db.commit()
+    except Exception:
+        db.rollback()
+        # WARNING, not debug: a standing failure here means the console's
+        # "Last active" column is quietly dead, and nothing else would say so.
+        logger.warning(
+            "last_sign_in stamp failed for clerk_user_id=%s — backing off %.0fs",
+            clerk_user_id, _LAST_SEEN_THROTTLE_SECONDS, exc_info=True,
+        )
+    # Recorded on BOTH paths, deliberately.
+    #   success  — including an UPDATE that matched no row, because another
+    #              worker stamped it inside the interval;
+    #   failure  — because a PERSISTENT fault (a missing column, a revoked
+    #              grant) would otherwise retry on every single authenticated
+    #              request, turning a bookkeeping write into a hot-path storm.
+    #              Backing off costs at most one interval of staleness.
+    if len(_last_seen_touched) >= _LAST_SEEN_CACHE_MAX:
+        _last_seen_touched.clear()
+    _last_seen_touched[clerk_user_id] = now
+
+
+# ---------------------------------------------------------------------------
 # PRD-233 S6 — the local operator's identity: ONE users row, resolved by email
 # ---------------------------------------------------------------------------
 
@@ -803,6 +871,10 @@ async def get_request_context_hybrid(request: Request) -> RequestContext:
             if claims:
                 info = clerk.extract_user_info(claims)
                 clerk_uid = info.get("clerk_user_id")
+
+                # Stamp last-seen before any branch below returns, so the admin
+                # console counts admin "__all__" calls as activity too.
+                _touch_last_seen(db, clerk_uid)
 
                 # Determine admin status
                 system_role = info.get("system_role") or info.get("role") or "user"

--- a/orchestrator/reports/route-manifest.json
+++ b/orchestrator/reports/route-manifest.json
@@ -1,5 +1,5 @@
 {
-  "route_count": 799,
+  "route_count": 801,
   "routes": [
     {
       "method": "GET",
@@ -138,6 +138,10 @@
       "path": "/api/admin/workspaces"
     },
     {
+      "method": "GET",
+      "path": "/api/admin/workspaces/plans"
+    },
+    {
       "method": "DELETE",
       "path": "/api/admin/workspaces/{workspace_id}"
     },
@@ -148,6 +152,10 @@
     {
       "method": "POST",
       "path": "/api/admin/workspaces/{workspace_id}/pause"
+    },
+    {
+      "method": "PATCH",
+      "path": "/api/admin/workspaces/{workspace_id}/plan"
     },
     {
       "method": "POST",

--- a/orchestrator/services/plan_tiers.py
+++ b/orchestrator/services/plan_tiers.py
@@ -64,11 +64,22 @@ def assignable_tiers(tiers: Optional[dict] = None) -> dict:
     return {name: t for name, t in resolved.items() if is_assignable(name, resolved)}
 
 
-def plan_limits_for_tier(plan: str, tiers: Optional[dict] = None) -> dict:
+def plan_limits_for_tier(
+    plan: str, tiers: Optional[dict] = None, with_budget: bool = True
+) -> dict:
     """The ``plan_limits`` fragment a tier implies, keyed for the LIVE consumers.
 
     Raises :class:`ValueError` for a non-assignable / unknown plan — the caller
     must never write limits for a tier that cannot be assigned.
+
+    ``with_budget=False`` omits the tier-owned ``budget`` key entirely, so the
+    tier's seats/agents apply WITHOUT minting a spend ceiling. The operator
+    console passes this (owner decision 2026-09-11): an admin moving a live
+    tenant between tiers must never hand it a ``check_budget`` throttle it did
+    not have a moment ago. Combined with :func:`assign_plan`'s existing
+    tier-owned-budget cleanup, the admin path also STRIPS a stale tier ceiling a
+    previous assignment wrote, and still never touches an admin custom budget
+    (``source != "tier"``).
     """
     resolved = _tiers(tiers)
     if not is_assignable(plan, resolved):
@@ -82,7 +93,7 @@ def plan_limits_for_tier(plan: str, tiers: Optional[dict] = None) -> dict:
         "marketplace_depth": tier["marketplace_depth"],
     }
     budget_usd = tier.get("budget_usd") or 0
-    if budget_usd and budget_usd > 0:
+    if with_budget and budget_usd and budget_usd > 0:
         # A tier-OWNED ceiling (``source="tier"``): re-derived on every assignment
         # and cleared when the workspace moves to a no-ceiling tier (see
         # :func:`assign_plan`). An admin budget carries no such marker and is never
@@ -94,7 +105,12 @@ def plan_limits_for_tier(plan: str, tiers: Optional[dict] = None) -> dict:
 
 
 def assign_plan(
-    db: Any, workspace: Any, plan: str, tiers: Optional[dict] = None, commit: bool = True
+    db: Any,
+    workspace: Any,
+    plan: str,
+    tiers: Optional[dict] = None,
+    commit: bool = True,
+    with_budget: bool = True,
 ) -> dict:
     """Set ``workspace.plan`` and merge the tier's limits into ``plan_limits``.
 
@@ -113,8 +129,14 @@ def assign_plan(
     ``plan_limits`` (GET /budget would otherwise still show it, and an enforce
     stage would throttle at it). An admin custom budget — ``source != "tier"`` —
     is the customer's own explicit ceiling and is left untouched on any tier.
+
+    ``with_budget=False`` (the admin console's plan dropdown) applies the tier's
+    seats/agents but mints NO ceiling: no ``budget`` key is produced, so the
+    cleanup below also clears a tier-owned ceiling a prior assignment left. An
+    admin custom budget still survives, exactly as on the budget-carrying path.
     """
-    limits = plan_limits_for_tier(plan, tiers)  # validates assignability first
+    # validates assignability first
+    limits = plan_limits_for_tier(plan, tiers, with_budget=with_budget)
     new_limits = dict(workspace.plan_limits or {})
     new_limits.update(limits)
     # RVW-4: a 0-budget tier implies NO 'budget' key, so the merge above cannot

--- a/orchestrator/tests/test_admin_plan_console.py
+++ b/orchestrator/tests/test_admin_plan_console.py
@@ -1,0 +1,438 @@
+"""Operator console: the plan dropdown + "Last active" (2026-09-11).
+
+Context — the defect these two features answer. PRD-222 W2b (#631) landed the
+tier gating and, in the same commit, a migration backfilling every legacy
+``plan = 'starter'`` row to ``'basic'``. ``basic`` declares
+``families.team = False``, so ``exposure_for_plan`` reports ``nav.team = False``
+and the rail drops Team Management. Every self-serve tenant was swept into that
+tier; only ``Automatos Primary`` (``enterprise``, which declares NO families and
+is therefore unrestricted) kept the full rail — so the platform owner never saw
+it. The console now lets an operator retier a workspace directly.
+
+Two properties are pinned here:
+
+  * ``with_budget=False`` — the console applies a tier's seats/agents but mints
+    NO spend ceiling. ``modules/policy/budget.py`` enforces
+    ``plan_limits.budget`` via ``check_budget``, and a workspace with no budget
+    key is ceiling-less, so minting one while retiering a live tenant would
+    silently throttle it. The default (``True``) is unchanged — the onboarding
+    path still writes tier ceilings.
+  * the last-seen stamp is throttled and never fatal — it sits on the hottest
+    path in the app (every authenticated request).
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from services import plan_tiers as pt
+
+
+# --------------------------------------------------------------------------- #
+# The regression that started it: basic hides Team, and the tiers that show it
+# --------------------------------------------------------------------------- #
+
+
+def test_basic_hides_team_and_analytics_nav():
+    """The exact reason a tenant loses Team Management from the rail."""
+    nav = pt.exposure_for_plan("basic")["nav"]
+    assert nav["team"] is False
+    assert nav["analytics"] is False
+
+
+@pytest.mark.parametrize("plan", ["pro", "business"])
+def test_paid_tiers_expose_team_nav(plan):
+    assert pt.exposure_for_plan(plan)["nav"]["team"] is True
+
+
+def test_enterprise_declares_no_families_so_nothing_is_gated():
+    """Why the owner's own workspace never showed the symptom."""
+    exposure = pt.exposure_for_plan("enterprise")
+    assert exposure["families"] == {}
+    assert exposure["nav"] == {"analytics": True, "team": True}
+
+
+# --------------------------------------------------------------------------- #
+# with_budget=False — the console's assignment never mints a ceiling
+# --------------------------------------------------------------------------- #
+
+
+def test_plan_limits_without_budget_keeps_every_other_limit():
+    """Seats/agents apply exactly as normal; only the ceiling is withheld."""
+    with_budget = pt.plan_limits_for_tier("pro")
+    without = pt.plan_limits_for_tier("pro", with_budget=False)
+
+    assert with_budget["budget"]["max_cost_usd"] == 100.0
+    assert "budget" not in without
+    # Every other key is identical — the switch withholds the ceiling, nothing else.
+    assert {k: v for k, v in with_budget.items() if k != "budget"} == without
+
+
+def test_plan_limits_with_budget_is_still_the_default():
+    """Regression guard: the onboarding path (US-025) is untouched."""
+    assert "budget" in pt.plan_limits_for_tier("basic")
+    assert "budget" in pt.plan_limits_for_tier("pro")
+
+
+def test_console_assignment_mints_no_ceiling_on_a_ceilingless_workspace():
+    """A live tenant with no budget key stays ceiling-less after retiering.
+
+    This is the InBuildUK shape: plan_limits carries generous legacy values and
+    NO budget, so the workspace is ceiling-less today (``check_budget`` only
+    binds on an explicit budget for a non-autonomy workspace).
+    """
+    ws = SimpleNamespace(
+        plan="basic",
+        plan_limits={"max_agents": 10, "max_members": 5, "max_documents": 100},
+    )
+    pt.assign_plan(None, ws, "pro", with_budget=False)
+
+    assert ws.plan == "pro"
+    assert "budget" not in ws.plan_limits  # no throttle appeared
+    assert ws.plan_limits["max_members"] == 5  # pro seats
+    assert ws.plan_limits["max_agents"] == 20
+    assert ws.plan_limits["max_documents"] == 100  # unmanaged key survives
+
+
+def test_console_assignment_clears_a_stale_tier_ceiling():
+    """A ceiling a previous tier assignment wrote is cleared, not inherited."""
+    ws = SimpleNamespace(plan="basic", plan_limits={})
+    pt.assign_plan(None, ws, "pro")  # normal path writes the $100 tier ceiling
+    assert ws.plan_limits["budget"]["max_cost_usd"] == 100.0
+
+    # basic carries its OWN $25 ceiling on the normal path, so this proves the
+    # switch both withholds the new ceiling and clears the stale one — a tier
+    # with budget_usd=0 (business) would have cleared it either way.
+    pt.assign_plan(None, ws, "basic", with_budget=False)
+    assert ws.plan == "basic"
+    assert "budget" not in ws.plan_limits
+
+
+def test_console_assignment_preserves_an_admin_custom_budget():
+    """An admin's own ceiling is the customer's, and survives any tier move."""
+    ws = SimpleNamespace(
+        plan="pro",
+        plan_limits={"budget": {"window": "month", "max_cost_usd": 500.0}},
+    )
+    pt.assign_plan(None, ws, "basic", with_budget=False)
+    assert ws.plan_limits["budget"] == {"window": "month", "max_cost_usd": 500.0}
+
+
+def test_console_assignment_still_rejects_a_non_assignable_tier():
+    """The endpoint maps this ValueError to a 400 — it must keep being raised."""
+    ws = SimpleNamespace(plan="basic", plan_limits={})
+    with pytest.raises(ValueError):
+        pt.assign_plan(None, ws, "enterprise", with_budget=False)
+    with pytest.raises(ValueError):
+        pt.assign_plan(None, ws, "nope", with_budget=False)
+    assert ws.plan == "basic"  # unchanged on rejection
+
+
+def test_downgrade_seats_below_current_members_is_allowed_not_blocked():
+    """The console warns; it does not refuse. The cap binds the NEXT invite
+    (core/workspaces/invitations.py), never the members already in place."""
+    ws = SimpleNamespace(plan="pro", plan_limits={"max_members": 5})
+    pt.assign_plan(None, ws, "basic", with_budget=False)
+    assert ws.plan == "basic"
+    assert ws.plan_limits["max_members"] == 1  # the cap the console warns about
+
+
+# --------------------------------------------------------------------------- #
+# The last-seen stamp — throttled, single-statement, never fatal
+# --------------------------------------------------------------------------- #
+
+
+class _FakeSession:
+    """Records statements; optionally raises on execute to prove non-fatality."""
+
+    def __init__(self, fail: bool = False):
+        self.fail = fail
+        self.executed: list = []
+        self.commits = 0
+        self.rollbacks = 0
+
+    def execute(self, statement, params=None):
+        if self.fail:
+            raise RuntimeError("database is having a day")
+        self.executed.append((str(statement), params))
+
+    def commit(self):
+        self.commits += 1
+
+    def rollback(self):
+        self.rollbacks += 1
+
+
+@pytest.fixture
+def hybrid():
+    mod = pytest.importorskip("core.auth.hybrid")
+    mod._last_seen_touched.clear()
+    yield mod
+    mod._last_seen_touched.clear()
+
+
+def test_last_seen_writes_once_then_throttles(hybrid):
+    db = _FakeSession()
+    hybrid._touch_last_seen(db, "user_abc")
+    hybrid._touch_last_seen(db, "user_abc")
+    hybrid._touch_last_seen(db, "user_abc")
+    assert len(db.executed) == 1, "in-process throttle must suppress repeats"
+    assert db.commits == 1
+
+
+def test_last_seen_throttle_is_per_user(hybrid):
+    db = _FakeSession()
+    hybrid._touch_last_seen(db, "user_abc")
+    hybrid._touch_last_seen(db, "user_xyz")
+    assert len(db.executed) == 2
+
+
+def test_last_seen_statement_carries_its_own_age_predicate(hybrid):
+    """The UPDATE re-checks the age, so a second worker or a cold process
+    cannot write more often than the interval either. No read-then-write."""
+    db = _FakeSession()
+    hybrid._touch_last_seen(db, "user_abc")
+    sql, params = db.executed[0]
+    assert "UPDATE users SET last_sign_in" in sql
+    assert "last_sign_in IS NULL" in sql
+    assert "make_interval" in sql
+    assert params["cid"] == "user_abc"
+    assert params["age"] == hybrid._LAST_SEEN_THROTTLE_SECONDS
+
+
+def test_last_seen_ignores_a_missing_principal(hybrid):
+    db = _FakeSession()
+    hybrid._touch_last_seen(db, None)
+    hybrid._touch_last_seen(db, "")
+    assert db.executed == []
+    assert db.commits == 0
+
+
+def test_last_seen_failure_rolls_back_and_never_raises(hybrid):
+    """Nobody loses a request because a bookkeeping write failed."""
+    db = _FakeSession(fail=True)
+    hybrid._touch_last_seen(db, "user_abc")  # must not raise
+    assert db.rollbacks == 1
+    assert db.commits == 0
+
+
+def test_last_seen_failure_backs_off_instead_of_retrying_every_request(hybrid):
+    """A PERSISTENT fault must not turn the hottest path into a write storm.
+
+    The stamp sits on every authenticated request, so a failing UPDATE that is
+    retried each time would hammer the database. Recording the attempt costs at
+    most one interval of staleness and bounds the damage to one try per user
+    per interval.
+    """
+    db = _FakeSession(fail=True)
+    for _ in range(25):
+        hybrid._touch_last_seen(db, "user_abc")
+    assert db.rollbacks == 1, "a standing failure must be attempted once, not 25 times"
+    assert hybrid._last_seen_touched.get("user_abc") is not None
+
+
+def test_last_seen_cache_is_bounded(hybrid):
+    """The map is per-process and must not grow without bound."""
+    db = _FakeSession()
+    for i in range(hybrid._LAST_SEEN_CACHE_MAX + 5):
+        hybrid._touch_last_seen(db, f"user_{i}")
+    assert len(hybrid._last_seen_touched) <= hybrid._LAST_SEEN_CACHE_MAX
+
+
+# --------------------------------------------------------------------------- #
+# The endpoints themselves — gate, validation, and the response the console reads
+# --------------------------------------------------------------------------- #
+
+
+class _FakeQuery:
+    """Chainable stand-in: `.filter(...)` returns self, terminals return fixtures."""
+
+    def __init__(self, result=None, scalar=None, one=None):
+        self._result = result
+        self._scalar = scalar
+        self._one = one
+
+    def filter(self, *args, **kwargs):
+        return self
+
+    def join(self, *args, **kwargs):
+        return self
+
+    def first(self):
+        return self._result
+
+    def scalar(self):
+        return self._scalar
+
+    def one(self):
+        return self._one
+
+
+def _client(workspace, members_count=0, system_role="super_admin"):
+    """A TestClient over the admin router with ctx/db dependency overrides."""
+    from unittest.mock import MagicMock
+    from uuid import uuid4
+
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from api.admin_workspaces import router as admin_router
+    from core.auth.dependencies import RequestContext, UserContext
+    from core.auth.hybrid import get_request_context_hybrid
+    from core.database.database import get_db
+    from core.models.workspaces import Workspace as WorkspaceModel
+
+    db = MagicMock()
+
+    def _query(*args):
+        if args and args[0] is WorkspaceModel:
+            return _FakeQuery(result=workspace)
+        # The members count (and the resolver's users lookup, which must miss).
+        return _FakeQuery(result=None, scalar=members_count)
+
+    db.query.side_effect = _query
+
+    app = FastAPI()
+    app.include_router(admin_router)
+    app.dependency_overrides[get_request_context_hybrid] = lambda: RequestContext(
+        workspace_id=uuid4(),
+        user=UserContext(
+            id="test-user",
+            email="admin@example.com",
+            role="owner",
+            system_role=system_role,
+        ),
+        auth_type="clerk",
+    )
+    app.dependency_overrides[get_db] = lambda: (yield db)
+    return TestClient(app)
+
+
+def _workspace(plan="basic", limits=None, deleted_at=None):
+    from uuid import uuid4
+
+    return SimpleNamespace(
+        id=uuid4(),
+        name="InBuild UK",
+        plan=plan,
+        plan_limits=limits if limits is not None else {"max_members": 5, "max_agents": 10},
+        deleted_at=deleted_at,
+    )
+
+
+def test_plans_catalogue_lists_every_tier_and_marks_assignability():
+    client = _client(_workspace())
+    res = client.get("/api/admin/workspaces/plans")
+    assert res.status_code == 200
+    tiers = {t["name"]: t for t in res.json()["tiers"]}
+    assert {"basic", "pro", "business", "enterprise"} <= set(tiers)
+    assert tiers["pro"]["assignable"] is True
+    # enterprise is coming-soon: visible (a workspace sits on it) but not selectable.
+    assert tiers["enterprise"]["assignable"] is False
+    assert tiers["enterprise"]["coming_soon"] is True
+    # The nav the dropdown explains its choice with.
+    assert tiers["basic"]["nav"]["team"] is False
+    assert tiers["pro"]["nav"]["team"] is True
+
+
+def test_plans_catalogue_refuses_a_non_admin():
+    client = _client(_workspace(), system_role="user")
+    assert client.get("/api/admin/workspaces/plans").status_code == 403
+
+
+def test_plan_change_moves_the_tier_and_writes_no_budget():
+    """The InBuildUK fix: basic → pro, seats applied, ceiling NOT minted."""
+    ws = _workspace(plan="basic", limits={"max_members": 5, "max_agents": 10})
+    client = _client(ws, members_count=5)
+
+    res = client.patch(f"/api/admin/workspaces/{ws.id}/plan", json={"plan": "pro"})
+    assert res.status_code == 200, res.text
+    body = res.json()
+
+    assert body["previous_plan"] == "basic"
+    assert body["plan"] == "pro"
+    assert ws.plan == "pro"
+    assert "budget" not in body["plan_limits"], "the console must never mint a ceiling"
+    assert body["plan_limits"]["max_agents"] == 20
+    assert body["limits_changed"]["max_agents"] == {"from": 10, "to": 20}
+    assert body["warnings"] == []  # pro seats (5) == members (5): no squeeze
+
+
+def test_plan_change_warns_when_seats_fall_below_current_members():
+    ws = _workspace(plan="pro", limits={"max_members": 5})
+    client = _client(ws, members_count=5)
+
+    res = client.patch(f"/api/admin/workspaces/{ws.id}/plan", json={"plan": "basic"})
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["plan"] == "basic"
+    assert len(body["warnings"]) == 1
+    assert "5 active members" in body["warnings"][0]
+    # Warned, not refused — the cap binds the next invitation, not the members.
+    assert body["plan_limits"]["max_members"] == 1
+
+
+@pytest.mark.parametrize("plan", ["enterprise", "nope", "starter"])
+def test_plan_change_rejects_a_non_assignable_tier_with_400(plan):
+    ws = _workspace(plan="basic")
+    client = _client(ws)
+    res = client.patch(f"/api/admin/workspaces/{ws.id}/plan", json={"plan": plan})
+    assert res.status_code == 400
+    assert ws.plan == "basic"  # nothing written on rejection
+
+
+def test_plan_change_refuses_a_non_admin():
+    ws = _workspace(plan="basic")
+    client = _client(ws, system_role="user")
+    res = client.patch(f"/api/admin/workspaces/{ws.id}/plan", json={"plan": "pro"})
+    assert res.status_code == 403
+    assert ws.plan == "basic"
+
+
+def test_plan_change_refuses_a_deleted_workspace():
+    """Every sibling mutator guards this; the client-side disable is not enough."""
+    from datetime import datetime
+
+    ws = _workspace(plan="basic", deleted_at=datetime(2026, 9, 1))
+    client = _client(ws)
+    res = client.patch(f"/api/admin/workspaces/{ws.id}/plan", json={"plan": "pro"})
+    assert res.status_code == 400
+    assert ws.plan == "basic"
+
+
+def test_plan_change_404s_for_an_unknown_workspace():
+    from uuid import uuid4
+
+    client = _client(None)
+    res = client.patch(f"/api/admin/workspaces/{uuid4()}/plan", json={"plan": "pro"})
+    assert res.status_code == 404
+
+
+# --------------------------------------------------------------------------- #
+# "Last active" is serialised as EXPLICIT UTC — a naive string would be read as
+# local time by the browser and the elapsed-time column would be wrong by the
+# viewer's offset.
+# --------------------------------------------------------------------------- #
+
+
+def test_last_active_is_serialised_with_an_explicit_utc_offset():
+    from datetime import datetime, timezone
+
+    from api.admin_workspaces import _utc_iso
+
+    naive = datetime(2026, 9, 11, 9, 20, 20)  # what the DB column hands back
+    out = _utc_iso(naive)
+    assert out.endswith("+00:00"), f"no offset in {out!r} — a browser would read it local"
+    # Round-trips to the same instant rather than shifting by the viewer's offset.
+    assert datetime.fromisoformat(out) == naive.replace(tzinfo=timezone.utc)
+
+
+def test_utc_iso_passes_through_none_and_keeps_an_aware_value():
+    from datetime import datetime, timedelta, timezone
+
+    from api.admin_workspaces import _utc_iso
+
+    assert _utc_iso(None) is None
+    aware = datetime(2026, 9, 11, 9, 20, 20, tzinfo=timezone(timedelta(hours=2)))
+    assert _utc_iso(aware) == aware.isoformat()  # already explicit: untouched

--- a/orchestrator/tests/test_p2w2_authz_boundary_sweep.py
+++ b/orchestrator/tests/test_p2w2_authz_boundary_sweep.py
@@ -138,6 +138,7 @@ ADMIN_GATED_IN_HANDLER = {
     ("POST", "/api/admin/prompts/{prompt_id}/rollback"),
     ("POST", "/api/admin/prompts/{prompt_id}/versions"),
     ("POST", "/api/admin/prompts/{prompt_id}/versions/{version_id}/activate"),
+    ("PATCH", "/api/admin/workspaces/{workspace_id}/plan"),
     ("POST", "/api/admin/workspaces/{workspace_id}/pause"),
     ("POST", "/api/admin/workspaces/{workspace_id}/purge"),
     ("POST", "/api/admin/workspaces/{workspace_id}/restore"),

--- a/orchestrator/tests/test_prd209_alembic_single_head.py
+++ b/orchestrator/tests/test_prd209_alembic_single_head.py
@@ -51,7 +51,10 @@ _COMPOSE = _REPO / "docker-compose.yml"
 # 2026-09-09 (analytics cost tracking): prd240_merge_heads joins that merge with the
 # calendar chain (calendar_scheduled_board_tasks); prd240_llm_usage_cache_tokens
 # chains onto it and is the single head.
-EXPECTED_HEAD = "prd240_llm_usage_cache_tokens"
+# 2026-09-11 (operator console): users_last_sign_in_column chains onto it —
+# users.last_sign_in was only ever a model attribute, never a declared column, and
+# the admin workspace routes now READ it (a missing column there is a 500 per load).
+EXPECTED_HEAD = "users_last_sign_in_column"
 
 
 def _literal(node: ast.AST):

--- a/orchestrator/tests/test_prd236_w1_routes.py
+++ b/orchestrator/tests/test_prd236_w1_routes.py
@@ -173,8 +173,13 @@ def test_migration_chains_onto_prd234_head_and_guard_follows():
     assert 'down_revision = "prd240_merge_heads"' in cache
     joins = (versions / "prd240_merge_heads.py").read_text()
     assert '"prd236w1_prd237_merge"' in joins and '"calendar_scheduled_board_tasks"' in joins
+    # 2026-09-11: users_last_sign_in_column chains onto the cache-tokens revision
+    # (declaring users.last_sign_in, which the operator console now reads); the
+    # guard follows it.
+    last_seen = (versions / "users_last_sign_in_column.py").read_text()
+    assert 'down_revision = "prd240_llm_usage_cache_tokens"' in last_seen
     guard = (Path(__file__).resolve().parent / "test_prd209_alembic_single_head.py").read_text()
-    assert 'EXPECTED_HEAD = "prd240_llm_usage_cache_tokens"' in guard
+    assert 'EXPECTED_HEAD = "users_last_sign_in_column"' in guard
 
 
 def test_orm_row_is_keyed_by_route():


### PR DESCRIPTION
## Why

I logged into a test client and Team Management was gone. It isn't the open-core work — production is `AUTH_EDITION = saas`, so the local-edition route hiding never fires.

**PRD-222 W2b (#631, 2026-08-28)** landed the plan-tier nav gating *and*, in the same commit, a migration backfilling every legacy `plan = 'starter'` row to `'basic'`. Basic declares `families.team = False`, so `exposure_for_plan` reports `nav.team = False` and the rail drops the item. Every self-serve tenant was swept in. `Automatos Primary` is `enterprise`, which declares **no** `families` key and is therefore treated as unrestricted — which is why the platform owner never saw it.

Production right now: **20 workspaces on `basic`, 1 on `enterprise`**. InBuildUK — the only multi-member workspace, 5 active members, `max_members: 5` — is on `basic`.

Those 20 tenants also silently lost Analytics, plus Auto's team/nl2sql/codegraph tools (trimmed by `filter_tools_by_plan`). Nothing appears in the Railway logs, because the exposure derivation is pure computation on a 200 response.

There was no way to fix that from the UI. Now there is.

## What's in here

**Plan dropdown** — `GET /api/admin/workspaces/plans`, `PATCH /api/admin/workspaces/{id}/plan`

Routed through `services.plan_tiers.assign_plan`, the documented single writer of `plan`/`plan_limits`. Upgrades apply on selection; a change that **removes** a surface, or caps seats below the members already in place, stops for confirmation and names what it removes first.

`with_budget=False` — the console applies a tier's seats and agent cap but mints **no spend ceiling**. `modules/policy/budget.py` enforces `plan_limits.budget` via `check_budget`, and a workspace with no budget key is ceiling-less, so writing one while retiering a live tenant would hand it a throttle it didn't have a moment ago. The same switch clears a stale *tier-owned* ceiling; an admin custom budget (`source != "tier"`) survives untouched.

Downgrades warn rather than refuse — the seat cap binds the *next* invitation, never the members already there.

**"Last active"** — `users.last_sign_in` has been a model attribute since the Clerk cutover with nothing writing it (1 of 25 production rows populated). Now stamped in the Clerk lane, throttled twice: an in-process map skips the statement outright, and the `UPDATE` repeats the age predicate so a second replica can't beat it. No read-then-write. A failure rolls back, logs at warning, and backs off rather than retrying on every request.

Serialised as **explicit UTC** — the column is `timestamp without time zone` on a UTC server, and ECMAScript parses an offset-less date-time as *local*, which would have made the elapsed-time column wrong by the viewer's own UTC offset (an hour, here, in BST).

**Migration** `users_last_sign_in_column` declares that column for the first time. `create_all` creates missing tables but never ALTERs an existing one, so until now its existence rested on luck — and these routes are the first code to *read* it, where a missing column is a 500 per console load. Idempotent; no-op downgrade (it would otherwise drop sign-in history it never created).

**Incidental:** `resolve_internal_user_id` was duplicated byte-identically in `api/team.py` and `api/harness.py` (harness's own docstring said "there is no shared util yet"). Rather than add a third copy for audit attribution, it moves to `core/auth/actor.py` and both import it.

## Test plan

Verified statically (CI is the gate; no local test runs):

- `tsc --noEmit`: **572 errors with these changes, 572 on pristine HEAD** — measured both ways by swapping the files out. Zero regression.
- Frontend route-contract gate: **0 new violations**.
- Alembic: single-head invariant holds, and all **177** revisions remain ancestors of the new head.
- Route manifest regenerated to match (799 → 801), `route_count` == entry count.
- New PATCH route added to `ADMIN_GATED_IN_HANDLER`, without which the authz boundary sweep fails it as unclassified.

27 new tests in `test_admin_plan_console.py` — tier gating, `with_budget` semantics (no ceiling minted, stale tier ceiling cleared, admin budget preserved), the throttle and its backoff, endpoint gate/validation/404/deleted-workspace, and the UTC serialisation.

**After rebuild, to confirm end to end:**
1. `/admin/workspaces` — every row shows a plan dropdown and a "Last active" value.
2. Set **InBuildUK → Pro**. It's an upgrade, so it applies straight away.
3. Log in as InBuildUK: **Team Management and Analytics are back** in the rail.
4. Check `plan_limits` on that workspace — `max_agents` 10 → 20, and **no `budget` key**.
5. Try moving a 5-member workspace down to Basic — it should warn (seats 1 < 5 members) and still apply, with nobody removed.
6. Reload the console a few minutes later — "Last active" should move for whoever has been using it.

## Flag, unrelated to this PR

The frontend tsc gate is **already breached on `main`**: `.tsc-baseline.json` pins 554, actual is 572 — identical with and without these changes. That lane is non-required, so it may have been quietly red for a while. Worth a separate look.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admins can view active member counts and relative “Last active” timestamps for workspaces.
  * Added an interactive workspace plan selector with confirmation details for impacted features and seat limits.
  * Added plan catalogue and plan-change API support, including validation and audit tracking.
  * Clerk-authenticated activity now updates users’ last-seen timestamps with throttling.

* **Bug Fixes**
  * Standardized internal user resolution across authentication-related workflows.
  * Plan changes no longer create a spend ceiling through the admin console.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->