### PR TITLE
feat(scheduler): leader reconcile tick — scheduled tasks and heartbeats register from any worker

### DIFF
--- a/orchestrator/main.py
+++ b/orchestrator/main.py
@@ -483,6 +483,14 @@ async def _boot_phase_2_extensions(app_instance: "FastAPI") -> "DeferredInitResu
                 except Exception as _st_err:
                     logger.warning("Could not load scheduled tasks: %s", _st_err)
 
+                # Leader reconcile tick: scheduled-task and heartbeat changes made on
+                # any worker reach this scheduler within a minute (not at next boot).
+                try:
+                    from services.schedule_reconcile import start_schedule_reconcile
+                    await start_schedule_reconcile(shared_sched)
+                except Exception as _rc_err:
+                    logger.warning("Could not start schedule reconcile tick: %s", _rc_err)
+
                 # PRD-82A: Coordinator tick — sequential mission orchestration
                 if config.COORDINATOR_ENABLED:
                     try:

--- a/orchestrator/services/activity_service.py
+++ b/orchestrator/services/activity_service.py
@@ -891,7 +891,11 @@ class ActivityService:
         for agent in agents:
             cfg = agent.configuration if isinstance(agent.configuration, dict) else {}
             hb = cfg.get("heartbeat")
-            if not isinstance(hb, dict) or hb.get("enabled") is False:
+            # The same rule the scheduler applies (heartbeat_service._load_heartbeat_configs:
+            # `if hb.get("enabled")`) and the GET config reports (`enabled` defaults to
+            # False): a block without the flag never fires, so it is not a routine. The old
+            # `is False` test put every such agent on the calendar hourly (2026-09-11).
+            if not isinstance(hb, dict) or not hb.get("enabled"):
                 continue
             interval = _coerce_int(hb.get("interval_minutes"), default=60)
             tz = hb.get("timezone") or "UTC"

--- a/orchestrator/services/heartbeat_service.py
+++ b/orchestrator/services/heartbeat_service.py
@@ -446,7 +446,6 @@ class HeartbeatService:
         for agent_id in existing:
             if agent_id not in desired:
                 self.unschedule_heartbeat(f"agent_hb_{agent_id}")
-                self._hb_signatures.pop(agent_id, None)
                 removed += 1
         if added or changed or removed:
             logger.info("[Heartbeat] reconcile: %d added, %d changed, %d removed", added, changed, removed)
@@ -481,7 +480,10 @@ class HeartbeatService:
         )
 
     def unschedule_heartbeat(self, job_id: str):
-        """Remove a scheduled heartbeat job."""
+        """Remove a scheduled heartbeat job (and forget its config signature)."""
+        suffix = job_id[len("agent_hb_"):]
+        if job_id.startswith("agent_hb_") and suffix.isdigit():
+            self._hb_signatures.pop(int(suffix), None)
         if self._scheduler and self._scheduler.get_job(job_id):
             self._scheduler.remove_job(job_id)
             logger.info("[Heartbeat] Unscheduled job %s", job_id)

--- a/orchestrator/services/heartbeat_service.py
+++ b/orchestrator/services/heartbeat_service.py
@@ -149,6 +149,9 @@ class HeartbeatService:
         # probe writes a heartbeat_results row only on a state CHANGE (not every tick).
         self._last_durable_probe_status: Optional[str] = None
         self._max_concurrent_per_workspace = 5
+        # agent_id -> heartbeat_signature(...) of the job currently registered,
+        # so the reconcile tick re-adds a job only when its config changed.
+        self._hb_signatures: Dict[int, str] = {}
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -403,11 +406,58 @@ class HeartbeatService:
             trigger,
         )
 
+    @staticmethod
+    def heartbeat_signature(workspace_id: str, hb_config: dict) -> str:
+        """What decides a heartbeat job's trigger and args — compared by the
+        reconcile tick to re-add a job only when the config actually changed."""
+        import json as _json
+        return _json.dumps({"ws": str(workspace_id), "hb": hb_config}, sort_keys=True, default=str)
+
+    def reconcile_agent_heartbeats(self, db) -> Dict[str, int]:
+        """Make the scheduler worker's agent heartbeat jobs match the DB (all
+        workspaces): enabled blocks get a job, disabled ones lose theirs, a changed
+        block is re-added. The config PUT / toggle only touch the scheduler on the
+        worker that served the request; only one worker hosts APScheduler, so
+        without this the leader learned of a change at the next restart."""
+        from core.models import Agent
+
+        if not self._scheduler or not getattr(self._scheduler, "running", False):
+            return {"added": 0, "removed": 0, "changed": 0}
+        desired: Dict[int, tuple] = {}
+        for agent in db.query(Agent.id, Agent.workspace_id, Agent.configuration).all():
+            cfg = agent.configuration if isinstance(agent.configuration, dict) else {}
+            hb = cfg.get("heartbeat")
+            if isinstance(hb, dict) and hb.get("enabled"):
+                desired[int(agent.id)] = (str(agent.workspace_id), hb)
+        existing = {
+            int(str(job.id)[len("agent_hb_"):]): job
+            for job in self._scheduler.get_jobs()
+            if str(getattr(job, "id", "")).startswith("agent_hb_") and str(job.id)[len("agent_hb_"):].isdigit()
+        }
+        added = changed = removed = 0
+        for agent_id, (ws_id, hb) in desired.items():
+            signature = self.heartbeat_signature(ws_id, hb)
+            if agent_id not in existing:
+                self.schedule_agent_heartbeat(agent_id, ws_id, hb)
+                added += 1
+            elif self._hb_signatures.get(agent_id) != signature:
+                self.schedule_agent_heartbeat(agent_id, ws_id, hb)
+                changed += 1
+        for agent_id in existing:
+            if agent_id not in desired:
+                self.unschedule_heartbeat(f"agent_hb_{agent_id}")
+                self._hb_signatures.pop(agent_id, None)
+                removed += 1
+        if added or changed or removed:
+            logger.info("[Heartbeat] reconcile: %d added, %d changed, %d removed", added, changed, removed)
+        return {"added": added, "removed": removed, "changed": changed}
+
     def schedule_agent_heartbeat(
         self, agent_id: int, workspace_id: str, hb_config: dict
     ):
         """Schedule or reschedule an agent heartbeat job."""
         job_id = f"agent_hb_{agent_id}"
