### PR TITLE
fix(compose): forward FIRECRAWL_API_KEY into the backend (a local .env key never reached the onboarding scan)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,6 +61,8 @@ ANTHROPIC_API_KEY=
 # Without it the Tools page says integrations are disabled and the catalogue
 # stays empty.
 COMPOSIO_KEY=
+# Firecrawl — the onboarding site scan (Settings → Onboarding; api/wizard.py). Optional.
+FIRECRAWL_API_KEY=
 
 # =============================================================================
 # Web access for your agents (PRD-240) — on by default in the local edition

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -197,6 +197,10 @@ services:
       # the process and integrations stayed off with no way to tell why.
       COMPOSIO_KEY: ${COMPOSIO_KEY:-}
       COMPOSIO_API_KEY: ${COMPOSIO_API_KEY:-}
+      # Firecrawl (the onboarding site scan, api/wizard.py): config.py reads
+      # FIRECRAWL_API_KEY but it was never forwarded — a .env key could not reach
+      # the process and the scan reported "Firecrawl is not configured" regardless.
+      FIRECRAWL_API_KEY: ${FIRECRAWL_API_KEY:-}
       # PRD-240 — agents read and search the web. On by default in the local
       # edition; WEB_ACCESS_DENY blocks hosts (suffix match); WEB_SEARCH_PROVIDER
       # pins the search engine (auto = openrouter -> composio -> searxng).


### PR DESCRIPTION
Same shape as #724's `COMPOSIO_KEY`: `config.py` reads `FIRECRAWL_API_KEY` (`api/wizard.py` refuses the onboarding site scan without it) but `docker-compose.yml` never forwarded it, so a key in `.env` could not reach the process and the wizard said *Firecrawl is not configured* regardless. Forwarded beside the other provider keys; `.env.example` carries the line. Found while adding the key to the local stack (2026-09-11).