### PR TITLE
feat(calendar): colour by kind, legend chips, hourly heartbeats off the grid, overlap lanes

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -2111,6 +2111,34 @@
   :is(.studio, .cc-cal-root) .cc-cal-toolbar {
     display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
   }
+  /* Legend — one chip per kind (calendar-kinds.ts); a chip hides its kind. */
+  :is(.studio, .cc-cal-root) .cc-cal-legend {
+    display: inline-flex; align-items: center; gap: 4px; flex-wrap: wrap;
+    margin-left: auto;
+  }
+  :is(.studio, .cc-cal-root) .cc-cal-legend button {
+    display: inline-flex; align-items: center; gap: 5px;
+    padding: 2px 8px; border-radius: 999px;
+    border: 1px solid hsl(var(--border));
+    background: hsl(var(--secondary)); color: hsl(var(--foreground));
+    font-family: var(--font-geist-mono, monospace);
+    font-size: 10px; letter-spacing: 0.04em; text-transform: uppercase;
+    cursor: pointer;
+  }
+  :is(.studio, .cc-cal-root) .cc-cal-legend button .sw {
+    width: 8px; height: 8px; border-radius: 2px;
+  }
+  :is(.studio, .cc-cal-root) .cc-cal-legend button.off {
+    opacity: 0.45; text-decoration: line-through;
+  }
+  :is(.studio, .cc-cal-root) .cc-cal-legend button:hover {
+    background: hsl(var(--cc-hover, var(--muted)));
+  }
+  /* The agent is the dot; the kind is the border. */
+  :is(.studio, .cc-cal-root) .cc-cal-event .agent-dot {
+    display: inline-block; width: 6px; height: 6px; border-radius: 50%;
+    margin-right: 4px; vertical-align: middle;
+  }
   :is(.studio, .cc-cal-root) .cc-cal-frame {
     flex: 1; min-height: 0; overflow: hidden;
     background: hsl(var(--card)); border: 1px solid hsl(var(--border));

--- a/frontend/components/agents/agent-configuration-modal.tsx
+++ b/frontend/components/agents/agent-configuration-modal.tsx
@@ -580,6 +580,12 @@ export function AgentConfigurationModal({
   // PRD-55: Save heartbeat config
   const saveHeartbeatConfig = async () => {
     if (!agentId) return
+    if (heartbeatLoadError) {
+      // The form holds defaults, not this agent's settings: saving would
+      // overwrite a live heartbeat with "off".
+      toast.error('Heartbeat settings didn’t load — nothing was saved')
+      return
+    }
     try {
       await apiClient.request(`/api/heartbeat/agents/${agentId}/config`, {
         method: 'PUT',
@@ -1859,6 +1865,7 @@ export function AgentConfigurationModal({
                           variant="outline"
                           size="sm"
                           onClick={saveHeartbeatConfig}
+                          disabled={Boolean(heartbeatLoadError)}
                           className="flex-1"
                         >
                           <Save className="w-4 h-4 mr-2" />

--- a/frontend/components/agents/agent-configuration-modal.tsx
+++ b/frontend/components/agents/agent-configuration-modal.tsx
@@ -165,6 +165,7 @@ export function AgentConfigurationModal({
     channel_id: '',
   })
   const [heartbeatRunning, setHeartbeatRunning] = useState(false)
+  const [heartbeatLoadError, setHeartbeatLoadError] = useState<string | null>(null)
   const [lastHeartbeatResult, setLastHeartbeatResult] = useState<any>(null)
   const [connectedIntegrations, setConnectedIntegrations] = useState<Array<{ key: string; platform: string }>>([])
 
@@ -320,6 +321,7 @@ export function AgentConfigurationModal({
   useEffect(() => {
     if (!open || !agentId) return
     let mounted = true
+    setHeartbeatLoadError(null)
     apiClient.request<any>(`/api/heartbeat/agents/${agentId}/config`)
       .then((data) => {
         if (!mounted) return
@@ -327,7 +329,13 @@ export function AgentConfigurationModal({
           setHeartbeatConfig(prev => ({ ...prev, ...data }))
         }
       })
-      .catch(() => { })
+      .catch((err: unknown) => {
+        // Rendering the form default (off) as this agent's state was a lie:
+        // the heartbeat router is super-admin-locked (PRD-143), so for anyone
+        // else every agent looked disabled while the scheduler kept firing it.
+        if (!mounted) return
+        setHeartbeatLoadError(err instanceof Error ? err.message : 'request failed')
+      })
     // Load last heartbeat result
     apiClient.request<any>(`/api/heartbeat/agents/${agentId}/last`)
       .then((data) => {
@@ -1684,6 +1692,16 @@ export function AgentConfigurationModal({
                       </p>
                     </CardHeader>
                     <CardContent className="space-y-6">
+                      {heartbeatLoadError && (
+                        <p
+                          role="alert"
+                          className="text-xs rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-destructive"
+                        >
+                          Couldn’t load this agent’s heartbeat settings ({heartbeatLoadError}). The form below
+                          shows defaults, not the saved state — the Command Center calendar shows what is
+                          actually scheduled.
+                        </p>
+                      )}
                       {/* Enable Heartbeat */}
                       <div className="flex items-center justify-between">
                         <div>
@@ -1692,6 +1710,7 @@ export function AgentConfigurationModal({
                         </div>
                         <Switch
                           checked={heartbeatConfig.enabled}
+                          disabled={Boolean(heartbeatLoadError)}
                           onCheckedChange={(v) => setHeartbeatConfig(prev => ({ ...prev, enabled: v }))}
                         />
                       </div>

--- a/frontend/components/command-center/__tests__/calendar-kinds.test.ts
+++ b/frontend/components/command-center/__tests__/calendar-kinds.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { KIND_META, KIND_ORDER, kindTone, layoutLanes } from '../calendar-kinds'
+
+describe('calendar kinds', () => {
+  it('every feed kind has a legend entry and a distinct colour', () => {
+    expect([...KIND_ORDER]).toEqual(['routine', 'recipe', 'task', 'mission', 'task_due'])
+    const tones = KIND_ORDER.map((k) => KIND_META[k].tone)
+    expect(new Set(tones).size).toBe(tones.length)
+    expect(kindTone('recipe')).toBe(KIND_META.recipe.tone)
+  })
+
+  it('falls back to the heartbeat tone for a kind the table does not know', () => {
+    expect(kindTone('mystery' as never)).toBe(KIND_META.routine.tone)
+  })
+})
+
+describe('layoutLanes', () => {
+  const span = (e: { s: number; e: number }): [number, number] => [e.s, e.e]
+
+  it('non-overlapping events each take the full column', () => {
+    const out = layoutLanes([{ s: 0, e: 10 }, { s: 10, e: 20 }], span)
+    expect(out.map((l) => [l.lane, l.lanes])).toEqual([[0, 1], [0, 1]])
+  })
+
+  it('overlapping events share the column', () => {
+    const out = layoutLanes([{ s: 0, e: 10 }, { s: 5, e: 15 }], span)
+    expect(out.map((l) => [l.lane, l.lanes])).toEqual([[0, 2], [1, 2]])
+  })
+
+  it('a chain reuses a freed lane and the whole cluster shares the lane count', () => {
+    const out = layoutLanes([{ s: 25, e: 40 }, { s: 0, e: 20 }, { s: 10, e: 30 }], span)
+    expect(out.map((l) => [l.evt.s, l.lane, l.lanes])).toEqual([[0, 0, 2], [10, 1, 2], [25, 0, 2]])
+  })
+
+  it('a later separate cluster starts fresh', () => {
+    const out = layoutLanes([{ s: 0, e: 10 }, { s: 5, e: 15 }, { s: 30, e: 40 }], span)
+    expect(out[2]).toMatchObject({ lane: 0, lanes: 1 })
+  })
+
+  it('does not mutate its input', () => {
+    const input = [{ s: 5, e: 15 }, { s: 0, e: 10 }]
+    layoutLanes(input, span)
+    expect(input).toEqual([{ s: 5, e: 15 }, { s: 0, e: 10 }])
+  })
+})

--- a/frontend/components/command-center/__tests__/calendar-tab-feed.test.tsx
+++ b/frontend/components/command-center/__tests__/calendar-tab-feed.test.tsx
@@ -157,6 +157,17 @@ describe('CalendarTab — kinds, lanes, legend', () => {
     ])
   })
 
+  it('short events closer together than the minimum box height share the column', () => {
+    // 15-minute deadlines 20 minutes apart: their 28px boxes would overlap.
+    const at = new Date(midToday().getTime() + 2 * 60 * 60_000)
+    feed.items = [deadline(1, 'A', at), deadline(2, 'B', new Date(at.getTime() + 20 * 60_000))]
+    const { container } = render(<CalendarTab />)
+    const lanes = Array.from(container.querySelectorAll('.cc-cal-event')).map((e) =>
+      e.getAttribute('data-lanes'),
+    )
+    expect(lanes).toEqual(['2', '2'])
+  })
+
   it('a legend chip hides its kind from the grid, band and Next Up', () => {
     feed.items = [
       routine(1, 'Ops', 15, midToday()),

--- a/frontend/components/command-center/__tests__/calendar-tab-feed.test.tsx
+++ b/frontend/components/command-center/__tests__/calendar-tab-feed.test.tsx
@@ -3,13 +3,16 @@
  * It used to take its routine rows and 24/7 band from /api/heartbeat/workspace,
  * a router behind the PRD-143 super-admin lock (403 for everyone else, polled
  * every 30s) whose next_run_at came from the one worker hosting APScheduler.
- * These tests pin the feed-only contract and the new deadline items.
+ * These tests pin the feed-only contract, the deadline items, and the
+ * 2026-09-11 rules: heartbeats at the band cadence stay off the grid, colour
+ * is by kind, overlapping events share the column, legend chips hide a kind.
  */
 import { describe, it, expect, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { readFileSync } from 'fs'
 import path from 'path'
 import type { ScheduleItem } from '@/hooks/use-activity-api'
+import { KIND_META } from '../calendar-kinds'
 
 const feed = vi.hoisted(() => ({ items: [] as unknown[] }))
 
@@ -58,6 +61,21 @@ function routine(id: number, name: string, intervalMinutes: number, nextRunAt: D
   }
 }
 
+function deadline(id: number, name: string, due: Date): ScheduleItem {
+  return {
+    id: `board-${id}`,
+    board_task_id: id,
+    name,
+    type: 'task_due',
+    next_run_at: due.toISOString(),
+    frequency: 'SLA deadline',
+    agent_name: 'Ops',
+    agent_id: 1,
+    status: 'assigned',
+    priority: 'high',
+  }
+}
+
 /** A moment inside today's visible week that is never near a day boundary. */
 function midToday(): Date {
   const d = new Date()
@@ -81,8 +99,16 @@ describe('CalendarTab — feed-only data contract', () => {
     expect(container.querySelector('.cc-cal-event')).toBeNull()
   })
 
-  it('an hourly routine is plotted from its structured recurrence and next run', () => {
-    feed.items = [routine(2, 'Research', 60, midToday())]
+  it('an hourly heartbeat stays in the band and off the grid', () => {
+    // WATCHTOWER hourly 08:00-20:00 was 13 grey blocks a day on the prod calendar.
+    feed.items = [routine(3, 'Watchtower', 60, midToday())]
+    const { container } = render(<CalendarTab />)
+    expect(screen.getByText(/Watchtower · every 60m/)).toBeInTheDocument()
+    expect(container.querySelector('.cc-cal-event')).toBeNull()
+  })
+
+  it('a slower routine is plotted from its structured recurrence and next run', () => {
+    feed.items = [routine(2, 'Research', 120, midToday())]
     const { container } = render(<CalendarTab />)
     const plotted = container.querySelectorAll('.cc-cal-event')
     expect(plotted.length).toBeGreaterThan(1) // expanded across the day, not one anchor
@@ -90,26 +116,72 @@ describe('CalendarTab — feed-only data contract', () => {
   })
 
   it('a board-task SLA deadline is a DUE event and sits in Next Up', () => {
-    const due = new Date(midToday().getTime() + 30 * 60_000)
-    feed.items = [
-      {
-        id: 'board-42',
-        board_task_id: 42,
-        name: 'Fix the calendar',
-        type: 'task_due',
-        next_run_at: due.toISOString(),
-        frequency: 'SLA deadline',
-        agent_name: 'Ops',
-        agent_id: 1,
-        status: 'assigned',
-        priority: 'high',
-      } satisfies ScheduleItem,
-    ]
+    feed.items = [deadline(42, 'Fix the calendar', new Date(midToday().getTime() + 30 * 60_000))]
     const { container } = render(<CalendarTab />)
     const evt = container.querySelector('.cc-cal-event')
     expect(evt).not.toBeNull()
     expect(evt!.textContent).toContain('Fix the calendar')
     expect(evt!.textContent).toMatch(/DUE|OVERDUE/)
     expect(screen.getByText('Next up')).toBeInTheDocument()
+  })
+})
+
+describe('CalendarTab — kinds, lanes, legend', () => {
+  it('colours an event by its kind, with the agent as the dot', () => {
+    feed.items = [
+      routine(2, 'Research', 120, midToday()),
+      deadline(42, 'Fix the calendar', new Date(midToday().getTime() + 5 * 60 * 60_000)),
+    ]
+    const { container } = render(<CalendarTab />)
+    const events = Array.from(container.querySelectorAll<HTMLElement>('.cc-cal-event'))
+    const byTitle = (re: RegExp) => events.find((e) => re.test(e.title))!
+    // The kind decides the border colour (calendar-kinds.ts); jsdom's style
+    // parser is unreliable with modern hsl() syntax, so assert the kind hook.
+    expect(byTitle(/^Heartbeat:/).dataset.kind).toBe('routine')
+    expect(byTitle(/^Task deadline:/).dataset.kind).toBe('task_due')
+    expect(KIND_META.routine.tone).not.toBe(KIND_META.task_due.tone)
+    expect(byTitle(/^Heartbeat:/).querySelector('.agent-dot')).not.toBeNull()
+  })
+
+  it('overlapping events share the column', () => {
+    const at = new Date(midToday().getTime() + 2 * 60 * 60_000)
+    feed.items = [deadline(1, 'A', at), deadline(2, 'B', at)]
+    const { container } = render(<CalendarTab />)
+    const lanes = Array.from(container.querySelectorAll('.cc-cal-event')).map((e) => [
+      e.getAttribute('data-lane'),
+      e.getAttribute('data-lanes'),
+    ])
+    expect(lanes).toEqual([
+      ['0', '2'],
+      ['1', '2'],
+    ])
+  })
+
+  it('a legend chip hides its kind from the grid, band and Next Up', () => {
+    feed.items = [
+      routine(1, 'Ops', 15, midToday()),
+      routine(2, 'Research', 120, midToday()),
+      deadline(42, 'Fix the calendar', new Date(midToday().getTime() + 30 * 60_000)),
+    ]
+    const { container } = render(<CalendarTab />)
+    expect(container.querySelectorAll('.cc-cal-event').length).toBeGreaterThan(1)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Heartbeat' }))
+
+    expect(screen.queryByText(/Ops · every 15m/)).toBeNull()
+    const left = Array.from(container.querySelectorAll<HTMLElement>('.cc-cal-event'))
+    expect(left).toHaveLength(1)
+    expect(left[0].title).toMatch(/^Task deadline:/)
+    expect(screen.getByRole('button', { name: 'Heartbeat' })).toHaveAttribute('aria-pressed', 'false')
+    expect(screen.getByRole('button', { name: 'Task deadline' })).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('Next Up drops a deadline overdue by more than a week', () => {
+    const soon = new Date(midToday().getTime() + 30 * 60_000)
+    const ancient = new Date(Date.now() - 8 * 24 * 60 * 60_000)
+    feed.items = [deadline(1, 'Soon ticket', soon), deadline(2, 'Ancient ticket', ancient)]
+    render(<CalendarTab />)
+    expect(screen.getByText('Soon ticket')).toBeInTheDocument()
+    expect(screen.queryByText('Ancient ticket')).toBeNull()
   })
 })

--- a/frontend/components/command-center/__tests__/calendar-tab-feed.test.tsx
+++ b/frontend/components/command-center/__tests__/calendar-tab-feed.test.tsx
@@ -181,7 +181,7 @@ describe('CalendarTab — kinds, lanes, legend', () => {
     const ancient = new Date(Date.now() - 8 * 24 * 60 * 60_000)
     feed.items = [deadline(1, 'Soon ticket', soon), deadline(2, 'Ancient ticket', ancient)]
     render(<CalendarTab />)
-    expect(screen.getByText('Soon ticket')).toBeInTheDocument()
+    expect(screen.getAllByText('Soon ticket').length).toBeGreaterThan(0) // Next Up and the grid
     expect(screen.queryByText('Ancient ticket')).toBeNull()
   })
 })

--- a/frontend/components/command-center/calendar-kinds.ts
+++ b/frontend/components/command-center/calendar-kinds.ts
@@ -1,0 +1,82 @@
+/**
+ * Calendar kinds — what an item IS decides its colour; the agent is the dot.
+ *
+ * The feed (GET /api/activity/schedule) carries five kinds. Colouring by agent
+ * (the old scheme) made a heartbeat, a playbook run and a deadline for the same
+ * agent indistinguishable, and a calendar full of WATCHTOWER grey said nothing
+ * about what was actually scheduled. The legend in the calendar toolbar uses
+ * the same table; each chip hides its kind.
+ */
+import type { ScheduleItemType } from '@/hooks/use-activity-api'
+
+export type { ScheduleItemType } from '@/hooks/use-activity-api'
+
+export interface KindMeta {
+  label: string
+  tone: string
+}
+
+export const KIND_META: Record<ScheduleItemType, KindMeta> = {
+  routine: { label: 'Heartbeat', tone: 'hsl(201 44% 40%)' },
+  recipe: { label: 'Playbook', tone: 'hsl(272 30% 45%)' },
+  task: { label: 'Scheduled task', tone: 'hsl(158 44% 35%)' },
+  mission: { label: 'Mission SLA', tone: 'hsl(28 70% 45%)' },
+  task_due: { label: 'Task deadline', tone: 'hsl(345 60% 45%)' },
+}
+
+/** Legend order: recurring things first, deadlines last. */
+export const KIND_ORDER: readonly ScheduleItemType[] = ['routine', 'recipe', 'task', 'mission', 'task_due']
+
+export function kindTone(type: ScheduleItemType): string {
+  return (KIND_META[type] ?? KIND_META.routine).tone
+}
+
+export interface Laned<T> {
+  evt: T
+  /** 0-based column inside the overlap cluster */
+  lane: number
+  /** how many columns the cluster needs — every member gets the same */
+  lanes: number
+}
+
+/**
+ * Same-column overlap layout. Events that overlap in time share the column
+ * width instead of stacking on top of each other; a cluster is a run of
+ * transitively overlapping events, and every member takes 1/lanes of the
+ * width. Returns the events sorted by start.
+ */
+export function layoutLanes<T>(
+  events: readonly T[],
+  span: (evt: T) => readonly [number, number],
+): Laned<T>[] {
+  const sorted = events
+    .map((evt) => {
+      const [start, end] = span(evt)
+      return { evt, start, end }
+    })
+    .sort((a, b) => a.start - b.start || b.end - a.end)
+
+  const out: Laned<T>[] = []
+  let cluster: Array<{ evt: T; lane: number }> = []
+  let laneEnds: number[] = []
+  let clusterEnd = Number.NEGATIVE_INFINITY
+
+  const flush = () => {
+    const lanes = Math.max(laneEnds.length, 1)
+    cluster.forEach((member) => out.push({ evt: member.evt, lane: member.lane, lanes }))
+    cluster = []
+    laneEnds = []
+    clusterEnd = Number.NEGATIVE_INFINITY
+  }
+
+  for (const { evt, start, end } of sorted) {
+    if (start >= clusterEnd) flush()
+    const free = laneEnds.findIndex((laneEnd) => laneEnd <= start)
+    const lane = free === -1 ? laneEnds.length : free
+    laneEnds = free === -1 ? [...laneEnds, end] : laneEnds.map((v, i) => (i === lane ? end : v))
+    cluster = [...cluster, { evt, lane }]
+    clusterEnd = Math.max(clusterEnd, end)
+  }
+  flush()
+  return out
+}

--- a/frontend/components/command-center/calendar-tab.tsx
+++ b/frontend/components/command-center/calendar-tab.tsx
@@ -70,6 +70,11 @@ const HOUR_PX = 44
 const START_HR = 0
 const END_HR = 22
 const HOURS = Array.from({ length: END_HR - START_HR + 1 }, (_, i) => i + START_HR)
+/** Smallest rendered event box. The overlap layout uses the same floor, so two
+ *  short events closer together than this share the column instead of
+ *  drawing on top of each other. */
+const MIN_EVENT_PX = 28
+const MIN_EVENT_MIN = (MIN_EVENT_PX / HOUR_PX) * 60
 /** Routines this frequent or more (heartbeats every 5/15/30/60 min) live in the
  *  always-on band ONLY. Plotted, an hourly heartbeat is 12+ blocks a day per
  *  agent and buries the one-off work the grid is for (2026-09-11). */
@@ -234,10 +239,11 @@ function occurrence(item: ScheduleItem, d: Date, durMin: number, recurring: bool
   }
 }
 
-/** [start, end] in ms — what the overlap layout compares. */
+/** [start, end] in ms — what the overlap layout compares. The end is the
+ *  rendered box, never shorter than MIN_EVENT_MIN. */
 const eventSpan = (evt: CalEvent): [number, number] => [
   evt.date.getTime(),
-  evt.date.getTime() + evt.durMin * 60_000,
+  evt.date.getTime() + Math.max(evt.durMin, MIN_EVENT_MIN) * 60_000,
 ]
 
 /** Walk an interval backwards and forwards from its anchor across the window. */
@@ -749,7 +755,7 @@ export function CalendarTab() {
                     const top =
                       (evt.hour - START_HR) * HOUR_PX +
                       (evt.min / 60) * HOUR_PX
-                    const height = Math.max((evt.durMin / 60) * HOUR_PX, 28)
+                    const height = Math.max((evt.durMin / 60) * HOUR_PX, MIN_EVENT_PX)
                     const tone = toneFor(evt.agent)
                     const overdue = Boolean(evt.due) && evt.date.getTime() < Date.now()
                     const kind = KIND_META[evt.item.type]?.label ?? evt.item.type

--- a/frontend/components/command-center/calendar-tab.tsx
+++ b/frontend/components/command-center/calendar-tab.tsx
@@ -23,6 +23,10 @@
  * playbook / mission / board card, pause a routine, pause or cancel a
  * scheduled task. Every action rides an endpoint that already exists (see
  * calendar-actions.ts). Deadline items carry a DUE tag; overdue ones go amber.
+ * Colour is by KIND (heartbeat / playbook / scheduled task / mission SLA /
+ * task deadline — calendar-kinds.ts); the agent is the small dot. Legend chips
+ * in the toolbar hide a kind. Heartbeats at the band cadence or faster stay in
+ * the 24/7 band and off the grid.
  *
  * Prev / Today / Next actually move the visible window. No speculative
  * "Schedule task" / "Filter" / "Export" CTAs — those don't belong on a
@@ -52,6 +56,7 @@ import {
 import { useToggleHeartbeat } from '@/hooks/use-heartbeats-api'
 import { useUpdateScheduledTaskStatus } from '@/hooks/use-scheduled-tasks-api'
 import { toneFor } from './agent-tones'
+import { KIND_META, KIND_ORDER, kindTone, layoutLanes, type ScheduleItemType } from './calendar-kinds'
 import {
   buildEventActions,
   isDeadlineItem,
@@ -65,11 +70,12 @@ const HOUR_PX = 44
 const START_HR = 0
 const END_HR = 22
 const HOURS = Array.from({ length: END_HR - START_HR + 1 }, (_, i) => i + START_HR)
-/** Routines more frequent than this stay in the always-on band: on the grid
- *  they would clutter every column. */
-const GRID_MIN_INTERVAL_MIN = 30
-/** Routines at least this frequent are summarised in the always-on band. */
+/** Routines this frequent or more (heartbeats every 5/15/30/60 min) live in the
+ *  always-on band ONLY. Plotted, an hourly heartbeat is 12+ blocks a day per
+ *  agent and buries the one-off work the grid is for (2026-09-11). */
 const BAND_MAX_INTERVAL_MIN = 60
+/** Next Up keeps an overdue deadline this long; after that it is the board's problem. */
+const NEXTUP_OVERDUE_MAX_MS = 7 * 24 * 60 * 60_000
 /** Safety cap per item so a frequent routine can't run away across a month. */
 const MAX_OCCURRENCES = 200
 const ROUTINE_MIN_DUR_MIN = 15
@@ -228,6 +234,12 @@ function occurrence(item: ScheduleItem, d: Date, durMin: number, recurring: bool
   }
 }
 
+/** [start, end] in ms — what the overlap layout compares. */
+const eventSpan = (evt: CalEvent): [number, number] => [
+  evt.date.getTime(),
+  evt.date.getTime() + evt.durMin * 60_000,
+]
+
 /** Walk an interval backwards and forwards from its anchor across the window. */
 function expandInterval(
   item: ScheduleItem,
@@ -261,11 +273,12 @@ function expandInterval(
 /** Every occurrence of one feed item inside the window. */
 function expandItem(item: ScheduleItem, span: WindowSpan): CalEvent[] {
   if (item.type === 'routine') {
-    // Structured recurrence from the feed — no string parsing. Sub-30-minute
-    // routines live in the always-on band only; a routine with no next run
-    // (outside its active hours for the whole horizon) has nothing to place.
+    // Structured recurrence from the feed — no string parsing. Routines at the
+    // band cadence or faster live in the always-on band only; a routine with
+    // no next run (outside its active hours for the whole horizon) has
+    // nothing to place.
     const interval = item.recurrence?.interval_minutes ?? null
-    if (interval === null || interval < GRID_MIN_INTERVAL_MIN || !item.next_run_at) return []
+    if (interval === null || interval <= BAND_MAX_INTERVAL_MIN || !item.next_run_at) return []
     const dur = Math.min(Math.max(interval, ROUTINE_MIN_DUR_MIN), ROUTINE_MAX_DUR_MIN)
     return expandInterval(item, new Date(item.next_run_at), interval, span, dur)
   }
@@ -362,19 +375,34 @@ export function CalendarTab() {
   const week = useMemo(() => buildWeek(anchor), [anchor])
   const monthCells = useMemo(() => buildMonthGrid(anchor), [anchor])
 
+  // Legend chips hide a kind everywhere (grid, band, Next Up) for this view.
+  const [hiddenKinds, setHiddenKinds] = useState<ReadonlySet<ScheduleItemType>>(() => new Set())
+  const toggleKind = (kind: ScheduleItemType) =>
+    setHiddenKinds((prev) => {
+      const next = new Set(prev)
+      if (next.has(kind)) next.delete(kind)
+      else next.add(kind)
+      return next
+    })
+  const visibleItems = useMemo(
+    () => (schedule?.scheduled ?? []).filter((i) => !hiddenKinds.has(i.type)),
+    [schedule, hiddenKinds],
+  )
+
   // Ported from the deleted classic ActivityCalendar (PRD-162 S4): the soonest
-  // upcoming items, straight from the DB-first schedule feed.
+  // upcoming items, straight from the DB-first schedule feed. A deadline
+  // overdue by more than a week drops out — it is a board problem by then.
   const nextUp = useMemo(() => {
-    const items = schedule?.scheduled ?? []
-    return [...items]
-      .filter((i) => i.next_run_at)
+    const floor = Date.now() - NEXTUP_OVERDUE_MAX_MS
+    return [...visibleItems]
+      .filter((i) => i.next_run_at && new Date(i.next_run_at).getTime() >= floor)
       .sort(
         (a, b) =>
           new Date(a.next_run_at as string).getTime() -
           new Date(b.next_run_at as string).getTime(),
       )
       .slice(0, 6)
-  }, [schedule])
+  }, [visibleItems])
 
   const visibleDays = useMemo<DayCell[]>(
     () => (mode === 'day' ? [toDayCell(new Date(anchor))] : week),
@@ -404,19 +432,19 @@ export function CalendarTab() {
   }, [mode, anchor])
 
   const events = useMemo<CalEvent[]>(
-    () => (schedule?.scheduled ?? []).flatMap((item) => expandItem(item, windowSpan)),
-    [schedule, windowSpan],
+    () => visibleItems.flatMap((item) => expandItem(item, windowSpan)),
+    [visibleItems, windowSpan],
   )
 
   // Routines frequent enough to summarise rather than plot, from the same feed.
   const alwaysOn = useMemo(
     () =>
-      (schedule?.scheduled ?? []).filter(
+      visibleItems.filter(
         (s) =>
           s.type === 'routine' &&
           (s.recurrence?.interval_minutes ?? Number.POSITIVE_INFINITY) <= BAND_MAX_INTERVAL_MIN,
       ),
-    [schedule],
+    [visibleItems],
   )
 
   const now = new Date()
@@ -517,6 +545,25 @@ export function CalendarTab() {
         >
           {monthLabel}
         </span>
+        <div className="cc-cal-legend" role="group" aria-label="Show on calendar">
+          {KIND_ORDER.map((kind) => {
+            const hidden = hiddenKinds.has(kind)
+            const { label, tone } = KIND_META[kind]
+            return (
+              <button
+                key={kind}
+                type="button"
+                className={hidden ? 'off' : ''}
+                aria-pressed={!hidden}
+                onClick={() => toggleKind(kind)}
+                title={hidden ? `Show ${label}` : `Hide ${label}`}
+              >
+                <span className="sw" style={{ background: tone }} />
+                {label}
+              </button>
+            )
+          })}
+        </div>
       </div>
 
       {health?.healthy === false && (
@@ -568,10 +615,10 @@ export function CalendarTab() {
                   <button
                     type="button"
                     className="pill"
-                    style={{ borderLeftColor: tone.bg, cursor: 'pointer' }}
-                    title={`${s.agent_name} routine — click for actions`}
+                    style={{ borderLeftColor: kindTone('routine'), cursor: 'pointer' }}
+                    title={`${s.agent_name} heartbeat — click for actions`}
                   >
-                    <span className="dot" />
+                    <span className="dot" style={{ background: tone.bg }} />
                     {s.agent_name} · every {s.recurrence?.interval_minutes}m
                   </button>
                 </EventMenu>
@@ -611,7 +658,7 @@ export function CalendarTab() {
             const overdue = item.next_run_at
               ? new Date(item.next_run_at).getTime() < Date.now()
               : false
-            const accent = overdue ? OVERDUE_TONE : 'hsl(var(--muted-foreground))'
+            const accent = overdue ? OVERDUE_TONE : kindTone(item.type)
             const due = isDeadlineItem(item)
             return (
               <span
@@ -698,32 +745,41 @@ export function CalendarTab() {
                     height: HOURS.length * HOUR_PX,
                   }}
                 >
-                  {dayEvents.map((evt) => {
+                  {layoutLanes(dayEvents, eventSpan).map(({ evt, lane, lanes }) => {
                     const top =
                       (evt.hour - START_HR) * HOUR_PX +
                       (evt.min / 60) * HOUR_PX
                     const height = Math.max((evt.durMin / 60) * HOUR_PX, 28)
                     const tone = toneFor(evt.agent)
                     const overdue = Boolean(evt.due) && evt.date.getTime() < Date.now()
+                    const kind = KIND_META[evt.item.type]?.label ?? evt.item.type
                     return (
                       <EventMenu key={evt.id} actions={buildEventActions(evt.item, actionDeps)}>
                         <button
                           type="button"
                           className="cc-cal-event"
+                          data-kind={evt.item.type}
+                          data-lane={lane}
+                          data-lanes={lanes}
                           style={{
                             top,
                             height,
-                            borderLeftColor: overdue ? OVERDUE_TONE : tone.bg,
+                            // overlapping events share the column instead of stacking
+                            left: `calc(${(lane / lanes) * 100}% + 3px)`,
+                            width: `calc(${100 / lanes}% - 6px)`,
+                            right: 'auto',
+                            borderLeftColor: overdue ? OVERDUE_TONE : kindTone(evt.item.type),
                             background: 'hsl(var(--secondary))',
                           }}
-                          title={`${evt.name} — click for actions`}
+                          title={`${kind}: ${evt.name} — click for actions`}
                         >
                           <div className="nm">
                             {String(evt.hour).padStart(2, '0')}:
                             {String(evt.min).padStart(2, '0')}
                             {evt.agent && (
                               <span style={{ marginLeft: 6, opacity: 0.85 }}>
-                                · {evt.agent}
+                                <span className="agent-dot" style={{ background: tone.bg }} />
+                                {evt.agent}
                               </span>
                             )}
                             {evt.due && <DueTag overdue={overdue} />}
@@ -796,15 +852,15 @@ function MonthGrid({
               <div className="n">{d.today ? <span>{d.n}</span> : d.n}</div>
               <div className="evts">
                 {dayEvents.slice(0, 3).map((evt) => {
-                  const tone = toneFor(evt.agent)
                   const overdue = Boolean(evt.due) && evt.date.getTime() < Date.now()
                   return (
                     <EventMenu key={evt.id} actions={buildEventActions(evt.item, actionDeps)}>
                       <button
                         type="button"
                         className="cc-cal-month-evt"
+                        data-kind={evt.item.type}
                         style={{
-                          borderLeftColor: overdue ? OVERDUE_TONE : tone.bg,
+                          borderLeftColor: overdue ? OVERDUE_TONE : kindTone(evt.item.type),
                           opacity: past && !evt.due ? 0.5 : 1,
                         }}
                         title={evt.name}


### PR DESCRIPTION
## Summary

The Command Centre calendar coloured events by **agent**, plotted hourly heartbeats on the grid (13 blocks a day per agent on the prod calendar), stacked same-time events on top of each other, and pinned any overdue deadline in Next Up forever. The agent modal also rendered "Heartbeat: off" whenever its config request failed — and it fails for everyone who is not a super admin (PRD-143 lock on `/api/heartbeat`), so an agent that the scheduler fires hourly looked disabled.

- **Colour by kind** — `calendar-kinds.ts`: heartbeat / playbook / scheduled task / mission SLA / task deadline each have a colour; the agent is the small dot. Week, month, band and Next Up all use it.
- **Legend chips** in the toolbar, one per kind; a chip hides its kind from the grid, the 24/7 band and Next Up.
- **Heartbeats at the band cadence (≤ 60 min) stay in the 24/7 band and off the grid.** Slower routines (e.g. every 2 h) are still plotted.
- **Overlap lanes** — events that overlap in a day column share the width (`layoutLanes`, pure function, tested).
- **Next Up** drops a deadline overdue by more than a week; it is a board problem by then.
- **Agent modal** — a failed heartbeat config load shows an alert and disables the toggle instead of showing the form default as the saved state.

No new endpoints; the calendar is still feed-only (`GET /api/activity/schedule`).

## Test plan

- [ ] `__tests__/calendar-kinds.test.ts` — legend table, lane layout (non-overlap, overlap, chain reuse, separate clusters, no mutation).
- [ ] `__tests__/calendar-tab-feed.test.tsx` — 15 m and 60 m heartbeats band-only, 120 m plotted, deadline DUE + Next Up, kind hooks + agent dot, lanes, legend hide, Next Up overdue cap.
- [ ] `__tests__/calendar-tab-scope.test.tsx` — unchanged, new CSS rules use the same `:is(.studio, .cc-cal-root)` scope.
- [ ] CI frontend lanes green.

## Review fixes (third commit)

- **Overlap lanes honour the minimum box height** — boxes render at least 28px (~38 min); the overlap window used raw 15–20 min durations, so short events 15–38 min apart still drew on top of each other. Same floor for both now, with a test.
- **Save gated on a failed load** — the toggle was disabled but Save still PUT the form defaults and would have switched a live heartbeat off. Save is disabled and guarded.