+        self._hb_signatures[int(agent_id)] = self.heartbeat_signature(workspace_id, hb_config)
         interval_minutes = hb_config.get("interval_minutes", 60)
 
         if self._scheduler.get_job(job_id):

--- a/orchestrator/services/schedule_reconcile.py
+++ b/orchestrator/services/schedule_reconcile.py
@@ -1,0 +1,76 @@
+"""Leader reconcile tick — the scheduler worker catches up with the DB.
+
+Production runs several uvicorn workers; exactly one holds the scheduler lock
+and hosts APScheduler (services.scheduler). Every write that changes what
+should be scheduled — a scheduled task created, paused, resumed or cancelled,
+a heartbeat toggled or re-configured — lands on whichever worker served the
+request and only touches THAT worker's (usually absent) scheduler. Before this
+tick the leader learned of the change at its next restart.
+
+The tick runs on the leader every ``RECONCILE_INTERVAL_SECONDS`` and diffs the
+DB against the registered jobs for both sources:
+
+* ``agent_scheduled_tasks`` rows ↔ ``scheduled_task_<id>`` jobs
+* ``agents.configuration.heartbeat`` blocks ↔ ``agent_hb_<id>`` jobs
+
+Both reconcilers are idempotent, so a request-worker edit that DID land on the
+leader is simply confirmed.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional
+
+from services.scheduled_task_service import RECONCILE_INTERVAL_SECONDS, ScheduledTaskService
+
+logger = logging.getLogger(__name__)
+
+RECONCILE_JOB_ID = "schedule_reconcile"
+
+
+def run_reconcile_once(scheduler: Any, db: Optional[Any] = None) -> Dict[str, Any]:
+    """One pass over both sources. Opens (and closes) its own session unless given one."""
+    from services.heartbeat_service import get_heartbeat_service
+
+    owns_db = db is None
+    if owns_db:
+        from core.database.database import SessionLocal
+
+        db = SessionLocal()
+    try:
+        tasks = ScheduledTaskService(db, workspace_id=None).reconcile_with_scheduler(scheduler)
+        heartbeats = get_heartbeat_service().reconcile_agent_heartbeats(db)
+    finally:
+        if owns_db:
+            db.close()
+    return {"tasks": tasks, "heartbeats": heartbeats}
+
+
+def _tick(scheduler: Any) -> None:
+    try:
+        run_reconcile_once(scheduler)
+    except Exception as exc:  # noqa: BLE001 — a failed pass must not kill the job
+        logger.warning("[ScheduleReconcile] pass failed: %s", exc)
+
+
+async def start_schedule_reconcile(scheduler: Any) -> bool:
+    """Register the tick on the leader's APScheduler and run the first pass now.
+
+    Returns False when this worker hosts no running scheduler (nothing to do).
+    """
+    if scheduler is None or not getattr(scheduler, "running", False):
+        return False
+    from apscheduler.triggers.interval import IntervalTrigger
+
+    scheduler.add_job(
+        _tick,
+        IntervalTrigger(seconds=RECONCILE_INTERVAL_SECONDS),
+        id=RECONCILE_JOB_ID,
+        args=[scheduler],
+        replace_existing=True,
+        max_instances=1,
+        coalesce=True,
+    )
+    _tick(scheduler)
+    logger.info("[ScheduleReconcile] tick registered every %ds", RECONCILE_INTERVAL_SECONDS)
+    return True

--- a/orchestrator/services/schedule_reconcile.py
+++ b/orchestrator/services/schedule_reconcile.py
@@ -46,8 +46,15 @@ def run_reconcile_once(scheduler: Any, db: Optional[Any] = None) -> Dict[str, An
     return {"tasks": tasks, "heartbeats": heartbeats}
 
 
-def _tick(scheduler: Any) -> None:
+def _tick(scheduler: Any = None) -> None:
+    """One pass. Registered WITHOUT args: a job store pickles job args
+    (RedisJobStore) and a scheduler instance refuses to be serialized, so the
+    live scheduler is resolved at call time instead."""
     try:
+        if scheduler is None:
+            from services.scheduler import get_unified_scheduler
+
+            scheduler = get_unified_scheduler().apscheduler
         run_reconcile_once(scheduler)
     except Exception as exc:  # noqa: BLE001 — a failed pass must not kill the job
         logger.warning("[ScheduleReconcile] pass failed: %s", exc)
@@ -66,7 +73,6 @@ async def start_schedule_reconcile(scheduler: Any) -> bool:
         _tick,
         IntervalTrigger(seconds=RECONCILE_INTERVAL_SECONDS),
         id=RECONCILE_JOB_ID,
-        args=[scheduler],
         replace_existing=True,
         max_instances=1,
         coalesce=True,

--- a/orchestrator/services/scheduled_task_service.py
+++ b/orchestrator/services/scheduled_task_service.py
@@ -33,6 +33,13 @@ MAX_RECURRING_PER_WORKSPACE = 25
 # Operator-scheduled rows (no creator agent) share one workspace-wide cap.
 MAX_OPERATOR_TASKS_PER_WORKSPACE = 50
 
+# APScheduler job id prefix for a scheduled task; the reconcile tick keys on it.
+JOB_ID_PREFIX = "scheduled_task_"
+# The scheduler worker catches up with the DB within this many seconds
+# (services.schedule_reconcile). Creates, pauses, resumes and cancels land on
+# ANY uvicorn worker; only the one holding the scheduler lock has APScheduler.
+RECONCILE_INTERVAL_SECONDS = 60
+
 # How a fired task is delivered.
 DELIVER_CHAT = "chat"              # PRD-77: open a chat with the target agent
 DELIVER_BOARD_TASK = "board_task"  # file a board ticket (assigned, or Inbox)
@@ -655,10 +662,16 @@ class ScheduledTaskService:
 
             scheduler = get_unified_scheduler()
             if not scheduler.apscheduler or not scheduler.apscheduler.running:
-                logger.warning("[ScheduledTask] Scheduler not running — task %d will be picked up on restart", task_id)
+                # This worker does not host APScheduler (another one holds the lock):
+                # the DB row is the truth and the scheduler worker's reconcile tick
+                # registers it within RECONCILE_INTERVAL_SECONDS.
+                logger.info(
+                    "[ScheduledTask] Scheduler not on this worker — task %d is registered by the reconcile tick within %ds",
+                    task_id, RECONCILE_INTERVAL_SECONDS,
+                )
                 return
 
-            job_id = f"scheduled_task_{task_id}"
+            job_id = f"{JOB_ID_PREFIX}{task_id}"
 
             if task_type == "one_shot":
                 run_at = datetime.fromisoformat(schedule.replace("Z", "+00:00"))
@@ -694,6 +707,50 @@ class ScheduledTaskService:
     def _next_cron_run(cron_expr: str) -> Optional[datetime]:
         """Next run from a cron expression via the shared schedule util (croniter)."""
         return _util_next_run(cron_expr, now=datetime.now(timezone.utc))
+
+    def reconcile_with_scheduler(self, scheduler: Any) -> Dict[str, Any]:
+        """Make the scheduler worker's APScheduler match the DB, all workspaces.
+
+        Active rows with no job get registered; jobs whose row is no longer active
+        (paused, cancelled, completed, deleted) are removed. Idempotent — an active
+        row with its job already present is left alone (re-adding a cron job would
+        recompute its next fire time). Runs on the leader every
+        RECONCILE_INTERVAL_SECONDS (services.schedule_reconcile) and once at boot.
+        """
+        if scheduler is None or not getattr(scheduler, "running", False):
+            return {"added": 0, "removed": 0, "skipped": True}
+        rows = self.db.execute(
+            text("""
+                SELECT id, task_type, schedule, target_agent_id
+                FROM agent_scheduled_tasks
+                WHERE status = 'active'
+            """),
+        ).fetchall()
+        active = {int(row.id): row for row in rows}
+        existing = {
+            str(job.id) for job in scheduler.get_jobs()
+            if str(getattr(job, "id", "")).startswith(JOB_ID_PREFIX)
+        }
+        added = 0
+        for task_id, row in active.items():
+            if f"{JOB_ID_PREFIX}{task_id}" not in existing:
+                self._register_with_scheduler(row.id, row.task_type, row.schedule, row.target_agent_id)
+                added += 1
+        removed = 0
+        for job_id in existing:
+            try:
+                task_id = int(job_id[len(JOB_ID_PREFIX):])
+            except ValueError:
+                continue
+            if task_id not in active:
+                try:
+                    scheduler.remove_job(job_id)
+                except Exception:  # noqa: BLE001 — already gone
+                    pass
+                removed += 1
+        if added or removed:
+            logger.info("[ScheduledTask] reconcile: %d job(s) added, %d removed", added, removed)
+        return {"added": added, "removed": removed, "skipped": False}
 
     async def load_active_tasks_to_scheduler(self) -> int:
         """

