### PR TITLE
fix(tests): PRD-233 composio-degrade test expects the canonical COMPOSIO_KEY wording (#724)

### DIFF
--- a/orchestrator/tests/test_prd233_s2_composio_degrade.py
+++ b/orchestrator/tests/test_prd233_s2_composio_degrade.py
@@ -87,7 +87,8 @@ def test_available_with_key_and_sdk(composio_on):
 def test_unavailable_without_key(composio_off):
     assert cc.composio_available() is False
     assert cc.composio_unavailable_reason() == cc.COMPOSIO_UNAVAILABLE_NO_KEY
-    assert "COMPOSIO_API_KEY" in cc.composio_unavailable_reason()
+    # #724: COMPOSIO_KEY is the canonical name (COMPOSIO_API_KEY the alias); the reason names it.
+    assert "COMPOSIO_KEY" in cc.composio_unavailable_reason()
 
 
 def test_unavailable_when_sdk_missing(monkeypatch):


### PR DESCRIPTION
One line. #724 renamed the reason string to `COMPOSIO_KEY is not configured` and left `test_unavailable_without_key` asserting the `COMPOSIO_API_KEY` alias — `orchestrator-tests` has been red on `main` since (1 failed, 5999 passed) and every PR inherits it (#725, #727). Merge first; the other two go green on rebase/merge.