### PR TITLE
fix(calendar): readable entries — left-aligned text, two-line boxes, crowded slots stack into one card

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -2257,8 +2257,18 @@
   :is(.studio, .cc-cal-root) .cc-cal-event {
     font-size: 11.5px; cursor: pointer;
     border-left-width: 3px;
+    /* a <button> centres its text; a calendar entry reads from the left edge */
+    text-align: left; padding: 3px 6px;
     transition: background 140ms ease, transform 140ms ease;
   }
+  /* Stacked card: a slot with more events than the column has lanes for */
+  :is(.studio, .cc-cal-root) .cc-cal-event.cc-cal-group {
+    box-shadow: 3px 3px 0 hsl(var(--border));
+  }
+  :is(.studio, .cc-cal-root) .cc-cal-event .agents {
+    display: inline-flex; gap: 3px; margin-left: 6px; vertical-align: middle;
+  }
+  :is(.studio, .cc-cal-root) .cc-cal-event .agents .agent-dot { margin-right: 0; }
   :is(.studio, .cc-cal-root) .cc-cal-event:hover {
     background: hsl(var(--cc-hover, var(--muted))) !important;
     transform: translateX(1px);

--- a/frontend/components/command-center/__tests__/calendar-kinds.test.ts
+++ b/frontend/components/command-center/__tests__/calendar-kinds.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { KIND_META, KIND_ORDER, kindTone, layoutLanes } from '../calendar-kinds'
+import { KIND_META, KIND_ORDER, collapseCrowded, kindTone, layoutLanes } from '../calendar-kinds'
 
 describe('calendar kinds', () => {
   it('every feed kind has a legend entry and a distinct colour', () => {
@@ -37,9 +37,42 @@ describe('layoutLanes', () => {
     expect(out[2]).toMatchObject({ lane: 0, lanes: 1 })
   })
 
+  it('numbers clusters by start order', () => {
+    const out = layoutLanes([{ s: 0, e: 10 }, { s: 5, e: 15 }, { s: 30, e: 40 }], span)
+    expect(out.map((l) => l.cluster)).toEqual([0, 0, 1])
+  })
+
   it('does not mutate its input', () => {
     const input = [{ s: 5, e: 15 }, { s: 0, e: 10 }]
     layoutLanes(input, span)
     expect(input).toEqual([{ s: 5, e: 15 }, { s: 0, e: 10 }])
+  })
+})
+
+describe('collapseCrowded', () => {
+  const span = (e: { s: number; e: number }): [number, number] => [e.s, e.e]
+
+  it('folds a cluster that needs more lanes than allowed into one card and leaves the rest', () => {
+    const laid = layoutLanes(
+      [{ s: 0, e: 10 }, { s: 0, e: 10 }, { s: 0, e: 10 }, { s: 50, e: 60 }, { s: 55, e: 65 }],
+      span,
+    )
+    const out = collapseCrowded(laid, 2, span)
+    expect(out.map((p) => p.kind)).toEqual(['group', 'single', 'single'])
+    expect(out[0]).toMatchObject({ kind: 'group', start: 0, end: 10 })
+    expect(out[0].kind === 'group' && out[0].members).toHaveLength(3)
+    expect(out[1]).toMatchObject({ kind: 'single', lane: 0, lanes: 2 })
+  })
+
+  it('a cluster within the limit is untouched', () => {
+    const out = collapseCrowded(layoutLanes([{ s: 0, e: 10 }, { s: 5, e: 15 }], span), 2, span)
+    expect(out.every((p) => p.kind === 'single')).toBe(true)
+  })
+
+  it('the card spans the earliest start to the latest end of its members', () => {
+    const out = collapseCrowded(layoutLanes([{ s: 0, e: 10 }, { s: 2, e: 30 }, { s: 4, e: 12 }], span), 2, span)
+    expect(out).toEqual([
+      { kind: 'group', members: [{ s: 0, e: 10 }, { s: 2, e: 30 }, { s: 4, e: 12 }], start: 0, end: 30 },
+    ])
   })
 })

--- a/frontend/components/command-center/__tests__/calendar-tab-feed.test.tsx
+++ b/frontend/components/command-center/__tests__/calendar-tab-feed.test.tsx
@@ -168,6 +168,32 @@ describe('CalendarTab — kinds, lanes, legend', () => {
     expect(lanes).toEqual(['2', '2'])
   })
 
+  it('a crowded slot is one stacked card in week view and lanes in day view', () => {
+    // Five daily heartbeats at the same minute (the prod 10:00 row).
+    const at = midToday()
+    feed.items = ['Vector', 'QA', 'Fixer', 'Auto', 'Sentinel'].map((n, i) => routine(10 + i, n, 1440, at))
+    const { container } = render(<CalendarTab />)
+    const cards = container.querySelectorAll('.cc-cal-group')
+    expect(cards.length).toBe(7) // one per day column
+    expect(cards[0].getAttribute('data-group-size')).toBe('5')
+    expect(cards[0].textContent).toContain('5 heartbeats')
+    expect(cards[0].querySelectorAll('.agent-dot').length).toBe(5)
+    expect(container.querySelectorAll('.cc-cal-event:not(.cc-cal-group)').length).toBe(0)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Day' }))
+    expect(container.querySelectorAll('.cc-cal-group').length).toBe(0)
+    const lanes = Array.from(container.querySelectorAll('.cc-cal-event')).map((e) =>
+      e.getAttribute('data-lanes'),
+    )
+    expect(lanes).toEqual(['5', '5', '5', '5', '5'])
+  })
+
+  it('a short event box is tall enough for its two lines', () => {
+    feed.items = [deadline(1, 'Short', new Date(midToday().getTime() + 60 * 60_000))]
+    const { container } = render(<CalendarTab />)
+    expect((container.querySelector('.cc-cal-event') as HTMLElement).style.height).toBe('38px')
+  })
+
   it('a legend chip hides its kind from the grid, band and Next Up', () => {
     feed.items = [
       routine(1, 'Ops', 15, midToday()),

--- a/frontend/components/command-center/__tests__/calendar-tab-scope.test.tsx
+++ b/frontend/components/command-center/__tests__/calendar-tab-scope.test.tsx
@@ -62,6 +62,10 @@ describe('CalendarTab — styled outside the studio theme', () => {
     }
   })
 
+  it('event text reads from the left edge (a <button> centres by default)', () => {
+    expect(css).toMatch(/:is\(\.studio, \.cc-cal-root\) \.cc-cal-event \{[^}]*text-align: left/)
+  })
+
   it('hover and live-dot colours fall back to theme tokens outside studio', () => {
     // CD's cream hover is a studio-only token; a dark-theme event must not
     // flash near-white on hover.

--- a/frontend/components/command-center/calendar-kinds.ts
+++ b/frontend/components/command-center/calendar-kinds.ts
@@ -13,15 +13,17 @@ export type { ScheduleItemType } from '@/hooks/use-activity-api'
 
 export interface KindMeta {
   label: string
+  /** for a stacked card: "5 heartbeats" */
+  plural: string
   tone: string
 }
 
 export const KIND_META: Record<ScheduleItemType, KindMeta> = {
-  routine: { label: 'Heartbeat', tone: 'hsl(201 44% 40%)' },
-  recipe: { label: 'Playbook', tone: 'hsl(272 30% 45%)' },
-  task: { label: 'Scheduled task', tone: 'hsl(158 44% 35%)' },
-  mission: { label: 'Mission SLA', tone: 'hsl(28 70% 45%)' },
-  task_due: { label: 'Task deadline', tone: 'hsl(345 60% 45%)' },
+  routine: { label: 'Heartbeat', plural: 'heartbeats', tone: 'hsl(201 44% 40%)' },
+  recipe: { label: 'Playbook', plural: 'playbooks', tone: 'hsl(272 30% 45%)' },
+  task: { label: 'Scheduled task', plural: 'scheduled tasks', tone: 'hsl(158 44% 35%)' },
+  mission: { label: 'Mission SLA', plural: 'mission SLAs', tone: 'hsl(28 70% 45%)' },
+  task_due: { label: 'Task deadline', plural: 'deadlines', tone: 'hsl(345 60% 45%)' },
 }
 
 /** Legend order: recurring things first, deadlines last. */
@@ -37,6 +39,8 @@ export interface Laned<T> {
   lane: number
   /** how many columns the cluster needs — every member gets the same */
   lanes: number
+  /** which run of overlapping events this belongs to (0-based, by start) */
+  cluster: number
 }
 
 /**
@@ -60,10 +64,15 @@ export function layoutLanes<T>(
   let cluster: Array<{ evt: T; lane: number }> = []
   let laneEnds: number[] = []
   let clusterEnd = Number.NEGATIVE_INFINITY
+  let clusterId = 0
 
   const flush = () => {
-    const lanes = Math.max(laneEnds.length, 1)
-    cluster.forEach((member) => out.push({ evt: member.evt, lane: member.lane, lanes }))
+    if (cluster.length === 0) return
+    const lanes = laneEnds.length
+    cluster.forEach((member) =>
+      out.push({ evt: member.evt, lane: member.lane, lanes, cluster: clusterId }),
+    )
+    clusterId += 1
     cluster = []
     laneEnds = []
     clusterEnd = Number.NEGATIVE_INFINITY
@@ -78,5 +87,41 @@ export function layoutLanes<T>(
     clusterEnd = Math.max(clusterEnd, end)
   }
   flush()
+  return out
+}
+
+export type Placed<T> =
+  | { kind: 'single'; evt: T; lane: number; lanes: number }
+  | { kind: 'group'; members: T[]; start: number; end: number }
+
+/**
+ * A cluster that needs more lanes than the column can show legibly becomes
+ * one stacked card (five daily heartbeats at 10:00 were five unreadable
+ * slivers in the week view); every other event keeps its lane.
+ */
+export function collapseCrowded<T>(
+  laid: readonly Laned<T>[],
+  maxLanes: number,
+  span: (evt: T) => readonly [number, number],
+): Placed<T>[] {
+  const crowded = new Set(laid.filter((l) => l.lanes > maxLanes).map((l) => l.cluster))
+  const folded = new Set<number>()
+  const out: Placed<T>[] = []
+  for (const l of laid) {
+    if (!crowded.has(l.cluster)) {
+      out.push({ kind: 'single', evt: l.evt, lane: l.lane, lanes: l.lanes })
+      continue
+    }
+    if (folded.has(l.cluster)) continue
+    folded.add(l.cluster)
+    const members = laid.filter((m) => m.cluster === l.cluster).map((m) => m.evt)
+    const spans = members.map(span)
+    out.push({
+      kind: 'group',
+      members,
+      start: Math.min(...spans.map((s) => s[0])),
+      end: Math.max(...spans.map((s) => s[1])),
+    })
+  }
   return out
 }

--- a/frontend/components/command-center/calendar-tab.tsx
+++ b/frontend/components/command-center/calendar-tab.tsx
@@ -46,6 +46,9 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import {
@@ -56,7 +59,14 @@ import {
 import { useToggleHeartbeat } from '@/hooks/use-heartbeats-api'
 import { useUpdateScheduledTaskStatus } from '@/hooks/use-scheduled-tasks-api'
 import { toneFor } from './agent-tones'
-import { KIND_META, KIND_ORDER, kindTone, layoutLanes, type ScheduleItemType } from './calendar-kinds'
+import {
+  KIND_META,
+  KIND_ORDER,
+  collapseCrowded,
+  kindTone,
+  layoutLanes,
+  type ScheduleItemType,
+} from './calendar-kinds'
 import {
   buildEventActions,
   isDeadlineItem,
@@ -70,11 +80,15 @@ const HOUR_PX = 44
 const START_HR = 0
 const END_HR = 22
 const HOURS = Array.from({ length: END_HR - START_HR + 1 }, (_, i) => i + START_HR)
-/** Smallest rendered event box. The overlap layout uses the same floor, so two
- *  short events closer together than this share the column instead of
- *  drawing on top of each other. */
-const MIN_EVENT_PX = 28
+/** Smallest rendered event box: the time line plus the title line (28px
+ *  clipped the title). The overlap layout uses the same floor, so two short
+ *  events closer together than this share the column instead of drawing on
+ *  top of each other. */
+const MIN_EVENT_PX = 38
 const MIN_EVENT_MIN = (MIN_EVENT_PX / HOUR_PX) * 60
+/** Lanes a column can show legibly per view; a slot needing more becomes one
+ *  stacked card with a submenu per member. */
+const MAX_LANES: Record<ViewMode, number> = { day: 6, week: 2, month: 1 }
 /** Routines this frequent or more (heartbeats every 5/15/30/60 min) live in the
  *  always-on band ONLY. Plotted, an hourly heartbeat is 12+ blocks a day per
  *  agent and buries the one-off work the grid is for (2026-09-11). */
@@ -319,22 +333,111 @@ function expandItem(item: ScheduleItem, span: WindowSpan): CalEvent[] {
   return []
 }
 
-function EventMenu({ actions, children }: { actions: EventAction[]; children: ReactNode }) {
+interface EventMenuGroup {
+  label: string
+  actions: EventAction[]
+}
+
+function MenuItems({ actions }: { actions: EventAction[] }) {
+  return (
+    <>
+      {actions.map((a) => (
+        <DropdownMenuItem
+          key={a.label}
+          onSelect={() => a.run()}
+          className={a.tone === 'danger' ? 'text-destructive focus:text-destructive' : undefined}
+        >
+          {a.label}
+        </DropdownMenuItem>
+      ))}
+    </>
+  )
+}
+
+/** One event's actions, or — for a stacked card — a submenu per member. */
+function EventMenu({
+  actions,
+  groups,
+  children,
+}: {
+  actions?: EventAction[]
+  groups?: EventMenuGroup[]
+  children: ReactNode
+}) {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>{children}</DropdownMenuTrigger>
       <DropdownMenuContent align="start" className="min-w-[180px]">
-        {actions.map((a) => (
-          <DropdownMenuItem
-            key={a.label}
-            onSelect={() => a.run()}
-            className={a.tone === 'danger' ? 'text-destructive focus:text-destructive' : undefined}
-          >
-            {a.label}
-          </DropdownMenuItem>
+        {actions && <MenuItems actions={actions} />}
+        {(groups ?? []).map((g, i) => (
+          <DropdownMenuSub key={`${g.label}-${i}`}>
+            <DropdownMenuSubTrigger>{g.label}</DropdownMenuSubTrigger>
+            <DropdownMenuSubContent>
+              <MenuItems actions={g.actions} />
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
         ))}
       </DropdownMenuContent>
     </DropdownMenu>
+  )
+}
+
+const hhmm = (evt: CalEvent) =>
+  `${String(evt.hour).padStart(2, '0')}:${String(evt.min).padStart(2, '0')}`
+
+/** A slot with more overlapping events than the column has lanes for: one
+ *  card, the members' agent dots, and a submenu per member. */
+function GroupCard({
+  members,
+  start,
+  end,
+  actionDeps,
+}: {
+  members: CalEvent[]
+  start: number
+  end: number
+  actionDeps: EventActionDeps
+}) {
+  const first = members[0]
+  const kinds = new Set(members.map((m) => m.item.type))
+  const kind = kinds.size === 1 ? first.item.type : null
+  const what = kind ? KIND_META[kind].plural : 'items'
+  const names = members.map((m) => (m.item.type === 'routine' && m.agent ? m.agent : m.name))
+  const top = (first.hour - START_HR) * HOUR_PX + (first.min / 60) * HOUR_PX
+  const height = Math.max(((end - start) / 3_600_000) * HOUR_PX, MIN_EVENT_PX)
+  const groups = members.map((m) => ({
+    label: `${hhmm(m)} ${m.name}`,
+    actions: buildEventActions(m.item, actionDeps),
+  }))
+  return (
+    <EventMenu groups={groups}>
+      <button
+        type="button"
+        className="cc-cal-event cc-cal-group"
+        data-kind={kind ?? 'mixed'}
+        data-group-size={members.length}
+        style={{
+          top,
+          height,
+          left: 'calc(0% + 3px)',
+          width: 'calc(100% - 6px)',
+          right: 'auto',
+          borderLeftColor: kind ? kindTone(kind) : 'hsl(var(--muted-foreground))',
+          background: 'hsl(var(--secondary))',
+        }}
+        title={`${members.length} ${what}: ${names.join(', ')} — click for actions`}
+      >
+        <div className="nm">
+          {hhmm(first)} · {members.length} {what}
+          <span className="agents">
+            {members.slice(0, 8).map((m) => (
+              <span key={m.id} className="agent-dot" style={{ background: toneFor(m.agent).bg }} />
+            ))}
+          </span>
+        </div>
+        <div className="ttl">{names.join(', ')}</div>
+      </button>
+    </EventMenu>
   )
 }
 
@@ -751,7 +854,19 @@ export function CalendarTab() {
                     height: HOURS.length * HOUR_PX,
                   }}
                 >
-                  {layoutLanes(dayEvents, eventSpan).map(({ evt, lane, lanes }) => {
+                  {collapseCrowded(layoutLanes(dayEvents, eventSpan), MAX_LANES[mode], eventSpan).map((placed) => {
+                    if (placed.kind === 'group') {
+                      return (
+                        <GroupCard
+                          key={`group-${placed.start}`}
+                          members={placed.members}
+                          start={placed.start}
+                          end={placed.end}
+                          actionDeps={actionDeps}
+                        />
+                      )
+                    }
+                    const { evt, lane, lanes } = placed
                     const top =
                       (evt.hour - START_HR) * HOUR_PX +
                       (evt.min / 60) * HOUR_PX


### PR DESCRIPTION
## Summary

Follow-up to #730 from Gerard's screenshots: the week view squeezed five daily heartbeats at 10:00 into five lanes per column (unreadable "10:0 / VECT"), every 15–20 minute event drew a 28px box that clipped its title, and the `<button>` default centred each label in the middle of a wide day-view bar.

- **Entries read from the left edge** — `text-align: left`, 3px vertical padding.
- **Two-line boxes** — minimum height 38px so the time line and the title both fit; the overlap window uses the same floor.
- **Crowded slots stack into one card** — a slot that needs more lanes than the column can show (day view 6, week view 2) becomes one card: `10:00 · 5 heartbeats`, the members' agent dots, their names, and a submenu per member carrying that member's actions. `collapseCrowded` in `calendar-kinds.ts`; `layoutLanes` now numbers its clusters.

## Test plan

- [ ] `calendar-kinds.test.ts` — cluster numbering; `collapseCrowded` folds a 3-lane cluster at limit 2, leaves a 2-lane cluster, spans earliest start → latest end.
- [ ] `calendar-tab-feed.test.tsx` — five daily heartbeats: one card per day column in week view (`data-group-size=5`, "5 heartbeats", 5 agent dots), five lanes in day view; a short event's box is 38px.
- [ ] `calendar-tab-scope.test.tsx` — the alignment rule is in the scoped block.
- [ ] Frontend CI green.