--- a/orchestrator/services/scheduled_task_service.py
+++ b/orchestrator/services/scheduled_task_service.py
@@ -15,7 +15,7 @@ like any other.
 
 import json
 import logging
-from datetime import datetime, timezone
+from datetime import timedelta, datetime, timezone
 from typing import Any, Dict, List, Optional
 from uuid import UUID
 
@@ -39,6 +39,12 @@ JOB_ID_PREFIX = "scheduled_task_"
 # (services.schedule_reconcile). Creates, pauses, resumes and cancels land on
 # ANY uvicorn worker; only the one holding the scheduler lock has APScheduler.
 RECONCILE_INTERVAL_SECONDS = 60
+# A one-shot registered late (created on a non-leader worker, re-registered by
+# the tick, or loaded at boot) still fires if its run time is at most this far
+# in the past. APScheduler's default grace is 1 s, which drops it as "missed".
+# Older ones are left alone — the calendar shows them as missed — instead of
+# being re-added and missed again on every tick.
+ONE_SHOT_MISFIRE_GRACE_SECONDS = 3 * RECONCILE_INTERVAL_SECONDS
 
 # How a fired task is delivered.
 DELIVER_CHAT = "chat"              # PRD-77: open a chat with the target agent
@@ -379,8 +385,11 @@ class ScheduledTaskService:
 
         db = SessionLocal()
         try:
+            # FOR UPDATE: a second firing of the same row (the reconcile tick
+            # re-registering a one-shot whose completion commit is in flight)
+            # waits here and then finds it no longer active.
             task = db.execute(
-                text("SELECT * FROM agent_scheduled_tasks WHERE id = :id AND status = 'active'"),
+                text("SELECT * FROM agent_scheduled_tasks WHERE id = :id AND status = 'active' FOR UPDATE"),
                 {"id": task_id},
             ).fetchone()
 
