### PR TITLE
Team page: last active, 30-day activity and inviter — from data the workspace already records

### DIFF
--- a/frontend/app/admin/workspaces/page.tsx
+++ b/frontend/app/admin/workspaces/page.tsx
@@ -28,6 +28,7 @@ import { usePageAPI } from '@/hooks/use-page-api'
 import { apiClient } from '@/lib/api-client'
 import { SaasOnlyNotice } from '@/components/local/saas-only-notice'
 import { isRouteAvailableInEdition } from '@/lib/auth-edition'
+import { formatAbsoluteDate as formatDate, formatRelative } from '@/lib/format-relative'
 import {
   WorkspacePlanSelect,
   type PlanTier,
@@ -79,37 +80,6 @@ function formatBytes(bytes: number): string {
     i++
   }
   return `${n.toFixed(i === 0 ? 0 : 1)} ${units[i]}`
-}
-
-function formatDate(iso: string | null): string {
-  if (!iso) return '—'
-  return new Date(iso).toLocaleDateString(undefined, {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-  })
-}
-
-/**
- * "Last active" reads as elapsed time, not a date — the console is scanned to
- * spot who is live during a pilot, and "3d ago" answers that at a glance where
- * a timestamp has to be subtracted first. Anything older than a month falls
- * back to the absolute date, where the elapsed form stops being informative.
- */
-function formatRelative(iso: string | null): string {
-  if (!iso) return 'never'
-  const then = new Date(iso).getTime()
-  if (Number.isNaN(then)) return 'never'
-  const seconds = Math.floor((Date.now() - then) / 1000)
-  if (seconds < 0) return 'just now'
-  if (seconds < 60) return 'just now'
-  const minutes = Math.floor(seconds / 60)
-  if (minutes < 60) return `${minutes}m ago`
-  const hours = Math.floor(minutes / 60)
-  if (hours < 24) return `${hours}h ago`
-  const days = Math.floor(hours / 24)
-  if (days < 31) return `${days}d ago`
-  return formatDate(iso)
 }
 
 function stateBadge(w: WorkspaceRow) {

--- a/frontend/components/team/team-management.tsx
+++ b/frontend/components/team/team-management.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react'
 import { motion } from 'framer-motion'
 import { Users, UserPlus, Shield, Trash2, Mail, Search, RefreshCw, Clock, X } from 'lucide-react'
 import { apiClient } from '@/lib/api-client'
+import { formatAbsoluteDate, formatRelative, isWithinDays } from '@/lib/format-relative'
 import { useWorkspace } from '@/hooks/use-workspace'
 import { InviteModal } from './invite-modal'
 import { useAuth } from '@/lib/auth-hooks'
@@ -16,9 +17,32 @@ interface TeamMember {
     id: number
     user_id: string
     email: string
-    name: string
+    name: string | null
     role: 'owner' | 'admin' | 'editor' | 'viewer'
     joined_at: string
+    last_active_at: string | null   // last chat or tool run IN THIS WORKSPACE
+    // null = not shown to this role (needs audit:view — owner/admin); 0 = nothing happened.
+    tool_runs_30d: number | null
+    chats_30d: number | null
+    invited_by_email: string | null
+}
+
+/** "Active this week": the pill's count and the row highlight share this window. */
+const ACTIVE_WITHIN_DAYS = 7
+
+/** "1 chat" / "4 chats" — the activity cell reads as a sentence, not a tally. */
+function plural(n: number, noun: string): string {
+    return `${n} ${noun}${n === 1 ? '' : 's'}`
+}
+
+/**
+ * The display label when `users.name` is empty — the email's local part.
+ * Every Clerk-provisioned user has a NULL name today (names were never synced
+ * into `users`), so "Unknown User" was the whole roster. This is derived from
+ * data the row already carries, not invented.
+ */
+function displayName(member: Pick<TeamMember, 'name' | 'email'>): string {
+    return member.name || member.email.split('@')[0]
 }
 
 interface PendingInvitation {
@@ -122,6 +146,10 @@ export function TeamManagement() {
         }
     }
 
+    // The API nulls the activity fields for roles without audit:view; render
+    // "—" for those, never a misleading "0 tool runs" or "never".
+    const canSeeActivity = members.some((m) => m.tool_runs_30d !== null)
+
     return (
         <div className="space-y-6">
             {/* Header */}
@@ -135,6 +163,11 @@ export function TeamManagement() {
                         <Badge variant="outline" className="text-brand-primary border-brand-primary/30">
                             <Users className="w-3 h-3 mr-1" />
                             {members.length} Members
+                            {canSeeActivity && (
+                                <span className="text-muted-foreground font-normal ml-1">
+                                    · {members.filter((m) => isWithinDays(m.last_active_at, ACTIVE_WITHIN_DAYS)).length} active this week
+                                </span>
+                            )}
                         </Badge>
 
                         <Button
@@ -215,11 +248,12 @@ export function TeamManagement() {
                 transition={{ duration: 0.6, delay: 0.2 }}
                 className="glass-card rounded-xl border border-border/30 overflow-hidden"
             >
-                <div className="p-4 border-b border-border/30 bg-white/5 hidden md:grid grid-cols-12 gap-4 font-medium text-sm text-muted-foreground">
-                    <div className="col-span-5">User</div>
-                    <div className="col-span-3">Role</div>
-                    <div className="col-span-3">Joined</div>
-                    <div className="col-span-1"></div>
+                <div className="p-4 pr-14 border-b border-border/30 bg-white/5 hidden md:grid grid-cols-12 gap-4 font-medium text-sm text-muted-foreground">
+                    <div className="col-span-4">User</div>
+                    <div className="col-span-2">Role</div>
+                    <div className="col-span-2">Last active</div>
+                    <div className="col-span-2">Activity · 30d</div>
+                    <div className="col-span-2">Joined</div>
                 </div>
 
                 {loading ? (
@@ -236,16 +270,16 @@ export function TeamManagement() {
                                 key={member.id}
                                 initial={{ opacity: 0 }}
                                 animate={{ opacity: 1 }}
-                                className="flex flex-col md:grid md:grid-cols-12 gap-2 md:gap-4 p-4 items-start md:items-center hover:bg-white/5 transition-colors group"
+                                className="relative flex flex-col md:grid md:grid-cols-12 gap-2 md:gap-4 p-4 pr-14 items-start md:items-center hover:bg-white/5 transition-colors group"
                             >
-                                <div className="md:col-span-5 flex items-center gap-3 w-full md:w-auto">
+                                <div className="md:col-span-4 flex items-center gap-3 w-full md:w-auto min-w-0">
                                     <div className="w-10 h-10 rounded-full bg-gradient-to-tr from-warning/20 to-purple-500/20 flex items-center justify-center border border-white/10 shrink-0">
                                         <span className="font-semibold text-foreground">
-                                            {member.name ? member.name[0].toUpperCase() : member.email[0].toUpperCase()}
+                                            {displayName(member).charAt(0).toUpperCase() || '?'}
                                         </span>
                                     </div>
                                     <div className="overflow-hidden">
-                                        <div className="font-medium text-foreground truncate">{member.name || 'Unknown User'}</div>
+                                        <div className="font-medium text-foreground truncate">{displayName(member)}</div>
                                         <div className="text-sm text-muted-foreground flex items-center gap-1 truncate">
                                             <Mail className="w-3 h-3 shrink-0" />
                                             {member.email}
@@ -253,7 +287,7 @@ export function TeamManagement() {
                                     </div>
                                 </div>
 
-                                <div className="md:col-span-3 flex items-center gap-2 pl-13 md:pl-0">
+                                <div className="md:col-span-2 flex items-center gap-2 pl-13 md:pl-0">
                                     <div className="relative inline-block">
                                         <select
                                             value={member.role}
@@ -272,11 +306,42 @@ export function TeamManagement() {
                                     </div>
                                 </div>
 
-                                <div className="md:col-span-3 text-sm text-muted-foreground pl-13 md:pl-0">
-                                    {new Date(member.joined_at).toLocaleDateString()}
+                                <div
+                                    className={`md:col-span-2 text-sm pl-13 md:pl-0 ${
+                                        isWithinDays(member.last_active_at, ACTIVE_WITHIN_DAYS) ? 'text-foreground' : 'text-muted-foreground'
+                                    }`}
+                                    title={
+                                        member.tool_runs_30d === null
+                                            ? 'Activity is shown to workspace owners and admins'
+                                            : member.last_active_at
+                                              ? 'Most recent chat or tool run in this workspace'
+                                              : 'No chats or tool runs in this workspace yet'
+                                    }
+                                >
+                                    {member.tool_runs_30d === null ? '—' : formatRelative(member.last_active_at)}
                                 </div>
 
-                                <div className="col-span-1 flex justify-end">
+                                <div className="md:col-span-2 text-sm text-muted-foreground pl-13 md:pl-0 tabular-nums leading-tight">
+                                    {member.tool_runs_30d === null || member.chats_30d === null ? (
+                                        '—'
+                                    ) : (
+                                        <>
+                                            <div>{plural(member.tool_runs_30d, 'tool run')}</div>
+                                            <div>{plural(member.chats_30d, 'chat')}</div>
+                                        </>
+                                    )}
+                                </div>
+
+                                <div className="md:col-span-2 text-sm text-muted-foreground pl-13 md:pl-0 min-w-0">
+                                    <div>{formatAbsoluteDate(member.joined_at)}</div>
+                                    {member.invited_by_email && (
+                                        <div className="text-xs truncate" title={`Invited by ${member.invited_by_email}`}>
+                                            by {member.invited_by_email}
+                                        </div>
+                                    )}
+                                </div>
+
+                                <div className="absolute right-3 top-3 md:top-1/2 md:-translate-y-1/2">
                                     {/* Don't allow deleting owner */}
                                     {member.role !== 'owner' && (
                                         <Button

--- a/frontend/lib/__tests__/format-relative.test.ts
+++ b/frontend/lib/__tests__/format-relative.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import { formatAbsoluteDate, formatRelative, isWithinDays } from '../format-relative'
+
+// A fixed "now" so the buckets are deterministic, and every input carries an
+// explicit offset — the contract the backend's utc_iso guarantees.
+const NOW = Date.parse('2026-09-11T12:00:00+00:00')
+const ago = (seconds: number) => new Date(NOW - seconds * 1000).toISOString()
+
+describe('formatRelative', () => {
+  it('reads "never" for nothing and for garbage', () => {
+    expect(formatRelative(null, NOW)).toBe('never')
+    expect(formatRelative(undefined, NOW)).toBe('never')
+    expect(formatRelative('not a date', NOW)).toBe('never')
+  })
+
+  it('buckets elapsed time the way a console is scanned', () => {
+    expect(formatRelative(ago(5), NOW)).toBe('just now')
+    expect(formatRelative(ago(59), NOW)).toBe('just now')
+    expect(formatRelative(ago(60), NOW)).toBe('1m ago')
+    expect(formatRelative(ago(59 * 60), NOW)).toBe('59m ago')
+    expect(formatRelative(ago(3600), NOW)).toBe('1h ago')
+    expect(formatRelative(ago(23 * 3600), NOW)).toBe('23h ago')
+    expect(formatRelative(ago(86_400), NOW)).toBe('1d ago')
+    expect(formatRelative(ago(30 * 86_400), NOW)).toBe('30d ago')
+  })
+
+  it('falls back to the absolute date once elapsed time stops informing', () => {
+    const old = ago(31 * 86_400)
+    expect(formatRelative(old, NOW)).toBe(formatAbsoluteDate(old))
+    expect(formatRelative(old, NOW)).not.toMatch(/ago$/)
+  })
+
+  it('is independent of the viewer timezone when the offset is explicit', () => {
+    // The same instant written with two different offsets must read identically.
+    const utc = '2026-09-11T11:00:00+00:00'
+    const bst = '2026-09-11T12:00:00+01:00'
+    expect(formatRelative(utc, NOW)).toBe('1h ago')
+    expect(formatRelative(bst, NOW)).toBe('1h ago')
+  })
+})
+
+describe('isWithinDays', () => {
+  it('counts a recent stamp and rejects an old, missing or invalid one', () => {
+    expect(isWithinDays(ago(6 * 86_400), 7, NOW)).toBe(true)
+    expect(isWithinDays(ago(7 * 86_400), 7, NOW)).toBe(true)
+    expect(isWithinDays(ago(7 * 86_400 + 1), 7, NOW)).toBe(false)
+    expect(isWithinDays(null, 7, NOW)).toBe(false)
+    expect(isWithinDays('nope', 7, NOW)).toBe(false)
+  })
+})
+
+describe('formatAbsoluteDate', () => {
+  it('renders a dash for nothing and a short date otherwise', () => {
+    expect(formatAbsoluteDate(null)).toBe('—')
+    expect(formatAbsoluteDate('garbage')).toBe('—')
+    expect(formatAbsoluteDate('2026-04-28T00:00:00+00:00')).toMatch(/2026/)
+  })
+})

--- a/frontend/lib/format-relative.ts
+++ b/frontend/lib/format-relative.ts
@@ -1,0 +1,42 @@
+/**
+ * Elapsed time for "when did this last happen" columns.
+ *
+ * A console is scanned to spot who is live; "3d ago" answers that at a glance
+ * where a timestamp has to be subtracted first. Beyond a month the elapsed form
+ * stops being informative, so it falls back to the absolute date. Input must be
+ * an ISO string WITH an offset (the backend's `utc_iso`) — an offset-less
+ * string is parsed as local time by every browser and the arithmetic goes wrong
+ * by the viewer's UTC offset.
+ *
+ * Extracted 2026-09-11 from app/admin/workspaces/page.tsx so the team page and
+ * the admin console share one definition.
+ */
+export function formatAbsoluteDate(iso: string | null | undefined): string {
+  if (!iso) return '—'
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return '—'
+  return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
+}
+
+export function formatRelative(iso: string | null | undefined, now: number = Date.now()): string {
+  if (!iso) return 'never'
+  const then = new Date(iso).getTime()
+  if (Number.isNaN(then)) return 'never'
+  const seconds = Math.floor((now - then) / 1000)
+  if (seconds < 60) return 'just now'
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  if (days < 31) return `${days}d ago`
+  return formatAbsoluteDate(iso)
+}
+
+/** True when `iso` falls inside the last `days` days (default: a week). */
+export function isWithinDays(iso: string | null | undefined, days = 7, now: number = Date.now()): boolean {
+  if (!iso) return false
+  const then = new Date(iso).getTime()
+  if (Number.isNaN(then)) return false
+  return now - then <= days * 86_400_000
+}

--- a/orchestrator/alembic/versions/tool_execution_logs_workspace_user_idx.py
+++ b/orchestrator/alembic/versions/tool_execution_logs_workspace_user_idx.py
@@ -1,0 +1,39 @@
+"""tool_execution_logs — index (workspace_id, user_id) for the team page's activity query.
+
+The team page now groups a workspace's tool runs by member
+(``api/team._activity_by_user``: ``WHERE workspace_id = :ws AND user_id IN (…)
+GROUP BY user_id``). ``tool_execution_logs`` indexes ``agent_id``, ``status`` and
+``executed_at`` — nothing that query filters on — and it is an audit table that
+only grows, so every team-page load would sequential-scan it. ``chats`` already
+carries ``ix_chats_workspace_user`` on the same pair; this brings the tool log
+in line.
+
+Two homes on purpose: the model's ``__table_args__`` gives a create_all-first
+install the index (fresh databases are stamped past migrations), and this
+migration gives it to every existing database. Same index name in both, so an
+upgraded database and a fresh one end up identical and neither path builds it
+twice. Idempotent (IF NOT EXISTS); downgrade drops only the index.
+
+Revision ID: tool_execution_logs_workspace_user_idx
+Revises: users_last_sign_in_column
+Create Date: 2026-09-11
+"""
+
+from alembic import op
+
+
+revision = "tool_execution_logs_workspace_user_idx"
+down_revision = "users_last_sign_in_column"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_tool_execution_logs_workspace_user "
+        "ON tool_execution_logs (workspace_id, user_id);"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_tool_execution_logs_workspace_user;")

--- a/orchestrator/api/admin_workspaces.py
+++ b/orchestrator/api/admin_workspaces.py
@@ -17,7 +17,7 @@ the normal list view (use `?include_deleted=true` to see them).
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Any, Dict, List, Optional
 from uuid import UUID
 
@@ -33,6 +33,7 @@ from core.database.database import get_db
 from core.models.core import Agent, Chat, Document, Message, User
 from core.models.workspaces import Workspace
 from core.workspaces.audit import AuditService
+from core.utils.timestamps import utc_iso
 from core.workspaces.models import WorkspaceMember
 from services.plan_tiers import assign_plan, assignable_tiers, exposure_for_plan, get_tier
 from services.workspace_purge import purge_workspace_sync
@@ -46,22 +47,9 @@ router = APIRouter(prefix="/api/admin/workspaces", tags=["Admin Workspaces"])
 # Helpers
 # ===================================================================
 
-def _utc_iso(value: Optional[datetime]) -> Optional[str]:
-    """A naive-UTC timestamp as an ISO-8601 string that SAYS it is UTC.
-
-    ``users.last_sign_in`` is ``timestamp without time zone`` stamped from
-    Postgres ``now()`` on a UTC server, so the value is UTC but carries no
-    offset. Plain ``.isoformat()`` would emit ``2026-09-11T09:20:20`` — and
-    ECMAScript parses a date-time string with NO offset as LOCAL time, so
-    ``new Date(...)`` in a UK browser would read it an hour early and the
-    console's elapsed-time column would be wrong by the viewer's UTC offset.
-    Stamping the offset here fixes it at the boundary, for every reader.
-    """
-    if value is None:
-        return None
-    if value.tzinfo is None:
-        value = value.replace(tzinfo=timezone.utc)
-    return value.isoformat()
+# The UTC-explicit serialiser now lives in core.utils.timestamps; the module-level
+# name is kept so call sites and tests in this file read unchanged.
+_utc_iso = utc_iso
 
 
 def _is_admin(ctx: RequestContext) -> bool:

--- a/orchestrator/api/team.py
+++ b/orchestrator/api/team.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, EmailStr
@@ -9,13 +9,16 @@ from core.auth.dependencies import RequestContext
 from core.auth.actor import resolve_internal_user_id
 from core.auth.clerk import get_clerk_auth
 from core.database.database import get_db
-from core.auth.workspace_permission import require_workspace_permission
+from core.auth.workspace_permission import require_workspace_permission, workspace_permission_granted
 from modules.policy.roles import WorkspaceRole
 from core.workspaces.invitations import WorkspaceInvitation, invite_member_to_workspace
 from core.workspaces.audit import AuditService
 from core.workspaces.models import WorkspaceMember
 from core.models.workspaces import Workspace
-from core.models.core import User
+from core.models.composio_cache import ToolExecutionLog
+from core.models.core import Chat, User
+from core.utils.timestamps import utc_iso
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 logger = logging.getLogger(__name__)
@@ -45,6 +48,28 @@ class TeamMemberResponse(BaseModel):
     name: Optional[str]
     role: str
     joined_at: Optional[str]
+    # 2026-09-11 — activity THIS workspace already records, surfaced per member.
+    # Field additions only: same route, so the route manifest is unchanged.
+    # Timestamps carry an explicit UTC offset (core/utils/timestamps) — the
+    # page renders elapsed time, which an offset-less string gets wrong by the
+    # viewer's own UTC offset.
+    #
+    # Deliberately NOT here: ``users.last_sign_in``. That stamp is platform-wide
+    # (core/auth/hybrid stamps every authenticated request, whichever workspace
+    # it was for), so surfacing it on a per-workspace page would tell workspace
+    # A's admins when a shared user was last active in workspace B. The team
+    # page reports what happened HERE; the super-admin console keeps the
+    # cross-tenant view.
+    #
+    # The three activity fields are shown only to callers holding
+    # ``audit:view`` (owner + admin in modules/policy/roles.py): per-teammate
+    # recency and volume is audit-class telemetry, and ``members:read`` is held
+    # by every role down to ``viewer``. For everyone else they are ``None`` —
+    # distinct from ``0``, which means "visible, and nothing happened".
+    last_active_at: Optional[str] = None   # max(last chat HERE, last tool run HERE)
+    tool_runs_30d: Optional[int] = None    # tool_execution_logs in THIS workspace, last 30 days
+    chats_30d: Optional[int] = None        # chats in THIS workspace, last 30 days
+    invited_by_email: Optional[str] = None  # roster metadata, like joined_at: every member sees it
     
 class InvitationResponse(BaseModel):
     id: int
@@ -63,6 +88,34 @@ class AcceptInvitationResponse(BaseModel):
     role: str
     already_member: bool
 
+ACTIVITY_WINDOW_DAYS = 30
+# Owner + admin only (modules/policy/roles.py). Reused rather than minted: the
+# activity columns answer "who did what, when", which is what audit:view guards.
+ACTIVITY_PERMISSION = "audit:view"
+
+
+def _activity_by_user(db, user_col, ts_col, ws_col, workspace_id, user_ids, since):
+    """``{user_id: (count_in_window, latest_ever)}`` for ONE activity table.
+
+    Scoped to the requested workspace on purpose — a member's activity in some
+    OTHER workspace must never show up on this team page. The count is
+    windowed (``since``); the latest is all-time, so "last active" does not go
+    blank the day the window rolls past someone's last action. One grouped
+    query per table, never one per member.
+    """
+    rows = (
+        db.query(
+            user_col,
+            func.count().filter(ts_col >= since),
+            func.max(ts_col),
+        )
+        .filter(ws_col == workspace_id, user_col.in_(user_ids))
+        .group_by(user_col)
+        .all()
+    )
+    return {uid: (int(count or 0), latest) for uid, count, latest in rows}
+
+
 @router.get(
     "/members",
     response_model=List[TeamMemberResponse],
@@ -75,41 +128,67 @@ async def list_team_members(
 ):
     """List all members of a workspace."""
     
-    # Check if we have a Clerk Org ID
-    if ctx.user.org_id:
-        clerk = get_clerk_auth()
-        try:
-            # Sync members from Clerk
-            # In a real sync engine, we'd upsert users/members properly.
-            # Here we just fetch them for display, or we could rely on existing DB records 
-            # if we trust we are syncing via webhooks.
-            # However, user requested integration.
-            # Let's fetch from DB, but maybe we could trigger a background sync?
-            # For simplicity & speed in this task, we will just return local DB members
-            # BUT ensuring the invite flow populates Clerk correctly.
-            pass
-        except Exception as e:
-            logger.error(f"Failed to sync with Clerk: {e}")
-
     members = db.query(WorkspaceMember).filter(
         WorkspaceMember.workspace_id == workspace_id,
         WorkspaceMember.is_active == True
     ).all()
-    
+    if not members:
+        return []
+
+    member_ids = {m.user_id for m in members}
+    inviter_ids = {m.invited_by for m in members if m.invited_by is not None}
+    # ONE users query covers the members and whoever invited them — this used to
+    # be a query per member.
+    users = db.query(User).filter(User.id.in_(member_ids | inviter_ids)).all()
+    user_by_id = {u.id: u for u in users}
+
+    # Editors and viewers get the roster and nothing else — the aggregate
+    # queries are not even issued for them.
+    show_activity = workspace_permission_granted(db, ctx, ACTIVITY_PERMISSION)
+    chats: dict = {}
+    tools: dict = {}
+    if show_activity:
+        since = datetime.utcnow() - timedelta(days=ACTIVITY_WINDOW_DAYS)
+        chats = _activity_by_user(
+            db, Chat.user_id, Chat.created_at, Chat.workspace_id, workspace_id, member_ids, since,
+        )
+        tools = _activity_by_user(
+            db, ToolExecutionLog.user_id, ToolExecutionLog.executed_at,
+            ToolExecutionLog.workspace_id, workspace_id, member_ids, since,
+        )
+
     response = []
     for m in members:
-        # Fetch user details
-        user = db.query(User).filter(User.id == m.user_id).first()
-        if user:
-            response.append(TeamMemberResponse(
-                id=m.id,
-                user_id=m.user_id,
-                email=user.email,
-                name=user.name,
-                role=m.role,
-                joined_at=m.joined_at.isoformat() if m.joined_at else None
-            ))
-            
+        user = user_by_id.get(m.user_id)
+        if not user:
+            continue  # a member row whose users row is gone — skipped before too
+        if show_activity:
+            chat_count, chat_last = chats.get(m.user_id, (0, None))
+            tool_count, tool_last = tools.get(m.user_id, (0, None))
+            # Both naive-UTC DateTime columns, so they compare directly. The
+            # global sign-in stamp is left out on purpose — see TeamMemberResponse.
+            seen = [t for t in (chat_last, tool_last) if t is not None]
+            last_active = utc_iso(max(seen)) if seen else None
+        else:
+            chat_count = tool_count = None
+            last_active = None
+        inviter = user_by_id.get(m.invited_by) if m.invited_by is not None else None
+        response.append(TeamMemberResponse(
+            id=m.id,
+            user_id=m.user_id,
+            email=user.email,
+            # NULL for every Clerk-provisioned user today (names were never
+            # synced into users.name); the page derives a display label. Not
+            # invented here.
+            name=user.name,
+            role=m.role,
+            joined_at=m.joined_at.isoformat() if m.joined_at else None,
+            last_active_at=last_active,
+            tool_runs_30d=tool_count,
+            chats_30d=chat_count,
+            invited_by_email=inviter.email if inviter else None,
+        ))
+
     return response
 
 @router.post(

--- a/orchestrator/core/models/composio_cache.py
+++ b/orchestrator/core/models/composio_cache.py
@@ -246,6 +246,12 @@ class ToolExecutionLog(Base):
     executed_at = Column(DateTime, default=datetime.utcnow)
     
     __table_args__ = (
+        # The team page groups tool runs by member within ONE workspace
+        # (api/team._activity_by_user); without this the query sequential-scans an
+        # audit table that only grows. Same name as the migration that adds it to
+        # existing databases, so a create_all-first install and an upgraded one end
+        # up identical.
+        Index("ix_tool_execution_logs_workspace_user", "workspace_id", "user_id"),
         Index("idx_tool_logs_agent", "agent_id"),
         Index("idx_tool_logs_status", "status"),
         Index("idx_tool_logs_executed", "executed_at"),

--- a/orchestrator/core/utils/timestamps.py
+++ b/orchestrator/core/utils/timestamps.py
@@ -1,0 +1,28 @@
+"""Timestamps that SAY they are UTC when they cross the API boundary.
+
+Most naive ``DateTime`` columns in this schema (``timestamp without time zone``)
+are written from Postgres ``now()`` or ``datetime.utcnow()`` on a UTC server, so
+the stored value IS UTC — but it carries no offset, and plain ``.isoformat()``
+emits none either. ECMAScript parses a date-time string with NO offset as LOCAL
+time, so ``new Date(...)`` in a UK browser reads such a value an hour early and
+any elapsed-time UI ("2h ago") is wrong by the viewer's own UTC offset.
+Date-only renderings hide the skew, which is why it went unnoticed for so long.
+
+Stamp the offset once, here, at the boundary — for every reader.
+
+Extracted 2026-09-11 from ``api/admin_workspaces._utc_iso``; six other sites
+still hand-roll ``replace(tzinfo=timezone.utc)`` and can move here over time.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Optional
+
+
+def utc_iso(value: Optional[datetime]) -> Optional[str]:
+    """A naive-UTC (or already-aware) timestamp as an explicit-offset ISO string."""
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.isoformat()

--- a/orchestrator/tests/test_prd209_alembic_single_head.py
+++ b/orchestrator/tests/test_prd209_alembic_single_head.py
@@ -54,7 +54,10 @@ _COMPOSE = _REPO / "docker-compose.yml"
 # 2026-09-11 (operator console): users_last_sign_in_column chains onto it —
 # users.last_sign_in was only ever a model attribute, never a declared column, and
 # the admin workspace routes now READ it (a missing column there is a 500 per load).
-EXPECTED_HEAD = "users_last_sign_in_column"
+# 2026-09-11 (team page activity): tool_execution_logs_workspace_user_idx chains onto it — the composite
+# index behind api/team._activity_by_user, declared on the model too for
+# create_all-first installs.
+EXPECTED_HEAD = "tool_execution_logs_workspace_user_idx"
 
 
 def _literal(node: ast.AST):

--- a/orchestrator/tests/test_prd236_w1_routes.py
+++ b/orchestrator/tests/test_prd236_w1_routes.py
@@ -179,7 +179,11 @@ def test_migration_chains_onto_prd234_head_and_guard_follows():
     last_seen = (versions / "users_last_sign_in_column.py").read_text()
     assert 'down_revision = "prd240_llm_usage_cache_tokens"' in last_seen
     guard = (Path(__file__).resolve().parent / "test_prd209_alembic_single_head.py").read_text()
-    assert 'EXPECTED_HEAD = "users_last_sign_in_column"' in guard
+    # 2026-09-11: tool_execution_logs_workspace_user_idx chains onto that (the team page's
+    # activity index); the guard follows it.
+    idx = (versions / "tool_execution_logs_workspace_user_idx.py").read_text()
+    assert 'down_revision = "users_last_sign_in_column"' in idx
+    assert 'EXPECTED_HEAD = "tool_execution_logs_workspace_user_idx"' in guard
 
 
 def test_orm_row_is_keyed_by_route():

--- a/orchestrator/tests/test_team_members_activity.py
+++ b/orchestrator/tests/test_team_members_activity.py
@@ -1,0 +1,278 @@
+"""Team page — per-member activity from data the workspace already records.
+
+``GET /api/workspaces/{id}/team/members`` gained ``last_active_at``,
+``last_sign_in_at``, ``tool_runs_30d``, ``chats_30d`` and ``invited_by_email``
+(2026-09-11). Field additions on the same route; the permission gate
+(``members:read``) is untouched and covered by the authz sweep, so these tests
+call the handler directly (the ``test_p2w2_authz_authority`` idiom) and pin the
+LOGIC:
+
+  * batched — one users query for members AND inviters, one grouped query per
+    activity table, never one per member (the old handler was an N+1);
+  * scoped — the activity queries filter on THIS workspace, so a member's work
+    in another workspace never shows here;
+  * "last active" is the max of last chat here / last tool run here — the
+    platform-wide ``users.last_sign_in`` is deliberately NOT folded in, because
+    a per-workspace page must not reveal when a shared user was active in some
+    OTHER workspace; the latest is all-time while the counts are windowed;
+  * timestamps carry an explicit UTC offset;
+  * ``name`` passes through as-is (NULL for every Clerk user today — the page
+    derives a label, the API does not invent one);
+  * the activity fields are shown only to ``audit:view`` holders (owner/admin);
+    everyone else gets ``None`` — not ``0`` — and no aggregate query is issued.
+"""
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+WS = str(uuid4())
+OTHER_WS = str(uuid4())
+
+
+@pytest.fixture(autouse=True)
+def _caller_can_see_activity(monkeypatch):
+    """Default every test to an owner/admin caller; the gate has its own tests."""
+    import api.team as team
+
+    monkeypatch.setattr(team, "workspace_permission_granted", lambda db, ctx, perm: True)
+
+
+class _Q:
+    """A chainable query stand-in that records its filters and returns fixtures."""
+
+    def __init__(self, rows, log):
+        self._rows = rows
+        self.filters = []
+        log.append(self)
+
+    def filter(self, *args):
+        self.filters.extend(args)
+        return self
+
+    def group_by(self, *args):
+        return self
+
+    def all(self):
+        return self._rows
+
+
+def _owner(arg):
+    """The mapped class a query's first argument belongs to."""
+    return getattr(arg, "class_", arg)
+
+
+def _fake_db(members, users, chats=(), tools=()):
+    from core.models.composio_cache import ToolExecutionLog
+    from core.models.core import Chat, User
+    from core.workspaces.models import WorkspaceMember
+
+    log: list = []
+    fixtures = {WorkspaceMember: members, User: users, Chat: list(chats), ToolExecutionLog: list(tools)}
+
+    class _DB:
+        def query(self, *args):
+            owner = _owner(args[0])
+            assert owner in fixtures, f"unexpected query root {owner!r}"
+            q = _Q(fixtures[owner], log)
+            q.owner = owner
+            return q
+
+    db = _DB()
+    db.log = log
+    return db
+
+
+def _member(mid, uid, role="admin", invited_by=None):
+    return SimpleNamespace(id=mid, user_id=uid, role=role, joined_at=datetime(2026, 4, 28), invited_by=invited_by)
+
+
+def _user(uid, email, last_sign_in=None, name=None):
+    return SimpleNamespace(id=uid, email=email, name=name, last_sign_in=last_sign_in)
+
+
+def _ctx():
+    from core.auth.dependencies import RequestContext, UserContext
+
+    return RequestContext(
+        workspace_id=uuid4(),
+        user=UserContext(id="u", email="owner@example.com", role="owner", system_role="user"),
+        auth_type="clerk",
+    )
+
+
+def _call(db, workspace_id=WS):
+    from api.team import list_team_members
+
+    return asyncio.run(list_team_members(workspace_id=workspace_id, ctx=_ctx(), db=db))
+
+
+def _queries(db, cls):
+    return [q for q in db.log if q.owner is cls]
+
+
+# --------------------------------------------------------------------------- #
+# batching
+# --------------------------------------------------------------------------- #
+
+
+def test_one_users_query_covers_members_and_inviters():
+    from core.models.core import User
+
+    members = [_member(1, 47, "owner"), _member(2, 2455, invited_by=47), _member(3, 2550, invited_by=47)]
+    users = [_user(47, "owner@x.com"), _user(2455, "ar@x.com"), _user(2550, "d@x.com")]
+    db = _fake_db(members, users)
+    out = _call(db)
+    assert len(out) == 3
+    assert len(_queries(db, User)) == 1, "the old handler queried users once PER member"
+
+
+def test_no_members_means_no_further_queries():
+    from core.models.core import Chat, User
+
+    db = _fake_db([], [])
+    assert _call(db) == []
+    assert _queries(db, User) == [] and _queries(db, Chat) == []
+
+
+# --------------------------------------------------------------------------- #
+# last active = max(last chat here, last tool run here) — workspace-scoped
+# --------------------------------------------------------------------------- #
+
+
+def test_last_active_takes_the_latest_of_chat_and_tool_run_here():
+    chat = datetime(2026, 9, 11, 11, 30)   # the winner for user 1
+    tool = datetime(2026, 9, 10, 8, 0)
+    members = [_member(1, 1), _member(2, 2), _member(3, 3)]
+    users = [_user(1, "a@x.com"), _user(2, "b@x.com"), _user(3, "c@x.com")]
+    db = _fake_db(members, users, chats=[(1, 4, chat)], tools=[(1, 131, tool), (2, 2, tool)])
+    by_uid = {m.user_id: m for m in _call(db)}
+
+    assert by_uid[1].last_active_at == "2026-09-11T11:30:00+00:00"   # chat beat the tool run
+    assert by_uid[2].last_active_at == "2026-09-10T08:00:00+00:00"   # only a tool run
+    assert by_uid[3].last_active_at is None                          # nothing here
+    assert by_uid[3].tool_runs_30d == 0 and by_uid[3].chats_30d == 0
+
+
+def test_platform_wide_sign_in_never_leaks_into_a_workspace_page():
+    """A user active in ANOTHER workspace five minutes ago must not read as
+    active here. ``users.last_sign_in`` is global, so the team page ignores it —
+    and there is no field carrying it either."""
+    fresh_sign_in_elsewhere = datetime(2026, 9, 11, 11, 55)
+    members = [_member(1, 1)]
+    users = [_user(1, "shared@x.com", last_sign_in=fresh_sign_in_elsewhere)]
+    (m,) = _call(_fake_db(members, users, chats=[(1, 0, datetime(2026, 8, 1))]))
+    assert m.last_active_at == "2026-08-01T00:00:00+00:00"
+    assert not hasattr(m, "last_sign_in_at")
+
+
+def test_counts_pass_through_with_explicit_utc():
+    members = [_member(1, 1)]
+    users = [_user(1, "a@x.com")]
+    db = _fake_db(members, users, chats=[(1, 4, datetime(2026, 9, 1))], tools=[(1, 102, datetime(2026, 9, 2))])
+    (m,) = _call(db)
+    assert m.chats_30d == 4 and m.tool_runs_30d == 102
+    assert m.last_active_at.endswith("+00:00"), "an offset-less string is read as LOCAL by browsers"
+
+
+# --------------------------------------------------------------------------- #
+# scoping — this workspace only
+# --------------------------------------------------------------------------- #
+
+
+def _filters_on(q, key):
+    return [f for f in q.filters if getattr(getattr(f, "left", None), "key", None) == key]
+
+
+def test_activity_queries_are_scoped_to_the_requested_workspace():
+    from core.models.composio_cache import ToolExecutionLog
+    from core.models.core import Chat
+
+    db = _fake_db([_member(1, 1)], [_user(1, "a@x.com")])
+    _call(db, workspace_id=WS)
+    for cls in (Chat, ToolExecutionLog):
+        (q,) = _queries(db, cls)
+        scoped = _filters_on(q, "workspace_id")
+        assert scoped, f"{cls.__name__} activity query carries no workspace_id filter"
+        assert scoped[0].right.value == WS
+
+
+# --------------------------------------------------------------------------- #
+# inviter, name, and a member whose users row is gone
+# --------------------------------------------------------------------------- #
+
+
+def test_invited_by_resolves_to_the_inviters_email():
+    members = [_member(1, 47, "owner"), _member(2, 2455, invited_by=47)]
+    users = [_user(47, "owner@x.com"), _user(2455, "ar@x.com")]
+    by_uid = {m.user_id: m for m in _call(_fake_db(members, users))}
+    assert by_uid[2455].invited_by_email == "owner@x.com"
+    assert by_uid[47].invited_by_email is None
+
+
+def test_name_is_passed_through_untouched_even_when_null():
+    (m,) = _call(_fake_db([_member(1, 1)], [_user(1, "daniel@x.com", name=None)]))
+    assert m.name is None  # the page derives a label; the API invents nothing
+
+
+def test_member_without_a_users_row_is_skipped():
+    out = _call(_fake_db([_member(1, 1), _member(2, 999)], [_user(1, "a@x.com")]))
+    assert [m.user_id for m in out] == [1]
+
+
+# --------------------------------------------------------------------------- #
+# the audit:view gate — roster for everyone, telemetry for owner/admin
+# --------------------------------------------------------------------------- #
+
+
+def test_activity_is_hidden_and_not_even_queried_without_audit_view(monkeypatch):
+    import api.team as team
+    from core.models.composio_cache import ToolExecutionLog
+    from core.models.core import Chat
+
+    asked = []
+
+    def _granted(db, ctx, perm):
+        asked.append(perm)
+        return False
+
+    monkeypatch.setattr(team, "workspace_permission_granted", _granted)
+    db = _fake_db([_member(1, 1, invited_by=47), _member(2, 47, "owner")],
+                  [_user(1, "v@x.com"), _user(47, "owner@x.com")],
+                  chats=[(1, 9, datetime(2026, 9, 1))])
+    by_uid = {m.user_id: m for m in _call(db)}
+
+    assert asked == ["audit:view"], "the gate must be the reused audit permission, asked once"
+    assert by_uid[1].tool_runs_30d is None and by_uid[1].chats_30d is None
+    assert by_uid[1].last_active_at is None
+    # None, not 0: the page renders "—", never a misleading "0 tool runs".
+    assert by_uid[1].invited_by_email == "owner@x.com"  # roster metadata still flows
+    assert _queries(db, Chat) == [] and _queries(db, ToolExecutionLog) == []
+
+
+def test_visible_but_idle_member_reads_zero_not_none():
+    (m,) = _call(_fake_db([_member(1, 1)], [_user(1, "a@x.com")]))
+    assert m.tool_runs_30d == 0 and m.chats_30d == 0 and m.last_active_at is None
+
+
+# --------------------------------------------------------------------------- #
+# the aggregate helper's contract
+# --------------------------------------------------------------------------- #
+
+
+def test_activity_by_user_maps_rows_and_coerces_null_counts():
+    from api.team import _activity_by_user
+    from core.models.core import Chat
+
+    log: list = []
+
+    class _DB:
+        def query(self, *args):
+            return _Q([(1, None, datetime(2026, 9, 1)), (2, 7, None)], log)
+
+    out = _activity_by_user(_DB(), Chat.user_id, Chat.created_at, Chat.workspace_id, WS, {1, 2}, datetime(2026, 8, 12))
+    assert out == {1: (0, datetime(2026, 9, 1)), 2: (7, None)}


### PR DESCRIPTION
## Why

The team page showed a roster — name, role, joined — and "Unknown User" on every row. Running a pilot means knowing who is *actually using* the workspace. That's already recorded; **nothing new is collected here.**

## What the page gains

| Column | Source (already stored) |
|---|---|
| **Last active** — relative, highlighted inside 7 days | latest of `chats.created_at` / `tool_execution_logs.executed_at` **in this workspace** |
| **Activity · 30d** — "102 tool runs" over "4 chats", stacked | the same two tables, windowed |
| **Joined** now carries "by *inviter*" | `workspace_members.invited_by`, resolved |
| Header pill: "4 Members · N active this week" | derived from the above |

"Unknown User" becomes the email's local part (`daniel`, `bfard`, …). `users.name` is NULL for every Clerk-provisioned user — names were never synced from Clerk into `users` — so the old label was honest but useless. Deriving a label from the row isn't inventing data; a Clerk→`users.name` sync would be, and that's a separate decision if you want it.

## Two decisions I made — easy to reverse, worth your eye

**1. "Last active" is scoped to this workspace; `users.last_sign_in` is deliberately *not* used here.** That stamp is platform-wide (the Clerk lane writes it on every authenticated request, whichever workspace), and one `users` row can be a member of many workspaces — so surfacing it would tell workspace A's admins when a shared user was last active in workspace B. It stays in the super-admin console, which is cross-tenant by design. Trade: someone who only browses this workspace reads "never" — for a pilot, the honest answer to "have they used it".

**2. The activity fields are visible to owners and admins only** (`audit:view`, already in `modules/policy/roles.py`). `members:read` is held by every role down to `viewer`, and per-teammate recency/volume is audit-class telemetry. Everyone else gets `null` — not `0` — and the page renders "—"; the aggregate queries aren't even issued for them. If you want editors or viewers to see it too, it's one constant.

## Also in here

- The handler was an N+1 (one users query per member). Now one users query (members ∪ inviters) and one grouped query per activity table — `count() FILTER (WHERE ts >= since)`, `max(ts)` — whatever the roster size.
- **New index** `tool_execution_logs (workspace_id, user_id)` — the grouped activity query filters on exactly that pair and the table indexed neither (`chats` already had it); it's an audit table that only grows, so without it every team-page load would seq-scan it. Declared on the model *and* added by migration `tool_execution_logs_workspace_user_idx` (fresh installs are stamped past migrations, existing databases need the migration) — same name in both. **Moves the alembic head**; both pins updated.
- Timestamps carry an explicit UTC offset (`core/utils/timestamps.utc_iso`, extracted from #726's `_utc_iso` — same definition, one home). The elapsed-time column would otherwise be wrong by the viewer's own UTC offset.
- `formatRelative` / `formatAbsoluteDate` / `isWithinDays` extracted to `frontend/lib/format-relative.ts`; the admin console now imports them instead of keeping its own copies.

## Verified (statically — CI is the gate)

- tsc: **537** with these changes, 537 without; CI baseline 554. The only two hits in touched files are the pre-existing `body: {…}`-into-`RequestInit` errors in `handlePause` / `handleRoleChange` — untouched code, already in the baseline.
- Same route, no manifest change; GET, so no authz-sweep entry; no new frontend→backend calls.
- import-linter: `api → core.models` is unconstrained, and four API modules already import `core.models.composio_cache`.
- Alembic: single head, all **178** revisions ancestors of the new one.

**Tests:** 12 handler-level tests (`test_team_members_activity.py`) — batching (one users query for three members; nothing queried for an empty roster), workspace scoping asserted on the actual filter expressions, last-active = max of chat/tool here, **the global sign-in provably never leaks in**, `audit:view` asked exactly once and no aggregate issued when denied, null-vs-zero, inviter resolution, explicit-UTC output. Plus vitest on the shared formatters, including timezone-independence given an explicit offset.

## After rebuild — quick check on InBuildUK

1. Open the team page as the owner: four rows now read `gerard161+inbuilduk`, `ar`, `daniel`, `bfard` instead of "Unknown User".
2. `bfard` and your own row show a real "Last active" and whatever tool runs / chats fell inside the last 30 days; `daniel` and `ar` read "0 tool runs" / "0 chats" and "never" — nothing recorded for them in this workspace.
3. Every invitee row shows "by gerard161+inbuilduk@gmail.com" under Joined.
4. If you have a viewer/editor login: both activity columns show "—" and the header pill drops "active this week".
