### PR TITLE
fix(tests): the composio-degrade probe names COMPOSIO_KEY since #724

### DIFF
--- a/orchestrator/tests/test_prd233_s2_composio_degrade.py
+++ b/orchestrator/tests/test_prd233_s2_composio_degrade.py
@@ -87,7 +87,9 @@ def test_available_with_key_and_sdk(composio_on):
 def test_unavailable_without_key(composio_off):
     assert cc.composio_available() is False
     assert cc.composio_unavailable_reason() == cc.COMPOSIO_UNAVAILABLE_NO_KEY
-    assert "COMPOSIO_API_KEY" in cc.composio_unavailable_reason()
+    # #724 renamed the operator-facing env var to COMPOSIO_KEY (the name a local
+    # .env actually sets); the reason must name THAT, not the config attribute.
+    assert "COMPOSIO_KEY" in cc.composio_unavailable_reason()
 
 
 def test_unavailable_when_sdk_missing(monkeypatch):


### PR DESCRIPTION
`orchestrator-tests` has been red on `main` since **#724** (`a64638002`) — one failure out of 6025, and it isn't in anything that merged after it:

```
FAILED tests/test_prd233_s2_composio_degrade.py::test_unavailable_without_key - AssertionError: assert 'COMPOSIO_API_KEY' in 'COMPOSIO_KEY is not configured'
```

#724 renamed the operator-facing env var to `COMPOSIO_KEY` (the name a local `.env` actually sets) and changed `COMPOSIO_UNAVAILABLE_NO_KEY` to say so. One assertion still looked for the old substring, which the new message provably does not contain.

**One line, test-only, no product code.** The sibling assertion on the router envelope (~line 281) is untouched — that test passed in the same run because the envelope carries both names.

Same failure reproduced verbatim on #726's run (which otherwise passed 6024 + skipped 14).