@@ -673,9 +682,11 @@ class ScheduledTaskService:
 
             job_id = f"{JOB_ID_PREFIX}{task_id}"
 
+            job_kwargs: Dict[str, Any] = {}
             if task_type == "one_shot":
                 run_at = datetime.fromisoformat(schedule.replace("Z", "+00:00"))
                 trigger = DateTrigger(run_date=run_at)
+                job_kwargs["misfire_grace_time"] = ONE_SHOT_MISFIRE_GRACE_SECONDS
             else:
                 # Standard crontab semantics so firing matches the calendar's
                 # croniter next_run (PRD-162 — one schedule truth).
@@ -697,6 +708,7 @@ class ScheduledTaskService:
                 id=job_id,
                 replace_existing=True,
                 max_instances=1,
+                **job_kwargs,
             )
             logger.info("[ScheduledTask] Registered job %s with scheduler", job_id)
 
@@ -718,7 +730,7 @@ class ScheduledTaskService:
         RECONCILE_INTERVAL_SECONDS (services.schedule_reconcile) and once at boot.
         """
         if scheduler is None or not getattr(scheduler, "running", False):
-            return {"added": 0, "removed": 0, "skipped": True}
+            return {"added": 0, "removed": 0, "stale": 0, "skipped": True}
         rows = self.db.execute(
             text("""
                 SELECT id, task_type, schedule, target_agent_id
@@ -731,11 +743,18 @@ class ScheduledTaskService:
             str(job.id) for job in scheduler.get_jobs()
             if str(getattr(job, "id", "")).startswith(JOB_ID_PREFIX)
         }
-        added = 0
+        added = stale = 0
+        now = datetime.now(timezone.utc)
         for task_id, row in active.items():
-            if f"{JOB_ID_PREFIX}{task_id}" not in existing:
-                self._register_with_scheduler(row.id, row.task_type, row.schedule, row.target_agent_id)
-                added += 1
+            if f"{JOB_ID_PREFIX}{task_id}" in existing:
+                continue
+            if row.task_type == "one_shot" and self._one_shot_too_late(row.schedule, now):
+                # Just fired (its completion commit is racing this pass) or missed
+                # long ago: re-adding would run it late or be "missed" every tick.
+                stale += 1
+                continue
+            self._register_with_scheduler(row.id, row.task_type, row.schedule, row.target_agent_id)
+            added += 1
         removed = 0
         for job_id in existing:
             try:
@@ -749,8 +768,19 @@ class ScheduledTaskService:
                     pass
                 removed += 1
         if added or removed:
