### PR TITLE
feat(prd-242): Template Studio — fix "Failed to fetch", brand kit logo upload, usable from chat/schedules/playbooks

### DIFF
--- a/docs/PRDS/PRD-242-TEMPLATE-STUDIO-USABLE.md
+++ b/docs/PRDS/PRD-242-TEMPLATE-STUDIO-USABLE.md
@@ -1,0 +1,59 @@
+# PRD-242: Template Studio — from "Failed to fetch" to a feature a non-technical user can run
+
+> **Status:** BUILT 2026-09-12 on `feat/prd-242-template-studio` (cut from `main` @ `258a10e07`, #737). Grounded @ the 2026-09-11 report ("the templates page fails to fetch") and a deep review of the PRD-167/PRD-190 surface against the running local stack.
+
+---
+
+## Framing (CLAUDE.md §3)
+
+**Extension + two bug fixes.** PRD-167 shipped the block schema, renderers, variable resolver, brand kit and a Template Studio; PRD-190 wired `template_id` onto the agent tool and the finalisation gate. What was missing was the *last inch* of the user-facing loop: the page crashed in both editions, the local edition had nothing to show, and a person who did get a template built could neither render a document from it nor brand it with their own logo. Nothing here is a new subsystem — every story activates or repairs a primitive that already exists.
+
+## What the review found (verified against the running local stack, 2026-09-11)
+
+| # | Finding | Evidence | Fix |
+|---|---|---|---|
+| F1 | **`GET /api/documents/variables` 500s in BOTH editions.** The route (and `preview-blocks`, `templates/{id}/preview`, `generate`) passed `ctx.user.id` as `user_id` into `VariableResolver`, which queries `User.id == user_id` (INTEGER). `ctx.user.id` is the Clerk subject string (SaaS) or the operator EMAIL (local, PRD-233 S6 — by design). | `psycopg2.errors.InvalidTextRepresentation: invalid input syntax for type integer: "local@automatos.local"` in the backend log; `curl` → 500. Same class as the 2026-07-09 chat outage (#513). | **S1** — one resolver, `core/auth/principal.py::resolve_user_pk`; `api/chat.py::get_user_id` delegates to it; every document route uses it. AST regression test. |
+| F2 | **The 500 reached the browser as `TypeError: Failed to fetch`.** `@app.exception_handler(Exception)` runs in Starlette's outermost `ServerErrorMiddleware`, outside `CORSMiddleware`, so the 500 has no `Access-Control-Allow-Origin` and the browser refuses to read it. Every unhandled backend error on every page looked like a network failure. | `curl -H "Origin: http://localhost:3000"` → 500 with no ACAO header. | **S1** — `core/observability/error_response.py`, registered in `main.py` *before* `CORSMiddleware` (later-added wraps outside). Behavioural test on a mini-app + AST placement guard. |
+| F3 | **Local edition never seeds the starter templates.** `seed_starter_templates` is called only from SaaS provisioning (`core/auth/hybrid.py`); the PRD-233 local first-run seed did not call it. `document_templates` had 0 rows. | `select count(*) from document_templates` → 0 on the local DB. | **S2** — the local first-run seed calls the same idempotent seeder (fixes existing installs on next boot). |
+| F4 | **The list endpoint never returned `has_blocks`**, which the gallery used to decide whether to show *Edit*. Users could only ever *Copy* their own templates. | `TemplateSummary.has_blocks` read in `TemplateStudio.tsx`; absent from the list payload. | **S2** — `modules/documents/template_summary.py` (`has_blocks`, `is_starter`, `data_fields`, `variable_paths`), used by list + get. |
+| F5 | **No way to produce a document from the Studio.** Templates could be built but only agents could render them; the API `/generate` route did not register a Deliverable (only the agent path did). | `api/document_generation.py::generate_document` vs `agent_platform_tools.py`. | **S4/S5** — the API route registers a Deliverable and returns the same links as the tool; the UI gets a *Generate* dialog. |
+| F6 | **Playbook `generate_document` step could not take `template_id`** and never registered a Deliverable — the file lived only in the step's output JSON. | `api/recipe_executor.py` step block. | **S4** — `_document_step_config` (pure; loud on a non-UUID id), registration with `source_type="playbook"`, share link in the step output. |
+| F7 | **An emailed document link was dead.** The tool result's `download_url` is an authenticated relative app path; an agent that pasted it into Gmail/Slack sent a link nobody outside the session could open. | `result_formatter.py` LLM summary: "Download URL: /api/documents/generated/…". | **S4** — `share_url` (7-day presign on the S3 copy via the PUBLIC client) + `app_url` on the tool result, the API response and the playbook step; the LLM summary tells the agent which link to use for email. |
+| F8 | **Logo = a public https URL only.** The WeasyPrint fetcher (PRD-156 S4) refuses non-public hosts and non-http schemes; the DOCX fetcher refuses redirects. A logo in MinIO (`localhost:9000`) or a private bucket could never render, and there was no upload at all. | `generation_service._safe_url_fetcher`, `docx_renderer._safe_image_bytes`. | **S3** — `modules/documents/brand_logo.py`: PNG/JPEG upload into `DOCUMENT_STORAGE_DIR` + S3 mirror, streamed back to the UI, **inlined as a `data:` URI at render time** (already admitted by the PDF fetcher; the DOCX renderer now decodes it). |
+| F9 | **The brand kit started blank** although onboarding already knows the company name, domain, scanned brand logos, and the operator. | `business_profiles` columns; `workspaces.name`; `users`. | **S3** — `GET /brand-kit/suggestions` + a "Use my profile details" button that fills only EMPTY fields. |
+| F10 | **UX**: no guide, no tooltips, JSON-only preview data, opaque errors with no retry, no delete, no "how do I use this from chat". | `TemplateStudio.tsx` (273 lines, one file). | **S5** — split into 9 files; guide panel; tooltip registry entries; per-field form for `data.*` chips (JSON one toggle away); `ErrorState` with retry; `DeleteConfirmation`; **Use with Auto** popover (chat / schedule / email / playbook-step snippets keyed by template id). |
+
+## Decisions
+
+- **D1 · One principal resolver.** `resolve_user_pk` is the only place that maps a request principal to `users.id`. It returns `None` for principal-less callers; chat keeps its own default-user fallback on top. Nothing may hand `ctx.user.id` to an integer column (guarded by test).
+- **D2 · Unhandled errors are JSON 500s inside CORS.** The outer global handler stays as a backstop. Route-level `HTTPException`s are untouched.
+- **D3 · Uploaded logos are inlined, never fetched.** `logo_path` is server-managed (a client `PUT` cannot set it); `logo_url` stays for external public images. PNG/JPEG only — python-docx cannot embed SVG, and one accepted set keeps PDF and DOCX honest.
+- **D4 · A share link is a 7-day presign on the S3 copy** (S3's SigV4 maximum), minted through `get_public_s3_client()` so it works from a browser. It is `None` when storage holds no copy; the tool summary says so and falls back to the in-app link.
+- **D5 · Every generation is a Deliverable** — chat tool, API/UI, playbook step — with `template_id` + `template_name` on `extra`.
+- **D6 · No editor library.** The Plate adoption (PRD-167 S1 memo, dossier J6) and the `repeat`/`each` block (J4) remain Gerard's to sequence — not absorbed, not dropped.
+
+## Stories
+
+- **S1 · Identity + error surfacing** — `core/auth/principal.py`, `core/observability/error_response.py`, `main.py`, `api/chat.py`, `api/document_generation.py`. Tests: `test_prd242_principal_pk.py`, `test_prd242_unhandled_error_cors.py`.
+- **S2 · Local seed + template summary** — `core/seeds/seed_local_first_run.py`, `modules/documents/template_summary.py`. Tests: `test_prd242_template_summary.py`, `test_prd242_seed_and_playbook.py`.
+- **S3 · Brand kit: logo upload + suggestions** — `modules/documents/brand_logo.py`, `brand_kit.py` (`logo_path`), `variables/resolver.py`, `blocks/docx_renderer.py`, `api/document_brand_kit.py` (sub-router under `/api/documents`), `main.py` (`UPLOAD_PATHS`), route manifest (+4). Tests: `test_prd242_brand_logo.py`, suggestions in `test_prd242_share_links.py`.
+- **S4 · Delivery** — `generation_service.py` (`share_link`, `deliverables_app_url`, attribution, `s3_key`), `models.py`, `agent_platform_tools.py`, `result_formatter.py`, `recipe_executor.py`, API `/generate`. Tests: `test_prd242_share_links.py`, `test_prd242_seed_and_playbook.py`.
+- **S5 · Studio UX** — `frontend/components/documents/blocks/` (`TemplateStudio`, `TemplateCards`, `TemplateEditor`, `TemplateGuide`, `PreviewDataForm`, `GenerateDocumentDialog`, `UseWithAutoPopover`, `BrandKitDialog`, `PreviewPane`, `templateFields.ts`, `promptSnippets.ts`, `api.ts`, `types.ts`), `lib/tooltips.json` (`deliverables.*`). Tests: `__tests__/templateFields.test.ts`, `__tests__/promptSnippets.test.ts`.
+
+## How to use it (the answer to "then how do we use?")
+
+1. **Deliverables → Templates → Brand Kit.** Click *Use my profile details*, upload the logo, save. Every template now renders in your colours with your logo.
+2. **Pick a starter (Branded Report / Branded Letter) → Copy → rename it "Weekly Report".** The chip bar shows what fills itself (`user.*`, `brand.*`, `company.*`, `date.*`) and what must be supplied per document (`data.title`, `data.summary`, …). Type preview values in the form; the preview updates. Save.
+3. **Generate now** (the ▶ on the card or the button in the editor) renders a PDF/DOCX, saves it to Deliverables, and gives you the download, the in-app link and the 7-day share link.
+4. **From chat**: *Use with Auto → Chat* copies a prompt like *"Research AI news this week, then generate a PDF with the 'Weekly Report' template (template_id …). Fill these fields from your research: title, summary. Save it to Deliverables and give me the link."* Auto calls `platform_list_templates` → `platform_get_template_schema` → `generate_document(template_id, data)`; the document lands in Deliverables.
+5. **On a schedule**: the *Schedule* snippet ("Every Monday at 09:00: …") — Auto files it via `platform_schedule_task`; each run produces a new document.
+6. **Email it**: the *Email* snippet appends "Then email the share link to marketing@… with a two-line summary." The tool result carries the share link; with a connected Gmail/Outlook (Composio) the agent sends it. Recipients need no login.
+7. **In a playbook**: the *Playbook* snippet is a `generate_document` step with `template_id`; a research step before it feeds `{{step_1.output}}` into the fields. The rendered file registers as a Deliverable with `source_type=playbook`.
+
+## Open questions (Gerard's call — surfaced, not deferred)
+
+1. **Email *attachments*.** Today the agent emails a share link. Attaching the file through Composio needs their file-upload flow (`GMAIL_SEND_EMAIL.attachment` takes a Composio-hosted `s3key`) — a separate integration story. Link-only ships now.
+2. **Share-link TTL.** 7 days is S3's ceiling for SigV4 presigns. A longer-lived link would need a platform-hosted public route with its own token table — new surface; not built.
+3. **SaaS download path.** `serve_generated_file` 302s to a presign; the FilePreview fetches with `fetch()` and follows the redirect cross-origin. Works only if the bucket's CORS policy allows the app origin — worth checking on the SaaS bucket (out of this PRD's local-first scope).
+4. **Playbook step in the step builder UI.** The step type is API/JSON-authored (as before); exposing it in `playbook-step-builder.tsx` is a small follow-on if wanted.
+5. **Plate editor (J6) and `repeat` blocks (J4)** — unchanged from PRD-190's open questions.

--- a/frontend/components/documents/blocks/BlockEditor.tsx
+++ b/frontend/components/documents/blocks/BlockEditor.tsx
@@ -130,7 +130,7 @@ function HeadingEditor({ block, onChange, variables }: { block: HeadingBlock; on
 }
 
 function TextEditor({ block, onChange, variables }: { block: TextBlock; onChange: (b: Block) => void; variables: VariableEntry[] }) {
-  return <InlineField content={block.content} onChange={(content) => onChange({ ...block, content })} variables={variables} multiline placeholder="Paragraph text… use Insert variable for {{chips}}" />
+  return <InlineField content={block.content} onChange={(content) => onChange({ ...block, content })} variables={variables} multiline placeholder="Paragraph text… add {{chips}} with Insert variable, e.g. Dear {{data.recipient_name}}," />
 }
 
 function ImageEditor({ block, onChange }: { block: ImageBlock; onChange: (b: Block) => void }) {
@@ -240,10 +240,13 @@ function TableEditor({ block, onChange, variables }: { block: TableBlock; onChan
           </tbody>
         </table>
       </div>
+      <p className="text-xs text-muted-foreground">
+        Type <code>{'{{data.field}}'}</code> chips straight into a cell (e.g. <code>{'{{data.total}}'}</code>) — the picker below lists every path.
+      </p>
       <VariablePicker
         variables={variables}
-        label="Copy a {{chip}} to paste into a cell"
-        onInsert={() => { /* chips are typed directly into cells; picker here is a reference */ }}
+        label="Browse variable paths"
+        onInsert={() => { /* chips are typed directly into cells; the picker is a reference */ }}
       />
     </div>
   )

--- a/frontend/components/documents/blocks/BrandKitDialog.tsx
+++ b/frontend/components/documents/blocks/BrandKitDialog.tsx
@@ -1,24 +1,27 @@
 'use client'
 
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
+import { ImagePlus, Loader2, Sparkles, Trash2 } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import {
-  Dialog,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog'
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { FieldHelp } from '@/components/ui/help-tooltip'
 import { templateBlocksApi } from './api'
-import type { BrandKit } from './types'
+import type { BrandKit, BrandSuggestions } from './types'
 
 interface BrandKitDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   onSaved?: (kit: BrandKit) => void
+}
+
+const HEX = /^#([0-9a-fA-F]{6})$/
+const SOURCE_LABEL: Record<string, string> = {
+  business_profile: 'your business profile',
+  workspace: 'your workspace name',
+  user: 'your account',
 }
 
 function ColorField({ label, value, onChange }: { label: string; value: string; onChange: (v: string) => void }) {
@@ -28,7 +31,7 @@ function ColorField({ label, value, onChange }: { label: string; value: string; 
       <div className="flex items-center gap-2">
         <input
           type="color"
-          value={/^#([0-9a-fA-F]{6})$/.test(value) ? value : '#1a1a2e'}
+          value={HEX.test(value) ? value : '#1a1a2e'}
           onChange={(e) => onChange(e.target.value)}
           className="h-9 w-10 cursor-pointer rounded border bg-transparent"
           aria-label={label}
@@ -39,27 +42,133 @@ function ColorField({ label, value, onChange }: { label: string; value: string; 
   )
 }
 
-// Edit the workspace brand kit (PRD-167 S4). Drives {{brand.*}} and the PDF/DOCX palette.
+// A live swatch of what the renderers will do with the palette (heading, rule, table head).
+function KitPreview({ kit, logoUrl }: { kit: BrandKit; logoUrl: string | null }) {
+  return (
+    <div className="rounded-md border bg-white p-3 text-[#1a1a2e]" style={{ fontFamily: kit.font_family || undefined, color: kit.text_color || undefined }}>
+      {logoUrl ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img src={logoUrl} alt="Logo" className="mb-2 h-8 w-auto object-contain" />
+      ) : kit.logo_url ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img src={kit.logo_url} alt="Logo" className="mb-2 h-8 w-auto object-contain" />
+      ) : null}
+      <div className="text-base font-bold" style={{ color: kit.primary_color, borderBottom: `2px solid ${kit.accent_color}` }}>
+        {kit.name || 'Your brand'}
+      </div>
+      <div className="mt-1 text-[11px]">{kit.tagline || 'Tagline'} · {kit.company.website || 'website'}</div>
+      <div className="mt-2 grid grid-cols-2 text-[10px]">
+        <div className="px-2 py-1 text-white" style={{ background: kit.primary_color }}>Table header</div>
+        <div className="border px-2 py-1" style={{ borderColor: `${kit.secondary_color}55` }}>Cell</div>
+      </div>
+    </div>
+  )
+}
+
+// Edit the workspace brand kit (PRD-167 S4 → PRD-242 S3): logo upload, prefill from
+// what the platform already knows, every colour the renderers use, and a live swatch.
 export function BrandKitDialog({ open, onOpenChange, onSaved }: BrandKitDialogProps) {
   const [kit, setKit] = useState<BrandKit | null>(null)
+  const [loadError, setLoadError] = useState<string | null>(null)
   const [saving, setSaving] = useState(false)
+  const [uploading, setUploading] = useState(false)
+  const [logoUrl, setLogoUrl] = useState<string | null>(null)
+  const [suggestions, setSuggestions] = useState<BrandSuggestions>({})
+  const fileInput = useRef<HTMLInputElement | null>(null)
+
+  const refreshLogo = async (hasLogo: boolean) => {
+    if (!hasLogo) {
+      setLogoUrl((prev) => {
+        if (prev) URL.revokeObjectURL(prev)
+        return null
+      })
+      return
+    }
+    try {
+      const url = await templateBlocksApi.fetchLogoObjectUrl()
+      setLogoUrl((prev) => {
+        if (prev) URL.revokeObjectURL(prev)
+        return url
+      })
+    } catch {
+      setLogoUrl(null)
+    }
+  }
 
   useEffect(() => {
     if (!open) return
+    setLoadError(null)
     templateBlocksApi
       .getBrandKit()
-      .then(setKit)
-      .catch(() => toast.error('Failed to load brand kit'))
+      .then((k) => {
+        setKit(k)
+        refreshLogo(!!k.logo_path)
+      })
+      .catch((e: any) => setLoadError(e?.message || 'Failed to load brand kit'))
+    templateBlocksApi
+      .getBrandSuggestions()
+      .then((r) => setSuggestions(r.suggestions || {}))
+      .catch(() => setSuggestions({}))
   }, [open])
 
   const patch = (p: Partial<BrandKit>) => setKit((k) => (k ? { ...k, ...p } : k))
   const patchCompany = (p: Partial<BrandKit['company']>) =>
     setKit((k) => (k ? { ...k, company: { ...k.company, ...p } } : k))
 
+  const applySuggestions = () => {
+    if (!kit) return
+    const next: BrandKit = {
+      ...kit,
+      name: kit.name || suggestions.name?.value || '',
+      tagline: kit.tagline || suggestions.tagline?.value || '',
+      logo_url: kit.logo_url || (kit.logo_path ? '' : suggestions.logo_url?.value || ''),
+      company: {
+        ...kit.company,
+        name: kit.company.name || suggestions.company_name?.value || '',
+        website: kit.company.website || suggestions.website?.value || '',
+        email: kit.company.email || suggestions.email?.value || '',
+      },
+    }
+    setKit(next)
+    const sources = Array.from(new Set(Object.values(suggestions).map((s) => SOURCE_LABEL[s.source] || s.source)))
+    toast.success(`Filled empty fields from ${sources.join(' and ')}`)
+  }
+
+  const uploadLogo = async (file: File | undefined) => {
+    if (!file) return
+    setUploading(true)
+    try {
+      const saved = await templateBlocksApi.uploadLogo(file)
+      setKit((k) => (k ? { ...k, logo_path: saved.logo_path, logo_url: saved.logo_url } : k))
+      await refreshLogo(true)
+      toast.success('Logo uploaded — it will appear in every document with a logo block')
+    } catch (e: any) {
+      toast.error(e?.message || 'Logo upload failed')
+    } finally {
+      setUploading(false)
+      if (fileInput.current) fileInput.current.value = ''
+    }
+  }
+
+  const removeLogo = async () => {
+    setUploading(true)
+    try {
+      const saved = await templateBlocksApi.deleteLogo()
+      setKit((k) => (k ? { ...k, logo_path: saved.logo_path } : k))
+      await refreshLogo(false)
+      toast.success('Logo removed')
+    } catch (e: any) {
+      toast.error(e?.message || 'Could not remove the logo')
+    } finally {
+      setUploading(false)
+    }
+  }
+
   const save = async () => {
     if (!kit) return
     setSaving(true)
     try {
+      // logo_path is server-managed; the update route ignores it (validate_brand_kit strips it).
       const saved = await templateBlocksApi.updateBrandKit(kit)
       toast.success('Brand kit saved')
       onSaved?.(saved)
@@ -71,50 +180,106 @@ export function BrandKitDialog({ open, onOpenChange, onSaved }: BrandKitDialogPr
     }
   }
 
+  const hasSuggestions = Object.keys(suggestions).length > 0
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-xl max-h-[90vh] overflow-y-auto">
+      <DialogContent className="max-h-[90vh] max-w-2xl overflow-y-auto">
         <DialogHeader>
-          <DialogTitle>Brand Kit</DialogTitle>
+          <DialogTitle className="flex items-center">
+            Brand Kit <FieldHelp id="deliverables.brand_kit.title" />
+          </DialogTitle>
+          <DialogDescription>
+            Applied to every document rendered from a template — logo, colours, font, and the {'{{brand.*}}'} / {'{{company.*}}'} chips.
+          </DialogDescription>
         </DialogHeader>
-        {!kit ? (
+
+        {loadError ? (
+          <p className="py-6 text-center text-sm text-destructive">{loadError}</p>
+        ) : !kit ? (
           <div className="py-8 text-center text-sm text-muted-foreground">Loading…</div>
         ) : (
-          <div className="space-y-4">
-            <div className="grid grid-cols-2 gap-3">
-              <div>
-                <Label className="text-xs">Brand name</Label>
-                <Input value={kit.name} onChange={(e) => patch({ name: e.target.value })} />
-              </div>
-              <div>
-                <Label className="text-xs">Tagline</Label>
-                <Input value={kit.tagline} onChange={(e) => patch({ tagline: e.target.value })} />
-              </div>
-            </div>
-            <div>
-              <Label className="text-xs">Logo URL</Label>
-              <Input value={kit.logo_url} onChange={(e) => patch({ logo_url: e.target.value })} placeholder="https://…/logo.png" />
-            </div>
-            <div className="grid grid-cols-3 gap-3">
-              <ColorField label="Primary" value={kit.primary_color} onChange={(v) => patch({ primary_color: v })} />
-              <ColorField label="Secondary" value={kit.secondary_color} onChange={(v) => patch({ secondary_color: v })} />
-              <ColorField label="Accent" value={kit.accent_color} onChange={(v) => patch({ accent_color: v })} />
-            </div>
-            <div>
-              <Label className="text-xs">Font family</Label>
-              <Input value={kit.font_family} onChange={(e) => patch({ font_family: e.target.value })} placeholder="Inter, system-ui, sans-serif" />
-            </div>
-            <div className="rounded-md border p-3">
-              <p className="mb-2 text-xs font-medium text-muted-foreground">Company contact (drives {'{{company.*}}'})</p>
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-5">
+            <div className="space-y-4 md:col-span-3">
+              {hasSuggestions && (
+                <Button type="button" variant="outline" size="sm" className="gap-2" onClick={applySuggestions}>
+                  <Sparkles className="h-4 w-4" /> Use my profile details
+                  <FieldHelp id="deliverables.brand_kit.use_profile" />
+                </Button>
+              )}
               <div className="grid grid-cols-2 gap-3">
-                <Input placeholder="Address" value={kit.company.address} onChange={(e) => patchCompany({ address: e.target.value })} />
-                <Input placeholder="Email" value={kit.company.email} onChange={(e) => patchCompany({ email: e.target.value })} />
-                <Input placeholder="Phone" value={kit.company.phone} onChange={(e) => patchCompany({ phone: e.target.value })} />
-                <Input placeholder="Website" value={kit.company.website} onChange={(e) => patchCompany({ website: e.target.value })} />
+                <div>
+                  <Label className="text-xs">Brand name</Label>
+                  <Input value={kit.name} onChange={(e) => patch({ name: e.target.value })} placeholder={suggestions.name?.value || 'Acme'} />
+                </div>
+                <div>
+                  <Label className="text-xs">Tagline</Label>
+                  <Input value={kit.tagline} onChange={(e) => patch({ tagline: e.target.value })} />
+                </div>
+              </div>
+
+              <div className="rounded-md border p-3">
+                <Label className="flex items-center text-xs">
+                  Logo <FieldHelp id="deliverables.brand_kit.logo" />
+                </Label>
+                <div className="mt-2 flex flex-wrap items-center gap-2">
+                  <input
+                    ref={fileInput}
+                    type="file"
+                    accept="image/png,image/jpeg"
+                    className="hidden"
+                    onChange={(e) => uploadLogo(e.target.files?.[0])}
+                  />
+                  <Button type="button" size="sm" variant="outline" className="gap-1.5" disabled={uploading} onClick={() => fileInput.current?.click()}>
+                    {uploading ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <ImagePlus className="h-3.5 w-3.5" />}
+                    {kit.logo_path ? 'Replace logo' : 'Upload logo (PNG/JPEG)'}
+                  </Button>
+                  {kit.logo_path && (
+                    <Button type="button" size="sm" variant="ghost" className="gap-1.5 text-destructive" disabled={uploading} onClick={removeLogo}>
+                      <Trash2 className="h-3.5 w-3.5" /> Remove
+                    </Button>
+                  )}
+                </div>
+                {!kit.logo_path && (
+                  <div className="mt-2">
+                    <Label className="text-xs text-muted-foreground">…or a public image URL</Label>
+                    <Input value={kit.logo_url} onChange={(e) => patch({ logo_url: e.target.value })} placeholder="https://…/logo.png" />
+                  </div>
+                )}
+              </div>
+
+              <div className="grid grid-cols-2 gap-3">
+                <ColorField label="Primary (headings)" value={kit.primary_color} onChange={(v) => patch({ primary_color: v })} />
+                <ColorField label="Accent (rules)" value={kit.accent_color} onChange={(v) => patch({ accent_color: v })} />
+                <ColorField label="Secondary (borders)" value={kit.secondary_color} onChange={(v) => patch({ secondary_color: v })} />
+                <ColorField label="Body text" value={kit.text_color} onChange={(v) => patch({ text_color: v })} />
+              </div>
+              <div>
+                <Label className="text-xs">Font family</Label>
+                <Input value={kit.font_family} onChange={(e) => patch({ font_family: e.target.value })} placeholder="Inter, system-ui, sans-serif" />
+              </div>
+              <div className="rounded-md border p-3">
+                <p className="mb-2 flex items-center text-xs font-medium text-muted-foreground">
+                  Company contact — fills {'{{company.*}}'} <FieldHelp id="deliverables.brand_kit.company" />
+                </p>
+                <div className="grid grid-cols-2 gap-3">
+                  <Input placeholder="Company name" value={kit.company.name} onChange={(e) => patchCompany({ name: e.target.value })} />
+                  <Input placeholder="Website" value={kit.company.website} onChange={(e) => patchCompany({ website: e.target.value })} />
+                  <Input placeholder="Address" value={kit.company.address} onChange={(e) => patchCompany({ address: e.target.value })} />
+                  <Input placeholder="Email" value={kit.company.email} onChange={(e) => patchCompany({ email: e.target.value })} />
+                  <Input placeholder="Phone" value={kit.company.phone} onChange={(e) => patchCompany({ phone: e.target.value })} />
+                </div>
+              </div>
+            </div>
+            <div className="md:col-span-2">
+              <Label className="text-xs text-muted-foreground">How it renders</Label>
+              <div className="mt-1">
+                <KitPreview kit={kit} logoUrl={logoUrl} />
               </div>
             </div>
           </div>
         )}
+
         <DialogFooter>
           <Button variant="outline" onClick={() => onOpenChange(false)}>Cancel</Button>
           <Button onClick={save} disabled={saving || !kit}>{saving ? 'Saving…' : 'Save'}</Button>

--- a/frontend/components/documents/blocks/GenerateDocumentDialog.tsx
+++ b/frontend/components/documents/blocks/GenerateDocumentDialog.tsx
@@ -1,0 +1,218 @@
+'use client'
+
+import React, { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { Check, Copy, Download, ExternalLink, FileText, Loader2 } from 'lucide-react'
+import { toast } from 'sonner'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Button } from '@/components/ui/button'
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { FieldHelp } from '@/components/ui/help-tooltip'
+import { downloadGeneratedFile, templateBlocksApi } from './api'
+import { PreviewDataForm } from './PreviewDataForm'
+import type { GenerateDocumentResult, TemplateSummary, UnresolvedDetail } from './types'
+
+interface GenerateDocumentDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  template: TemplateSummary | null
+  // Prefill for the data.* fields (the editor's preview data, or the template's sample data).
+  initialData?: Record<string, any>
+  missingOnFile?: string[]
+  onOpenBrandKit: () => void
+}
+
+const FORMATS = ['pdf', 'docx'] as const
+
+function parseUnresolved(message: string): UnresolvedDetail | null {
+  // The API client stringifies a JSON `detail`; recover the finalisation-gate shape.
+  try {
+    const parsed = JSON.parse(message)
+    return parsed && typeof parsed === 'object' && 'message' in parsed ? (parsed as UnresolvedDetail) : null
+  } catch {
+    return null
+  }
+}
+
+function CopyLink({ url }: { url: string }) {
+  const [copied, setCopied] = useState(false)
+  return (
+    <Button
+      type="button"
+      size="sm"
+      variant="outline"
+      className="h-7 gap-1.5"
+      onClick={async () => {
+        try {
+          await navigator.clipboard.writeText(url)
+          setCopied(true)
+          setTimeout(() => setCopied(false), 1500)
+        } catch {
+          toast.error('Could not copy the link')
+        }
+      }}
+    >
+      {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />} Copy share link
+    </Button>
+  )
+}
+
+// Render a real document from a template, right here (PRD-242 S5). It is saved to
+// Deliverables like an agent's output, and the dialog hands over the same links.
+export function GenerateDocumentDialog({
+  open,
+  onOpenChange,
+  template,
+  initialData,
+  missingOnFile = [],
+  onOpenBrandKit,
+}: GenerateDocumentDialogProps) {
+  const [title, setTitle] = useState('')
+  const [format, setFormat] = useState<string>('pdf')
+  const [data, setData] = useState<Record<string, any>>({})
+  const [busy, setBusy] = useState(false)
+  const [result, setResult] = useState<GenerateDocumentResult | null>(null)
+  const [blocked, setBlocked] = useState<UnresolvedDetail | null>(null)
+
+  useEffect(() => {
+    if (!open || !template) return
+    setTitle(template.name)
+    setFormat(FORMATS.includes(template.format as any) ? String(template.format) : 'pdf')
+    const seed = initialData ?? (template.sample_data?.data as Record<string, any> | undefined) ?? template.sample_data ?? {}
+    setData(seed && typeof seed === 'object' ? seed : {})
+    setResult(null)
+    setBlocked(null)
+  }, [open, template, initialData])
+
+  const generate = async () => {
+    if (!template) return
+    if (!title.trim()) {
+      toast.error('Give the document a title')
+      return
+    }
+    setBusy(true)
+    setBlocked(null)
+    try {
+      const res = await templateBlocksApi.generateDocument({ title: title.trim(), format, template_id: template.id, data })
+      setResult(res)
+      toast.success('Document generated and saved to Deliverables')
+    } catch (e: any) {
+      const detail = parseUnresolved(String(e?.message || ''))
+      if (detail) setBlocked(detail)
+      else toast.error(e?.message || 'Generation failed')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const download = async () => {
+    if (!result) return
+    try {
+      await downloadGeneratedFile(result.download_url, result.filename)
+    } catch (e: any) {
+      toast.error(e?.message || 'Download failed')
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[90vh] max-w-2xl overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <FileText className="h-4 w-4" /> Generate from “{template?.name}”
+          </DialogTitle>
+          <DialogDescription>
+            Fills the template with the values below, renders it, and saves it to Deliverables — exactly what an agent does with generate_document.
+          </DialogDescription>
+        </DialogHeader>
+
+        {result ? (
+          <div className="space-y-3">
+            <Alert className="border-success/40 bg-success/5">
+              <AlertDescription className="text-sm">
+                <strong>{result.filename}</strong> ({result.size_kb} KB) is saved to Deliverables
+                {result.template_name ? ` from “${result.template_name}”` : ''}.
+              </AlertDescription>
+            </Alert>
+            <div className="flex flex-wrap items-center gap-2">
+              <Button type="button" size="sm" className="h-8 gap-1.5" onClick={download}>
+                <Download className="h-3.5 w-3.5" /> Download
+              </Button>
+              <Button asChild type="button" size="sm" variant="outline" className="h-8 gap-1.5">
+                <Link href="/deliverables?tab=outputs">
+                  <ExternalLink className="h-3.5 w-3.5" /> Open Deliverables
+                </Link>
+              </Button>
+              {result.share_url && <CopyLink url={result.share_url} />}
+            </div>
+            <p className="text-xs text-muted-foreground">
+              {result.share_url
+                ? 'The share link opens without signing in and expires in 7 days — it is what an agent emails or posts.'
+                : 'No share link: object storage holds no copy of this file, so only signed-in workspace members can download it.'}
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {blocked && (
+              <Alert variant="destructive" className="py-2">
+                <AlertDescription className="text-xs">
+                  <p className="font-medium">Not delivered — some chips did not resolve.</p>
+                  {blocked.unresolved && blocked.unresolved.length > 0 && (
+                    <p>
+                      Empty: <span className="font-mono">{blocked.unresolved.join(', ')}</span> — fill them below or in the Brand Kit.
+                    </p>
+                  )}
+                  {blocked.unknown && blocked.unknown.length > 0 && (
+                    <p>
+                      Unknown chips (fix the template): <span className="font-mono">{blocked.unknown.join(', ')}</span>
+                    </p>
+                  )}
+                </AlertDescription>
+              </Alert>
+            )}
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+              <div className="sm:col-span-2">
+                <Label className="text-xs">Document title</Label>
+                <Input value={title} onChange={(e) => setTitle(e.target.value)} />
+              </div>
+              <div>
+                <Label className="flex items-center text-xs">
+                  Format <FieldHelp id="deliverables.templates.editor.format" />
+                </Label>
+                <Select value={format} onValueChange={setFormat}>
+                  <SelectTrigger><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    {FORMATS.map((f) => (
+                      <SelectItem key={f} value={f}>{f.toUpperCase()}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+            <PreviewDataForm
+              fields={template?.data_fields ?? []}
+              data={data}
+              onChange={setData}
+              missingOnFile={missingOnFile}
+              onOpenBrandKit={onOpenBrandKit}
+              title="Values for this document"
+            />
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>{result ? 'Close' : 'Cancel'}</Button>
+          {!result && (
+            <Button type="button" onClick={generate} disabled={busy || !template}>
+              {busy ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <FileText className="mr-2 h-4 w-4" />}
+              {busy ? 'Rendering…' : 'Generate'}
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/components/documents/blocks/PreviewDataForm.tsx
+++ b/frontend/components/documents/blocks/PreviewDataForm.tsx
@@ -1,0 +1,125 @@
+'use client'
+
+import React, { useState } from 'react'
+import { Braces, Palette } from 'lucide-react'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import { FieldHelp } from '@/components/ui/help-tooltip'
+import { fieldLabel, getDataField, setDataField } from './templateFields'
+
+interface PreviewDataFormProps {
+  // The data.* names the template references (prefix stripped).
+  fields: string[]
+  // The `data` object (what generate_document's `data` carries).
+  data: Record<string, any>
+  onChange: (data: Record<string, any>) => void
+  // Catalog chips with no value on file (brand/company/user) → send the author to the Brand Kit.
+  missingOnFile: string[]
+  onOpenBrandKit: () => void
+  title?: string
+}
+
+// One input per data.* chip, so an author sees exactly the contract an agent must fill
+// (PRD-242 S5). The raw JSON stays one toggle away for nested/legacy shapes.
+export function PreviewDataForm({
+  fields,
+  data,
+  onChange,
+  missingOnFile,
+  onOpenBrandKit,
+  title = 'Fill-in fields',
+}: PreviewDataFormProps) {
+  const [advanced, setAdvanced] = useState(false)
+  const [jsonText, setJsonText] = useState(() => JSON.stringify(data, null, 2))
+  const [jsonError, setJsonError] = useState<string | null>(null)
+
+  const openAdvanced = () => {
+    setJsonText(JSON.stringify(data, null, 2))
+    setJsonError(null)
+    setAdvanced(true)
+  }
+
+  const applyJson = (text: string) => {
+    setJsonText(text)
+    try {
+      const parsed = JSON.parse(text)
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        setJsonError('Must be a JSON object')
+        return
+      }
+      setJsonError(null)
+      onChange(parsed)
+    } catch (e: any) {
+      setJsonError(e?.message || 'Invalid JSON')
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <Label className="flex items-center text-xs text-muted-foreground">
+          {title}
+          <FieldHelp id="deliverables.templates.editor.fill_in_fields" />
+        </Label>
+        <Button type="button" variant="ghost" size="sm" className="h-7 gap-1.5 text-xs" onClick={advanced ? () => setAdvanced(false) : openAdvanced}>
+          <Braces className="h-3.5 w-3.5" /> {advanced ? 'Form view' : 'JSON view'}
+        </Button>
+      </div>
+
+      {missingOnFile.length > 0 && (
+        <Alert className="border-warning/40 bg-warning/5 py-2">
+          <AlertDescription className="flex flex-wrap items-center gap-2 text-xs">
+            <span>
+              Not on file yet: <span className="font-mono">{missingOnFile.join(', ')}</span> — a document with these chips is blocked until they are filled.
+            </span>
+            <Button type="button" size="sm" variant="outline" className="h-6 gap-1 text-xs" onClick={onOpenBrandKit}>
+              <Palette className="h-3 w-3" /> Open Brand Kit
+            </Button>
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {advanced ? (
+        <div className="space-y-1">
+          <Textarea
+            value={jsonText}
+            onChange={(e) => applyJson(e.target.value)}
+            className="min-h-[120px] font-mono text-xs"
+            aria-label="Preview data as JSON"
+          />
+          {jsonError ? (
+            <p className="text-xs text-destructive">{jsonError}</p>
+          ) : (
+            <p className="text-xs text-muted-foreground">This is the object an agent passes as <code>data</code> to generate_document.</p>
+          )}
+        </div>
+      ) : fields.length === 0 ? (
+        <p className="text-xs text-muted-foreground">
+          This template has no <code>data.*</code> chips — add one with “Insert variable → data” to create a fill-in field.
+        </p>
+      ) : (
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+          {fields.map((field) => {
+            const value = getDataField(data, field)
+            const long = value.length > 80 || /summary|body|details|content|notes|appendix/i.test(field)
+            return (
+              <div key={field} className={long ? 'sm:col-span-2' : ''}>
+                <Label className="text-xs">
+                  {fieldLabel(field)} <span className="font-mono text-[10px] text-muted-foreground">data.{field}</span>
+                </Label>
+                {long ? (
+                  <Textarea value={value} onChange={(e) => onChange(setDataField(data, field, e.target.value))} className="min-h-[64px] text-sm" />
+                ) : (
+                  <Input value={value} onChange={(e) => onChange(setDataField(data, field, e.target.value))} />
+                )}
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/components/documents/blocks/PreviewPane.tsx
+++ b/frontend/components/documents/blocks/PreviewPane.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useRef, useState } from 'react'
 import { AlertTriangle, Loader2 } from 'lucide-react'
 import { Alert, AlertDescription } from '@/components/ui/alert'
+import { FieldHelp } from '@/components/ui/help-tooltip'
 import { templateBlocksApi } from './api'
 import type { BlockDocument } from './types'
 
@@ -11,9 +12,11 @@ interface PreviewPaneProps {
   data?: Record<string, any>
 }
 
+const DEBOUNCE_MS = 500
+
 // Debounced server-side render of the block tree to HTML, shown in a sandboxed iframe
 // (PRD-167 S5). Surfaces unresolved/unknown variable paths so authors fix them rather
-// than ship blanks.
+// than ship blanks — split so the author knows WHO fills each gap (PRD-242 S5).
 export function PreviewPane({ doc, data }: PreviewPaneProps) {
   const [html, setHtml] = useState('')
   const [unresolved, setUnresolved] = useState<string[]>([])
@@ -39,47 +42,58 @@ export function PreviewPane({ doc, data }: PreviewPaneProps) {
       } finally {
         setLoading(false)
       }
-    }, 500)
+    }, DEBOUNCE_MS)
     return () => {
       if (timer.current) clearTimeout(timer.current)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [serialized])
 
+  const perDocument = unresolved.filter((p) => p.startsWith('data.'))
+  const onFile = unresolved.filter((p) => !p.startsWith('data.'))
+
   return (
     <div className="flex h-full flex-col gap-2">
       <div className="flex items-center justify-between">
-        <span className="text-sm font-medium text-muted-foreground">Preview</span>
+        <span className="flex items-center text-sm font-medium text-muted-foreground">
+          Preview <FieldHelp id="deliverables.templates.editor.preview" />
+        </span>
         {loading && <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />}
       </div>
 
       {(unresolved.length > 0 || unknown.length > 0) && (
         <Alert variant="default" className="border-warning/40 bg-warning/5 py-2">
           <AlertTriangle className="h-4 w-4 text-warning" />
-          <AlertDescription className="text-xs">
-            {unresolved.length > 0 && (
+          <AlertDescription className="space-y-1 text-xs">
+            {perDocument.length > 0 && (
               <div>
-                Unresolved (will render as <code>[[path]]</code>):{' '}
-                <span className="font-mono">{unresolved.join(', ')}</span>
+                Filled per document (type a preview value or leave for the agent):{' '}
+                <span className="font-mono">{perDocument.join(', ')}</span>
+              </div>
+            )}
+            {onFile.length > 0 && (
+              <div>
+                Not on file yet — set in Brand Kit / your profile: <span className="font-mono">{onFile.join(', ')}</span>
               </div>
             )}
             {unknown.length > 0 && (
               <div>
-                Unknown variable paths: <span className="font-mono">{unknown.join(', ')}</span>
+                Unknown chips (typo? see “Insert variable” for the list): <span className="font-mono">{unknown.join(', ')}</span>
               </div>
             )}
+            <div className="text-muted-foreground">Red <code>[[markers]]</code> below show where each gap lands. A document is never delivered with one.</div>
           </AlertDescription>
         </Alert>
       )}
 
       {error ? (
         <Alert variant="destructive" className="py-2">
-          <AlertDescription className="text-xs">{error}</AlertDescription>
+          <AlertDescription className="text-xs">Preview failed: {error}</AlertDescription>
         </Alert>
       ) : (
         <iframe
           title="Template preview"
-          className="flex-1 w-full rounded-md border bg-white"
+          className="w-full flex-1 rounded-md border bg-white"
           sandbox=""
           srcDoc={html}
         />

--- a/frontend/components/documents/blocks/TemplateCards.tsx
+++ b/frontend/components/documents/blocks/TemplateCards.tsx
@@ -1,0 +1,151 @@
+'use client'
+
+import React from 'react'
+import { Copy, FileText, Pencil, Play, Sparkles, Trash2 } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import { EmptyState } from '@/components/shared'
+import { UseWithAutoPopover } from './UseWithAutoPopover'
+import type { TemplateSummary } from './types'
+
+interface TemplateCardsProps {
+  templates: TemplateSummary[]
+  onEdit: (t: TemplateSummary) => void
+  onCopy: (t: TemplateSummary) => void
+  onGenerate: (t: TemplateSummary) => void
+  onDelete: (t: TemplateSummary) => void
+  onCreate: () => void
+}
+
+function IconAction({
+  label,
+  onClick,
+  children,
+  destructive,
+}: {
+  label: string
+  onClick: () => void
+  children: React.ReactNode
+  destructive?: boolean
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className={destructive ? 'h-7 w-7 text-destructive hover:text-destructive' : 'h-7 w-7'}
+          aria-label={label}
+          onClick={onClick}
+        >
+          {children}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>{label}</TooltipContent>
+    </Tooltip>
+  )
+}
+
+function FieldsLine({ t }: { t: TemplateSummary }) {
+  if (t.has_blocks && t.data_fields.length === 0) {
+    return <p className="text-xs text-muted-foreground">No fill-in fields — renders from your brand kit and profile alone.</p>
+  }
+  if (!t.has_blocks) {
+    return (
+      <p className="text-xs text-muted-foreground">
+        Built-in layout · fills from its sample data structure (not block-editable — copy it to start a block version).
+      </p>
+    )
+  }
+  return (
+    <div className="flex flex-wrap items-center gap-1">
+      <span className="text-xs text-muted-foreground">Needs:</span>
+      {t.data_fields.map((f) => (
+        <code key={f} className="rounded bg-muted px-1 py-0.5 font-mono text-[11px]">
+          {f}
+        </code>
+      ))}
+    </div>
+  )
+}
+
+// Gallery cards (PRD-242 S5): what each template IS (starter / block / legacy), what it
+// NEEDS (data.* chips), and every action a non-technical user might want, in one place.
+export function TemplateCards({ templates, onEdit, onCopy, onGenerate, onDelete, onCreate }: TemplateCardsProps) {
+  if (templates.length === 0) {
+    return (
+      <EmptyState
+        icon={FileText}
+        title="No templates yet"
+        description="Start from a blank page, or ask Auto to draft one — every document your agents generate can use it."
+        action={
+          <Button onClick={onCreate}>
+            <Sparkles className="mr-2 h-4 w-4" /> New template
+          </Button>
+        }
+      />
+    )
+  }
+
+  return (
+    <TooltipProvider delayDuration={200}>
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {templates.map((t) => (
+          <Card key={t.id} className="group flex flex-col transition-colors hover:border-primary/30">
+            <CardContent className="flex flex-1 flex-col p-5">
+              <div className="mb-2 flex items-start justify-between gap-2">
+                <div className="min-w-0 flex-1">
+                  <h3 className="truncate font-semibold">{t.name}</h3>
+                  <p className="mt-1 line-clamp-2 text-sm text-muted-foreground">{t.description || 'No description'}</p>
+                </div>
+                <div className="flex shrink-0 flex-col items-end gap-1">
+                  <Badge variant="outline" className="uppercase">{String(t.format)}</Badge>
+                  {t.is_starter && (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Badge variant="secondary" className="text-[10px]">Starter</Badge>
+                      </TooltipTrigger>
+                      <TooltipContent className="max-w-xs">
+                        A platform starter. Copy it to customise — your copy is yours to edit or delete; the starter stays.
+                      </TooltipContent>
+                    </Tooltip>
+                  )}
+                </div>
+              </div>
+
+              <div className="mb-3">
+                <FieldsLine t={t} />
+              </div>
+
+              <div className="mt-auto flex items-center justify-between gap-2 pt-2">
+                <Badge variant="secondary" className="text-xs">{t.category}</Badge>
+                <div className="flex items-center gap-0.5">
+                  {t.has_blocks && !t.is_starter && (
+                    <IconAction label="Edit" onClick={() => onEdit(t)}>
+                      <Pencil className="h-3.5 w-3.5" />
+                    </IconAction>
+                  )}
+                  <IconAction label={t.has_blocks ? 'Copy to customise' : 'Copy as a block template'} onClick={() => onCopy(t)}>
+                    <Copy className="h-3.5 w-3.5" />
+                  </IconAction>
+                  <IconAction label="Generate a document now" onClick={() => onGenerate(t)}>
+                    <Play className="h-3.5 w-3.5" />
+                  </IconAction>
+                  {!t.is_starter && (
+                    <IconAction label="Delete" destructive onClick={() => onDelete(t)}>
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </IconAction>
+                  )}
+                  <UseWithAutoPopover template={t} />
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </TooltipProvider>
+  )
+}

--- a/frontend/components/documents/blocks/TemplateEditor.tsx
+++ b/frontend/components/documents/blocks/TemplateEditor.tsx
@@ -1,0 +1,164 @@
+'use client'
+
+import React, { useMemo } from 'react'
+import { ArrowLeft, FileText, Palette, Save } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { FieldHelp } from '@/components/ui/help-tooltip'
+import { BlockEditor } from './BlockEditor'
+import { PreviewDataForm } from './PreviewDataForm'
+import { PreviewPane } from './PreviewPane'
+import { UseWithAutoPopover } from './UseWithAutoPopover'
+import { collectDataFields, collectMissingOnFile, collectVariablePaths } from './templateFields'
+import { SCHEMA_VERSION } from './types'
+import type { Block, VariableEntry } from './types'
+
+export const CATEGORIES = ['general', 'report', 'invoice', 'contract', 'letter', 'proposal', 'data']
+export const FORMATS = ['pdf', 'docx']
+
+export interface EditorDraft {
+  id: string | null // null = new (or a copy)
+  name: string
+  description: string
+  category: string
+  format: string
+  blocks: Block[]
+  previewData: Record<string, any>
+}
+
+interface TemplateEditorProps {
+  draft: EditorDraft
+  variables: VariableEntry[]
+  saving: boolean
+  onChange: (draft: EditorDraft) => void
+  onBack: () => void
+  onSave: () => void
+  onGenerate: () => void
+  onOpenBrandKit: () => void
+}
+
+// The authoring surface (PRD-167 S5 → PRD-242 S5): template metadata, the block
+// editor, the fill-in fields it implies, and the live preview — with the chip
+// contract summarised so the author sees what an agent will have to supply.
+export function TemplateEditor({
+  draft,
+  variables,
+  saving,
+  onChange,
+  onBack,
+  onSave,
+  onGenerate,
+  onOpenBrandKit,
+}: TemplateEditorProps) {
+  const paths = useMemo(() => collectVariablePaths(draft.blocks), [draft.blocks])
+  const dataFields = useMemo(() => collectDataFields(draft.blocks), [draft.blocks])
+  const missingOnFile = useMemo(() => collectMissingOnFile(paths, variables), [paths, variables])
+  const autoFilled = paths.filter((p) => !p.startsWith('data.'))
+  const patch = (p: Partial<EditorDraft>) => onChange({ ...draft, ...p })
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <Button variant="ghost" size="sm" onClick={onBack}>
+          <ArrowLeft className="mr-2 h-4 w-4" /> Back to templates
+        </Button>
+        <div className="flex flex-wrap items-center gap-2">
+          <Button variant="outline" size="sm" onClick={onOpenBrandKit}>
+            <Palette className="mr-2 h-4 w-4" /> Brand Kit
+          </Button>
+          {draft.id && (
+            <UseWithAutoPopover template={{ id: draft.id, name: draft.name, format: draft.format, data_fields: dataFields }} />
+          )}
+          <Button variant="outline" size="sm" onClick={onGenerate} disabled={!draft.id}>
+            <FileText className="mr-2 h-4 w-4" /> Generate a document
+          </Button>
+          <Button size="sm" onClick={onSave} disabled={saving}>
+            <Save className="mr-2 h-4 w-4" /> {saving ? 'Saving…' : draft.id ? 'Save changes' : 'Save template'}
+          </Button>
+        </div>
+      </div>
+      {!draft.id && (
+        <p className="text-xs text-muted-foreground">Save the template first to generate from it or hand it to Auto — it needs an id.</p>
+      )}
+
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-4">
+        <div className="sm:col-span-2">
+          <Label className="flex items-center text-xs">
+            Name <FieldHelp id="deliverables.templates.editor.name" />
+          </Label>
+          <Input value={draft.name} onChange={(e) => patch({ name: e.target.value })} placeholder="Weekly Report" />
+        </div>
+        <div>
+          <Label className="flex items-center text-xs">
+            Category <FieldHelp id="deliverables.templates.editor.category" />
+          </Label>
+          <Select value={draft.category} onValueChange={(category) => patch({ category })}>
+            <SelectTrigger><SelectValue /></SelectTrigger>
+            <SelectContent>
+              {CATEGORIES.map((c) => (
+                <SelectItem key={c} value={c}>{c[0].toUpperCase() + c.slice(1)}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div>
+          <Label className="flex items-center text-xs">
+            Default format <FieldHelp id="deliverables.templates.editor.format" />
+          </Label>
+          <Select value={draft.format} onValueChange={(format) => patch({ format })}>
+            <SelectTrigger><SelectValue /></SelectTrigger>
+            <SelectContent>
+              {FORMATS.map((f) => (
+                <SelectItem key={f} value={f}>{f.toUpperCase()}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="sm:col-span-4">
+          <Label className="text-xs">Description</Label>
+          <Input
+            value={draft.description}
+            onChange={(e) => patch({ description: e.target.value })}
+            placeholder="What this template is for — agents read this when choosing a template"
+          />
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-1.5 rounded-md border bg-muted/30 px-3 py-2 text-xs">
+        <span className="font-medium">Chips in this template:</span>
+        {paths.length === 0 && <span className="text-muted-foreground">none yet — use “Insert variable” inside a block</span>}
+        {dataFields.map((f) => (
+          <Badge key={f} variant="outline" className="font-mono text-[10px]">data.{f}</Badge>
+        ))}
+        {autoFilled.map((p) => (
+          <Badge key={p} variant="secondary" className="font-mono text-[10px]">{p}</Badge>
+        ))}
+        {paths.length > 0 && (
+          <span className="ml-1 text-muted-foreground">
+            — outlined chips are filled per document (by an agent or you); grey ones fill themselves from your profile, brand kit and the date.
+          </span>
+        )}
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <div className="space-y-4">
+          <BlockEditor blocks={draft.blocks} variables={variables} onChange={(blocks) => patch({ blocks })} />
+          <PreviewDataForm
+            fields={dataFields}
+            data={draft.previewData}
+            onChange={(previewData) => patch({ previewData })}
+            missingOnFile={missingOnFile}
+            onOpenBrandKit={onOpenBrandKit}
+            title="Preview values (also saved as the template's sample data)"
+          />
+        </div>
+        <div className="lg:sticky lg:top-4 lg:h-[80vh]">
+          <PreviewPane doc={{ version: SCHEMA_VERSION, blocks: draft.blocks }} data={draft.previewData} />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/components/documents/blocks/TemplateGuide.tsx
+++ b/frontend/components/documents/blocks/TemplateGuide.tsx
@@ -1,0 +1,140 @@
+'use client'
+
+import React, { useEffect, useState } from 'react'
+import { BookOpen, Bot, Braces, ChevronDown, ChevronUp, Palette, X } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import { cn } from '@/lib/utils'
+
+const DISMISSED_KEY = 'automatos.templates.guide.dismissed'
+
+function readDismissed(): boolean {
+  try {
+    return localStorage.getItem(DISMISSED_KEY) === '1'
+  } catch {
+    return false
+  }
+}
+
+function writeDismissed(value: boolean) {
+  try {
+    if (value) localStorage.setItem(DISMISSED_KEY, '1')
+    else localStorage.removeItem(DISMISSED_KEY)
+  } catch {
+    /* private mode / blocked storage — the guide simply shows again next time */
+  }
+}
+
+const STEPS: { icon: React.ComponentType<{ className?: string }>; title: string; body: string }[] = [
+  {
+    icon: Palette,
+    title: '1 · Set your Brand Kit once',
+    body: 'Upload your logo and pick your colours. Every document rendered from any template picks them up — {{brand.*}} and {{company.*}} chips fill in from here and from your business profile.',
+  },
+  {
+    icon: Braces,
+    title: '2 · Build a template from blocks',
+    body: 'Headings, text, tables, your logo. Drop in chips: {{user.name}} and {{date.long}} fill themselves; {{data.title}} and other data.* chips are the fields an agent (or you) supplies when a document is generated.',
+  },
+  {
+    icon: Bot,
+    title: '3 · Use it from chat, a schedule, or a playbook',
+    body: 'Tell Auto “generate the Weekly Report with the … template” — it lists your templates, reads which data.* fields each needs, fills them from its research, and saves the PDF/DOCX to Deliverables with a share link you can email.',
+  },
+]
+
+interface TemplateGuideProps {
+  onOpenBrandKit: () => void
+  className?: string
+}
+
+// "How templates work" — a dismissable, per-browser panel (PRD-242 S5). The three
+// steps are the whole feature in one screen so a first-time user never has to guess.
+export function TemplateGuide({ onOpenBrandKit, className }: TemplateGuideProps) {
+  const [dismissed, setDismissed] = useState(true) // assume dismissed until storage is read (no flash)
+  const [collapsed, setCollapsed] = useState(false)
+
+  useEffect(() => {
+    setDismissed(readDismissed())
+  }, [])
+
+  if (dismissed) {
+    return (
+      <div className={cn('flex justify-end', className)}>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-7 gap-1.5 text-xs text-muted-foreground"
+          onClick={() => {
+            writeDismissed(false)
+            setDismissed(false)
+          }}
+        >
+          <BookOpen className="h-3.5 w-3.5" /> How templates work
+        </Button>
+      </div>
+    )
+  }
+
+  return (
+    <Card className={cn('border-primary/20 bg-primary/[0.03]', className)}>
+      <CardContent className="p-4 sm:p-5">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex items-center gap-2">
+            <BookOpen className="h-4 w-4 text-primary" />
+            <h3 className="text-sm font-semibold">How templates work</h3>
+          </div>
+          <div className="flex items-center gap-1">
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7"
+              aria-label={collapsed ? 'Expand guide' : 'Collapse guide'}
+              onClick={() => setCollapsed((c) => !c)}
+            >
+              {collapsed ? <ChevronDown className="h-4 w-4" /> : <ChevronUp className="h-4 w-4" />}
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7"
+              aria-label="Dismiss guide"
+              onClick={() => {
+                writeDismissed(true)
+                setDismissed(true)
+              }}
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          </div>
+        </div>
+
+        {!collapsed && (
+          <>
+            <div className="mt-4 grid grid-cols-1 gap-4 md:grid-cols-3">
+              {STEPS.map(({ icon: Icon, title, body }) => (
+                <div key={title} className="flex gap-3">
+                  <div className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-background border">
+                    <Icon className="h-4 w-4 text-primary" />
+                  </div>
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium">{title}</p>
+                    <p className="mt-1 text-xs leading-relaxed text-muted-foreground">{body}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+            <div className="mt-4 flex flex-wrap items-center gap-2">
+              <Button size="sm" variant="outline" onClick={onOpenBrandKit}>
+                <Palette className="mr-2 h-4 w-4" /> Start with the Brand Kit
+              </Button>
+              <p className="text-xs text-muted-foreground">
+                A document with an unfilled chip is never delivered — the preview shows every gap before you save.
+              </p>
+            </div>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/components/documents/blocks/TemplateStudio.tsx
+++ b/frontend/components/documents/blocks/TemplateStudio.tsx
@@ -1,71 +1,65 @@
 'use client'
 
 import React, { useCallback, useEffect, useState } from 'react'
-import { ArrowLeft, Copy, FileText, Palette, Pencil, Plus, Save } from 'lucide-react'
+import { Palette, Plus } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
-import { Badge } from '@/components/ui/badge'
-import { Card, CardContent } from '@/components/ui/card'
-import { Textarea } from '@/components/ui/textarea'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select'
-import { apiClient } from '@/lib/api-client'
-import { BlockEditor } from './BlockEditor'
-import { PreviewPane } from './PreviewPane'
-import { BrandKitDialog } from './BrandKitDialog'
+import { HelpTooltip } from '@/components/ui/help-tooltip'
+import { DeleteConfirmation, ErrorState, LoadingState } from '@/components/shared'
 import { templateBlocksApi } from './api'
+import { BrandKitDialog } from './BrandKitDialog'
+import { GenerateDocumentDialog } from './GenerateDocumentDialog'
+import { TemplateCards } from './TemplateCards'
+import { TemplateEditor, type EditorDraft } from './TemplateEditor'
+import { TemplateGuide } from './TemplateGuide'
 import { newBlockId } from './inline'
+import { collectMissingOnFile } from './templateFields'
 import { SCHEMA_VERSION } from './types'
-import type { Block, BlockDocument, VariableEntry } from './types'
+import type { BlockDocument, TemplateSummary, VariableEntry } from './types'
 
-interface TemplateSummary {
-  id: string
-  name: string
-  description?: string
-  format: string
-  category: string
-  has_blocks?: boolean
+function blankDraft(): EditorDraft {
+  return {
+    id: null,
+    name: '',
+    description: '',
+    category: 'report',
+    format: 'pdf',
+    blocks: [{ type: 'heading', id: newBlockId(), level: 1, content: [] }],
+    previewData: {},
+  }
 }
 
-const CATEGORIES = ['general', 'report', 'invoice', 'contract', 'letter', 'proposal', 'data']
+function sampleDataOf(sample: Record<string, any> | null | undefined): Record<string, any> {
+  if (!sample || typeof sample !== 'object') return {}
+  const inner = (sample as Record<string, any>).data
+  return inner && typeof inner === 'object' ? inner : sample
+}
 
-// PRD-167 S5: the non-technical block-template studio — gallery (copy-on-customise),
-// block editor, live preview, and brand-kit access in one surface.
+// PRD-167 S5 → PRD-242 S5: the non-technical Template Studio — a guided gallery
+// (copy-on-customise), the block editor with live preview, brand kit, and a
+// generate-now path that lands in Deliverables. Errors show their cause and retry.
 export function TemplateStudio() {
   const [mode, setMode] = useState<'gallery' | 'editor'>('gallery')
   const [templates, setTemplates] = useState<TemplateSummary[]>([])
   const [variables, setVariables] = useState<VariableEntry[]>([])
-  const [brandOpen, setBrandOpen] = useState(false)
   const [loading, setLoading] = useState(true)
-
-  // Editor state
-  const [editingId, setEditingId] = useState<string | null>(null)
-  const [name, setName] = useState('')
-  const [description, setDescription] = useState('')
-  const [category, setCategory] = useState('report')
-  const [format, setFormat] = useState('pdf')
-  const [blocks, setBlocks] = useState<Block[]>([])
-  const [previewData, setPreviewData] = useState('{\n  "data": {}\n}')
+  const [loadError, setLoadError] = useState<unknown>(null)
+  const [brandOpen, setBrandOpen] = useState(false)
+  const [draft, setDraft] = useState<EditorDraft>(blankDraft)
   const [saving, setSaving] = useState(false)
+  const [generateFor, setGenerateFor] = useState<TemplateSummary | null>(null)
+  const [generateData, setGenerateData] = useState<Record<string, any> | undefined>(undefined)
+  const [deleteFor, setDeleteFor] = useState<TemplateSummary | null>(null)
 
   const loadGallery = useCallback(async () => {
     setLoading(true)
+    setLoadError(null)
     try {
-      const [tpls, vars] = await Promise.all([
-        apiClient.get<TemplateSummary[]>('/api/documents/templates'),
-        templateBlocksApi.getVariables(),
-      ])
+      const [tpls, vars] = await Promise.all([templateBlocksApi.listTemplates(), templateBlocksApi.getVariables()])
       setTemplates(tpls)
       setVariables(vars.variables)
     } catch (e) {
-      toast.error('Failed to load templates')
+      setLoadError(e)
     } finally {
       setLoading(false)
     }
@@ -76,140 +70,140 @@ export function TemplateStudio() {
   }, [loadGallery])
 
   const startBlank = () => {
-    setEditingId(null)
-    setName('')
-    setDescription('')
-    setCategory('report')
-    setFormat('pdf')
-    setBlocks([{ type: 'heading', id: newBlockId(), level: 1, content: [] }])
-    setPreviewData('{\n  "data": {}\n}')
+    setDraft(blankDraft())
     setMode('editor')
   }
 
-  const openTemplate = async (id: string, asCopy: boolean) => {
+  const openTemplate = async (t: TemplateSummary, asCopy: boolean) => {
     try {
-      const full = await apiClient.get<any>(`/api/documents/templates/${id}`)
-      setEditingId(asCopy ? null : id)
-      setName(asCopy ? `${full.name} (copy)` : full.name)
-      setDescription(full.description || '')
-      setCategory(full.category || 'report')
-      setFormat(full.format || 'pdf')
+      const full = await templateBlocksApi.getTemplate(t.id)
       const doc: BlockDocument | null = full.blocks
-      setBlocks(doc?.blocks ?? [])
-      setPreviewData(JSON.stringify(full.sample_data || { data: {} }, null, 2))
+      setDraft({
+        id: asCopy ? null : full.id,
+        name: asCopy ? `${full.name} (copy)` : full.name,
+        description: full.description || '',
+        category: full.category || 'report',
+        format: full.format || 'pdf',
+        blocks: doc?.blocks ?? blankDraft().blocks,
+        previewData: sampleDataOf(full.sample_data),
+      })
       setMode('editor')
-    } catch {
-      toast.error('Failed to open template')
+      if (asCopy && !full.has_blocks) {
+        toast.info('This layout is not block-based — your copy starts as a blank block template with its sample values.')
+      }
+    } catch (e: any) {
+      toast.error(`Could not open template: ${e?.message || 'unknown error'}`)
     }
   }
 
-  const parsedPreviewData = (() => {
-    try {
-      return JSON.parse(previewData)
-    } catch {
-      return {}
-    }
-  })()
-
   const save = async () => {
-    if (!name.trim()) {
+    if (!draft.name.trim()) {
       toast.error('Template needs a name')
       return
     }
     setSaving(true)
-    const doc: BlockDocument = { version: SCHEMA_VERSION, blocks }
-    const body = { name, description, category, format, blocks: doc }
+    const body = {
+      name: draft.name.trim(),
+      description: draft.description,
+      category: draft.category,
+      format: draft.format,
+      blocks: { version: SCHEMA_VERSION, blocks: draft.blocks },
+      sample_data: { data: draft.previewData },
+    }
     try {
-      if (editingId) {
-        await apiClient.put(`/api/documents/templates/${editingId}`, body)
+      if (draft.id) {
+        await templateBlocksApi.updateTemplate(draft.id, body)
+        toast.success('Template saved')
       } else {
-        await apiClient.post('/api/documents/templates', body)
+        const created = await templateBlocksApi.createTemplate(body)
+        setDraft({ ...draft, id: created.id })
+        toast.success('Template created — you can now generate from it or hand it to Auto')
       }
-      toast.success('Template saved')
-      setMode('gallery')
-      loadGallery()
+      await loadGallery()
     } catch (e: any) {
-      // Surface field-level block errors from the 422 (PRD-167 S2).
-      const detail = e?.response?.data?.detail
-      if (detail?.errors) {
-        toast.error(`Invalid blocks: ${detail.errors.map((x: any) => `${x.loc} ${x.msg}`).join('; ')}`)
-      } else {
-        toast.error(e?.message || 'Failed to save template')
+      // Field-level block errors from the 422 arrive as a stringified detail (PRD-167 S2).
+      const message = String(e?.message || '')
+      try {
+        const detail = JSON.parse(message)
+        if (detail?.errors) {
+          toast.error(`Invalid blocks: ${detail.errors.map((x: any) => `${x.loc} ${x.msg}`).join('; ')}`)
+          return
+        }
+      } catch {
+        /* not JSON — fall through */
       }
+      toast.error(message || 'Failed to save template')
     } finally {
       setSaving(false)
     }
   }
 
-  if (mode === 'editor') {
-    return (
-      <div className="space-y-4">
-        <div className="flex items-center justify-between gap-3">
-          <Button variant="ghost" size="sm" onClick={() => setMode('gallery')}>
-            <ArrowLeft className="mr-2 h-4 w-4" /> Back
-          </Button>
-          <div className="flex items-center gap-2">
-            <Button variant="outline" size="sm" onClick={() => setBrandOpen(true)}>
-              <Palette className="mr-2 h-4 w-4" /> Brand Kit
-            </Button>
-            <Button size="sm" onClick={save} disabled={saving}>
-              <Save className="mr-2 h-4 w-4" /> {saving ? 'Saving…' : 'Save template'}
-            </Button>
-          </div>
-        </div>
+  const confirmDelete = async () => {
+    if (!deleteFor) return
+    await templateBlocksApi.deleteTemplate(deleteFor.id)
+    toast.success(`Deleted “${deleteFor.name}”`)
+    setDeleteFor(null)
+    await loadGallery()
+  }
 
-        <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-          <div className="sm:col-span-1">
-            <Label className="text-xs">Name</Label>
-            <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="Branded Letter" />
-          </div>
-          <div>
-            <Label className="text-xs">Category</Label>
-            <Select value={category} onValueChange={setCategory}>
-              <SelectTrigger><SelectValue /></SelectTrigger>
-              <SelectContent>
-                {CATEGORIES.map((c) => (
-                  <SelectItem key={c} value={c}>{c[0].toUpperCase() + c.slice(1)}</SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-          <div>
-            <Label className="text-xs">Description</Label>
-            <Input value={description} onChange={(e) => setDescription(e.target.value)} placeholder="What this template is for" />
-          </div>
-        </div>
-
-        <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-          <div className="space-y-3">
-            <BlockEditor blocks={blocks} variables={variables} onChange={setBlocks} />
-            <div>
-              <Label className="text-xs text-muted-foreground">Preview data (fills {'{{data.*}}'} chips)</Label>
-              <Textarea
-                value={previewData}
-                onChange={(e) => setPreviewData(e.target.value)}
-                className="font-mono text-xs min-h-[80px]"
-              />
-            </div>
-          </div>
-          <div className="lg:sticky lg:top-4 lg:h-[80vh]">
-            <PreviewPane doc={{ version: SCHEMA_VERSION, blocks }} data={parsedPreviewData.data || parsedPreviewData} />
-          </div>
-        </div>
-
-        <BrandKitDialog open={brandOpen} onOpenChange={setBrandOpen} />
-      </div>
+  const openGenerateForDraft = () => {
+    if (!draft.id) return
+    const current = templates.find((t) => t.id === draft.id)
+    setGenerateData(draft.previewData)
+    setGenerateFor(
+      current ?? {
+        id: draft.id,
+        name: draft.name,
+        description: draft.description,
+        format: draft.format,
+        category: draft.category,
+        tags: [],
+        version: 1,
+        has_blocks: true,
+        is_starter: false,
+        variable_paths: [],
+        data_fields: [],
+      },
     )
   }
 
-  // Gallery
+  const missingForGenerate = generateFor ? collectMissingOnFile(generateFor.variable_paths, variables) : []
+
+  if (mode === 'editor') {
+    return (
+      <>
+        <TemplateEditor
+          draft={draft}
+          variables={variables}
+          saving={saving}
+          onChange={setDraft}
+          onBack={() => setMode('gallery')}
+          onSave={save}
+          onGenerate={openGenerateForDraft}
+          onOpenBrandKit={() => setBrandOpen(true)}
+        />
+        <BrandKitDialog open={brandOpen} onOpenChange={setBrandOpen} onSaved={() => loadGallery()} />
+        <GenerateDocumentDialog
+          open={!!generateFor}
+          onOpenChange={(open) => !open && setGenerateFor(null)}
+          template={generateFor}
+          initialData={generateData}
+          missingOnFile={missingForGenerate}
+          onOpenBrandKit={() => setBrandOpen(true)}
+        />
+      </>
+    )
+  }
+
   return (
     <div className="space-y-6">
       <div className="flex flex-col items-start justify-between gap-4 sm:flex-row sm:items-center">
         <div>
-          <h2 className="text-xl font-bold">Template Studio</h2>
+          <h2 className="flex items-center text-xl font-bold">
+            Template Studio <HelpTooltip id="deliverables.templates.gallery.title" inline />
+          </h2>
           <p className="text-sm text-muted-foreground">
-            Build branded document templates with blocks and variable chips — no code.
+            Branded document templates your agents fill — reports, letters, invoices — no code.
           </p>
         </div>
         <div className="flex gap-2">
@@ -222,52 +216,47 @@ export function TemplateStudio() {
         </div>
       </div>
 
+      <TemplateGuide onOpenBrandKit={() => setBrandOpen(true)} />
+
       {loading ? (
-        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
-          {[1, 2, 3].map((i) => (
-            <Card key={i} className="animate-pulse"><CardContent className="h-32 p-6" /></Card>
-          ))}
-        </div>
+        <LoadingState variant="cards" count={3} label="Loading templates" />
+      ) : loadError ? (
+        <ErrorState
+          title="Templates could not be loaded"
+          error={loadError}
+          onRetry={loadGallery}
+          retryLabel="Try again"
+        />
       ) : (
-        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
-          {templates.map((t) => (
-            <Card key={t.id} className="group transition-colors hover:border-primary/30">
-              <CardContent className="p-5">
-                <div className="mb-3 flex items-start justify-between">
-                  <div className="min-w-0 flex-1">
-                    <h3 className="truncate font-semibold">{t.name}</h3>
-                    <p className="mt-1 line-clamp-2 text-sm text-muted-foreground">{t.description || 'No description'}</p>
-                  </div>
-                  <Badge variant="outline" className="uppercase">{t.format}</Badge>
-                </div>
-                <div className="mt-4 flex items-center justify-between">
-                  <Badge variant="secondary" className="text-xs">{t.category}</Badge>
-                  <div className="flex gap-1">
-                    {t.has_blocks && (
-                      <Button variant="ghost" size="sm" className="h-7" onClick={() => openTemplate(t.id, false)}>
-                        <Pencil className="mr-1.5 h-3.5 w-3.5" /> Edit
-                      </Button>
-                    )}
-                    <Button variant="ghost" size="sm" className="h-7" onClick={() => openTemplate(t.id, true)}>
-                      <Copy className="mr-1.5 h-3.5 w-3.5" /> Copy
-                    </Button>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
-          ))}
-          {templates.length === 0 && (
-            <Card className="md:col-span-2 lg:col-span-3">
-              <CardContent className="p-12 text-center text-muted-foreground">
-                <FileText className="mx-auto mb-4 h-12 w-12 opacity-50" />
-                <p>No templates yet. Create one to get started.</p>
-              </CardContent>
-            </Card>
-          )}
-        </div>
+        <TemplateCards
+          templates={templates}
+          onEdit={(t) => openTemplate(t, false)}
+          onCopy={(t) => openTemplate(t, true)}
+          onGenerate={(t) => {
+            setGenerateData(undefined)
+            setGenerateFor(t)
+          }}
+          onDelete={setDeleteFor}
+          onCreate={startBlank}
+        />
       )}
 
-      <BrandKitDialog open={brandOpen} onOpenChange={setBrandOpen} />
+      <BrandKitDialog open={brandOpen} onOpenChange={setBrandOpen} onSaved={() => loadGallery()} />
+      <GenerateDocumentDialog
+        open={!!generateFor}
+        onOpenChange={(open) => !open && setGenerateFor(null)}
+        template={generateFor}
+        initialData={generateData}
+        missingOnFile={missingForGenerate}
+        onOpenBrandKit={() => setBrandOpen(true)}
+      />
+      <DeleteConfirmation
+        open={!!deleteFor}
+        onOpenChange={(open) => !open && setDeleteFor(null)}
+        title="Delete template?"
+        itemName={deleteFor?.name}
+        onConfirm={confirmDelete}
+      />
     </div>
   )
 }

--- a/frontend/components/documents/blocks/UseWithAutoPopover.tsx
+++ b/frontend/components/documents/blocks/UseWithAutoPopover.tsx
@@ -1,0 +1,89 @@
+'use client'
+
+import React, { useState } from 'react'
+import { Bot, Check, Copy } from 'lucide-react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { autoPrompt, emailPrompt, playbookStepJson, schedulePrompt } from './promptSnippets'
+import type { TemplateSummary } from './types'
+
+interface UseWithAutoPopoverProps {
+  template: Pick<TemplateSummary, 'id' | 'name' | 'format' | 'data_fields'>
+  size?: 'sm' | 'default'
+}
+
+function CopyBlock({ text, hint }: { text: string; hint: string }) {
+  const [copied, setCopied] = useState(false)
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(text)
+      setCopied(true)
+      toast.success('Copied')
+      setTimeout(() => setCopied(false), 1500)
+    } catch {
+      toast.error('Could not copy — select the text and copy it manually')
+    }
+  }
+  return (
+    <div className="space-y-2">
+      <p className="text-xs text-muted-foreground">{hint}</p>
+      <pre className="max-h-40 overflow-auto whitespace-pre-wrap rounded-md border bg-muted/40 p-2 text-[11px] leading-relaxed">
+        {text}
+      </pre>
+      <Button type="button" size="sm" variant="outline" className="h-7 gap-1.5" onClick={copy}>
+        {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />} Copy
+      </Button>
+    </div>
+  )
+}
+
+// The "how do I actually use this?" answer, per template (PRD-242 S5): a prompt for
+// chat, one for a schedule, one that emails the result, and a playbook step.
+export function UseWithAutoPopover({ template, size = 'sm' }: UseWithAutoPopoverProps) {
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button type="button" variant="outline" size={size} className={size === 'sm' ? 'h-7 gap-1.5' : 'gap-2'}>
+          <Bot className="h-3.5 w-3.5" /> Use with Auto
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-[26rem] max-w-[95vw] p-3">
+        <p className="mb-2 text-sm font-medium">Use “{template.name}” from…</p>
+        <Tabs defaultValue="chat">
+          <TabsList className="grid w-full grid-cols-4">
+            <TabsTrigger value="chat">Chat</TabsTrigger>
+            <TabsTrigger value="schedule">Schedule</TabsTrigger>
+            <TabsTrigger value="email">Email</TabsTrigger>
+            <TabsTrigger value="playbook">Playbook</TabsTrigger>
+          </TabsList>
+          <TabsContent value="chat" className="mt-3">
+            <CopyBlock
+              hint="Paste into the chat with Auto (or any agent with document tools). Replace the placeholder with what to research."
+              text={autoPrompt(template)}
+            />
+          </TabsContent>
+          <TabsContent value="schedule" className="mt-3">
+            <CopyBlock
+              hint="Auto files it as a scheduled task; each run produces a fresh document in Deliverables."
+              text={schedulePrompt(template)}
+            />
+          </TabsContent>
+          <TabsContent value="email" className="mt-3">
+            <CopyBlock
+              hint="Needs a connected email app (Composio Gmail/Outlook). The agent sends the 7-day share link — no sign-in needed to open it."
+              text={emailPrompt(template)}
+            />
+          </TabsContent>
+          <TabsContent value="playbook" className="mt-3">
+            <CopyBlock
+              hint="A deterministic playbook step: a research step (step 1) feeds this one. Pass it as a step in the playbook's JSON definition."
+              text={playbookStepJson(template)}
+            />
+          </TabsContent>
+        </Tabs>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/frontend/components/documents/blocks/__tests__/promptSnippets.test.ts
+++ b/frontend/components/documents/blocks/__tests__/promptSnippets.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { autoPrompt, emailPrompt, playbookStepJson, schedulePrompt } from '../promptSnippets'
+
+const t = { id: '11111111-1111-1111-1111-111111111111', name: 'Weekly Report', format: 'pdf', data_fields: ['title', 'summary'] }
+
+describe('promptSnippets', () => {
+  it('names the template by id and lists the fill-in fields', () => {
+    const p = autoPrompt(t, 'AI news this week')
+    expect(p).toContain('Research AI news this week')
+    expect(p).toContain('"Weekly Report" template (template_id 11111111-1111-1111-1111-111111111111)')
+    expect(p).toContain('Fill these fields from your research: title, summary.')
+    expect(p).toContain('Save it to Deliverables')
+  })
+  it('says when a template has no fields', () => {
+    expect(autoPrompt({ ...t, data_fields: [] })).toContain('no fill-in fields')
+  })
+  it('prefixes the schedule and appends the email delivery', () => {
+    expect(schedulePrompt(t, 'x', 'every Friday at 17:00')).toMatch(/^Every Friday at 17:00: Research x/)
+    expect(emailPrompt(t, 'x', 'marketing@acme.com')).toContain('email the share link to marketing@acme.com')
+  })
+  it('emits a valid generate_document playbook step', () => {
+    const step = JSON.parse(playbookStepJson(t))
+    expect(step).toEqual({
+      type: 'generate_document',
+      title: 'Weekly Report',
+      format: 'pdf',
+      template_id: t.id,
+      data: { title: '{{step_1.output}}', summary: '{{step_1.output}}' },
+    })
+  })
+})

--- a/frontend/components/documents/blocks/__tests__/templateFields.test.ts
+++ b/frontend/components/documents/blocks/__tests__/templateFields.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest'
+import {
+  collectDataFields,
+  collectMissingOnFile,
+  collectVariablePaths,
+  fieldLabel,
+  getDataField,
+  setDataField,
+} from '../templateFields'
+import type { Block, VariableEntry } from '../types'
+
+const blocks: Block[] = [
+  { type: 'image', id: 'logo', source: 'brand_logo', alt: 'Logo', width_mm: 40 },
+  { type: 'heading', id: 'h', level: 1, content: [{ type: 'variable', path: 'data.title' }] },
+  {
+    type: 'section',
+    id: 's',
+    title: 'Summary',
+    children: [
+      { type: 'text', id: 't', content: [{ type: 'text', text: 'By ' }, { type: 'variable', path: 'user.name' }] },
+      { type: 'variable', id: 'v', path: 'data.summary' },
+    ],
+  },
+  { type: 'table', id: 'tb', header: true, rows: [[[{ type: 'variable', path: 'data.client.name' }], []]] },
+  { type: 'page_break', id: 'pb' },
+  { type: 'text', id: 'dup', content: [{ type: 'variable', path: 'data.title' }] },
+]
+
+describe('collectVariablePaths / collectDataFields', () => {
+  it('walks every block type, de-duplicates and sorts', () => {
+    expect(collectVariablePaths(blocks)).toEqual([
+      'brand.logo_url',
+      'data.client.name',
+      'data.summary',
+      'data.title',
+      'user.name',
+    ])
+  })
+  it('strips the data. prefix for the fill-in fields', () => {
+    expect(collectDataFields(blocks)).toEqual(['client.name', 'summary', 'title'])
+  })
+  it('handles an empty tree', () => {
+    expect(collectVariablePaths([])).toEqual([])
+    expect(collectDataFields([])).toEqual([])
+  })
+})
+
+describe('collectMissingOnFile', () => {
+  const catalog: VariableEntry[] = [
+    { path: 'user.name', category: 'user', label: 'Name', sample: 'Jane', value: 'Gerard', resolved: true },
+    { path: 'brand.logo_url', category: 'brand', label: 'Logo', sample: '/l.png', value: null, resolved: false },
+    { path: 'company.address', category: 'company', label: 'Address', sample: '1 St', value: '', resolved: false },
+  ]
+  it('reports known catalog chips with no value, never data.* chips', () => {
+    expect(collectMissingOnFile(collectVariablePaths(blocks), catalog)).toEqual(['brand.logo_url'])
+    expect(collectMissingOnFile(['company.address', 'data.x', 'not.in.catalog'], catalog)).toEqual(['company.address'])
+  })
+})
+
+describe('get/setDataField', () => {
+  it('sets nested dotted fields immutably', () => {
+    const base = { title: 'T', client: { name: 'Old' } }
+    const next = setDataField(base, 'client.name', 'Acme')
+    expect(next).toEqual({ title: 'T', client: { name: 'Acme' } })
+    expect(base.client.name).toBe('Old')
+    expect(setDataField({}, 'summary', 'S')).toEqual({ summary: 'S' })
+    expect(setDataField({ client: 'not-an-object' }, 'client.name', 'A')).toEqual({ client: { name: 'A' } })
+  })
+  it('reads nested fields and stringifies non-strings', () => {
+    expect(getDataField({ client: { name: 'Acme' } }, 'client.name')).toBe('Acme')
+    expect(getDataField({ n: 3 }, 'n')).toBe('3')
+    expect(getDataField({}, 'missing.deep')).toBe('')
+  })
+})
+
+describe('fieldLabel', () => {
+  it('humanises dotted / snake / camel names', () => {
+    expect(fieldLabel('client.name')).toBe('Client name')
+    expect(fieldLabel('recipient_name')).toBe('Recipient name')
+    expect(fieldLabel('executiveSummary')).toBe('Executive summary')
+  })
+})

--- a/frontend/components/documents/blocks/api.ts
+++ b/frontend/components/documents/blocks/api.ts
@@ -1,6 +1,15 @@
-// API helpers for the document-template block editor (PRD-167 S3/S4/S5).
+// API helpers for the document-template studio (PRD-167 S3/S4/S5 → PRD-242).
 import { apiClient } from '@/lib/api-client'
-import type { BlockDocument, BrandKit, VariablesResponse } from './types'
+import type {
+  BlockDocument,
+  BrandKit,
+  BrandSuggestions,
+  GenerateDocumentResult,
+  TemplateDetail,
+  TemplateSummary,
+  TemplateWriteBody,
+  VariablesResponse,
+} from './types'
 
 export interface PreviewBlocksResult {
   html: string
@@ -8,17 +17,65 @@ export interface PreviewBlocksResult {
   unknown: string[]
 }
 
+export const BRAND_LOGO_PATH = '/api/documents/brand-kit/logo'
+
 export const templateBlocksApi = {
   // Variable catalog with resolved sample values (drives the chip picker).
   getVariables: () => apiClient.get<VariablesResponse>('/api/documents/variables'),
 
+  // Templates
+  listTemplates: () => apiClient.get<TemplateSummary[]>('/api/documents/templates'),
+  getTemplate: (id: string) => apiClient.get<TemplateDetail>(`/api/documents/templates/${id}`),
+  createTemplate: (body: TemplateWriteBody) =>
+    apiClient.post<{ id: string; name: string }>('/api/documents/templates', body),
+  updateTemplate: (id: string, body: TemplateWriteBody) =>
+    apiClient.put<{ id: string; updated: boolean }>(`/api/documents/templates/${id}`, body),
+  deleteTemplate: (id: string) => apiClient.delete<{ deleted: boolean }>(`/api/documents/templates/${id}`),
+
+  // Render a real document from a template — it lands in Deliverables (PRD-242 S4).
+  generateDocument: (input: { title: string; format: string; template_id: string; data: Record<string, any> }) =>
+    apiClient.post<GenerateDocumentResult>('/api/documents/generate', input),
+
   // Brand kit (defaults merged in).
   getBrandKit: () => apiClient.get<BrandKit>('/api/documents/brand-kit'),
+  updateBrandKit: (patch: Partial<BrandKit>) => apiClient.put<BrandKit>('/api/documents/brand-kit', patch),
+  getBrandSuggestions: () =>
+    apiClient.get<{ suggestions: BrandSuggestions }>('/api/documents/brand-kit/suggestions'),
 
-  updateBrandKit: (patch: Partial<BrandKit>) =>
-    apiClient.put<BrandKit>('/api/documents/brand-kit', patch),
+  // Logo upload/removal (PRD-242 S3). FormData: the client drops the JSON content-type.
+  uploadLogo: (file: File) => {
+    const form = new FormData()
+    form.append('file', file)
+    return apiClient.post<BrandKit & { logo_route: string }>(BRAND_LOGO_PATH, form)
+  },
+  deleteLogo: () => apiClient.delete<BrandKit>(BRAND_LOGO_PATH),
+
+  // The stored logo needs auth headers a plain <img src> cannot send (SaaS), so
+  // fetch it and hand back an object URL (the FilePreview pattern). null = none.
+  fetchLogoObjectUrl: async (): Promise<string | null> => {
+    const headers = await apiClient.getAuthHeaders()
+    const resp = await fetch(`${apiClient.getBaseUrl()}${BRAND_LOGO_PATH}`, { headers })
+    if (!resp.ok) return null
+    return URL.createObjectURL(await resp.blob())
+  },
 
   // Live preview: render a block tree to HTML without persisting.
   previewBlocks: (blocks: BlockDocument, data: Record<string, any> = {}) =>
     apiClient.post<PreviewBlocksResult>('/api/documents/preview-blocks', { blocks, data }),
+}
+
+// Generated files sit behind an authenticated route; a plain <a href> cannot send the
+// Authorization header in SaaS. Fetch with auth and hand the bytes to the browser.
+export async function downloadGeneratedFile(downloadUrl: string, filename: string): Promise<void> {
+  const headers = await apiClient.getAuthHeaders()
+  const resp = await fetch(`${apiClient.getBaseUrl()}${downloadUrl}`, { headers })
+  if (!resp.ok) throw new Error(`Download failed (HTTP ${resp.status})`)
+  const objectUrl = URL.createObjectURL(await resp.blob())
+  const anchor = document.createElement('a')
+  anchor.href = objectUrl
+  anchor.download = filename
+  document.body.appendChild(anchor)
+  anchor.click()
+  anchor.remove()
+  URL.revokeObjectURL(objectUrl)
 }

--- a/frontend/components/documents/blocks/promptSnippets.ts
+++ b/frontend/components/documents/blocks/promptSnippets.ts
@@ -1,0 +1,50 @@
+// Copy-ready instructions that make a template USABLE from chat, a schedule, or a
+// playbook (PRD-242 S5). The text names the template by id — the id is what
+// generate_document(template_id=…) takes, so an agent cannot pick the wrong one.
+import type { TemplateSummary } from './types'
+
+type TemplateRef = Pick<TemplateSummary, 'id' | 'name' | 'format' | 'data_fields'>
+
+function fieldsClause(t: TemplateRef): string {
+  if (!t.data_fields.length) return 'The template has no fill-in fields.'
+  return `Fill these fields from your research: ${t.data_fields.join(', ')}.`
+}
+
+function fmt(t: TemplateRef): string {
+  return String(t.format || 'pdf').toUpperCase()
+}
+
+// Ask Auto (or any agent) in chat.
+export function autoPrompt(t: TemplateRef, topic = '<what to research>'): string {
+  return [
+    `Research ${topic}, then generate a ${fmt(t)} with the "${t.name}" template (template_id ${t.id}).`,
+    fieldsClause(t),
+    'Save it to Deliverables and give me the link.',
+  ].join(' ')
+}
+
+// Same, on a schedule — the agent files it via platform_schedule_task.
+export function schedulePrompt(t: TemplateRef, topic = '<what to research>', when = 'every Monday at 09:00'): string {
+  return `${when.charAt(0).toUpperCase()}${when.slice(1)}: ${autoPrompt(t, topic)}`
+}
+
+// Deliver by email — the tool result carries a no-sign-in share link (valid 7 days).
+export function emailPrompt(t: TemplateRef, topic = '<what to research>', recipient = 'marketing@yourcompany.com'): string {
+  return `${autoPrompt(t, topic)} Then email the share link to ${recipient} with a two-line summary.`
+}
+
+// A deterministic playbook step (recipe_executor generate_document step type).
+export function playbookStepJson(t: TemplateRef): string {
+  const data = Object.fromEntries(t.data_fields.map((f) => [f, `{{step_1.output}}`]))
+  return JSON.stringify(
+    {
+      type: 'generate_document',
+      title: t.name,
+      format: t.format || 'pdf',
+      template_id: t.id,
+      data,
+    },
+    null,
+    2,
+  )
+}

--- a/frontend/components/documents/blocks/templateFields.ts
+++ b/frontend/components/documents/blocks/templateFields.ts
@@ -1,0 +1,71 @@
+// Pure helpers over the block tree (PRD-242 S2): which chips a template uses,
+// which data.* fields an agent (or a person) must supply, and an immutable
+// nested get/set for dotted field names. Mirrors
+// orchestrator/modules/documents/template_summary.py.
+import type { Block, Inline, VariableEntry } from './types'
+
+export const DATA_PREFIX = 'data.'
+
+function inlinePaths(content: Inline[] | undefined): string[] {
+  return (content || []).flatMap((run) => (run.type === 'variable' ? [run.path] : []))
+}
+
+function blockPaths(block: Block): string[] {
+  switch (block.type) {
+    case 'heading':
+    case 'text':
+      return inlinePaths(block.content)
+    case 'table':
+      return block.rows.flatMap((row) => row.flatMap((cell) => inlinePaths(cell)))
+    case 'variable':
+      return [block.path]
+    case 'image':
+      return block.source === 'brand_logo' ? ['brand.logo_url'] : []
+    case 'section':
+      return block.children.flatMap(blockPaths)
+    case 'page_break':
+      return []
+  }
+}
+
+// Sorted, de-duplicated variable paths referenced anywhere in the tree.
+export function collectVariablePaths(blocks: Block[]): string[] {
+  return Array.from(new Set(blocks.flatMap(blockPaths))).sort()
+}
+
+// The data.* names (prefix stripped) the template expects at generation time.
+export function collectDataFields(blocks: Block[]): string[] {
+  return collectVariablePaths(blocks)
+    .filter((p) => p.startsWith(DATA_PREFIX) && p.length > DATA_PREFIX.length)
+    .map((p) => p.slice(DATA_PREFIX.length))
+}
+
+// Catalog chips the template uses that have NO value on file for this workspace/user
+// (e.g. company.address before the brand kit is filled). data.* is excluded — those are
+// supplied per generation, not "missing".
+export function collectMissingOnFile(paths: string[], variables: VariableEntry[]): string[] {
+  const resolved = new Set(variables.filter((v) => v.resolved && v.value).map((v) => v.path))
+  const known = new Set(variables.map((v) => v.path))
+  return paths.filter((p) => !p.startsWith(DATA_PREFIX) && known.has(p) && !resolved.has(p))
+}
+
+export function getDataField(data: Record<string, any>, field: string): string {
+  const value = field.split('.').reduce<any>((cur, part) => (cur && typeof cur === 'object' ? cur[part] : undefined), data)
+  if (value === undefined || value === null) return ''
+  return typeof value === 'string' ? value : JSON.stringify(value)
+}
+
+// Immutable nested set: setDataField({}, 'client.name', 'Acme') → { client: { name: 'Acme' } }
+export function setDataField(data: Record<string, any>, field: string, value: string): Record<string, any> {
+  const [head, ...rest] = field.split('.')
+  if (!head) return data
+  if (rest.length === 0) return { ...data, [head]: value }
+  const child = data[head] && typeof data[head] === 'object' && !Array.isArray(data[head]) ? data[head] : {}
+  return { ...data, [head]: setDataField(child, rest.join('.'), value) }
+}
+
+// Label a dotted field for a form: 'client.name' → 'Client name', 'summary' → 'Summary'.
+export function fieldLabel(field: string): string {
+  const words = field.replace(/[._]+/g, ' ').replace(/([a-z])([A-Z])/g, '$1 $2').trim()
+  return words.charAt(0).toUpperCase() + words.slice(1).toLowerCase()
+}

--- a/frontend/components/documents/blocks/types.ts
+++ b/frontend/components/documents/blocks/types.ts
@@ -103,6 +103,10 @@ export interface BrandKit {
   name: string
   tagline: string
   logo_url: string
+  // PRD-242 S3: storage path of an UPLOADED logo (server-managed; set by the
+  // upload route). When present the renderers inline it; the UI streams it
+  // from /api/documents/brand-kit/logo.
+  logo_path: string
   primary_color: string
   secondary_color: string
   accent_color: string
@@ -115,4 +119,74 @@ export interface BrandKit {
     phone: string
     website: string
   }
+}
+
+// GET /api/documents/brand-kit/suggestions — prefill candidates with provenance.
+export type BrandSuggestionSource = 'business_profile' | 'workspace' | 'user'
+export interface BrandSuggestion {
+  value: string
+  source: BrandSuggestionSource
+}
+export type BrandSuggestions = Partial<
+  Record<'name' | 'company_name' | 'website' | 'logo_url' | 'tagline' | 'email', BrandSuggestion>
+>
+
+export type TemplateFormat = 'pdf' | 'docx' | 'xlsx'
+
+// GET /api/documents/templates entry (PRD-242 S2 — modules/documents/template_summary.py)
+export interface TemplateSummary {
+  id: string
+  name: string
+  description?: string | null
+  format: TemplateFormat | string
+  category: string
+  tags: string[]
+  version: number
+  sample_data?: Record<string, any> | null
+  data_schema?: Record<string, any> | null
+  // Block-editable (vs a legacy Jinja/uploaded-DOCX template that can only be copied or rendered).
+  has_blocks: boolean
+  // Seeded by the platform — copy-on-customise.
+  is_starter: boolean
+  // Every variable chip the template references, and the data.* names an agent must supply.
+  variable_paths: string[]
+  data_fields: string[]
+  created_at?: string | null
+  updated_at?: string | null
+}
+
+export interface TemplateDetail extends TemplateSummary {
+  blocks: BlockDocument | null
+  template_content?: string | null
+  template_file_path?: string | null
+}
+
+export interface TemplateWriteBody {
+  name: string
+  description: string
+  category: string
+  format: string
+  blocks: BlockDocument
+  sample_data?: Record<string, any>
+}
+
+// POST /api/documents/generate
+export interface GenerateDocumentResult {
+  status: string
+  filename: string
+  format: string
+  download_url: string
+  size_kb: number
+  deliverable_id?: string | null
+  app_url?: string | null
+  share_url?: string | null
+  template_id?: string | null
+  template_name?: string | null
+}
+
+// 422 from the finalisation gate (P2-09 S3): which chips did not resolve.
+export interface UnresolvedDetail {
+  message: string
+  unresolved?: string[]
+  unknown?: string[]
 }

--- a/frontend/lib/tooltips.json
+++ b/frontend/lib/tooltips.json
@@ -51,7 +51,6 @@
       }
     }
   },
-
   "agents": {
     "page": {
       "title": "Agent Management",
@@ -234,7 +233,6 @@
       }
     }
   },
-
   "chat": {
     "input": {
       "text": "Type your message and press Enter. The Universal Router automatically sends it to the best agent.",
@@ -271,7 +269,6 @@
       }
     }
   },
-
   "tools": {
     "page": {
       "title": "Tools & Integrations",
@@ -318,7 +315,6 @@
       }
     }
   },
-
   "knowledge": {
     "page": {
       "title": "Knowledge Bases",
@@ -429,7 +425,6 @@
       }
     }
   },
-
   "marketplace": {
     "page": {
       "title": "Community Marketplace",
@@ -490,7 +485,6 @@
       }
     }
   },
-
   "team": {
     "page": {
       "title": "Team Management",
@@ -509,7 +503,6 @@
       "docLink": "/team"
     }
   },
-
   "analytics": {
     "page": {
       "title": "Analytics",
@@ -564,7 +557,6 @@
       }
     }
   },
-
   "settings": {
     "page": {
       "title": "Settings",
@@ -860,7 +852,6 @@
       }
     }
   },
-
   "recipes": {
     "schedule": {
       "type": {
@@ -910,7 +901,6 @@
       }
     }
   },
-
   "common": {
     "filters": {
       "time_range": {
@@ -930,6 +920,57 @@
       "export": {
         "text": "Export data as CSV for external analysis or reporting.",
         "docLink": "/"
+      }
+    }
+  },
+  "deliverables": {
+    "templates": {
+      "gallery": {
+        "title": {
+          "text": "Templates are branded document layouts your agents fill. Starters are copy-on-customise; your own can be edited, generated from, or deleted. Each card shows the data.* fields an agent must supply.",
+          "docLink": "/deliverables"
+        }
+      },
+      "editor": {
+        "name": {
+          "text": "Agents pick a template by name or id (platform_list_templates). Use a name people would say in chat, e.g. \"Weekly Report\".",
+          "docLink": "/deliverables"
+        },
+        "category": {
+          "text": "A filter for people and agents: report, letter, invoice, proposal, contract, data, general. Agents can ask for \"invoice templates\".",
+          "docLink": "/deliverables"
+        },
+        "format": {
+          "text": "PDF renders through the brand-aware HTML engine; DOCX compiles the same blocks into an editable Word file. Either can be requested at generation time.",
+          "docLink": "/deliverables",
+          "example": "Client-facing → PDF | Something the team will edit → DOCX"
+        },
+        "fill_in_fields": {
+          "text": "Every {{data.*}} chip in the template becomes a field here. An agent fills these from its research when it calls generate_document; you can type preview values to see the layout with real text. They are saved as the template's sample data.",
+          "docLink": "/deliverables"
+        },
+        "preview": {
+          "text": "Rendered by the server exactly as the PDF will be. Red [[markers]] show chips with no value — a document is never delivered while one remains.",
+          "docLink": "/deliverables"
+        }
+      }
+    },
+    "brand_kit": {
+      "title": {
+        "text": "One kit per workspace. The logo, colours and font are applied to every rendered PDF/DOCX; the fields also fill the {{brand.*}} and {{company.*}} chips.",
+        "docLink": "/deliverables"
+      },
+      "logo": {
+        "text": "Upload a PNG or JPEG (2 MB max). It is stored in the platform and embedded in documents directly, so it works without a public URL. SVG is not supported because Word files cannot embed it.",
+        "docLink": "/deliverables"
+      },
+      "use_profile": {
+        "text": "Fills the EMPTY fields from what the platform already knows: your onboarding business profile (company name, website, tagline, scanned logo), the workspace name, and your account email. Nothing you typed is overwritten.",
+        "docLink": "/deliverables"
+      },
+      "company": {
+        "text": "Contact details for letterheads and footers — {{company.name}}, {{company.address}}, {{company.email}}, {{company.phone}}, {{company.website}}. Company name falls back to your business profile.",
+        "docLink": "/deliverables"
       }
     }
   }

--- a/orchestrator/api/chat.py
+++ b/orchestrator/api/chat.py
@@ -22,6 +22,7 @@ from consumers.chatbot.auto import Action, AutoBrain, apply_assign_bias
 from core.auth.hybrid import get_request_context_hybrid
 from core.auth.workspace_permission import require_workspace_permission
 from core.auth.dependencies import RequestContext
+from core.auth.principal import resolve_user_pk
 from core.routing.cache import get_routing_cache
 from core.routing.engine import UniversalRouter
 from core.routing.ingestors.chatbot import ChatbotIngestor
@@ -117,39 +118,15 @@ def get_user_id(db: Session, ctx=None) -> int:
     (_driving_clerk derives from this) to user 1.
 
     IMPORTANT: ``UserContext.id`` carries the *Clerk subject string* (or email)
-    for SaaS auth — NOT the integer ``users.id``. But ``chats.user_id`` and the
-    ``messages`` / ``votes`` FKs are INTEGER references to ``users.id``. Returning
-    the raw Clerk string wrote ``'user_xxx'`` into an INTEGER column and 500'd
-    every chat request. So resolve the principal to the integer PK via
-    ``users.clerk_user_id`` — the same pattern team.py, harness.py, marketplace.py
-    and hybrid.py's own provisioning already use.
+    for SaaS auth — NOT the integer ``users.id`` (see
+    ``core.auth.principal.resolve_user_pk``, the one resolver every integer-FK
+    site must use; PRD-242 moved the lookup there so the document renderers
+    stopped 500-ing on the same bug).
     """
-    if ctx is not None and getattr(ctx, "user", None) is not None:
-        uid = getattr(ctx.user, "id", None)
-        # Fast path: an auth lane that already carries the integer PK.
-        if isinstance(uid, int):
-            return uid
-        # SaaS/Clerk lane: ``uid`` is the Clerk subject string (or email).
-        # Resolve to the integer users.id. The row is guaranteed present —
-        # hybrid auth provisions it on first sign-in (INSERT ... ON CONFLICT).
-        clerk_uid = getattr(ctx.user, "clerk_user_id", None) or (uid if isinstance(uid, str) else None)
-        if clerk_uid:
-            row = db.execute(
-                text("SELECT id FROM users WHERE clerk_user_id = :cid LIMIT 1"),
-                {"cid": clerk_uid},
-            ).fetchone()
-            if row:
-                return int(row[0])
-        email = getattr(ctx.user, "email", None)
-        if email:
-            row = db.execute(
-                text("SELECT id FROM users WHERE email = :em LIMIT 1"),
-                {"em": email},
-            ).fetchone()
-            if row:
-                return int(row[0])
-        # Authenticated but unresolvable (should not happen post-provisioning) —
-        # fall through to the default below rather than 500-ing the chat.
+    resolved = resolve_user_pk(db, ctx)
+    if resolved is not None:
+        return resolved
+    # Principal-less (system/anonymous) or unresolvable — the chat default user.
     result = db.execute(text("SELECT id FROM users WHERE id = 1 LIMIT 1")).fetchone()
     if not result:
         result = db.execute(text("SELECT id FROM users LIMIT 1")).fetchone()

--- a/orchestrator/api/document_brand_kit.py
+++ b/orchestrator/api/document_brand_kit.py
@@ -1,0 +1,244 @@
+"""Workspace brand kit routes (PRD-167 S4 → PRD-242 S3).
+
+Sub-router included into ``api.document_generation.router`` (prefix
+``/api/documents``) — not a new mount in ``main.py``. Carries the brand kit
+read/update that PRD-167 shipped, plus what a non-technical user needed to
+actually brand a document:
+
+* ``POST/GET/DELETE /brand-kit/logo`` — upload a PNG/JPEG logo into platform
+  storage (the renderers inline it; see ``modules.documents.brand_logo``),
+  stream it back for the UI, remove it;
+* ``GET /brand-kit/suggestions`` — prefill candidates from what the workspace
+  already knows about itself (workspace name, the onboarding business profile,
+  the signed-in user) so the kit starts filled rather than blank.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional
+
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
+from fastapi.responses import Response
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from core.auth.dependencies import RequestContext
+from core.auth.hybrid import get_request_context_hybrid
+from core.auth.principal import resolve_user_pk
+from core.auth.workspace_permission import require_workspace_permission
+from core.database.database import get_db
+
+logger = logging.getLogger(__name__)
+router = APIRouter(tags=["document-generation"])
+
+_MANAGE = Depends(require_workspace_permission("workspace:manage"))
+
+
+class BrandKitUpdateRequest(BaseModel):
+    name: Optional[str] = None
+    tagline: Optional[str] = None
+    logo_url: Optional[str] = None
+    primary_color: Optional[str] = None
+    secondary_color: Optional[str] = None
+    accent_color: Optional[str] = None
+    text_color: Optional[str] = None
+    font_family: Optional[str] = None
+    company: Optional[dict] = None
+
+
+def _workspace_or_404(db: Session, workspace_id):
+    from core.models.workspaces import Workspace
+
+    ws = db.query(Workspace).filter(Workspace.id == workspace_id).first()
+    if not ws:
+        raise HTTPException(status_code=404, detail="Workspace not found")
+    return ws
+
+
+def _persist_kit(db: Session, ws, new_kit: Dict[str, Any]) -> None:
+    from modules.documents.brand_kit import BRAND_KIT_SETTINGS_KEY
+
+    # Reassign settings (not in-place mutate) so SQLAlchemy tracks the JSONB change.
+    ws.settings = {**(ws.settings or {}), BRAND_KIT_SETTINGS_KEY: new_kit}
+    db.commit()
+
+
+# ------------------------------------------------------------------
+# Kit read / update
+# ------------------------------------------------------------------
+
+
+@router.get("/brand-kit")
+async def get_brand_kit_endpoint(
+    ctx: RequestContext = Depends(get_request_context_hybrid),
+    db: Session = Depends(get_db),
+):
+    """Return the workspace brand kit (defaults merged in)."""
+    from modules.documents.brand_kit import get_brand_kit
+
+    ws = _workspace_or_404(db, ctx.workspace_id)
+    return get_brand_kit(ws.settings)
+
+
+@router.put("/brand-kit", dependencies=[_MANAGE])
+async def update_brand_kit_endpoint(
+    body: BrandKitUpdateRequest,
+    ctx: RequestContext = Depends(get_request_context_hybrid),
+    db: Session = Depends(get_db),
+):
+    """Update the workspace brand kit (validated, persisted on workspace.settings)."""
+    from pydantic import ValidationError
+
+    from modules.documents.brand_kit import BRAND_KIT_SETTINGS_KEY, validate_brand_kit
+
+    ws = _workspace_or_404(db, ctx.workspace_id)
+    existing = (ws.settings or {}).get(BRAND_KIT_SETTINGS_KEY)
+    patch = {k: v for k, v in body.model_dump().items() if v is not None}
+    try:
+        new_kit = validate_brand_kit(patch, existing)
+    except ValidationError as e:
+        raise HTTPException(status_code=422, detail={"message": "Invalid brand kit", "errors": e.errors()})
+    _persist_kit(db, ws, new_kit)
+    return new_kit
+
+
+# ------------------------------------------------------------------
+# Suggestions — reuse what the platform already knows (PRD-242 S3)
+# ------------------------------------------------------------------
+
+
+def build_brand_suggestions(workspace, business_profile, user) -> Dict[str, Dict[str, str]]:
+    """Prefill candidates ``field -> {value, source}``; only fields with a value. Pure."""
+    out: Dict[str, Dict[str, str]] = {}
+
+    def put(field: str, value: Any, source: str) -> None:
+        if field in out:
+            return
+        text = str(value).strip() if value is not None else ""
+        if text:
+            out[field] = {"value": text, "source": source}
+
+    if business_profile is not None:
+        put("name", getattr(business_profile, "company_name", None), "business_profile")
+        put("company_name", getattr(business_profile, "company_name", None), "business_profile")
+        domain = getattr(business_profile, "domain", None)
+        if domain:
+            website = domain if str(domain).startswith(("http://", "https://")) else f"https://{domain}"
+            put("website", website, "business_profile")
+        brands = getattr(business_profile, "brands", None) or []
+        for brand in brands if isinstance(brands, list) else []:
+            if isinstance(brand, dict) and brand.get("logo_url"):
+                put("logo_url", brand["logo_url"], "business_profile")
+                break
+        voice = getattr(business_profile, "voice_notes", None)
+        if voice:
+            put("tagline", str(voice).strip().splitlines()[0][:120], "business_profile")
+    if workspace is not None:
+        put("name", getattr(workspace, "name", None), "workspace")
+        put("company_name", getattr(workspace, "name", None), "workspace")
+    if user is not None:
+        put("email", getattr(user, "email", None), "user")
+    return out
+
+
+@router.get("/brand-kit/suggestions")
+async def brand_kit_suggestions(
+    ctx: RequestContext = Depends(get_request_context_hybrid),
+    db: Session = Depends(get_db),
+):
+    """Prefill candidates from the workspace, its business profile and the signed-in user."""
+    from core.models.business_profiles import BusinessProfile
+    from core.models.core import User
+
+    ws = _workspace_or_404(db, ctx.workspace_id)
+    profile = (
+        db.query(BusinessProfile)
+        .filter(BusinessProfile.workspace_id == ctx.workspace_id)
+        .order_by(BusinessProfile.created_at.desc())
+        .first()
+    )
+    user_pk = resolve_user_pk(db, ctx)
+    user = db.query(User).filter(User.id == user_pk).first() if user_pk is not None else None
+    return {"suggestions": build_brand_suggestions(ws, profile, user)}
+
+
+# ------------------------------------------------------------------
+# Logo upload / stream / delete (PRD-242 S3)
+# ------------------------------------------------------------------
+
+
+@router.post("/brand-kit/logo", dependencies=[_MANAGE])
+async def upload_brand_logo(
+    file: UploadFile = File(...),
+    ctx: RequestContext = Depends(get_request_context_hybrid),
+    db: Session = Depends(get_db),
+):
+    """Store a PNG/JPEG logo for the workspace and point the brand kit at it."""
+    from modules.documents.brand_kit import BRAND_KIT_SETTINGS_KEY, get_brand_kit
+    from modules.documents.brand_logo import (
+        BRAND_LOGO_ROUTE,
+        MAX_LOGO_BYTES,
+        BrandLogoError,
+        delete_brand_logo,
+        save_brand_logo,
+    )
+
+    ws = _workspace_or_404(db, ctx.workspace_id)
+    data = await file.read(MAX_LOGO_BYTES + 1)
+    try:
+        logo_path = save_brand_logo(ctx.workspace_id, data)
+    except BrandLogoError as e:
+        raise HTTPException(status_code=422, detail=str(e))
+
+    kit = get_brand_kit(ws.settings)
+    previous = kit.get("logo_path") or ""
+    if previous and previous != logo_path:
+        delete_brand_logo(previous)
+    # An uploaded logo supersedes any external URL the kit carried.
+    new_kit = {**kit, "logo_path": logo_path, "logo_url": ""}
+    _persist_kit(db, ws, new_kit)
+    logger.info("[BrandKit] logo uploaded for workspace %s (%d bytes)", ctx.workspace_id, len(data))
+    return {**new_kit, "logo_route": BRAND_LOGO_ROUTE}
+
+
+@router.get("/brand-kit/logo")
+async def stream_brand_logo(
+    ctx: RequestContext = Depends(get_request_context_hybrid),
+    db: Session = Depends(get_db),
+):
+    """Stream the stored logo (local file, then object storage)."""
+    from modules.documents.brand_kit import get_brand_kit
+    from modules.documents.brand_logo import load_brand_logo, logo_mime
+
+    ws = _workspace_or_404(db, ctx.workspace_id)
+    logo_path = get_brand_kit(ws.settings).get("logo_path") or ""
+    data = load_brand_logo(logo_path) if logo_path else None
+    if not data:
+        raise HTTPException(status_code=404, detail="No logo uploaded")
+    return Response(
+        content=data,
+        media_type=logo_mime(logo_path),
+        headers={"Cache-Control": "private, max-age=300"},
+    )
+
+
+@router.delete("/brand-kit/logo", dependencies=[_MANAGE])
+async def delete_brand_logo_endpoint(
+    ctx: RequestContext = Depends(get_request_context_hybrid),
+    db: Session = Depends(get_db),
+):
+    """Remove the stored logo and clear it from the kit."""
+    from modules.documents.brand_kit import get_brand_kit
+    from modules.documents.brand_logo import delete_brand_logo
+
+    ws = _workspace_or_404(db, ctx.workspace_id)
+    kit = get_brand_kit(ws.settings)
+    if kit.get("logo_path"):
+        delete_brand_logo(kit["logo_path"])
+    new_kit = {**kit, "logo_path": ""}
+    _persist_kit(db, ws, new_kit)
+    return new_kit
+
+
+__all__ = ["router", "build_brand_suggestions"]

--- a/orchestrator/api/document_generation.py
+++ b/orchestrator/api/document_generation.py
@@ -17,14 +17,19 @@ from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
 from core.auth.hybrid import get_request_context_hybrid
+from core.auth.principal import resolve_user_pk
 from core.auth.workspace_permission import require_workspace_permission
 from core.auth.dependencies import RequestContext
 from core.database.database import get_db
 from config import config
 from modules.documents.models import UnresolvedDeliverableError
+from api.document_brand_kit import router as brand_kit_router
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/documents", tags=["document-generation"])
+# PRD-242 S3: brand kit + logo routes live in their own module (file-size rule);
+# included here so they mount under /api/documents without a new main.py mount.
+router.include_router(brand_kit_router)
 
 GENERATED_DIR = config.DOCUMENT_STORAGE_DIR
 
@@ -56,18 +61,6 @@ class TemplateUpdateRequest(BaseModel):
     blocks: Optional[dict] = None  # PRD-167 S2
 
 
-class BrandKitUpdateRequest(BaseModel):
-    name: Optional[str] = None
-    tagline: Optional[str] = None
-    logo_url: Optional[str] = None
-    primary_color: Optional[str] = None
-    secondary_color: Optional[str] = None
-    accent_color: Optional[str] = None
-    text_color: Optional[str] = None
-    font_family: Optional[str] = None
-    company: Optional[dict] = None
-
-
 class PreviewBlocksRequest(BaseModel):
     """Live-preview a block tree without persisting (PRD-167 S5)."""
     blocks: dict
@@ -88,6 +81,14 @@ class GenerateDocumentResponse(BaseModel):
     format: str
     download_url: str
     size_kb: int
+    # PRD-242 S4: a UI/API generation is a Deliverable too, and callers get the
+    # links an agent would (in-app feed + a no-sign-in share link when storage
+    # holds a copy).
+    deliverable_id: Optional[str] = None
+    app_url: Optional[str] = None
+    share_url: Optional[str] = None
+    template_id: Optional[str] = None
+    template_name: Optional[str] = None
 
 
 # ------------------------------------------------------------------
@@ -146,6 +147,7 @@ async def create_template(
         "format": template.format,
         "category": template.category,
         "version": template.version,
+        "has_blocks": bool(template.blocks),
     }
 
 
@@ -156,28 +158,21 @@ async def list_templates(
     ctx: RequestContext = Depends(get_request_context_hybrid),
     db: Session = Depends(get_db),
 ):
-    """List document templates for the workspace."""
+    """List document templates for the workspace.
+
+    PRD-242 S2: each entry also says whether it is block-editable
+    (``has_blocks``), a platform starter (``is_starter``), and which ``data.*``
+    fields an agent must supply (``data_fields``) — the gallery renders those
+    instead of a bare name.
+    """
     from modules.documents.template_service import DocumentTemplateService
+    from modules.documents.template_summary import summarize_template
 
     service = DocumentTemplateService(db)
     templates = service.list_templates(
         workspace_id=ctx.workspace_id, format=format, category=category
     )
-    return [
-        {
-            "id": str(t.id),
-            "name": t.name,
-            "description": t.description,
-            "format": t.format,
-            "category": t.category,
-            "tags": t.tags or [],
-            "version": t.version,
-            "data_schema": t.data_schema,
-            "sample_data": t.sample_data,
-            "created_at": t.created_at.isoformat() if t.created_at else None,
-        }
-        for t in templates
-    ]
+    return [summarize_template(t) for t in templates]
 
 
 @router.get("/templates/{template_id}")
@@ -189,25 +184,17 @@ async def get_template(
     """Get a single template with full details."""
     from modules.documents.template_service import DocumentTemplateService
 
+    from modules.documents.template_summary import summarize_template
+
     service = DocumentTemplateService(db)
     template = service.get_template(template_id, ctx.workspace_id)
     if not template:
         raise HTTPException(status_code=404, detail="Template not found")
     return {
-        "id": str(template.id),
-        "name": template.name,
-        "description": template.description,
-        "format": template.format,
-        "category": template.category,
-        "tags": template.tags or [],
-        "version": template.version,
+        **summarize_template(template),
         "template_content": template.template_content,
         "template_file_path": template.template_file_path,
-        "data_schema": template.data_schema,
-        "sample_data": template.sample_data,
         "blocks": template.blocks,
-        "created_at": template.created_at.isoformat() if template.created_at else None,
-        "updated_at": template.updated_at.isoformat() if template.updated_at else None,
     }
 
 
@@ -276,7 +263,7 @@ async def preview_template(
             data=preview_data,
             workspace_id=ctx.workspace_id,
             template_id=template.id,
-            user_id=ctx.user.id if ctx.user else None,
+            user_id=resolve_user_pk(db, ctx),
         )
     except UnresolvedDeliverableError as e:
         # P2-09 S3: the finalisation gate — tell the caller WHICH variables
@@ -369,8 +356,19 @@ async def generate_document(
     ctx: RequestContext = Depends(get_request_context_hybrid),
     db: Session = Depends(get_db),
 ):
-    """Generate a document from data + template."""
-    from modules.documents.generation_service import DocumentGenerationService
+    """Generate a document from data + template.
+
+    PRD-242 S4: the file is registered as a Deliverable (it used to vanish
+    into the download link — only agent generations reached the feed), and the
+    response carries the same links an agent gets: the in-app feed and a
+    no-sign-in share link when object storage holds a copy.
+    """
+    from modules.documents.generation_service import DocumentGenerationService, deliverables_app_url
+
+    try:
+        template_uuid = UUID(body.template_id) if body.template_id else None
+    except ValueError:
+        raise HTTPException(status_code=400, detail="template_id must be a UUID")
 
     service = DocumentGenerationService(db, ctx.workspace_id)
     try:
@@ -380,8 +378,8 @@ async def generate_document(
             data=body.data,
             workspace_id=ctx.workspace_id,
             template_name=body.template_name,
-            template_id=UUID(body.template_id) if body.template_id else None,
-            user_id=ctx.user.id if ctx.user else None,
+            template_id=template_uuid,
+            user_id=resolve_user_pk(db, ctx),
         )
     except UnresolvedDeliverableError as e:
         # P2-09 S3: a Deliverable with [[unresolved]]/unknown variables is
@@ -405,17 +403,28 @@ async def generate_document(
         logger.exception("Document generation failed")
         raise HTTPException(status_code=500, detail="Internal server error")
 
+    registration = service.register_as_deliverable(
+        result,
+        title=body.title,
+        source_type="document",
+        template_id=UUID(result.template_id) if result.template_id else None,
+    )
     return GenerateDocumentResponse(
         status="success",
         filename=result.filename,
         format=result.format,
         download_url=result.download_url,
         size_kb=result.size // 1024,
+        deliverable_id=(registration or {}).get("deliverable_id"),
+        app_url=deliverables_app_url(),
+        share_url=service.share_link(result),
+        template_id=result.template_id,
+        template_name=result.template_name,
     )
 
 
 # ------------------------------------------------------------------
-# Variables + Brand Kit (PRD-167 S3 / S4)
+# Variables + live preview (PRD-167 S3 / S5). Brand kit: api/document_brand_kit.py
 # ------------------------------------------------------------------
 
 
@@ -435,9 +444,9 @@ async def list_variables(
 
     resolver = VariableResolver(db)
     paths = [e["path"] for e in CATALOG]
-    resolved = resolver.resolve(
-        ctx.workspace_id, ctx.user.id if ctx.user else None, paths
-    )
+    # PRD-242 S1: ``ctx.user.id`` is the Clerk string / operator email, never the
+    # integer PK — handing it to ``User.id`` 500'd this endpoint in both editions.
+    resolved = resolver.resolve(ctx.workspace_id, resolve_user_pk(db, ctx), paths)
     entries = [
         {
             "path": e["path"],
@@ -454,50 +463,6 @@ async def list_variables(
     for entry in entries:
         grouped.setdefault(entry["category"], []).append(entry)
     return {"variables": entries, "by_category": grouped}
-
-
-@router.get("/brand-kit")
-async def get_brand_kit_endpoint(
-    ctx: RequestContext = Depends(get_request_context_hybrid),
-    db: Session = Depends(get_db),
-):
-    """Return the workspace brand kit (defaults merged in)."""
-    from core.models.workspaces import Workspace
-    from modules.documents.brand_kit import get_brand_kit
-
-    ws = db.query(Workspace).filter(Workspace.id == ctx.workspace_id).first()
-    if not ws:
-        raise HTTPException(status_code=404, detail="Workspace not found")
-    return get_brand_kit(ws.settings)
-
-
-@router.put("/brand-kit", dependencies=[Depends(require_workspace_permission("workspace:manage"))])
-async def update_brand_kit_endpoint(
-    body: BrandKitUpdateRequest,
-    ctx: RequestContext = Depends(get_request_context_hybrid),
-    db: Session = Depends(get_db),
-):
-    """Update the workspace brand kit (validated, persisted on workspace.settings)."""
-    from pydantic import ValidationError
-
-    from core.models.workspaces import Workspace
-    from modules.documents.brand_kit import BRAND_KIT_SETTINGS_KEY, get_brand_kit, validate_brand_kit
-
-    ws = db.query(Workspace).filter(Workspace.id == ctx.workspace_id).first()
-    if not ws:
-        raise HTTPException(status_code=404, detail="Workspace not found")
-
-    existing = (ws.settings or {}).get(BRAND_KIT_SETTINGS_KEY)
-    patch = {k: v for k, v in body.model_dump().items() if v is not None}
-    try:
-        new_kit = validate_brand_kit(patch, existing)
-    except ValidationError as e:
-        raise HTTPException(status_code=422, detail={"message": "Invalid brand kit", "errors": e.errors()})
-
-    # Reassign settings (not in-place mutate) so SQLAlchemy tracks the JSONB change.
-    ws.settings = {**(ws.settings or {}), BRAND_KIT_SETTINGS_KEY: new_kit}
-    db.commit()
-    return new_kit
 
 
 @router.post("/preview-blocks", dependencies=[Depends(require_workspace_permission("documents:create"))])
@@ -518,6 +483,7 @@ async def preview_blocks(
         validate_blocks,
     )
     from modules.documents.brand_kit import get_brand_kit
+    from modules.documents.brand_logo import brand_kit_for_render
     from modules.documents.variables.resolver import VariableResolver
     from core.models.workspaces import Workspace
 
@@ -529,10 +495,11 @@ async def preview_blocks(
     paths = collect_variable_paths(block_doc)
     resolver = VariableResolver(db)
     resolved = resolver.resolve(
-        ctx.workspace_id, ctx.user.id if ctx.user else None, paths, extra_data=body.data
+        ctx.workspace_id, resolve_user_pk(db, ctx), paths, extra_data=body.data
     )
     ws = db.query(Workspace).filter(Workspace.id == ctx.workspace_id).first()
-    brand_kit = get_brand_kit(getattr(ws, "settings", None))
+    # Render-ready kit: an uploaded logo is inlined so the live preview shows it.
+    brand_kit = brand_kit_for_render(get_brand_kit(getattr(ws, "settings", None)))
     rendered = render_document_html(block_doc, resolved.values, brand_kit, title="Preview")
     return {
         "html": rendered.html,

--- a/orchestrator/api/recipe_executor.py
+++ b/orchestrator/api/recipe_executor.py
@@ -1475,24 +1475,35 @@ async def _execute_recipe_inner(
             step_type = step.get("type", "agent")
             if step_type == "generate_document":
                 try:
-                    from modules.documents.generation_service import DocumentGenerationService
-                    gen_config = step.get("config", step)
-                    gen_title = gen_config.get("title", "Document")
-                    gen_format = gen_config.get("format", "pdf")
-                    gen_data = gen_config.get("data", {})
-                    gen_template_name = gen_config.get("template_name")
+                    from modules.documents.generation_service import (
+                        DocumentGenerationService,
+                        deliverables_app_url,
+                    )
+                    gen = _document_step_config(step)
 
                     # Resolve {{step_N.field}} variables in data from scratchpad
+                    gen_data = gen["data"]
                     if scratchpad and isinstance(gen_data, dict):
                         gen_data = _resolve_doc_step_variables(gen_data, scratchpad)
 
                     gen_service = DocumentGenerationService(db, workspace_id)
                     gen_result = await gen_service.generate(
-                        title=gen_title,
-                        format=gen_format,
+                        title=gen["title"],
+                        format=gen["format"],
                         data=gen_data,
                         workspace_id=workspace_id,
-                        template_name=gen_template_name,
+                        template_name=gen["template_name"],
+                        template_id=gen["template_id"],
+                    )
+                    # PRD-242 S4: a playbook-rendered document is a Deliverable —
+                    # it used to live only inside the step's output JSON.
+                    registration = gen_service.register_as_deliverable(
+                        gen_result,
+                        title=gen["title"],
+                        source_type="playbook",
+                        source_id=str(getattr(execution, "execution_id", "") or ""),
+                        agent_name=getattr(recipe, "name", None),
+                        template_id=gen["template_id"],
                     )
 
                     step_result["status"] = "completed"
@@ -1501,6 +1512,11 @@ async def _execute_recipe_inner(
                         "filename": gen_result.filename,
                         "format": gen_result.format,
                         "size_kb": gen_result.size // 1024,
+                        "deliverable_id": (registration or {}).get("deliverable_id"),
+                        "app_url": deliverables_app_url(),
+                        "share_url": gen_service.share_link(gen_result),
+                        "template_id": gen_result.template_id,
+                        "template_name": gen_result.template_name,
                     })
                     step_result["duration_ms"] = int((time.time() - step_start) * 1000)
                     step_result["completed_at"] = datetime.now(timezone.utc).isoformat()
@@ -2065,6 +2081,32 @@ def _resolve_prompt(
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+def _document_step_config(step: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalise a ``generate_document`` playbook step (PRD-242 S4). Pure.
+
+    The step may carry its settings under ``config`` or inline. ``template_id``
+    (a UUID string — the id ``platform_list_templates`` hands out) is parsed
+    here so an invalid one fails the step with a clear message instead of a
+    stack trace deep in the renderer; it takes precedence over ``template_name``.
+    """
+    cfg = step.get("config", step) if isinstance(step, dict) else {}
+    raw_id = cfg.get("template_id")
+    template_id = None
+    if raw_id:
+        try:
+            template_id = UUID(str(raw_id))
+        except (ValueError, TypeError):
+            raise ValueError(f"generate_document step: template_id {raw_id!r} is not a UUID")
+    data = cfg.get("data", {})
+    return {
+        "title": cfg.get("title", "Document"),
+        "format": cfg.get("format", "pdf"),
+        "data": data if isinstance(data, dict) else {},
+        "template_name": cfg.get("template_name"),
+        "template_id": template_id,
+    }
+
 
 def _resolve_doc_step_variables(data: Any, scratchpad) -> Any:
     """

--- a/orchestrator/core/auth/principal.py
+++ b/orchestrator/core/auth/principal.py
@@ -1,0 +1,73 @@
+"""Resolve the request principal to the integer ``users.id`` primary key.
+
+``UserContext.id`` is NOT the ``users.id`` PK. The Clerk lane binds it to the
+Clerk subject string (``user_xxx``) or the email, and the local-operator lane
+(PRD-233 S6) binds it to the operator's EMAIL on purpose — every
+``clerk_user_id == ctx.user.id`` site in the tree would 500 on an integer.
+Any code that hands ``ctx.user.id`` to an INTEGER column (``chats.user_id``,
+``User.id == …``) therefore raises ``psycopg2 InvalidTextRepresentation`` — the
+2026-07-09 chat outage (#513) and the 2026-09-11 Template Studio "Failed to
+fetch" (``GET /api/documents/variables``) are the same bug.
+
+This is the ONE resolver. Lanes that already carry the PK (an int ``id``, or
+the local operator's ``raw_claims["user_id"]``) resolve without a query; the
+Clerk lane looks the row up by ``clerk_user_id`` and then by email.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from sqlalchemy import text
+
+
+def _claimed_pk(user: Any) -> Optional[int]:
+    """The integer PK a lane may have stashed on ``raw_claims`` (local operator)."""
+    claims = getattr(user, "raw_claims", None)
+    if not isinstance(claims, dict):
+        return None
+    claimed = claims.get("user_id")
+    return claimed if isinstance(claimed, int) and not isinstance(claimed, bool) else None
+
+
+def _lookup(db: Any, column: str, value: str) -> Optional[int]:
+    row = db.execute(
+        text(f"SELECT id FROM users WHERE {column} = :value LIMIT 1"),  # noqa: S608 — column is a literal below
+        {"value": value},
+    ).fetchone()
+    return int(row[0]) if row else None
+
+
+def resolve_user_pk(db: Any, ctx: Any) -> Optional[int]:
+    """Integer ``users.id`` for the request principal, or ``None``.
+
+    ``None`` means "no resolvable person" (anonymous / system / API-key
+    callers, or a principal whose row is missing). Callers that need a default
+    user for principal-less paths (chat) add that themselves — a document
+    render must NOT silently attribute ``{{user.*}}`` to user 1.
+    """
+    user = getattr(ctx, "user", None) if ctx is not None else None
+    if user is None:
+        return None
+
+    uid = getattr(user, "id", None)
+    if isinstance(uid, int) and not isinstance(uid, bool):
+        return uid
+
+    claimed = _claimed_pk(user)
+    if claimed is not None:
+        return claimed
+
+    clerk_uid = getattr(user, "clerk_user_id", None) or (uid if isinstance(uid, str) else None)
+    if clerk_uid:
+        found = _lookup(db, "clerk_user_id", clerk_uid)
+        if found is not None:
+            return found
+
+    email = getattr(user, "email", None)
+    if email:
+        return _lookup(db, "email", email)
+    return None
+
+
+__all__ = ["resolve_user_pk"]

--- a/orchestrator/core/observability/error_response.py
+++ b/orchestrator/core/observability/error_response.py
@@ -1,0 +1,48 @@
+"""Unhandled exceptions become a JSON 500 *inside* the CORS layer (PRD-242 S1).
+
+Starlette runs ``@app.exception_handler(Exception)`` in ``ServerErrorMiddleware``
+— the outermost layer, outside ``CORSMiddleware``. A 500 minted there carries no
+``Access-Control-Allow-Origin``, so the browser refuses to read it and every
+unhandled backend error reaches the UI as ``TypeError: Failed to fetch`` — the
+real status and message never surface (the 2026-09-11 Template Studio report:
+a psycopg2 type error on ``/api/documents/variables`` showed up as a network
+failure).
+
+Mounted BEFORE ``CORSMiddleware`` in ``main.py`` (Starlette wraps later-added
+middleware *outside* earlier ones), this converts the exception to a plain JSON
+500 that then passes through CORS on the way out. ``HTTPException`` never
+reaches here — ``ExceptionMiddleware`` (innermost) already turned it into a
+response. The global handler in ``main.py`` stays as the last-resort backstop.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Awaitable, Callable
+
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+
+logger = logging.getLogger(__name__)
+
+INTERNAL_ERROR_DETAIL = "Internal server error"
+
+
+async def json_500_for_unhandled_errors(
+    request: Request, call_next: Callable[[Request], Awaitable[Response]]
+) -> Response:
+    """``@app.middleware("http")`` dispatch: unhandled → logged JSON 500."""
+    try:
+        return await call_next(request)
+    except Exception:  # noqa: BLE001 — this IS the catch-all; it logs and answers
+        request_id = request.headers.get("X-Request-ID") or ""
+        logger.exception(
+            "Unhandled error in %s %s (request_id=%s)", request.method, request.url.path, request_id
+        )
+        body = {"detail": INTERNAL_ERROR_DETAIL}
+        if request_id:
+            body["request_id"] = request_id
+        return JSONResponse(status_code=500, content=body)
+
+
+__all__ = ["INTERNAL_ERROR_DETAIL", "json_500_for_unhandled_errors"]

--- a/orchestrator/core/seeds/seed_local_first_run.py
+++ b/orchestrator/core/seeds/seed_local_first_run.py
@@ -62,6 +62,7 @@ from core.models.core import Agent, BlogPost, User, WorkflowTemplate
 from core.models.workspaces import Workspace
 from core.seeds.seed_auto_agent import seed_auto_agent
 
+from modules.documents.seed_templates import seed_starter_templates
 # NOTE: nothing from core.services is imported here on purpose. The seed
 # loader (core/database/load_seed_data.py) puts /app/core at sys.path[0], so
 # under it `core/services/__init__` → analytics_engine → core.redis resolves
@@ -773,6 +774,10 @@ def seed_local_first_run(db: Session) -> dict[str, Any]:
     result["agents"] = dict(Counter(_upsert_agent(ctx, spec) for spec in ROSTER))
     result["playbooks"] = dict(Counter([_upsert_playbook(ctx, PLAYBOOK, _roster_ids(ctx))]))
     result["deliverables"] = dict(Counter([_upsert_welcome_post(ctx, auto.id)]))
+    # PRD-242 S2: the starter document templates were seeded only at SaaS
+    # workspace provisioning (core/auth/hybrid.py), so a local install opened the
+    # Template Studio to an empty gallery. Same idempotent seeder, by name.
+    result["templates"] = {"created": seed_starter_templates(db, workspace_id)}
     result["ledger_updated"] = _record_ledger(workspace, ctx)
     db.flush()
 

--- a/orchestrator/main.py
+++ b/orchestrator/main.py
@@ -856,6 +856,14 @@ else:
         "Set OPENROUTER_API_KEY on the API service to unblock pilot users."
     )
 
+# PRD-242 S1: unhandled errors become a JSON 500 INSIDE the CORS layer. Starlette
+# wraps later-added middleware OUTSIDE earlier ones, so this must be registered
+# BEFORE CORSMiddleware: a 500 minted by the global handler (ServerErrorMiddleware,
+# outermost) carries no Access-Control-Allow-Origin and the browser reports every
+# backend crash as "TypeError: Failed to fetch" instead of the real status.
+from core.observability.error_response import json_500_for_unhandled_errors
+app.middleware("http")(json_500_for_unhandled_errors)
+
 # CORS middleware - use centralized config
 # Parse and clean CORS origins (handle comma-separated list with whitespace)
 cors_origins = [origin.strip() for origin in config.CORS_ALLOW_ORIGINS.split(",") if origin.strip()]
@@ -917,7 +925,7 @@ if _policy_plane_on:
 # Request body size limit middleware (10MB default, 50MB for uploads)
 MAX_BODY_SIZE = 10 * 1024 * 1024  # 10MB
 MAX_UPLOAD_SIZE = 50 * 1024 * 1024  # 50MB
-UPLOAD_PATHS = ("/api/documents/upload", "/api/admin/plugins/upload", "/api/documents/templates/upload", "/api/knowledge/graph/import")
+UPLOAD_PATHS = ("/api/documents/upload", "/api/admin/plugins/upload", "/api/documents/templates/upload", "/api/documents/brand-kit/logo", "/api/knowledge/graph/import")
 
 @app.middleware("http")
 async def limit_request_body(request, call_next):

--- a/orchestrator/modules/agents/services/agent_platform_tools.py
+++ b/orchestrator/modules/agents/services/agent_platform_tools.py
@@ -827,6 +827,11 @@ class AgentPlatformTools:
                     )
 
                 self.logger.info(f"  ✅ Document generated: {result.filename} ({result.size // 1024}KB)")
+                # PRD-242 S4: the links an agent needs to DELIVER the document, not
+                # just download it — the in-app feed (workspace members) and a
+                # no-sign-in share link for an email/Slack recipient (None when
+                # object storage holds no copy). Plus which template filled it.
+                from modules.documents.generation_service import deliverables_app_url
                 return ToolResultFormatter.standardize_result(
                     {
                         "success": True,
@@ -837,6 +842,11 @@ class AgentPlatformTools:
                             "download_url": result.download_url,
                             "size_kb": result.size // 1024,
                             "content": result.content,
+                            "deliverable_id": (registration or {}).get("deliverable_id"),
+                            "app_url": deliverables_app_url(),
+                            "share_url": gen_service.share_link(result),
+                            "template_id": result.template_id,
+                            "template_name": result.template_name,
                         }],
                     },
                     tool_name

--- a/orchestrator/modules/documents/blocks/docx_renderer.py
+++ b/orchestrator/modules/documents/blocks/docx_renderer.py
@@ -14,6 +14,8 @@ font from ``brand.font_family`` — no hardcoded Automatos styling.
 
 from __future__ import annotations
 
+import base64
+import binascii
 import ipaddress
 import logging
 import os
@@ -85,16 +87,35 @@ def _safe_local_image(src: str) -> Optional[BytesIO]:
         return None
 
 
+def _inline_image_bytes(src: str) -> Optional[BytesIO]:
+    """Decode a base64 ``data:image/…`` URI (PRD-242 S3 — the inlined brand logo).
+
+    Same size cap as fetched images; anything that is not a base64 image URI
+    (or does not decode) yields ``None`` so the caller falls back to alt text."""
+    header, sep, payload = src.partition(",")
+    if not sep or not header.startswith("data:image/") or ";base64" not in header:
+        return None
+    if len(payload) > _MAX_IMAGE_BYTES * 4 // 3 + 4:
+        return None
+    try:
+        return BytesIO(base64.b64decode(payload, validate=True))
+    except (ValueError, binascii.Error):
+        return None
+
+
 def _safe_image_bytes(src: str) -> Optional[BytesIO]:
     """Best-effort, SSRF-guarded image fetch for DOCX embedding.
 
-    Local/upload paths are read only from within the document-storage root
+    ``data:`` URIs (the inlined brand logo, PRD-242 S3) are decoded in-process;
+    local/upload paths are read only from within the document-storage root
     (:func:`_safe_local_image`); http(s) URLs are fetched only when every resolved
     address is public AND redirects are refused (a 30x must not pivot into a private
     host — mirrors and tightens the PRD-156 S4 WeasyPrint SSRF posture). Any failure
     returns ``None`` (the caller falls back to alt text)."""
     if not src:
         return None
+    if src.startswith("data:"):
+        return _inline_image_bytes(src)
     if not src.startswith(("http://", "https://")):
         return _safe_local_image(src)
     parsed = urlparse(src)

--- a/orchestrator/modules/documents/brand_kit.py
+++ b/orchestrator/modules/documents/brand_kit.py
@@ -51,6 +51,10 @@ class BrandKit(BaseModel):
     name: str = ""
     tagline: str = ""
     logo_url: str = ""
+    # PRD-242 S3: storage-relative path of an UPLOADED logo (``<ws>/brand/logo.png``).
+    # Server-managed — set by the logo upload route, never by a client PUT. When
+    # present the renderers inline it (modules.documents.brand_logo).
+    logo_path: str = ""
     primary_color: str = DEFAULT_PRIMARY
     secondary_color: str = DEFAULT_SECONDARY
     accent_color: str = DEFAULT_ACCENT
@@ -87,6 +91,9 @@ def validate_brand_kit(patch: Dict[str, Any], existing: Optional[Dict[str, Any]]
     Raises ``pydantic.ValidationError`` (surfaced as 422 by the API) on bad input.
     """
     base = get_brand_kit({BRAND_KIT_SETTINGS_KEY: existing} if existing else None)
+    # ``logo_path`` is owned by the upload/delete routes; a client patch cannot
+    # point the kit at an arbitrary stored file.
+    patch = {k: v for k, v in patch.items() if k != "logo_path"}
     merged = {**base, **{k: v for k, v in patch.items() if v is not None}}
     if "company" in patch and patch["company"] is not None:
         merged["company"] = {**base.get("company", {}), **patch["company"]}

--- a/orchestrator/modules/documents/brand_logo.py
+++ b/orchestrator/modules/documents/brand_logo.py
@@ -1,0 +1,224 @@
+"""Workspace brand logo — upload, storage, and render-time inlining (PRD-242 S3).
+
+PRD-167 S4 exposed ``brand_kit.logo_url`` as a *public https URL* only: the
+WeasyPrint fetcher (PRD-156 S4) refuses every non-public host and every
+non-http scheme, and the DOCX image fetch refuses redirects — so a logo living
+in the platform's own object store (MinIO on ``localhost:9000`` locally, a
+private bucket in SaaS) could never be rendered, and a non-technical user had
+no way to upload one at all.
+
+The logo is now a stored file, referenced by a storage-relative ``logo_path``
+(``<workspace_id>/brand/logo.png``) on the brand kit:
+
+* uploaded through ``POST /api/documents/brand-kit/logo`` (PNG/JPEG only —
+  python-docx cannot embed SVG, and one accepted set keeps PDF and DOCX honest),
+* written under ``config.DOCUMENT_STORAGE_DIR`` (the same root the DOCX
+  renderer's path-confined reader trusts) and mirrored to S3 like generated
+  documents (Railway containers are ephemeral),
+* served back to the UI by ``GET /api/documents/brand-kit/logo`` (local file,
+  then S3 — the ``serve_generated_file`` pattern),
+* **inlined as a ``data:`` URI at render time** (:func:`brand_kit_for_render`)
+  so neither renderer needs network access: the WeasyPrint fetcher already
+  admits ``data:``, and the DOCX renderer decodes it to bytes.
+
+Nothing here reads ``os.getenv`` — every setting comes through ``config``.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional
+from uuid import UUID
+
+from config import config
+from core.storage import ensure_bucket, get_s3_client, is_storage_configured
+
+logger = logging.getLogger(__name__)
+
+# The UI route that streams the stored logo (mounted under /api/documents).
+BRAND_LOGO_ROUTE = "/api/documents/brand-kit/logo"
+
+MAX_LOGO_BYTES = 2 * 1024 * 1024  # 2 MB — a letterhead logo, not a poster
+
+# Accepted image types, keyed by the magic bytes we sniff (never trust the
+# declared Content-Type). SVG is deliberately absent: python-docx cannot embed it.
+_MAGIC = (
+    (b"\x89PNG\r\n\x1a\n", "image/png", ".png"),
+    (b"\xff\xd8\xff", "image/jpeg", ".jpg"),
+)
+_MIME_BY_EXT = {".png": "image/png", ".jpg": "image/jpeg", ".jpeg": "image/jpeg"}
+
+
+class BrandLogoError(ValueError):
+    """The upload was refused (type, size, or shape). Message is user-facing."""
+
+
+def sniff_image_type(data: bytes) -> Optional[tuple[str, str]]:
+    """``(mime, extension)`` for a PNG/JPEG payload, else ``None``."""
+    for magic, mime, ext in _MAGIC:
+        if data[: len(magic)] == magic:
+            return mime, ext
+    return None
+
+
+def _storage_root() -> Path:
+    return Path(config.DOCUMENT_STORAGE_DIR).resolve()
+
+
+def _confined_local_path(logo_path: str) -> Optional[Path]:
+    """Absolute path under the storage root, or ``None`` if the path escapes it."""
+    if not logo_path:
+        return None
+    root = _storage_root()
+    candidate = (root / logo_path.lstrip("/\\")).resolve()
+    if root != candidate and root not in candidate.parents:
+        logger.warning("[BrandLogo] refusing path outside storage root: %r", logo_path)
+        return None
+    return candidate
+
+
+def s3_logo_key(logo_path: str) -> str:
+    return f"workspaces/{logo_path}"
+
+
+def logo_storage_path(workspace_id: UUID, ext: str) -> str:
+    return f"{workspace_id}/brand/logo{ext}"
+
+
+def save_brand_logo(workspace_id: UUID, data: bytes) -> str:
+    """Validate and persist an uploaded logo; return its storage-relative path.
+
+    Raises :class:`BrandLogoError` with a user-facing message on a bad upload.
+    The S3 mirror is best-effort (local serving covers the container's lifetime).
+    """
+    if not data:
+        raise BrandLogoError("The uploaded file is empty.")
+    if len(data) > MAX_LOGO_BYTES:
+        raise BrandLogoError(f"Logo must be {MAX_LOGO_BYTES // (1024 * 1024)} MB or smaller.")
+    sniffed = sniff_image_type(data)
+    if sniffed is None:
+        raise BrandLogoError("Logo must be a PNG or JPEG image (SVG is not supported in DOCX output).")
+    mime, ext = sniffed
+
+    logo_path = logo_storage_path(workspace_id, ext)
+    local = _confined_local_path(logo_path)
+    if local is None:  # pragma: no cover — a UUID can't escape the root
+        raise BrandLogoError("Invalid logo path.")
+    local.parent.mkdir(parents=True, exist_ok=True)
+    local.write_bytes(data)
+    # A previous upload with the other extension must not linger as a stale twin.
+    for stale_ext in (".png", ".jpg"):
+        if stale_ext != ext:
+            stale = local.parent / f"logo{stale_ext}"
+            if stale.exists():
+                stale.unlink()
+
+    _mirror_to_s3(logo_path, data, mime)
+    return logo_path
+
+
+def _mirror_to_s3(logo_path: str, data: bytes, mime: str) -> bool:
+    if not is_storage_configured():
+        return False
+    bucket = config.S3_DOCUMENTS_BUCKET or "automatos-ai"
+    try:
+        ensure_bucket(bucket)
+        get_s3_client().put_object(Bucket=bucket, Key=s3_logo_key(logo_path), Body=data, ContentType=mime)
+        return True
+    except Exception:  # noqa: BLE001 — persistence mirror only; local serving still works
+        logger.exception("[BrandLogo] S3 mirror failed for %s", logo_path)
+        return False
+
+
+def load_brand_logo(logo_path: str) -> Optional[bytes]:
+    """Logo bytes from the local store, then S3; ``None`` when neither has it."""
+    local = _confined_local_path(logo_path)
+    if local is None:
+        return None
+    if local.is_file():
+        try:
+            return local.read_bytes()
+        except OSError:
+            logger.warning("[BrandLogo] unreadable local logo %s", local)
+    if not is_storage_configured():
+        return None
+    bucket = config.S3_DOCUMENTS_BUCKET or "automatos-ai"
+    try:
+        body = get_s3_client().get_object(Bucket=bucket, Key=s3_logo_key(logo_path))["Body"].read()
+    except Exception:  # noqa: BLE001 — missing object / storage hiccup → no logo
+        logger.info("[BrandLogo] logo %s not in object storage", logo_path)
+        return None
+    if len(body) > MAX_LOGO_BYTES:
+        return None
+    try:  # re-warm the local cache so the next render skips the round-trip
+        local.parent.mkdir(parents=True, exist_ok=True)
+        local.write_bytes(body)
+    except OSError:
+        pass
+    return body
+
+
+def delete_brand_logo(logo_path: str) -> None:
+    """Remove the stored logo everywhere (best-effort; never raises)."""
+    local = _confined_local_path(logo_path)
+    if local is not None and local.exists():
+        try:
+            local.unlink()
+        except OSError:
+            logger.warning("[BrandLogo] could not delete local logo %s", local)
+    if is_storage_configured():
+        try:
+            bucket = config.S3_DOCUMENTS_BUCKET or "automatos-ai"
+            get_s3_client().delete_object(Bucket=bucket, Key=s3_logo_key(logo_path))
+        except Exception:  # noqa: BLE001
+            logger.info("[BrandLogo] S3 delete skipped for %s", logo_path)
+
+
+def logo_mime(logo_path: str) -> str:
+    return _MIME_BY_EXT.get(os.path.splitext(logo_path)[1].lower(), "application/octet-stream")
+
+
+def logo_data_uri(logo_path: str) -> Optional[str]:
+    data = load_brand_logo(logo_path) if logo_path else None
+    if not data:
+        return None
+    return f"data:{logo_mime(logo_path)};base64,{base64.b64encode(data).decode('ascii')}"
+
+
+def brand_kit_for_render(kit: Dict[str, Any]) -> Dict[str, Any]:
+    """A copy of the kit whose ``logo_url`` the renderers can actually load.
+
+    An uploaded logo (``logo_path``) becomes an inline ``data:`` URI — allowed by
+    the WeasyPrint fetcher and decoded by the DOCX renderer — so a private object
+    store never has to be reachable from the render path. An external
+    ``logo_url`` is left as-is (the fetchers keep their public-host rules).
+    """
+    if not isinstance(kit, dict):
+        return kit
+    logo_path = kit.get("logo_path") or ""
+    if not logo_path:
+        return dict(kit)
+    inline = logo_data_uri(logo_path)
+    if inline is None:
+        # Stored path but no bytes anywhere: fall back to the external URL, if any.
+        return dict(kit)
+    return {**kit, "logo_url": inline}
+
+
+__all__ = [
+    "BRAND_LOGO_ROUTE",
+    "MAX_LOGO_BYTES",
+    "BrandLogoError",
+    "brand_kit_for_render",
+    "delete_brand_logo",
+    "load_brand_logo",
+    "logo_data_uri",
+    "logo_mime",
+    "logo_storage_path",
+    "s3_logo_key",
+    "save_brand_logo",
+    "sniff_image_type",
+]

--- a/orchestrator/modules/documents/generation_service.py
+++ b/orchestrator/modules/documents/generation_service.py
@@ -56,12 +56,13 @@ def _safe_url_fetcher(url, *args, **kwargs):
     return default_url_fetcher(url, *args, **kwargs)
 
 from config import config
-from core.storage import ensure_bucket, get_s3_client, is_storage_configured
+from core.storage import ensure_bucket, get_public_s3_client, get_s3_client, is_storage_configured
 from core.models.core import DocumentTemplate
 from core.models.workspaces import Workspace
 from modules.documents.models import GeneratedDocument, UnresolvedDeliverableError
 from modules.documents.template_service import DocumentTemplateService
 from modules.documents.brand_kit import get_brand_kit
+from modules.documents.brand_logo import brand_kit_for_render
 from modules.documents.blocks import (
     blocks_from_legacy,
     collect_variable_paths,
@@ -75,6 +76,17 @@ logger = logging.getLogger(__name__)
 
 # Base directory for generated documents
 GENERATED_DIR = config.DOCUMENT_STORAGE_DIR
+
+# PRD-242 S4: a share link is a presigned URL on the S3 persistence copy — the
+# only link that works for someone who cannot sign in (an emailed report). S3
+# caps SigV4 presigns at 7 days.
+SHARE_LINK_TTL_SECONDS = 7 * 24 * 3600
+DELIVERABLES_APP_PATH = "/deliverables?tab=outputs"
+
+
+def deliverables_app_url() -> str:
+    """Absolute link to the Deliverables feed for messages that leave the app."""
+    return f"{(config.FRONTEND_URL or '').rstrip('/')}{DELIVERABLES_APP_PATH}"
 
 # PRD-167 S2/S4: the hardcoded `_FALLBACK_PDF_TEMPLATE` (with the `#ff6b35` Automatos
 # orange) is gone. When a template has no blocks and no template_content, the no-template
@@ -165,6 +177,11 @@ class DocumentGenerationService:
 
         # Attach markdown content for live widget display
         result.content = self._data_to_markdown(data, title)
+        # PRD-242 S4: attribution rides the result so callers (tool result,
+        # Deliverable extra, playbook step output) can say WHICH template filled it.
+        if template is not None:
+            result.template_id = str(template.id)
+            result.template_name = template.name
         return result
 
     # ------------------------------------------------------------------
@@ -172,8 +189,10 @@ class DocumentGenerationService:
     # ------------------------------------------------------------------
 
     def _brand_kit_for(self, workspace_id: UUID) -> dict:
+        """The workspace brand kit, render-ready: an uploaded logo is inlined as a
+        ``data:`` URI so neither renderer needs to reach the object store (PRD-242 S3)."""
         ws = self.db.query(Workspace).filter(Workspace.id == workspace_id).first()
-        return get_brand_kit(getattr(ws, "settings", None))
+        return brand_kit_for_render(get_brand_kit(getattr(ws, "settings", None)))
 
     def _render_block_html(self, block_doc, data, workspace_id, user_id, title):
         """Resolve a block document's variables and render it to a full HTML page.
@@ -231,6 +250,8 @@ class DocumentGenerationService:
             }
             if template_id:
                 extra["template_id"] = str(template_id)
+            if getattr(result, "template_name", None):
+                extra["template_name"] = result.template_name
             return DeliverableService(self.db, ws).register(
                 file_path=f"generated/{result.filename}",
                 title=title or result.filename,
@@ -247,6 +268,31 @@ class DocumentGenerationService:
             )
         except Exception:
             logger.exception("[DocGen] deliverable registration failed (non-fatal)")
+            return None
+
+    def share_link(self, result: GeneratedDocument, expires_in: int = SHARE_LINK_TTL_SECONDS) -> Optional[str]:
+        """A time-limited link to the S3 persistence copy that needs no sign-in (PRD-242 S4).
+
+        This is what an agent puts in an email or a Slack message: the stable
+        ``download_url`` is an authenticated app route and dead for anyone
+        outside the workspace. ``None`` when storage is off or the upload never
+        happened (the caller then offers the in-app link only).
+        """
+        if not result.s3_key or not is_storage_configured():
+            return None
+        bucket = config.S3_DOCUMENTS_BUCKET or "automatos-ai"
+        try:
+            return get_public_s3_client().generate_presigned_url(
+                "get_object",
+                Params={
+                    "Bucket": bucket,
+                    "Key": result.s3_key,
+                    "ResponseContentDisposition": f'attachment; filename="{result.filename}"',
+                },
+                ExpiresIn=expires_in,
+            )
+        except Exception:  # noqa: BLE001 — a share link is optional; never fail the generation
+            logger.exception("[DocGen] share link presign failed for %s", result.filename)
             return None
 
     # ------------------------------------------------------------------
@@ -704,7 +750,7 @@ class DocumentGenerationService:
         # Upload a persistence copy to S3 (containers are ephemeral); the link we
         # persist stays the app path — the re-mint endpoint owns presigning.
         download_url = f"/api/documents/generated/{filename}"
-        self._upload_to_s3(path, filename, workspace_id)
+        uploaded = self._upload_to_s3(path, filename, workspace_id)
 
         return GeneratedDocument(
             path=path,
@@ -716,7 +762,12 @@ class DocumentGenerationService:
             unresolved=list(unresolved or []),
             unknown=list(unknown or []),
             template_lane=template_lane,
+            s3_key=self._s3_key(filename, workspace_id) if uploaded else None,
         )
+
+    def _s3_key(self, filename: str, workspace_id: UUID = None) -> str:
+        ws_id = workspace_id or self.workspace_id
+        return f"workspaces/{ws_id}/generated-documents/{filename}"
 
     def _upload_to_s3(
         self, local_path: str, filename: str, workspace_id: UUID = None
@@ -732,9 +783,8 @@ class DocumentGenerationService:
             logger.debug("[DocGen] object storage not configured, skipping S3 upload")
             return False
 
-        ws_id = workspace_id or self.workspace_id
         bucket = config.S3_DOCUMENTS_BUCKET or "automatos-ai"
-        s3_key = f"workspaces/{ws_id}/generated-documents/{filename}"
+        s3_key = self._s3_key(filename, workspace_id)
         content_type = mimetypes.guess_type(filename)[0] or "application/octet-stream"
 
         try:

--- a/orchestrator/modules/documents/models.py
+++ b/orchestrator/modules/documents/models.py
@@ -52,3 +52,9 @@ class GeneratedDocument:
     # HTML / uploaded-docx). None when no template render applies (xlsx).
     # Persisted on the Deliverable ``extra`` so lane coverage is a tracked number.
     template_lane: Optional[str] = None
+    # PRD-242 S4: which template produced the file (attribution for the
+    # Deliverable + the tool result), and the S3 object key when the
+    # persistence copy landed (a share link can only be minted for that copy).
+    template_id: Optional[str] = None
+    template_name: Optional[str] = None
+    s3_key: Optional[str] = None

--- a/orchestrator/modules/documents/template_summary.py
+++ b/orchestrator/modules/documents/template_summary.py
@@ -1,0 +1,70 @@
+"""API-facing shape of a document template (PRD-242 S2).
+
+The Template Studio needs to tell a non-technical author three things a raw
+``DocumentTemplate`` row does not say directly:
+
+* **can it be edited in the block editor?** (``has_blocks`` — a legacy Jinja /
+  uploaded-DOCX template can only be copied or rendered, not block-edited),
+* **is it a platform starter?** (``is_starter`` — seeded rows are marked
+  ``created_by='system'``; the gallery shows a badge and the copy-on-customise
+  hint instead of pretending the user wrote them),
+* **what must an agent (or a person) supply at generation time?**
+  (``data_fields`` — every ``data.*`` chip the template references, which is
+  exactly the contract ``generate_document(template_id, data)`` has to fill).
+
+Pure — no DB, no IO — so the list endpoint can call it per row and tests can
+drive it with plain objects.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from modules.documents.blocks import BlockValidationError, collect_variable_paths, validate_blocks
+from modules.documents.variables.catalog import DYNAMIC_PREFIX
+
+STARTER_CREATOR = "system"
+
+
+def variable_paths_of(blocks: Optional[dict]) -> List[str]:
+    """Sorted, de-duplicated variable paths referenced by a block body ([] when none)."""
+    if not blocks:
+        return []
+    try:
+        doc = validate_blocks(blocks)
+    except BlockValidationError:
+        return []
+    return sorted(set(collect_variable_paths(doc)))
+
+
+def data_fields_of(paths: List[str]) -> List[str]:
+    """The ``data.*`` field names (without the prefix) an author/agent must supply."""
+    return [p[len(DYNAMIC_PREFIX):] for p in paths if p.startswith(DYNAMIC_PREFIX)]
+
+
+def summarize_template(t: Any) -> Dict[str, Any]:
+    """The gallery/list entry for one template row (or row-shaped object)."""
+    blocks = getattr(t, "blocks", None)
+    paths = variable_paths_of(blocks)
+    created_at = getattr(t, "created_at", None)
+    updated_at = getattr(t, "updated_at", None)
+    return {
+        "id": str(getattr(t, "id", "")),
+        "name": getattr(t, "name", ""),
+        "description": getattr(t, "description", None),
+        "format": getattr(t, "format", "pdf"),
+        "category": getattr(t, "category", "general"),
+        "tags": list(getattr(t, "tags", None) or []),
+        "version": getattr(t, "version", 1),
+        "data_schema": getattr(t, "data_schema", None),
+        "sample_data": getattr(t, "sample_data", None),
+        "has_blocks": bool(blocks),
+        "is_starter": (getattr(t, "created_by", None) or "") == STARTER_CREATOR,
+        "variable_paths": paths,
+        "data_fields": data_fields_of(paths),
+        "created_at": created_at.isoformat() if created_at else None,
+        "updated_at": updated_at.isoformat() if updated_at else None,
+    }
+
+
+__all__ = ["STARTER_CREATOR", "data_fields_of", "summarize_template", "variable_paths_of"]

--- a/orchestrator/modules/documents/variables/resolver.py
+++ b/orchestrator/modules/documents/variables/resolver.py
@@ -24,6 +24,7 @@ from uuid import UUID
 from sqlalchemy.orm import Session
 
 from ..brand_kit import get_brand_kit
+from ..brand_logo import BRAND_LOGO_ROUTE
 from .catalog import is_dynamic_path, is_known_path, DYNAMIC_PREFIX
 
 logger = logging.getLogger(__name__)
@@ -89,10 +90,15 @@ def build_context(
         "phone": company_contact.get("phone", ""),
     }
 
+    # PRD-242 S3: an uploaded logo has no public URL; the chip resolves to the
+    # platform route that streams it (the renderers inline the bytes instead).
+    logo_url = brand_kit.get("logo_url", "") or (
+        BRAND_LOGO_ROUTE if brand_kit.get("logo_path") else ""
+    )
     brand_ctx = {
         "name": brand_kit.get("name") or company_name or "",
         "tagline": brand_kit.get("tagline", ""),
-        "logo_url": brand_kit.get("logo_url", ""),
+        "logo_url": logo_url,
         "primary_color": brand_kit.get("primary_color", ""),
         "secondary_color": brand_kit.get("secondary_color", ""),
         "accent_color": brand_kit.get("accent_color", ""),

--- a/orchestrator/modules/tools/formatting/result_formatter.py
+++ b/orchestrator/modules/tools/formatting/result_formatter.py
@@ -751,6 +751,11 @@ class ToolResultFormatter:
                 'size_kb': doc_result.get('size_kb', 0),
                 'title': doc_result.get('title', doc_result.get('filename', 'Document')),
                 'content': doc_result.get('content', ''),
+                # PRD-242 S4: delivery links + template attribution ride to the widget.
+                'deliverable_id': doc_result.get('deliverable_id'),
+                'app_url': doc_result.get('app_url'),
+                'share_url': doc_result.get('share_url'),
+                'template_name': doc_result.get('template_name'),
             }
             logger.info(f"[FrontendData] generate_document: {frontend_data['generated_document']['filename']}")
 
@@ -949,8 +954,20 @@ class ToolResultFormatter:
             size_kb = doc_result.get('size_kb', 0)
             download_url = doc_result.get('download_url', '')
             summary_parts.append(f"\nGenerated {fmt.upper()} document: {filename} ({size_kb} KB)")
+            if doc_result.get('template_name'):
+                summary_parts.append(f"Template used: {doc_result['template_name']}")
             summary_parts.append(f"Download URL: {download_url}")
             summary_parts.append("IMPORTANT: Show the download link to the user using the exact URL above. Do NOT invent document:// links.")
+            # PRD-242 S4: the document is already saved; say where, and hand over the
+            # ONE link that works for someone who cannot sign in (email / Slack).
+            if doc_result.get('deliverable_id'):
+                summary_parts.append(f"Saved to Deliverables (id {doc_result['deliverable_id']}); in-app: {doc_result.get('app_url') or 'Deliverables page'}")
+            if doc_result.get('share_url'):
+                summary_parts.append(
+                    f"Share link (no sign-in needed, valid 7 days) — use THIS when emailing or messaging the document: {doc_result['share_url']}"
+                )
+            else:
+                summary_parts.append("No share link is available (object storage has no copy); the download URL requires a signed-in workspace member.")
 
         full_summary = "\n".join(summary_parts)
         

--- a/orchestrator/reports/route-manifest.json
+++ b/orchestrator/reports/route-manifest.json
@@ -1,5 +1,5 @@
 {
-  "route_count": 801,
+  "route_count": 805,
   "routes": [
     {
       "method": "GET",
@@ -1032,6 +1032,22 @@
     {
       "method": "PUT",
       "path": "/api/documents/brand-kit"
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/documents/brand-kit/logo"
+    },
+    {
+      "method": "GET",
+      "path": "/api/documents/brand-kit/logo"
+    },
+    {
+      "method": "POST",
+      "path": "/api/documents/brand-kit/logo"
+    },
+    {
+      "method": "GET",
+      "path": "/api/documents/brand-kit/suggestions"
     },
     {
       "method": "POST",

--- a/orchestrator/tests/test_prd242_brand_logo.py
+++ b/orchestrator/tests/test_prd242_brand_logo.py
@@ -1,0 +1,123 @@
+"""PRD-242 S3 — an uploaded brand logo is stored under the document root and
+INLINED at render time, so neither renderer needs a public URL.
+
+Pure at the boundary: a tmp storage root, object storage unconfigured (the
+mirror is skipped), no WeasyPrint, no python-docx document build.
+"""
+
+from __future__ import annotations
+
+import base64
+from uuid import uuid4
+
+import pytest
+
+import modules.documents.brand_logo as bl
+from modules.documents.blocks import render_document_html, validate_blocks
+from modules.documents.blocks.docx_renderer import _inline_image_bytes, _safe_image_bytes
+from modules.documents.brand_kit import get_brand_kit, validate_brand_kit
+from modules.documents.variables.resolver import build_context, resolve_paths
+
+from datetime import datetime
+
+PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 32
+JPEG = b"\xff\xd8\xff\xe0" + b"\x00" * 32
+WS = uuid4()
+
+
+@pytest.fixture
+def storage(tmp_path, monkeypatch):
+    monkeypatch.setattr(bl.config, "DOCUMENT_STORAGE_DIR", str(tmp_path), raising=False)
+    monkeypatch.setattr(bl, "is_storage_configured", lambda: False)
+    return tmp_path
+
+
+def test_sniff_accepts_png_jpeg_only():
+    assert bl.sniff_image_type(PNG) == ("image/png", ".png")
+    assert bl.sniff_image_type(JPEG) == ("image/jpeg", ".jpg")
+    assert bl.sniff_image_type(b"<svg xmlns='http://www.w3.org/2000/svg'/>") is None
+    assert bl.sniff_image_type(b"") is None
+
+
+def test_save_validates_type_and_size(storage):
+    with pytest.raises(bl.BrandLogoError, match="PNG or JPEG"):
+        bl.save_brand_logo(WS, b"GIF89a" + b"\x00" * 10)
+    with pytest.raises(bl.BrandLogoError, match="empty"):
+        bl.save_brand_logo(WS, b"")
+    with pytest.raises(bl.BrandLogoError, match="MB or smaller"):
+        bl.save_brand_logo(WS, PNG + b"\x00" * bl.MAX_LOGO_BYTES)
+
+
+def test_save_load_replace_delete_roundtrip(storage):
+    path = bl.save_brand_logo(WS, PNG)
+    assert path == f"{WS}/brand/logo.png"
+    assert (storage / path).read_bytes() == PNG
+    assert bl.load_brand_logo(path) == PNG
+    assert bl.logo_mime(path) == "image/png"
+
+    # Re-upload as JPEG: the stale PNG twin must not linger.
+    path2 = bl.save_brand_logo(WS, JPEG)
+    assert path2.endswith(".jpg")
+    assert not (storage / path).exists()
+    assert bl.load_brand_logo(path2) == JPEG
+
+    bl.delete_brand_logo(path2)
+    assert bl.load_brand_logo(path2) is None
+
+
+def test_load_refuses_paths_outside_the_storage_root(storage):
+    (storage.parent / "secret.png").write_bytes(PNG)
+    assert bl.load_brand_logo("../secret.png") is None
+
+
+def test_data_uri_and_render_ready_kit(storage):
+    path = bl.save_brand_logo(WS, PNG)
+    uri = bl.logo_data_uri(path)
+    assert uri == "data:image/png;base64," + base64.b64encode(PNG).decode()
+
+    kit = {"logo_path": path, "logo_url": "", "name": "Acme"}
+    rendered = bl.brand_kit_for_render(kit)
+    assert rendered["logo_url"] == uri
+    assert kit["logo_url"] == ""  # input untouched (no in-place mutation)
+
+    # No stored bytes anywhere → the kit is returned as-is (external URL, if any, survives).
+    missing = bl.brand_kit_for_render({"logo_path": f"{WS}/brand/logo.jpg", "logo_url": "https://x/y.png"})
+    assert missing["logo_url"] == "https://x/y.png"
+    assert bl.brand_kit_for_render({"logo_path": "", "logo_url": "https://x/y.png"})["logo_url"] == "https://x/y.png"
+
+
+def test_html_renderer_embeds_the_inlined_logo(storage):
+    path = bl.save_brand_logo(WS, PNG)
+    kit = bl.brand_kit_for_render({**get_brand_kit(None), "logo_path": path})
+    doc = validate_blocks({"blocks": [{"type": "image", "id": "logo", "source": "brand_logo", "alt": "Logo", "width_mm": 40}]})
+    out = render_document_html(doc, {}, kit, title="t")
+    assert 'src="data:image/png;base64,' in out.html
+    assert out.unresolved == []
+
+
+def test_docx_renderer_decodes_inline_data_uris():
+    uri = "data:image/png;base64," + base64.b64encode(PNG).decode()
+    assert _inline_image_bytes(uri).read() == PNG
+    assert _safe_image_bytes(uri).read() == PNG
+    assert _inline_image_bytes("data:text/plain;base64,aGk=") is None
+    assert _inline_image_bytes("data:image/png;base64,***not-base64***") is None
+    assert _inline_image_bytes("data:image/png,rawbytes") is None
+
+
+def test_brand_kit_model_carries_logo_path_but_clients_cannot_set_it():
+    kit = get_brand_kit({"brand_kit": {"logo_path": "ws/brand/logo.png"}})
+    assert kit["logo_path"] == "ws/brand/logo.png"
+    # A PUT patch cannot point the kit at an arbitrary stored file — the field is dropped.
+    merged = validate_brand_kit({"logo_path": "../../etc/passwd", "name": "Acme"}, {"logo_path": "ws/brand/logo.png"})
+    assert merged["logo_path"] == "ws/brand/logo.png"
+    assert merged["name"] == "Acme"
+
+
+def test_brand_logo_url_chip_resolves_to_the_stream_route_for_uploads():
+    kit = get_brand_kit({"brand_kit": {"logo_path": "ws/brand/logo.png"}})
+    ctx = build_context(None, None, kit, datetime(2026, 9, 11))
+    res = resolve_paths(ctx, ["brand.logo_url"])
+    assert res.values["brand.logo_url"] == bl.BRAND_LOGO_ROUTE
+    # An external URL still wins when both are present.
+    kit2 = get_brand_kit({"brand_kit": {"logo_path": "ws/brand/logo.png", "logo_url": "https://cdn/x.png"}})
+    assert resolve_paths(build_context(None, None, kit2, datetime(2026, 9, 11)), ["brand.logo_url"]).values["brand.logo_url"] == "https://cdn/x.png"

--- a/orchestrator/tests/test_prd242_principal_pk.py
+++ b/orchestrator/tests/test_prd242_principal_pk.py
@@ -1,0 +1,90 @@
+"""PRD-242 S1 — one principal→PK resolver, and the document routes use it.
+
+``UserContext.id`` is the Clerk subject string (SaaS) or the operator EMAIL
+(local, PRD-233 S6) — never ``users.id``. ``GET /api/documents/variables`` (and
+the preview / generate routes) handed it straight to ``User.id == …``, so the
+Template Studio 500'd in both editions — surfaced in the browser as
+"Failed to fetch" because the 500 carried no CORS header.
+
+Pure: the db is a MagicMock; the request context is a stub.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from core.auth.principal import resolve_user_pk
+
+_API = Path(__file__).resolve().parent.parent / "api"
+
+
+def _ctx(**user):
+    return SimpleNamespace(user=SimpleNamespace(**user))
+
+
+def test_int_id_fast_path_needs_no_query():
+    db = MagicMock()
+    assert resolve_user_pk(db, _ctx(id=42, email="x@y")) == 42
+    db.execute.assert_not_called()
+
+
+def test_local_operator_lane_uses_raw_claims_pk_without_a_query():
+    # PRD-233 S6 binds id=email and stashes the integer PK on raw_claims.
+    db = MagicMock()
+    ctx = _ctx(id="local@automatos.local", email="local@automatos.local", raw_claims={"user_id": 1})
+    assert resolve_user_pk(db, ctx) == 1
+    db.execute.assert_not_called()
+
+
+def test_clerk_string_resolves_through_clerk_user_id_then_email():
+    db = MagicMock()
+    db.execute.return_value.fetchone.side_effect = [None, (17,)]
+    ctx = _ctx(id="user_38Zabc", email="jane@acme.com", clerk_user_id="user_38Zabc", raw_claims=None)
+    assert resolve_user_pk(db, ctx) == 17
+    assert db.execute.call_count == 2
+    first_params = db.execute.call_args_list[0].args[1]
+    second_params = db.execute.call_args_list[1].args[1]
+    assert first_params == {"value": "user_38Zabc"}
+    assert second_params == {"value": "jane@acme.com"}
+
+
+def test_unresolvable_or_principal_less_is_none_not_user_one():
+    db = MagicMock()
+    db.execute.return_value.fetchone.return_value = None
+    assert resolve_user_pk(db, None) is None
+    assert resolve_user_pk(db, SimpleNamespace(user=None)) is None
+    assert resolve_user_pk(db, _ctx(id="user_missing", email=None, clerk_user_id=None, raw_claims=None)) is None
+
+
+def test_bool_is_not_an_int_pk():
+    db = MagicMock()
+    db.execute.return_value.fetchone.return_value = None
+    assert resolve_user_pk(db, _ctx(id=True, email=None, clerk_user_id=None, raw_claims={"user_id": False})) is None
+
+
+def _user_id_kwargs_in(module: str) -> list[str]:
+    """Every ``user_id=<expr>`` keyword passed in the module, as source text."""
+    tree = ast.parse((_API / module).read_text(encoding="utf-8"))
+    found = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            for kw in node.keywords:
+                if kw.arg == "user_id":
+                    found.append(ast.unparse(kw.value))
+    return found
+
+
+def test_document_routes_never_pass_ctx_user_id_as_user_id():
+    """The regression guard: no route hands the principal string to an integer column."""
+    exprs = _user_id_kwargs_in("document_generation.py")
+    assert exprs, "expected user_id keywords in document_generation.py"
+    assert all("ctx.user.id" not in e for e in exprs), exprs
+    assert any("resolve_user_pk" in e for e in exprs)
+
+
+def test_positional_resolver_calls_in_document_routes_use_resolve_user_pk():
+    src = (_API / "document_generation.py").read_text(encoding="utf-8")
+    assert "ctx.user.id if ctx.user else None" not in src

--- a/orchestrator/tests/test_prd242_seed_and_playbook.py
+++ b/orchestrator/tests/test_prd242_seed_and_playbook.py
@@ -1,0 +1,69 @@
+"""PRD-242 S2/S4 — static guards for two one-line wirings.
+
+* the local-edition first-run seed calls the starter-template seeder (a local
+  install used to open the Template Studio to an empty gallery);
+* the playbook ``generate_document`` step passes ``template_id`` and registers
+  the file as a Deliverable (it used to accept only ``template_name`` and leave
+  the document inside the step's output JSON).
+
+AST reads — no boot, no DB — plus the pure step-config helper.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from uuid import UUID
+
+import pytest
+
+_ORCH = Path(__file__).resolve().parent.parent
+
+
+def _calls_in_function(path: Path, func_name: str) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == func_name:
+            names = set()
+            for call in ast.walk(node):
+                if isinstance(call, ast.Call):
+                    f = call.func
+                    names.add(f.id if isinstance(f, ast.Name) else getattr(f, "attr", ""))
+            return names
+    raise AssertionError(f"{func_name} not found in {path.name}")
+
+
+def test_local_first_run_seeds_starter_templates():
+    calls = _calls_in_function(_ORCH / "core" / "seeds" / "seed_local_first_run.py", "seed_local_first_run")
+    assert "seed_starter_templates" in calls
+
+
+def test_playbook_document_step_passes_template_id_and_registers_a_deliverable():
+    calls = _calls_in_function(_ORCH / "api" / "recipe_executor.py", "_execute_recipe_inner")
+    assert "register_as_deliverable" in calls
+    assert "_document_step_config" in calls
+    assert "share_link" in calls
+
+
+def _document_step_config():
+    try:
+        from api.recipe_executor import _document_step_config
+    except Exception as e:  # env without the heavy router deps
+        pytest.skip(f"api.recipe_executor not importable in this env: {e}")
+    return _document_step_config
+
+
+def test_document_step_config_reads_inline_or_nested_config():
+    fn = _document_step_config()
+    tid = "11111111-1111-1111-1111-111111111111"
+    inline = fn({"type": "generate_document", "title": "Weekly", "format": "docx", "template_id": tid, "data": {"a": 1}})
+    nested = fn({"type": "generate_document", "config": {"title": "Weekly", "template_name": "Weekly Report"}})
+    assert inline["template_id"] == UUID(tid) and inline["format"] == "docx" and inline["data"] == {"a": 1}
+    assert nested["template_id"] is None and nested["template_name"] == "Weekly Report"
+    assert nested["format"] == "pdf" and nested["data"] == {}
+
+
+def test_document_step_config_rejects_a_non_uuid_template_id_loudly():
+    fn = _document_step_config()
+    with pytest.raises(ValueError, match="not a UUID"):
+        fn({"type": "generate_document", "template_id": "Weekly Report"})

--- a/orchestrator/tests/test_prd242_share_links.py
+++ b/orchestrator/tests/test_prd242_share_links.py
@@ -1,0 +1,187 @@
+"""PRD-242 S4 — a generated document is delivered, not just downloadable.
+
+* ``_build_result`` keeps the S3 object key when the persistence upload landed;
+* ``share_link`` mints a 7-day presign through the PUBLIC client (the only link
+  that works for someone who cannot sign in), and is ``None`` when storage
+  holds no copy — never an exception;
+* ``deliverables_app_url`` is the absolute in-app feed link;
+* ``generate()`` stamps template attribution on the result;
+* the brand-kit suggestions builder prefers the business profile, then the
+  workspace, and only emits fields that have a value.
+
+Boundary mocks as in test_prd190_deliverables — no AWS, no DB, no WeasyPrint.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+WS = uuid4()
+
+
+class _FakeQuery:
+    def filter(self, *a, **k):
+        return self
+
+    def order_by(self, *a, **k):
+        return self
+
+    def first(self):
+        return None
+
+
+class _FakeDb:
+    def query(self, *a, **k):
+        return _FakeQuery()
+
+
+@pytest.fixture(autouse=True)
+def _fresh_storage_factory():
+    import core.storage.s3 as s3mod
+
+    s3mod.reset_s3_client()
+    yield
+    s3mod.reset_s3_client()
+
+
+def _storage_config(monkeypatch, gs, *, configured: bool, public_endpoint: str = ""):
+    import core.storage.s3 as s3mod
+
+    for cfg in {id(gs.config): gs.config, id(s3mod.config): s3mod.config}.values():
+        monkeypatch.setattr(cfg, "S3_ENDPOINT_URL", "", raising=False)
+        monkeypatch.setattr(cfg, "S3_PUBLIC_ENDPOINT_URL", public_endpoint, raising=False)
+        monkeypatch.setattr(cfg, "S3_USE_PATH_STYLE", False, raising=False)
+        monkeypatch.setattr(cfg, "AWS_ACCESS_KEY_ID", "test-key" if configured else None, raising=False)
+        monkeypatch.setattr(cfg, "AWS_SECRET_ACCESS_KEY", "test-secret" if configured else None, raising=False)
+        monkeypatch.setattr(cfg, "S3_DOCUMENTS_BUCKET", "test-bucket", raising=False)
+
+
+def _mock_s3(monkeypatch, gs):
+    import boto3
+
+    fake_boto = MagicMock()
+    fake_boto.client.return_value.generate_presigned_url.return_value = (
+        "https://test-bucket.s3.amazonaws.com/workspaces/x/generated-documents/f.pdf?X-Amz-Expires=604800&X-Amz-Signature=abc"
+    )
+    monkeypatch.setattr(boto3, "client", fake_boto.client)
+    _storage_config(monkeypatch, gs, configured=True)
+    return fake_boto
+
+
+def _service():
+    import modules.documents.generation_service as gs
+
+    return gs.DocumentGenerationService(_FakeDb(), WS)
+
+
+def test_build_result_keeps_the_s3_key_when_the_upload_lands(tmp_path, monkeypatch):
+    import modules.documents.generation_service as gs
+
+    _mock_s3(monkeypatch, gs)
+    doc = tmp_path / "20260911_120000_Weekly.pdf"
+    doc.write_bytes(b"%PDF-1.4 test")
+    result = _service()._build_result(str(doc), "pdf", "Weekly", WS)
+    assert result.s3_key == f"workspaces/{WS}/generated-documents/{doc.name}"
+    assert result.download_url == f"/api/documents/generated/{doc.name}"
+
+
+def test_build_result_has_no_s3_key_when_storage_is_off(tmp_path, monkeypatch):
+    import modules.documents.generation_service as gs
+
+    _storage_config(monkeypatch, gs, configured=False)
+    doc = tmp_path / "x.docx"
+    doc.write_bytes(b"PK")
+    result = _service()._build_result(str(doc), "docx", "x", WS)
+    assert result.s3_key is None
+    assert _service().share_link(result) is None
+
+
+def test_share_link_presigns_seven_days_via_the_public_client(monkeypatch):
+    import modules.documents.generation_service as gs
+    from modules.documents.models import GeneratedDocument
+
+    fake_boto = _mock_s3(monkeypatch, gs)
+    result = GeneratedDocument(path="/x/f.pdf", format="pdf", filename="f.pdf", size=10, s3_key="workspaces/x/generated-documents/f.pdf")
+    url = _service().share_link(result)
+    assert url and "X-Amz-Expires=604800" in url
+    call = fake_boto.client.return_value.generate_presigned_url.call_args
+    assert call.args[0] == "get_object"
+    assert call.kwargs["ExpiresIn"] == gs.SHARE_LINK_TTL_SECONDS == 7 * 24 * 3600
+    assert call.kwargs["Params"]["Key"] == result.s3_key
+    assert 'filename="f.pdf"' in call.kwargs["Params"]["ResponseContentDisposition"]
+
+
+def test_share_link_never_raises(monkeypatch):
+    import modules.documents.generation_service as gs
+    from modules.documents.models import GeneratedDocument
+
+    fake_boto = _mock_s3(monkeypatch, gs)
+    fake_boto.client.return_value.generate_presigned_url.side_effect = RuntimeError("boom")
+    result = GeneratedDocument(path="/x/f.pdf", format="pdf", filename="f.pdf", size=10, s3_key="k")
+    assert _service().share_link(result) is None
+
+
+def test_deliverables_app_url_is_absolute(monkeypatch):
+    import modules.documents.generation_service as gs
+
+    monkeypatch.setattr(gs.config, "FRONTEND_URL", "https://app.automatos.app/", raising=False)
+    assert gs.deliverables_app_url() == "https://app.automatos.app/deliverables?tab=outputs"
+
+
+@pytest.mark.asyncio
+async def test_generate_stamps_template_attribution(monkeypatch, tmp_path):
+    import modules.documents.generation_service as gs
+    from modules.documents.models import GeneratedDocument
+
+    _storage_config(monkeypatch, gs, configured=False)
+    svc = _service()
+    tid = uuid4()
+    template = SimpleNamespace(id=tid, name="Weekly Report", blocks={"blocks": []}, template_content=None, template_file_path=None, data_schema=None)
+    svc.template_service = SimpleNamespace(get_template=lambda t, ws: template, get_template_by_name=lambda ws, n: template)
+
+    async def _fake_pdf(template, data, workspace_id, title="Document", user_id=None):
+        return GeneratedDocument(path="/x/f.pdf", format="pdf", filename="f.pdf", size=1)
+
+    monkeypatch.setattr(svc, "generate_pdf", _fake_pdf)
+    result = await svc.generate(title="Weekly", format="pdf", data={"sections": []}, workspace_id=WS, template_id=tid)
+    assert result.template_id == str(tid)
+    assert result.template_name == "Weekly Report"
+
+
+def _suggestions():
+    try:
+        from api.document_brand_kit import build_brand_suggestions
+    except Exception as e:  # env without the heavy router deps
+        pytest.skip(f"api.document_brand_kit not importable in this env: {e}")
+    return build_brand_suggestions
+
+
+def test_brand_suggestions_prefer_the_business_profile_then_the_workspace():
+    build = _suggestions()
+    ws = SimpleNamespace(name="Local Workspace")
+    profile = SimpleNamespace(
+        company_name="Acme Ltd", domain="acme.com",
+        brands=[{"brand_name": "Acme", "logo_url": "https://acme.com/logo.png"}],
+        voice_notes="Build better, together.\nMore notes",
+    )
+    user = SimpleNamespace(email="jane@acme.com")
+    out = build(ws, profile, user)
+    assert out["name"] == {"value": "Acme Ltd", "source": "business_profile"}
+    assert out["website"] == {"value": "https://acme.com", "source": "business_profile"}
+    assert out["logo_url"] == {"value": "https://acme.com/logo.png", "source": "business_profile"}
+    assert out["tagline"] == {"value": "Build better, together.", "source": "business_profile"}
+    assert out["email"] == {"value": "jane@acme.com", "source": "user"}
+
+
+def test_brand_suggestions_fall_back_to_the_workspace_and_skip_empties():
+    build = _suggestions()
+    out = build(SimpleNamespace(name="Local Workspace"), None, None)
+    assert out == {
+        "name": {"value": "Local Workspace", "source": "workspace"},
+        "company_name": {"value": "Local Workspace", "source": "workspace"},
+    }
+    assert build(None, SimpleNamespace(company_name="  ", domain="", brands=None, voice_notes=None), None) == {}

--- a/orchestrator/tests/test_prd242_template_summary.py
+++ b/orchestrator/tests/test_prd242_template_summary.py
@@ -1,0 +1,78 @@
+"""PRD-242 S2 — the gallery entry says what a raw template row does not.
+
+``has_blocks`` (block-editable vs legacy), ``is_starter`` (seeded, copy-on-
+customise) and ``data_fields`` (the ``data.*`` chips an agent must supply).
+Pure — plain objects in, dicts out.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from types import SimpleNamespace
+
+from modules.documents.template_summary import data_fields_of, summarize_template, variable_paths_of
+
+
+def _blocks(*paths):
+    return {
+        "version": 1,
+        "blocks": [
+            {"type": "text", "id": f"t{i}", "content": [{"type": "variable", "path": p}]}
+            for i, p in enumerate(paths)
+        ],
+    }
+
+
+def test_variable_paths_sorted_and_deduplicated():
+    paths = variable_paths_of(_blocks("data.summary", "user.name", "data.summary", "brand.name"))
+    assert paths == ["brand.name", "data.summary", "user.name"]
+
+
+def test_data_fields_strip_the_dynamic_prefix_and_keep_order():
+    assert data_fields_of(["brand.name", "data.summary", "data.title", "user.name"]) == ["summary", "title"]
+
+
+def test_no_blocks_or_malformed_blocks_yield_empty_lists():
+    assert variable_paths_of(None) == []
+    assert variable_paths_of({}) == []
+    # malformed body (level 9) → not an authoring surface we can read; no crash
+    assert variable_paths_of({"blocks": [{"type": "heading", "id": "h", "level": 9, "content": []}]}) == []
+
+
+def test_summarize_block_starter():
+    row = SimpleNamespace(
+        id="11111111-1111-1111-1111-111111111111",
+        name="Branded Report",
+        description="desc",
+        format="pdf",
+        category="report",
+        tags=None,
+        version=1,
+        data_schema={},
+        sample_data={"data": {"title": "Q1"}},
+        blocks=_blocks("data.title", "data.summary", "brand.name"),
+        created_by="system",
+        created_at=datetime(2026, 9, 11, 10, 0, 0),
+        updated_at=None,
+    )
+    out = summarize_template(row)
+    assert out["has_blocks"] is True
+    assert out["is_starter"] is True
+    assert out["data_fields"] == ["summary", "title"]
+    assert out["variable_paths"] == ["brand.name", "data.summary", "data.title"]
+    assert out["created_at"] == "2026-09-11T10:00:00"
+    assert out["updated_at"] is None
+    assert out["tags"] == []
+
+
+def test_summarize_legacy_user_template():
+    row = SimpleNamespace(
+        id="x", name="Invoice", description=None, format="pdf", category="invoice", tags=["a"],
+        version=2, data_schema={"type": "object"}, sample_data={}, blocks=None,
+        created_by="user_abc", created_at=None, updated_at=None,
+    )
+    out = summarize_template(row)
+    assert out["has_blocks"] is False
+    assert out["is_starter"] is False
+    assert out["data_fields"] == []
+    assert out["tags"] == ["a"]

--- a/orchestrator/tests/test_prd242_unhandled_error_cors.py
+++ b/orchestrator/tests/test_prd242_unhandled_error_cors.py
@@ -1,0 +1,97 @@
+"""PRD-242 S1 — an unhandled backend error must reach the browser as a 500 it
+can READ, not as "TypeError: Failed to fetch".
+
+Starlette's ``@app.exception_handler(Exception)`` runs in ServerErrorMiddleware
+(outermost) — outside CORSMiddleware — so its 500 has no
+Access-Control-Allow-Origin. The fix is a plain-JSON conversion registered
+BEFORE CORS (later-added middleware wraps earlier ones). Two guards:
+
+1. behaviour — a minimal Starlette app wired in the same order returns a 500
+   WITH the CORS header;
+2. placement — main.py registers the converter before it adds CORSMiddleware
+   (an AST read; no boot, no DB).
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.testclient import TestClient
+
+from core.observability.error_response import INTERNAL_ERROR_DETAIL, json_500_for_unhandled_errors
+
+_MAIN_PY = Path(__file__).resolve().parent.parent / "main.py"
+ORIGIN = "http://localhost:3000"
+
+
+def _app(convert_inside_cors: bool) -> FastAPI:
+    app = FastAPI()
+    if convert_inside_cors:
+        app.middleware("http")(json_500_for_unhandled_errors)
+    app.add_middleware(CORSMiddleware, allow_origins=[ORIGIN], allow_credentials=True, allow_methods=["*"], allow_headers=["*"])
+
+    @app.get("/boom")
+    async def boom():
+        raise RuntimeError("psycopg2 says no")
+
+    @app.get("/fine")
+    async def fine():
+        return {"ok": True}
+
+    return app
+
+
+def test_unhandled_error_is_a_json_500_with_cors_headers():
+    client = TestClient(_app(convert_inside_cors=True), raise_server_exceptions=False)
+    resp = client.get("/boom", headers={"Origin": ORIGIN, "X-Request-ID": "req-1"})
+    assert resp.status_code == 500
+    assert resp.headers.get("access-control-allow-origin") == ORIGIN
+    assert resp.json() == {"detail": INTERNAL_ERROR_DETAIL, "request_id": "req-1"}
+
+
+def test_without_the_converter_the_500_has_no_cors_header():
+    """Documents the failure the converter exists for."""
+    client = TestClient(_app(convert_inside_cors=False), raise_server_exceptions=False)
+    resp = client.get("/boom", headers={"Origin": ORIGIN})
+    assert resp.status_code == 500
+    assert "access-control-allow-origin" not in resp.headers
+
+
+def test_happy_path_untouched():
+    client = TestClient(_app(convert_inside_cors=True))
+    resp = client.get("/fine", headers={"Origin": ORIGIN})
+    assert resp.status_code == 200 and resp.json() == {"ok": True}
+    assert resp.headers.get("access-control-allow-origin") == ORIGIN
+
+
+def _top_level_statement_index(pred) -> int:
+    tree = ast.parse(_MAIN_PY.read_text(encoding="utf-8"))
+    for i, node in enumerate(tree.body):
+        if pred(node):
+            return i
+    raise AssertionError("statement not found in main.py")
+
+
+def _is_call_named(node, attr: str) -> bool:
+    return (
+        isinstance(node, ast.Expr)
+        and isinstance(node.value, ast.Call)
+        and isinstance(node.value.func, ast.Attribute)
+        and node.value.func.attr == attr
+    )
+
+
+def test_main_registers_the_converter_before_cors_middleware():
+    converter = _top_level_statement_index(
+        lambda n: isinstance(n, ast.Expr)
+        and isinstance(n.value, ast.Call)
+        and any(isinstance(a, ast.Name) and a.id == "json_500_for_unhandled_errors" for a in n.value.args)
+    )
+    cors = _top_level_statement_index(
+        lambda n: _is_call_named(n, "add_middleware")
+        and any(isinstance(a, ast.Name) and a.id == "CORSMiddleware" for a in n.value.args)
+    )
+    assert converter < cors, "the JSON-500 converter must be added BEFORE CORSMiddleware (it wraps inside it)"


### PR DESCRIPTION
## Summary

The Templates tab (Deliverables → Templates) failed with **"Failed to fetch"**. Three root causes, verified against the running local stack, none of them in the Studio UI:

1. **`GET /api/documents/variables` 500s in both editions.** The route (and `preview-blocks` / `templates/{id}/preview` / `generate`) handed `ctx.user.id` to `User.id` (INTEGER). `ctx.user.id` is the Clerk subject string in SaaS and the operator's **email** in the local edition (PRD-233 S6, by design) → `psycopg2 InvalidTextRepresentation`. Same bug class as #513. Fix: **one resolver**, `core/auth/principal.py::resolve_user_pk`; `api/chat.py::get_user_id` now delegates to it; an AST test forbids `ctx.user.id` as a `user_id=` argument in the document routes.
2. **The 500 arrived as a network error.** `@app.exception_handler(Exception)` runs in Starlette's outermost `ServerErrorMiddleware` — outside `CORSMiddleware` — so the 500 had no `Access-Control-Allow-Origin` and the browser reported `TypeError: Failed to fetch`. Every unhandled backend error on every page looked like this. Fix: `core/observability/error_response.py`, registered in `main.py` *before* `CORSMiddleware` (later-added wraps outside). Behavioural test on a mini-app + AST placement guard.
3. **The local edition never seeded the starter templates** — `seed_starter_templates` only ran at SaaS provisioning. `document_templates` had 0 rows locally. The first-run seed now calls the same idempotent seeder (existing installs pick it up on next boot).

## What was built on top (PRD-242, `docs/PRDS/PRD-242-TEMPLATE-STUDIO-USABLE.md`)

- **Template list says what a row is** — `has_blocks` / `is_starter` / `data_fields` / `variable_paths` (`modules/documents/template_summary.py`). The list never returned `has_blocks`, so *Edit* never appeared; users could only *Copy* their own templates.
- **Brand kit: logo upload + profile prefill** (`api/document_brand_kit.py`, a sub-router under `/api/documents`; `modules/documents/brand_logo.py`). PNG/JPEG into `DOCUMENT_STORAGE_DIR` + S3 mirror, streamed back to the UI, **inlined as a `data:` URI at render time** — the WeasyPrint/DOCX fetchers refuse private hosts, so a logo in MinIO or a private bucket could never render before. `logo_path` is server-managed (a client `PUT` cannot set it). `GET /brand-kit/suggestions` fills empty fields from the business profile, workspace name and user.
- **Delivery, not just download.** Tool result, API response and playbook step now carry `share_url` (7-day presign via the public S3 client — the only link an email recipient can open), `app_url`, `deliverable_id`, `template_id/name`. API `/generate` and playbook `generate_document` steps register Deliverables (they didn't); the playbook step accepts `template_id`. The LLM summary tells the agent which link to use when emailing.
- **Studio UX** — split into 9 files: guide panel (dismissable), tooltip-registry entries (`deliverables.*`), a per-field form for the `data.*` chips (JSON one toggle away), `ErrorState` with retry, delete confirmation, a *Generate* dialog, and a **Use with Auto** popover with copy-ready prompts for chat / schedule / email / a playbook step, keyed by template id.

Route manifest +4 entries (count 805), hand-added.

## Test plan

- [ ] CI: `test_prd242_*` (6 pure pytest files: principal resolution, template summary, CORS-safe 500 + main.py placement, seed/playbook wiring, brand logo roundtrip + inlining, share links + suggestions), vitest (`templateFields`, `promptSnippets`), route-manifest, tsc baseline (local run: 537 errors, 0 in the new files; baseline 554).
- [ ] Local edition (after merge/redeploy): Deliverables → Templates loads; starters appear; Brand Kit → *Use my profile details* + logo upload; Copy "Branded Report" → save → ▶ Generate → file appears in Deliverables with a working download; PDF shows the logo.
- [ ] SaaS: same page loads for a Clerk user (the variables endpoint no longer 500s).
- [ ] Chat: "list our document templates" → "generate a PDF with the Branded Report template about X" → link in chat + Deliverables entry; the tool summary shows a share link.

## Open questions (Gerard's call — in the PRD)

Email *attachments* via Composio (link-only ships now); share-link TTL beyond S3's 7-day ceiling; SaaS bucket CORS for the FilePreview redirect; exposing the document step in the playbook step builder; Plate editor / `repeat` blocks (unchanged from PRD-190).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a complete Template Studio for creating, editing, previewing, copying, and managing document templates.
  * Added document generation with field entry, validation, downloads, Deliverables access, and share links.
  * Added Brand Kit editing with suggestions, company details, color settings, logo upload, and live previews.
  * Added “Use with Auto” prompts for chat, schedules, email, and playbooks.
  * Added starter templates for local first-time setup.

* **Bug Fixes**
  * Improved variable guidance and missing-field warnings.
  * Unhandled errors now return readable responses with CORS support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->