-            logger.info("[ScheduledTask] reconcile: %d job(s) added, %d removed", added, removed)
-        return {"added": added, "removed": removed, "skipped": False}
+            logger.info("[ScheduledTask] reconcile: %d job(s) added, %d removed, %d stale one-shot(s) left", added, removed, stale)
+        return {"added": added, "removed": removed, "stale": stale, "skipped": False}
+
+    @staticmethod
+    def _one_shot_too_late(schedule: str, now: datetime) -> bool:
+        """True when a one-shot's run time is further in the past than the misfire grace."""
+        try:
+            run_at = datetime.fromisoformat(str(schedule).replace("Z", "+00:00"))
+        except ValueError:
+            return True  # cannot be registered either; don't retry it every tick
+        if run_at.tzinfo is None:
+            run_at = run_at.replace(tzinfo=timezone.utc)
+        return (now - run_at).total_seconds() > ONE_SHOT_MISFIRE_GRACE_SECONDS
 
     async def load_active_tasks_to_scheduler(self) -> int:
         """

--- a/orchestrator/tests/test_schedule_endpoint.py
+++ b/orchestrator/tests/test_schedule_endpoint.py
@@ -168,7 +168,9 @@ def _svc(db):
 
 
 def _heartbeat_agent(agent_id, minutes=30, **hb):
-    cfg = {"heartbeat": {"interval_minutes": minutes, **hb}}
+    # Enabled unless the test says otherwise — the feed lists a heartbeat only
+    # when the scheduler would fire it (`enabled` truthy).
+    cfg = {"heartbeat": {"interval_minutes": minutes, "enabled": True, **hb}}
     return _Row(id=agent_id, name=f"Agent {agent_id}", configuration=cfg)
 
 
@@ -250,6 +252,19 @@ def test_get_schedule_disabled_heartbeat_excluded():
     out = _svc(db).get_schedule(range_days=7)
     ids = {i["id"] for i in out["scheduled"]}
     assert "routine-2" in ids and "routine-1" not in ids
+
+
+@_needs_croniter
+def test_get_schedule_heartbeat_without_enabled_flag_excluded():
+    """A block with no `enabled` key never fires (heartbeat_service loads only
+    truthy `enabled`), so it is not a routine. The old `is False` test showed
+    every such agent hourly on the calendar."""
+    unset = _Row(id=3, name="Agent 3", configuration={"heartbeat": {"interval_minutes": 60}})
+    null = _Row(id=4, name="Agent 4", configuration={"heartbeat": {"interval_minutes": 60, "enabled": None}})
+    db = _FakeScheduleDB(agents=[unset, null, _heartbeat_agent(5, 60)], templates=[], tasks=[])
+    out = _svc(db).get_schedule(range_days=7)
+    ids = {i["id"] for i in out["scheduled"]}
+    assert ids == {"routine-5"}
 
 
 # ── S2: mission SLA deadlines (the 5th feed source) ────────────────────────

--- a/orchestrator/tests/test_schedule_reconcile.py
+++ b/orchestrator/tests/test_schedule_reconcile.py
@@ -1,0 +1,267 @@
+"""Leader reconcile tick — a schedule change made on any worker reaches the
+scheduler worker within a minute, not at the next restart.
+
+Production runs several uvicorn workers; exactly one holds the scheduler lock
+and hosts APScheduler. A scheduled task created / paused / resumed / cancelled,
+or a heartbeat toggled / re-configured, is written by whichever worker served
+the request and only touched THAT worker's (absent) scheduler. The tick diffs
+the DB against the registered jobs for both sources.
+
+Fake-session tests (raw-DDL ``agent_scheduled_tasks``; no DB in CI).
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+os.environ.setdefault("POSTGRES_USER", "test")
+os.environ.setdefault("POSTGRES_PASSWORD", "test")
+os.environ.setdefault("POSTGRES_HOST", "127.0.0.1")
+os.environ.setdefault("POSTGRES_PORT", "59432")
+os.environ.setdefault("POSTGRES_DB", "test")
+
+_ORCH = Path(__file__).resolve().parents[1]
+if str(_ORCH) not in sys.path:
+    sys.path.insert(0, str(_ORCH))
+
+from services import schedule_reconcile as sr  # noqa: E402
+from services.heartbeat_service import HeartbeatService  # noqa: E402
+from services.scheduled_task_service import JOB_ID_PREFIX, ScheduledTaskService  # noqa: E402
+
+
+class _Job:
+    def __init__(self, job_id):
+        self.id = job_id
+
+
+class _FakeScheduler:
+    """The slice of APScheduler both reconcilers touch."""
+
+    def __init__(self, jobs=(), running=True):
+        self.running = running
+        self._jobs = {job_id: _Job(job_id) for job_id in jobs}
+        self.added: list = []
+        self.removed: list = []
+
+    def get_jobs(self):
+        return list(self._jobs.values())
+
+    def get_job(self, job_id):
+        return self._jobs.get(job_id)
+
+    def add_job(self, func, trigger=None, id=None, **kw):  # noqa: A002 — APScheduler's name
+        self._jobs[id] = _Job(id)
+        self.added.append(id)
+        return self._jobs[id]
+
+    def remove_job(self, job_id):
+        del self._jobs[job_id]
+        self.removed.append(job_id)
+
+    def ids(self):
+        return set(self._jobs)
+
+
+class _Result:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def fetchall(self):
+        return self._rows
+
+    def fetchone(self):
+        return self._rows[0] if self._rows else None
+
+
+class _FakeTaskDB:
+    def __init__(self, active_rows):
+        self.rows = active_rows
+        self.execute_calls = 0
+        self.closed = False
+
+    def execute(self, stmt, params=None):
+        self.execute_calls += 1
+        return _Result(self.rows)
+
+    def close(self):
+        self.closed = True
+
+
+class _FakeAgentDB:
+    def __init__(self, agents):
+        self._agents = agents
+
+    def query(self, *cols):
+        return SimpleNamespace(all=lambda: list(self._agents))
+
+
+def _task_row(task_id, task_type="recurring", schedule="0 9 * * 1-5", agent=7):
+    return SimpleNamespace(id=task_id, task_type=task_type, schedule=schedule, target_agent_id=agent)
+
+
+def _agent(agent_id, hb, ws="ws-1"):
+    cfg = {"heartbeat": hb} if hb is not None else {}
+    return SimpleNamespace(id=agent_id, workspace_id=ws, configuration=cfg)
+
+
+@pytest.fixture
+def unified(monkeypatch):
+    """_register_with_scheduler resolves the unified scheduler itself — point it
+    at the same fake the reconcile diffs against."""
+    fake = _FakeScheduler()
+    import services.scheduler as sched_mod
+
+    monkeypatch.setattr(sched_mod, "get_unified_scheduler", lambda: SimpleNamespace(apscheduler=fake))
+    return fake
+
+
+# ── scheduled tasks ────────────────────────────────────────────────────────
+
+
+class TestScheduledTaskReconcile:
+    def test_adds_missing_removes_stale_leaves_present(self, unified):
+        for job_id in (f"{JOB_ID_PREFIX}2", f"{JOB_ID_PREFIX}3", "agent_hb_9"):
+            unified.add_job(None, id=job_id)
+        unified.added.clear()
+        db = _FakeTaskDB([_task_row(1), _task_row(2)])
+
+        out = ScheduledTaskService(db, workspace_id=None).reconcile_with_scheduler(unified)
+
+        assert out == {"added": 1, "removed": 1, "skipped": False}
+        assert unified.added == [f"{JOB_ID_PREFIX}1"]  # task 2 present: NOT re-added
+        assert unified.removed == [f"{JOB_ID_PREFIX}3"]  # cancelled elsewhere
+        assert unified.ids() == {f"{JOB_ID_PREFIX}1", f"{JOB_ID_PREFIX}2", "agent_hb_9"}
+
+    def test_second_pass_is_a_noop(self, unified):
+        db = _FakeTaskDB([_task_row(1)])
+        svc = ScheduledTaskService(db, workspace_id=None)
+        svc.reconcile_with_scheduler(unified)
+        assert svc.reconcile_with_scheduler(unified) == {"added": 0, "removed": 0, "skipped": False}
+
+    def test_skips_off_the_leader_without_touching_the_db(self):
+        db = _FakeTaskDB([_task_row(1)])
+        svc = ScheduledTaskService(db, workspace_id=None)
+        assert svc.reconcile_with_scheduler(_FakeScheduler(running=False))["skipped"] is True
+        assert svc.reconcile_with_scheduler(None)["skipped"] is True
+        assert db.execute_calls == 0
+
+    def test_non_leader_register_points_at_the_tick_not_a_restart(self, monkeypatch, caplog):
+        import services.scheduler as sched_mod
+
+        monkeypatch.setattr(sched_mod, "get_unified_scheduler", lambda: SimpleNamespace(apscheduler=None))
+        svc = ScheduledTaskService(_FakeTaskDB([]), workspace_id=None)
+        with caplog.at_level("INFO"):
+            svc._register_with_scheduler(5, "recurring", "0 9 * * *", 7)
+        assert "reconcile tick" in caplog.text
+        assert "restart" not in caplog.text
+
+
+# ── heartbeats ─────────────────────────────────────────────────────────────
+
+
+class TestHeartbeatReconcile:
+    @staticmethod
+    def _service(fake):
+        svc = HeartbeatService()
+        svc._scheduler = fake
+        return svc
+
+    def test_diff_adds_changes_removes(self):
+        fake = _FakeScheduler(jobs=("agent_hb_2", "agent_hb_3", "agent_hb_4", f"{JOB_ID_PREFIX}1"))
+        svc = self._service(fake)
+        unchanged = {"enabled": True, "interval_minutes": 30}
+        svc._hb_signatures[2] = svc.heartbeat_signature("ws-1", unchanged)
+        svc._hb_signatures[3] = svc.heartbeat_signature("ws-1", {"enabled": True, "interval_minutes": 15})
+        db = _FakeAgentDB([
+            _agent(1, {"enabled": True, "interval_minutes": 60}),   # toggled on elsewhere: no job yet
+            _agent(2, unchanged),                                    # present, same config
+            _agent(3, {"enabled": True, "interval_minutes": 60}),   # re-configured 15m → 60m
+            _agent(4, {"enabled": False, "interval_minutes": 60}),  # toggled off elsewhere
+            _agent(5, {"interval_minutes": 60}),                     # no flag: never fires
+            _agent(6, None),
+        ])
+
+        out = svc.reconcile_agent_heartbeats(db)
+
+        assert out == {"added": 1, "removed": 1, "changed": 1}
+        assert fake.added == ["agent_hb_1", "agent_hb_3"]
+        assert fake.removed == ["agent_hb_3", "agent_hb_4"]  # 3 = replace, 4 = gone
+        assert fake.ids() == {"agent_hb_1", "agent_hb_2", "agent_hb_3", f"{JOB_ID_PREFIX}1"}
+        assert 4 not in svc._hb_signatures
+        # a second pass with the same DB changes nothing
+        assert svc.reconcile_agent_heartbeats(db) == {"added": 0, "removed": 0, "changed": 0}
+
+    def test_no_scheduler_on_this_worker_is_a_noop(self):
+        svc = HeartbeatService()
+        db = _FakeAgentDB([_agent(1, {"enabled": True, "interval_minutes": 60})])
+        assert svc.reconcile_agent_heartbeats(db) == {"added": 0, "removed": 0, "changed": 0}
+
+    def test_boot_loader_populates_signatures_via_schedule(self):
+        """schedule_agent_heartbeat records the signature, so jobs the boot
+        loader adds are recognised as current by the first tick."""
+        fake = _FakeScheduler()
+        svc = self._service(fake)
+        hb = {"enabled": True, "interval_minutes": 30}
+        svc.schedule_agent_heartbeat(8, "ws-1", hb)
+        assert svc._hb_signatures[8] == svc.heartbeat_signature("ws-1", hb)
+        assert svc.reconcile_agent_heartbeats(_FakeAgentDB([_agent(8, hb)])) == {"added": 0, "removed": 0, "changed": 0}
+
+
+# ── the tick ───────────────────────────────────────────────────────────────
+
+
+class TestTick:
+    def test_run_reconcile_once_opens_and_closes_its_own_session(self, monkeypatch):
+        db = _FakeTaskDB([])
+        import core.database.database as dbmod
+        import services.heartbeat_service as hbmod
+
+        monkeypatch.setattr(dbmod, "SessionLocal", lambda: db)
+        monkeypatch.setattr(
+            sr, "ScheduledTaskService",
+            lambda _db, workspace_id=None: SimpleNamespace(
+                reconcile_with_scheduler=lambda s: {"added": 1, "removed": 0, "skipped": False}),
+        )
+        monkeypatch.setattr(
+            hbmod, "get_heartbeat_service",
+            lambda: SimpleNamespace(reconcile_agent_heartbeats=lambda _db: {"added": 0, "removed": 2, "changed": 0}),
+        )
+        out = sr.run_reconcile_once(_FakeScheduler())
+        assert out == {
+            "tasks": {"added": 1, "removed": 0, "skipped": False},
+            "heartbeats": {"added": 0, "removed": 2, "changed": 0},
+        }
+        assert db.closed is True
+
+    def test_start_registers_the_interval_job_and_runs_a_first_pass(self, monkeypatch):
+        fake = _FakeScheduler()
+        passes: list = []
+        monkeypatch.setattr(sr, "run_reconcile_once", lambda s, db=None: passes.append(s) or {})
+        assert asyncio.run(sr.start_schedule_reconcile(fake)) is True
+        assert fake.added == [sr.RECONCILE_JOB_ID]
+        assert passes == [fake]
+
+    def test_start_is_a_noop_off_the_leader(self):
+        assert asyncio.run(sr.start_schedule_reconcile(None)) is False
+        fake = _FakeScheduler(running=False)
+        assert asyncio.run(sr.start_schedule_reconcile(fake)) is False
+        assert fake.added == []
+
+    def test_a_failed_pass_does_not_kill_the_job(self, monkeypatch):
+        def boom(s, db=None):
+            raise RuntimeError("db down")
+
+        monkeypatch.setattr(sr, "run_reconcile_once", boom)
+        sr._tick(_FakeScheduler())  # no raise
+
+    def test_boot_starts_the_tick_after_loading_tasks(self):
+        src = (_ORCH / "main.py").read_text()
+        load = src.index("load_active_tasks_to_scheduler()")
+        tick = src.index("start_schedule_reconcile(shared_sched)")
+        coordinator = src.index("PRD-82A: Coordinator tick")
+        assert load < tick < coordinator

--- a/orchestrator/tests/test_schedule_reconcile.py
+++ b/orchestrator/tests/test_schedule_reconcile.py
@@ -31,7 +31,11 @@ if str(_ORCH) not in sys.path:
 
 from services import schedule_reconcile as sr  # noqa: E402
 from services.heartbeat_service import HeartbeatService  # noqa: E402
-from services.scheduled_task_service import JOB_ID_PREFIX, ScheduledTaskService  # noqa: E402
+from services.scheduled_task_service import (  # noqa: E402
+    JOB_ID_PREFIX,
+    ONE_SHOT_MISFIRE_GRACE_SECONDS,
+    ScheduledTaskService,
+)
 
 
 class _Job:
@@ -46,6 +50,7 @@ class _FakeScheduler:
         self.running = running
         self._jobs = {job_id: _Job(job_id) for job_id in jobs}
         self.added: list = []
+        self.added_kwargs: dict = {}
         self.removed: list = []
 
     def get_jobs(self):
@@ -57,6 +62,7 @@ class _FakeScheduler:
     def add_job(self, func, trigger=None, id=None, **kw):  # noqa: A002 — APScheduler's name
         self._jobs[id] = _Job(id)
         self.added.append(id)
+        self.added_kwargs[id] = kw
         return self._jobs[id]
 
     def remove_job(self, job_id):
@@ -132,7 +138,8 @@ class TestScheduledTaskReconcile:
 
         out = ScheduledTaskService(db, workspace_id=None).reconcile_with_scheduler(unified)
 
-        assert out == {"added": 1, "removed": 1, "skipped": False}
+        assert out == {"added": 1, "removed": 1, "stale": 0, "skipped": False}
+        assert "misfire_grace_time" not in unified.added_kwargs[f"{JOB_ID_PREFIX}1"]  # cron: no catch-up
         assert unified.added == [f"{JOB_ID_PREFIX}1"]  # task 2 present: NOT re-added
         assert unified.removed == [f"{JOB_ID_PREFIX}3"]  # cancelled elsewhere
         assert unified.ids() == {f"{JOB_ID_PREFIX}1", f"{JOB_ID_PREFIX}2", "agent_hb_9"}
@@ -141,7 +148,7 @@ class TestScheduledTaskReconcile:
         db = _FakeTaskDB([_task_row(1)])
         svc = ScheduledTaskService(db, workspace_id=None)
         svc.reconcile_with_scheduler(unified)
-        assert svc.reconcile_with_scheduler(unified) == {"added": 0, "removed": 0, "skipped": False}
+        assert svc.reconcile_with_scheduler(unified) == {"added": 0, "removed": 0, "stale": 0, "skipped": False}
 
     def test_skips_off_the_leader_without_touching_the_db(self):
         db = _FakeTaskDB([_task_row(1)])
@@ -149,6 +156,34 @@ class TestScheduledTaskReconcile:
         assert svc.reconcile_with_scheduler(_FakeScheduler(running=False))["skipped"] is True
         assert svc.reconcile_with_scheduler(None)["skipped"] is True
         assert db.execute_calls == 0
+
+    def test_stale_one_shot_is_left_alone_but_a_recent_one_fires_with_grace(self, unified):
+        """APScheduler's default 1 s misfire grace drops a late one-shot as "missed";
+        registered with a grace, one the tick learns of a minute late still fires.
+        One missed long ago is not re-added (it would be missed again every tick,
+        or — if it just fired — run twice)."""
+        from datetime import datetime, timedelta, timezone
+
+        now = datetime.now(timezone.utc)
+        old = _task_row(1, task_type="one_shot", schedule=(now - timedelta(minutes=10)).isoformat())
+        recent = _task_row(2, task_type="one_shot", schedule=(now - timedelta(seconds=30)).isoformat())
+        future = _task_row(3, task_type="one_shot", schedule=(now + timedelta(minutes=5)).isoformat().replace("+00:00", "Z"))
+        db = _FakeTaskDB([old, recent, future])
+
+        out = ScheduledTaskService(db, workspace_id=None).reconcile_with_scheduler(unified)
+
+        assert out == {"added": 2, "removed": 0, "stale": 1, "skipped": False}
+        assert unified.added == [f"{JOB_ID_PREFIX}2", f"{JOB_ID_PREFIX}3"]
+        for job_id in unified.added:
+            assert unified.added_kwargs[job_id]["misfire_grace_time"] == ONE_SHOT_MISFIRE_GRACE_SECONDS
+
+    def test_execute_claims_the_row_with_a_lock(self):
+        """A re-registered one-shot that fires while the first run's completion
+        commit is in flight must wait for it and then see the row inactive."""
+        import inspect
+
+        src = inspect.getsource(ScheduledTaskService.execute_task)
+        assert "status = 'active' FOR UPDATE" in src
 
     def test_non_leader_register_points_at_the_tick_not_a_restart(self, monkeypatch, caplog):
         import services.scheduler as sched_mod
@@ -195,6 +230,15 @@ class TestHeartbeatReconcile:
         assert 4 not in svc._hb_signatures
         # a second pass with the same DB changes nothing
         assert svc.reconcile_agent_heartbeats(db) == {"added": 0, "removed": 0, "changed": 0}
+
+    def test_unschedule_forgets_the_signature(self):
+        fake = _FakeScheduler()
+        svc = self._service(fake)
+        hb = {"enabled": True, "interval_minutes": 30}
+        svc.schedule_agent_heartbeat(8, "ws-1", hb)
+        svc.unschedule_heartbeat("agent_hb_8")
+        assert 8 not in svc._hb_signatures
+        assert fake.ids() == set()
 
     def test_no_scheduler_on_this_worker_is_a_noop(self):
         svc = HeartbeatService()
@@ -244,6 +288,26 @@ class TestTick:
         monkeypatch.setattr(sr, "run_reconcile_once", lambda s, db=None: passes.append(s) or {})
         assert asyncio.run(sr.start_schedule_reconcile(fake)) is True
         assert fake.added == [sr.RECONCILE_JOB_ID]
+        assert passes == [fake]
+
+    def test_tick_job_carries_no_scheduler_argument(self, monkeypatch):
+        """A job store pickles job args (RedisJobStore); a scheduler instance
+        refuses to be serialized, which would kill the tick at registration."""
+        fake = _FakeScheduler()
+        monkeypatch.setattr(sr, "run_reconcile_once", lambda s, db=None: {})
+        asyncio.run(sr.start_schedule_reconcile(fake))
+        kwargs = fake.added_kwargs[sr.RECONCILE_JOB_ID]
+        assert "args" not in kwargs and "kwargs" not in kwargs
+        assert kwargs["replace_existing"] is True and kwargs["max_instances"] == 1
+
+    def test_tick_resolves_the_live_scheduler_at_call_time(self, monkeypatch):
+        fake = _FakeScheduler()
+        import services.scheduler as sched_mod
+
+        monkeypatch.setattr(sched_mod, "get_unified_scheduler", lambda: SimpleNamespace(apscheduler=fake))
+        passes: list = []
+        monkeypatch.setattr(sr, "run_reconcile_once", lambda s, db=None: passes.append(s) or {})
+        sr._tick()
         assert passes == [fake]
 
     def test_start_is_a_noop_off_the_leader(self):


### PR DESCRIPTION
## Summary

Production runs several uvicorn workers; one holds the scheduler lock and hosts APScheduler. A scheduled task created / paused / resumed / cancelled, or a heartbeat toggled or re-configured, is written by whichever worker served the request and only touches **that** worker's (absent) scheduler — so the leader learned of the change at its next restart. The calendar's own "Schedule for later" and "Pause routine" actions (#712/#713) hit this on every request that didn't land on the leader.

- **`services/schedule_reconcile.py`** — an interval job on the leader (every 60 s, and once at boot) that diffs the DB against the registered jobs for both sources.
- **`ScheduledTaskService.reconcile_with_scheduler`** — active rows without a `scheduled_task_<id>` job are registered; jobs whose row is no longer active are removed; a present row is left alone (re-adding a cron job would reset its next fire time). The non-leader register path now logs that the tick will pick the task up, instead of "on restart".
- **`HeartbeatService.reconcile_agent_heartbeats`** — enabled blocks get a job, disabled ones lose theirs, a changed block is re-added. A per-agent config signature means an unchanged job is never churned.
- **`main.py`** — started right after the boot load of scheduled tasks.

### Feed alignment (the WATCHTOWER-style "hourly routine that never fires")

`ActivityService._heartbeat_items` treated a heartbeat block as a routine unless `enabled` was literally `False`; the scheduler only fires blocks whose `enabled` is truthy. A block without the flag showed hourly on the calendar and never ran. The feed now uses the scheduler's rule.

## Test plan

- [ ] `tests/test_schedule_reconcile.py` — fake scheduler/session coverage: adds missing, removes stale, leaves present, no-op second pass, skipped off the leader, non-leader wording, heartbeat add/change/remove, boot-loader signatures, tick composition + session close, boot order guard.
- [ ] `tests/test_schedule_endpoint.py` — helper now builds enabled blocks; new test: block without the flag (or `null`) is excluded.
- [ ] CI orchestrator lanes green.

## Review fixes (second commit)

- **Tick job carries no scheduler argument** — job stores pickle job args and a scheduler instance refuses to be serialized; under RedisJobStore the tick would have died at registration. The job resolves the live scheduler at call time. Prod logs show `[Scheduler] Using memory job store` (the Redis path never engages: `RedisJobStore(url=…)` is not a valid kwarg — flagged, not fixed here), so this was latent.
- **One-shot misfire grace** — APScheduler's default grace is 1 s, so a one-shot registered late was dropped as "missed" and would have been re-added and missed again every tick. One-shots register with a 3-minute grace; older ones are left alone (the calendar shows them as missed).
- **No double firing** — `execute_task` claims the row with `SELECT … FOR UPDATE`, so a one-shot re-registered while its completion commit is in flight waits and then finds the row inactive.
- `unschedule_heartbeat` forgets the config signature.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic reconciliation to keep scheduled tasks and agent heartbeat schedules synchronized.
  * Added recovery for missing, changed, stale, or disabled scheduled jobs across scheduler workers.
  * Added handling for overdue one-time schedules to prevent unintended duplicate execution.

* **Bug Fixes**
  * Heartbeats without an explicitly enabled configuration are no longer scheduled.
  * Improved protection against concurrent duplicate task execution.
  * Reconciliation failures no longer stop recurring scheduler activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->